### PR TITLE
Strip the STX and ETX markers when found

### DIFF
--- a/logreader.go
+++ b/logreader.go
@@ -1,7 +1,6 @@
 package tfe
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -87,14 +86,30 @@ func (r *LogReader) read(l []byte) (int, error) {
 
 	if written > 0 {
 		// Check for an STX (Start of Text) ASCII control marker.
-		if !r.startOfText && bytes.Contains(l, []byte("\x02")) {
+		if !r.startOfText && l[0] == byte(2) {
 			r.startOfText = true
+
+			// Remove the STX marker from the received chunk.
+			copy(l[:written-1], l[1:])
+			l[written-1] = byte(0)
+			r.offset++
+			written--
+
+			// Return early if we only received the STX marker.
+			if written == 0 {
+				return 0, io.ErrNoProgress
+			}
 		}
 
 		// If we found an STX ASCII control character, start looking for
 		// the ETX (End of Text) control character.
-		if r.startOfText && bytes.Contains(l, []byte("\x03")) {
+		if r.startOfText && l[written-1] == byte(3) {
 			r.endOfText = true
+
+			// Remove the ETX marker from the received chunk.
+			l[written-1] = byte(0)
+			r.offset++
+			written--
 		}
 	}
 


### PR DESCRIPTION
Stripping the STX and ETX markers isn't required as they aren't visible characters. But in combination with how the remote backend writes the logs, this causes us to print one additional newline at the end of the log output. By removing the characters when we found then, we prevent that from happening.