### PR TITLE
Add a `run` field to the StateVersionCreateOptions

### DIFF
--- a/state_version.go
+++ b/state_version.go
@@ -105,6 +105,9 @@ type StateVersionCreateOptions struct {
 
 	// The base64 encoded state.
 	State *string `jsonapi:"attr,state"`
+
+	// Specifies the run to associate the state with.
+	Run *Run `jsonapi:"relation,run,omitempty"`
 }
 
 func (o StateVersionCreateOptions) valid() error {


### PR DESCRIPTION
If this field is populated, the created state version will be associated with the given run.