### PR TITLE
Add force-cancel method for Runs

### DIFF
--- a/run.go
+++ b/run.go
@@ -31,6 +31,9 @@ type Runs interface {
 	// Cancel a run by its ID.
 	Cancel(ctx context.Context, runID string, options RunCancelOptions) error
 
+	// Force-cancel a run by its ID.
+	ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error
+
 	// Discard a run by its ID.
 	Discard(ctx context.Context, runID string, options RunDiscardOptions) error
 }
@@ -77,16 +80,17 @@ type RunList struct {
 
 // Run represents a Terraform Enterprise run.
 type Run struct {
-	ID               string               `jsonapi:"primary,runs"`
-	Actions          *RunActions          `jsonapi:"attr,actions"`
-	CreatedAt        time.Time            `jsonapi:"attr,created-at,iso8601"`
-	HasChanges       bool                 `jsonapi:"attr,has-changes"`
-	IsDestroy        bool                 `jsonapi:"attr,is-destroy"`
-	Message          string               `jsonapi:"attr,message"`
-	Permissions      *RunPermissions      `jsonapi:"attr,permissions"`
-	Source           RunSource            `jsonapi:"attr,source"`
-	Status           RunStatus            `jsonapi:"attr,status"`
-	StatusTimestamps *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	ID                     string               `jsonapi:"primary,runs"`
+	Actions                *RunActions          `jsonapi:"attr,actions"`
+	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
+	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at"`
+	HasChanges             bool                 `jsonapi:"attr,has-changes"`
+	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
+	Message                string               `jsonapi:"attr,message"`
+	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
+	Source                 RunSource            `jsonapi:"attr,source"`
+	Status                 RunStatus            `jsonapi:"attr,status"`
+	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
 
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
@@ -98,9 +102,10 @@ type Run struct {
 
 // RunActions represents the run actions.
 type RunActions struct {
-	IsCancelable  bool `json:"is-cancelable"`
-	IsConfirmable bool `json:"is-confirmable"`
-	IsDiscardable bool `json:"is-discardable"`
+	IsCancelable      bool `json:"is-cancelable"`
+	IsConfirmable     bool `json:"is-confirmable"`
+	IsDiscardable     bool `json:"is-discardable"`
+	IsForceCancelable bool `json:"is-force-cancelable"`
 }
 
 // RunPermissions represents the run permissions.
@@ -108,6 +113,7 @@ type RunPermissions struct {
 	CanApply        bool `json:"can-apply"`
 	CanCancel       bool `json:"can-cancel"`
 	CanDiscard      bool `json:"can-discard"`
+	CanForceCancel  bool `json:"can-force-cancel"`
 	CanForceExecute bool `json:"can-force-execute"`
 }
 
@@ -251,6 +257,27 @@ func (s *runs) Cancel(ctx context.Context, runID string, options RunCancelOption
 	}
 
 	u := fmt.Sprintf("runs/%s/actions/cancel", url.QueryEscape(runID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// RunCancelOptions represents the options for force-canceling a run.
+type RunForceCancelOptions struct {
+	// An optional comment explaining the reason for the force-cancel.
+	Comment *string `json:"comment,omitempty"`
+}
+
+// ForceCancel is used to forcefully cancel a run by its ID.
+func (s *runs) ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error {
+	if !validStringID(&runID) {
+		return errors.New("Invalid value for run ID")
+	}
+
+	u := fmt.Sprintf("runs/%s/actions/force-cancel", url.QueryEscape(runID))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
 		return err

--- a/run.go
+++ b/run.go
@@ -83,7 +83,7 @@ type Run struct {
 	ID                     string               `jsonapi:"primary,runs"`
 	Actions                *RunActions          `jsonapi:"attr,actions"`
 	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
-	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at"`
+	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
 	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
 	Message                string               `jsonapi:"attr,message"`

--- a/run_test.go
+++ b/run_test.go
@@ -222,7 +222,7 @@ func TestRunsForceCancel(t *testing.T) {
 				break
 			}
 
-			if i > 5 {
+			if i > 30 {
 				t.Fatal("Timeout waiting for run to be canceled")
 			}
 

--- a/run_test.go
+++ b/run_test.go
@@ -3,6 +3,7 @@ package tfe
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -196,20 +197,48 @@ func TestRunsForceCancel(t *testing.T) {
 	// be pending until the first one is confirmed or discarded, so we
 	// can cancel that one.
 	_, _ = createRun(t, client, wTest)
-	rTest2, _ := createRun(t, client, wTest)
+	rTest, _ := createRun(t, client, wTest)
 
-	t.Run("when the run exists", func(t *testing.T) {
-		err := client.Runs.Cancel(ctx, rTest2.ID, RunCancelOptions{})
+	t.Run("run is not force-cancelable", func(t *testing.T) {
+		assert.False(t, rTest.Actions.IsForceCancelable)
+	})
+
+	t.Run("user is allowed to force-cancel", func(t *testing.T) {
+		assert.True(t, rTest.Permissions.CanForceCancel)
+	})
+
+	t.Run("after a normal cancel", func(t *testing.T) {
+		// Request the normal cancel
+		err := client.Runs.Cancel(ctx, rTest.ID, RunCancelOptions{})
 		assert.NoError(t, err)
+
+		// Allow time for the async cancel request to operate.
+		time.Sleep(5 * time.Second)
+
+		// Refresh the view of the run
+		rTest, err = client.Runs.Read(ctx, rTest.ID)
+		assert.NoError(t, err)
+
+		t.Run("force-cancel-available-at timestamp is present", func(t *testing.T) {
+			assert.True(t, rTest.ForceCancelAvailableAt.After(time.Now()))
+		})
+
+		// This test case is minimal because a force-cancel is not needed in
+		// any normal circumstance. Only if Terraform encounters unexpected
+		// errors or behaves abnormaly should this functionality be required.
+		// Force-cancel only becomes available if a normal cancel is performed
+		// first, and the desired canceled state is not reached within a pre-
+		// determined amount of time (see
+		// https://www.terraform.io/docs/enterprise/api/run.html#forcefully-cancel-a-run).
 	})
 
 	t.Run("when the run does not exist", func(t *testing.T) {
-		err := client.Runs.Cancel(ctx, "nonexisting", RunCancelOptions{})
+		err := client.Runs.ForceCancel(ctx, "nonexisting", RunForceCancelOptions{})
 		assert.Equal(t, err, ErrResourceNotFound)
 	})
 
 	t.Run("with invalid run ID", func(t *testing.T) {
-		err := client.Runs.Cancel(ctx, badIdentifier, RunCancelOptions{})
+		err := client.Runs.ForceCancel(ctx, badIdentifier, RunForceCancelOptions{})
 		assert.EqualError(t, err, "Invalid value for run ID")
 	})
 }


### PR DESCRIPTION
Force-cancel is now [available in TFE](https://www.terraform.io/docs/enterprise/api/run.html#forcefully-cancel-a-run)! This adds a function and some additional fields to support calling the force-cancel operation from this client.