### PR TITLE
Use a pooled HTTP client for performance

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -58,7 +58,7 @@ func DefaultConfig() *Config {
 		Address:    os.Getenv("TFE_ADDRESS"),
 		BasePath:   DefaultBasePath,
 		Token:      os.Getenv("TFE_TOKEN"),
-		HTTPClient: cleanhttp.DefaultClient(),
+		HTTPClient: cleanhttp.DefaultPooledClient(),
 	}
 
 	// Set the default address if none is given.


### PR DESCRIPTION
I was debugging why API calls were so slow (~3x slower then making the same call from the web UI) and in the end found that the slowdown was caused by the overhead of setting up a new TCP connection each time.

Switching to the pooled client solves this problem and seems perfectly safe for this kind of use case (it’s only used to target a single host)