### PR TITLE
Check for STX and ETX when polling for logs

### DIFF
--- a/logreader_test.go
+++ b/logreader_test.go
@@ -1,0 +1,173 @@
+package tfe
+
+import (
+	"context"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func testLogReader(t *testing.T, h http.HandlerFunc) (*httptest.Server, *LogReader) {
+	ts := httptest.NewServer(h)
+
+	cfg := &Config{
+		Address:    ts.URL,
+		Token:      "dummy-token",
+		HTTPClient: ts.Client(),
+	}
+
+	client, err := NewClient(cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	logURL, err := url.Parse(ts.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lr := &LogReader{
+		client: client,
+		ctx:    context.Background(),
+		logURL: logURL,
+	}
+
+	return ts, lr
+}
+
+func TestLogReader_withMarkers(t *testing.T) {
+	t.Parallel()
+
+	logReads := 0
+	ts, lr := testLogReader(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logReads++
+		switch {
+		case logReads == 1:
+			w.Write([]byte("\x02"))
+		case logReads == 2:
+			w.Write([]byte("Terraform run started"))
+		case logReads == 15:
+			w.Write([]byte(" - logs - "))
+		case logReads == 29:
+			w.Write([]byte("Terraform run finished"))
+		case logReads == 30:
+			w.Write([]byte("\x03"))
+		}
+	}))
+	defer ts.Close()
+
+	doneReads := 0
+	lr.done = func() (bool, error) {
+		doneReads++
+		if logReads >= 30 {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	logs, err := ioutil.ReadAll(lr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "\x02Terraform run started - logs - Terraform run finished\x03"
+	if string(logs) != expected {
+		t.Fatalf("expected %s, got: %s", expected, string(logs))
+	}
+	if doneReads != 4 {
+		t.Fatalf("expected 4 done reads, got %d reads", doneReads)
+	}
+	if logReads != 31 {
+		t.Fatalf("expected 31 log reads, got %d reads", logReads)
+	}
+}
+
+func TestLogReader_withoutMarkers(t *testing.T) {
+	t.Parallel()
+
+	logReads := 0
+	ts, lr := testLogReader(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logReads++
+		switch {
+		case logReads == 1:
+			w.Write([]byte("Terraform run started"))
+		case logReads == 15:
+			w.Write([]byte(" - logs - "))
+		case logReads == 30:
+			w.Write([]byte("Terraform run finished"))
+		}
+	}))
+	defer ts.Close()
+
+	doneReads := 0
+	lr.done = func() (bool, error) {
+		doneReads++
+		if logReads >= 30 {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	logs, err := ioutil.ReadAll(lr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "Terraform run started - logs - Terraform run finished"
+	if string(logs) != expected {
+		t.Fatalf("expected %s, got: %s", expected, string(logs))
+	}
+	if doneReads != 25 {
+		t.Fatalf("expected 14 done reads, got %d reads", doneReads)
+	}
+	if logReads != 31 {
+		t.Fatalf("expected 31 log reads, got %d reads", logReads)
+	}
+}
+
+func TestLogReader_withoutEndOfTextMarker(t *testing.T) {
+	t.Parallel()
+
+	logReads := 0
+	ts, lr := testLogReader(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		logReads++
+		switch {
+		case logReads == 1:
+			w.Write([]byte("\x02"))
+		case logReads == 2:
+			w.Write([]byte("Terraform run started"))
+		case logReads == 15:
+			w.Write([]byte(" - logs - "))
+		case logReads == 30:
+			w.Write([]byte("Terraform run finished"))
+		}
+	}))
+	defer ts.Close()
+
+	doneReads := 0
+	lr.done = func() (bool, error) {
+		doneReads++
+		if logReads >= 30 {
+			return true, nil
+		}
+		return false, nil
+	}
+
+	logs, err := ioutil.ReadAll(lr)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	expected := "\x02Terraform run started - logs - Terraform run finished"
+	if string(logs) != expected {
+		t.Fatalf("expected %s, got: %s", expected, string(logs))
+	}
+	if doneReads != 4 {
+		t.Fatalf("expected 4 done reads, got %d reads", doneReads)
+	}
+	if logReads != 41 {
+		t.Fatalf("expected 41 log reads, got %d reads", logReads)
+	}
+}


### PR DESCRIPTION
By checking for the STX and ETX characters, we have a way to determine if the process generating the logs is finished.

This prevents the need to poll for the status of a plan or apply during its execution.

The STX and ETX ASCII contol characters are part of the transmission control characters which are intended to structure a data stream.

The Start of Text character (STX) is to mark the start of the textual part of a stream and the End of Text character (ETX) marked the end of the data of a message.

___________________________________________________________________________________________________
➜  go-tfe git:(f-polling) ✗ go test -run=TestLogReader -v
=== RUN   TestLogReader_withMarkers
=== PAUSE TestLogReader_withMarkers
=== RUN   TestLogReader_withoutMarkers
=== PAUSE TestLogReader_withoutMarkers
=== RUN   TestLogReader_withoutEndOfTextMarker
=== PAUSE TestLogReader_withoutEndOfTextMarker
=== CONT  TestLogReader_withMarkers
=== CONT  TestLogReader_withoutEndOfTextMarker
=== CONT  TestLogReader_withoutMarkers
--- PASS: TestLogReader_withMarkers (33.26s)
--- PASS: TestLogReader_withoutMarkers (37.26s)
--- PASS: TestLogReader_withoutEndOfTextMarker (46.89s)
PASS
ok      github.com/hashicorp/go-tfe     47.742s
