### PR TITLE
add delete method to oauth client and some example code

### DIFF
--- a/examples/oauth-client/main.go
+++ b/examples/oauth-client/main.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"context"
+	"log"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+func main() {
+	config := &tfe.Config{
+		Token: "insert-your-token-here",
+	}
+
+	client, err := tfe.NewClient(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a context
+	ctx := context.Background()
+	// Create an oauth-client
+	o, err := client.OAuthClients.Create(ctx, "org-name", tfe.OAuthClientCreateOptions{
+		ServiceProvider: tfe.ServiceProvider(tfe.ServiceProviderGithubEE),
+		HTTPURL:         tfe.String("http-url"),
+		APIURL:          tfe.String("api-url"),
+		Key:             tfe.String("key"),
+		Secret:          tfe.String("secret"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Delete an oauth-client
+	err = client.OAuthClients.Delete(ctx, o.ID)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -170,13 +170,11 @@ func createOAuthToken(t *testing.T, client *Client, org *Organization) (*OAuthTo
 	// created. To get a token, the client needs to be connected through the UI
 	// first. So the test using this (TestOAuthTokensList) is currently disabled.
 	return oc.OAuthToken[0], func() {
-		// There currently isn't a way to delete an OAuth client.
-		//
-		// if err := client.OAuthClients.Delete(ctx, oc.ID); err != nil {
-		// 	t.Errorf("Error destroying OAuth client! WARNING: Dangling resources\n"+
-		// 		"may exist! The full error is shown below.\n\n"+
-		// 		"OAuthClient: %s\nError: %s", oc.ID, err)
-		// }
+		if err := client.OAuthClients.Delete(ctx, oc.ID); err != nil {
+			t.Errorf("Error destroying OAuth client! WARNING: Dangling resources\n"+
+				"may exist! The full error is shown below.\n\n"+
+				"OAuthClient: %s\nError: %s", oc.ID, err)
+		}
 
 		if orgCleanup != nil {
 			orgCleanup()

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -19,6 +19,8 @@ var _ OAuthClients = (*oAuthClients)(nil)
 type OAuthClients interface {
 	// Create a VCS connection between an organization and a VCS provider.
 	Create(ctx context.Context, organization string, options OAuthClientCreateOptions) (*OAuthClient, error)
+	//Delete a VCS connection by id
+	Delete(ctx context.Context, id string) error
 }
 
 // oAuthClients implements OAuthClients.
@@ -124,4 +126,18 @@ func (s *oAuthClients) Create(ctx context.Context, organization string, options 
 	}
 
 	return oc, nil
+}
+
+//Delete a VCS connection between an organization and a VCS provider.
+func (s *oAuthClients) Delete(ctx context.Context, id string) error {
+	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(id))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+	err = s.client.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -109,3 +109,16 @@ func TestOAuthClientCreate(t *testing.T) {
 		assert.EqualError(t, err, "ServiceProvider is required")
 	})
 }
+
+func TestOAuthClientDelete(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	oaTest, oaTestCleanup := createOAuthToken(t, client)
+	defer oaTestCleanup()
+
+	t.Run("with valid id", func(t *testing.T) {
+		err := client.OAuthClients.Delete(ctx, oaTest.ID)
+		assert.NoError(t, err)
+	})
+}


### PR DESCRIPTION
Add delete method to oauth client. Need this so the tfe provider can have the oauth client as a proper resource.

Closed previous pull request because i was on the wrong branch