### PR TITLE
Add support for Sentinel policy sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ Currently the following endpoints are supported:
 - [x] [Organizations](https://www.terraform.io/docs/enterprise/api/organizations.html)
 - [x] [Organization Tokens](https://www.terraform.io/docs/enterprise/api/organization-tokens.html)
 - [x] [Policies](https://www.terraform.io/docs/enterprise/api/policies.html)
+- [x] [Policy Sets](https://www.terraform.io/docs/enterprise/api/policy-sets.html)
 - [x] [Policy Checks](https://www.terraform.io/docs/enterprise/api/policy-checks.html)
 - [ ] [Registry Modules](https://www.terraform.io/docs/enterprise/api/modules.html)
 - [x] [Runs](https://www.terraform.io/docs/enterprise/api/run.html)

--- a/policy.go
+++ b/policy.go
@@ -116,6 +116,9 @@ type PolicyCreateOptions struct {
 	// The name of the policy.
 	Name *string `jsonapi:"attr,name"`
 
+	// A description of the policy's purpose.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
 	// The enforcements of the policy.
 	Enforce []*EnforcementOptions `jsonapi:"attr,enforce"`
 }
@@ -200,24 +203,17 @@ type PolicyUpdateOptions struct {
 	// For internal use only!
 	ID string `jsonapi:"primary,policies"`
 
-	// The enforcements of the policy.
-	Enforce []*EnforcementOptions `jsonapi:"attr,enforce"`
-}
+	// A description of the policy's purpose.
+	Description *string `jsonapi:"attr,description,omitempty"`
 
-func (o PolicyUpdateOptions) valid() error {
-	if o.Enforce == nil {
-		return errors.New("Enforce is required")
-	}
-	return nil
+	// The enforcements of the policy.
+	Enforce []*EnforcementOptions `jsonapi:"attr,enforce,omitempty"`
 }
 
 // Update an existing policy.
 func (s *policies) Update(ctx context.Context, policyID string, options PolicyUpdateOptions) (*Policy, error) {
 	if !validStringID(&policyID) {
 		return nil, errors.New("Invalid value for policy ID")
-	}
-	if err := options.valid(); err != nil {
-		return nil, err
 	}
 
 	// Make sure we don't send a user provided ID.

--- a/policy.go
+++ b/policy.go
@@ -62,10 +62,15 @@ type PolicyList struct {
 
 // Policy represents a Terraform Enterprise policy.
 type Policy struct {
-	ID        string         `jsonapi:"primary,policies"`
-	Name      string         `jsonapi:"attr,name"`
-	Enforce   []*Enforcement `jsonapi:"attr,enforce"`
-	UpdatedAt time.Time      `jsonapi:"attr,updated-at,iso8601"`
+	ID             string         `jsonapi:"primary,policies"`
+	Name           string         `jsonapi:"attr,name"`
+	Description    string         `jsonapi:"attr,description"`
+	Enforce        []*Enforcement `jsonapi:"attr,enforce"`
+	PolicySetCount int            `jsonapi:"attr,policy-set-count"`
+	UpdatedAt      time.Time      `jsonapi:"attr,updated-at,iso8601"`
+
+	// Relations
+	Organization *Organization `jsonapi:"relation,organization"`
 }
 
 // Enforcement describes a enforcement.
@@ -77,6 +82,9 @@ type Enforcement struct {
 // PolicyListOptions represents the options for listing policies.
 type PolicyListOptions struct {
 	ListOptions
+
+	// A search string (partial policy name) used to filter the results.
+	Search *string `url:"search[name],omitempty"`
 }
 
 // List all the policies for a given organization

--- a/policy_check_test.go
+++ b/policy_check_test.go
@@ -16,10 +16,12 @@ func TestPolicyChecksList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	createUploadedPolicy(t, client, true, orgTest)
-	createUploadedPolicy(t, client, true, orgTest)
-
+	pTest1, _ := createUploadedPolicy(t, client, true, orgTest)
+	pTest2, _ := createUploadedPolicy(t, client, true, orgTest)
 	wTest, _ := createWorkspace(t, client, orgTest)
+
+	createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, []*Workspace{wTest})
+
 	rTest, _ := createPlannedRun(t, client, wTest)
 
 	t.Run("without list options", func(t *testing.T) {
@@ -78,9 +80,11 @@ func TestPolicyChecksRead(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	createUploadedPolicy(t, client, true, orgTest)
-
+	pTest, _ := createUploadedPolicy(t, client, true, orgTest)
 	wTest, _ := createWorkspace(t, client, orgTest)
+
+	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
+
 	rTest, _ := createPlannedRun(t, client, wTest)
 	require.Equal(t, 1, len(rTest.PolicyChecks))
 
@@ -120,10 +124,12 @@ func TestPolicyChecksOverride(t *testing.T) {
 	defer orgTestCleanup()
 
 	t.Run("when the policy failed", func(t *testing.T) {
-		_, pTestCleanup := createUploadedPolicy(t, client, false, orgTest)
+		pTest, pTestCleanup := createUploadedPolicy(t, client, false, orgTest)
 		defer pTestCleanup()
 
 		wTest, _ := createWorkspace(t, client, orgTest)
+
+		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
 		rTest, _ := createPlannedRun(t, client, wTest)
 
 		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
@@ -139,10 +145,11 @@ func TestPolicyChecksOverride(t *testing.T) {
 	})
 
 	t.Run("when the policy passed", func(t *testing.T) {
-		_, pTestCleanup := createUploadedPolicy(t, client, true, orgTest)
+		pTest, pTestCleanup := createUploadedPolicy(t, client, true, orgTest)
 		defer pTestCleanup()
 
 		wTest, _ := createWorkspace(t, client, orgTest)
+		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
 		rTest, _ := createPlannedRun(t, client, wTest)
 
 		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
@@ -168,9 +175,10 @@ func TestPolicyChecksLogs(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	createUploadedPolicy(t, client, true, orgTest)
+	pTest, _ := createUploadedPolicy(t, client, true, orgTest)
 
 	wTest, _ := createWorkspace(t, client, orgTest)
+	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
 	rTest, _ := createPlannedRun(t, client, wTest)
 	require.Equal(t, 1, len(rTest.PolicyChecks))
 

--- a/policy_set.go
+++ b/policy_set.go
@@ -1,0 +1,381 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ PolicySets = (*policySets)(nil)
+
+// PolicySets describes all the policy set related methods that the Terraform
+// Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/docs/enterprise/api/policies.html
+type PolicySets interface {
+	// List all the policy sets for a given organization
+	List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error)
+
+	// Create a policy set and associate it with an organization.
+	Create(ctx context.Context, organization string, options PolicySetCreateOptions) (*PolicySet, error)
+
+	// Read a policy set by its ID.
+	Read(ctx context.Context, policySetID string) (*PolicySet, error)
+
+	// Update an existing policy set.
+	Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error)
+
+	// Add policies to a policy set.
+	AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error
+
+	// Remove policies from a policy set.
+	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
+
+	// Attach a policy set to workspaces.
+	AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error
+
+	// Detach a policy set from workspaces.
+	DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error
+
+	// Delete a policy set by its ID.
+	Delete(ctx context.Context, policyID string) error
+}
+
+// policySets implements PolicySets.
+type policySets struct {
+	client *Client
+}
+
+// PolicySetList represents a list of policy sets..
+type PolicySetList struct {
+	*Pagination
+	Items []*PolicySet
+}
+
+// PolicySet represents a Terraform Enterprise policy set.
+type PolicySet struct {
+	ID             string    `jsonapi:"primary,policy-sets"`
+	Name           string    `jsonapi:"attr,name"`
+	Description    string    `jsonapi:"attr,description"`
+	Global         bool      `jsonapi:"attr,global"`
+	PolicyCount    int       `jsonapi:"attr,policy-count"`
+	WorkspaceCount int       `jsonapi:"attr,workspace-count"`
+	CreatedAt      time.Time `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt      time.Time `jsonapi:"attr,updated-at,iso8601"`
+
+	// Relations
+	Organization *Organization `jsonapi:"relation,organization"`
+	Policies     []*Policy     `jsonapi:"relation,policies"`
+	Workspaces   []*Workspace  `jsonapi:"relation,workspaces"`
+}
+
+// PolicySetListOptions represents the options for listing policy sets.
+type PolicySetListOptions struct {
+	ListOptions
+
+	// A search string (partial policy set name) used to filter the results.
+	Search *string `url:"search[name],omitempty"`
+}
+
+// List all the policies for a given organization
+func (s *policySets) List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("Invalid value for organization")
+	}
+
+	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	psl := &PolicySetList{}
+	err = s.client.do(ctx, req, psl)
+	if err != nil {
+		return nil, err
+	}
+
+	return psl, nil
+}
+
+// PolicySetCreateOptions represents the options for creating a new policy set.
+type PolicySetCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,policy-sets"`
+
+	// The name of the policy set.
+	Name *string `jsonapi:"attr,name"`
+
+	// The description of the policy set.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
+	// Whether or not the policy set is global.
+	Global *bool `jsonapi:"attr,global,omitempty"`
+
+	// The initial members of the policy set.
+	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
+
+	// The initial list of workspaces the policy set should be attached to.
+	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`
+}
+
+func (o PolicySetCreateOptions) valid() error {
+	if !validString(o.Name) {
+		return errors.New("Name is required")
+	}
+	if !validStringID(o.Name) {
+		return errors.New("Invalid value for name")
+	}
+	return nil
+}
+
+// Create a policy set and associate it with an organization.
+func (s *policySets) Create(ctx context.Context, organization string, options PolicySetCreateOptions) (*PolicySet, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("Invalid value for organization")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &PolicySet{}
+	err = s.client.do(ctx, req, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, err
+}
+
+// Read a policy set by its ID.
+func (s *policySets) Read(ctx context.Context, policySetID string) (*PolicySet, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("Invalid value for policy set ID")
+	}
+
+	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &PolicySet{}
+	err = s.client.do(ctx, req, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, err
+}
+
+// PolicySetUpdateOptions represents the options for updating a policy set.
+type PolicySetUpdateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,policy-sets"`
+
+	/// The name of the policy set.
+	Name *string `jsonapi:"attr,name,omitempty"`
+
+	// The description of the policy set.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
+	// Whether or not the policy set is global.
+	Global *bool `jsonapi:"attr,global,omitempty"`
+}
+
+func (o PolicySetUpdateOptions) valid() error {
+	if o.Name != nil && !validStringID(o.Name) {
+		return errors.New("Invalid value for name")
+	}
+	return nil
+}
+
+// Update an existing policy set.
+func (s *policySets) Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &PolicySet{}
+	err = s.client.do(ctx, req, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, err
+}
+
+// PolicySetAddPoliciesOptions represents the options for adding policies to a policy set.
+type PolicySetAddPoliciesOptions struct {
+	/// The policies to add to the policy set.
+	Policies []*Policy
+}
+
+func (o PolicySetAddPoliciesOptions) valid() error {
+	if o.Policies == nil {
+		return errors.New("Policies is required")
+	}
+	if len(o.Policies) == 0 {
+		return errors.New("Must provide at least one policy")
+	}
+	return nil
+}
+
+// Add policies to a policy set
+func (s *policySets) AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("POST", u, options.Policies)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// PolicySetRemovePoliciesOptions represents the options for removing policies from a policy set.
+type PolicySetRemovePoliciesOptions struct {
+	/// The policies to remove from the policy set.
+	Policies []*Policy
+}
+
+func (o PolicySetRemovePoliciesOptions) valid() error {
+	if o.Policies == nil {
+		return errors.New("Policies is required")
+	}
+	if len(o.Policies) == 0 {
+		return errors.New("Must provide at least one policy")
+	}
+	return nil
+}
+
+// Remove policies from a policy set
+func (s *policySets) RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("DELETE", u, options.Policies)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// PolicySetAttachToWorkspacesOptions represents the options for attaching a policy set to workspaces.
+type PolicySetAttachToWorkspacesOptions struct {
+	/// The workspaces on which to attach the policy set.
+	Workspaces []*Workspace
+}
+
+func (o PolicySetAttachToWorkspacesOptions) valid() error {
+	if o.Workspaces == nil {
+		return errors.New("Workspaces is required")
+	}
+	if len(o.Workspaces) == 0 {
+		return errors.New("Must provide at least one workspace")
+	}
+	return nil
+}
+
+// Attach a policy set to workspaces
+func (s *policySets) AttachToWorkspaces(ctx context.Context, policySetID string, options PolicySetAttachToWorkspacesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("POST", u, options.Workspaces)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// PolicySetDetachFromWorkspacesOptions represents the options for detaching a policy set from workspaces.
+type PolicySetDetachFromWorkspacesOptions struct {
+	/// The workspaces from which to detach the policy set.
+	Workspaces []*Workspace
+}
+
+func (o PolicySetDetachFromWorkspacesOptions) valid() error {
+	if o.Workspaces == nil {
+		return errors.New("Workspaces is required")
+	}
+	if len(o.Workspaces) == 0 {
+		return errors.New("Must provide at least one workspace")
+	}
+	return nil
+}
+
+// Detach a policy set from workspaces
+func (s *policySets) DetachFromWorkspaces(ctx context.Context, policySetID string, options PolicySetDetachFromWorkspacesOptions) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("DELETE", u, options.Workspaces)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// Delete a policy set by its ID.
+func (s *policySets) Delete(ctx context.Context, policySetID string) error {
+	if !validStringID(&policySetID) {
+		return errors.New("Invalid value for policy set ID")
+	}
+
+	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -1,0 +1,377 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicySetsList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	psTest1, _ := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{})
+	psTest2, _ := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{})
+
+	t.Run("without list options", func(t *testing.T) {
+		psl, err := client.PolicySets.List(ctx, orgTest.Name, PolicySetListOptions{})
+		require.NoError(t, err)
+		assert.Contains(t, psl.Items, psTest1)
+		assert.Contains(t, psl.Items, psTest2)
+
+		assert.Equal(t, 1, psl.CurrentPage)
+		assert.Equal(t, 2, psl.TotalCount)
+	})
+
+	t.Run("with pagination", func(t *testing.T) {
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		psl, err := client.PolicySets.List(ctx, orgTest.Name, PolicySetListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, psl.Items)
+		assert.Equal(t, 999, psl.CurrentPage)
+		assert.Equal(t, 2, psl.TotalCount)
+	})
+
+	t.Run("with search", func(t *testing.T) {
+		// Search by one of the policy set's names; we should get only that policy
+		// set and pagination data should reflect the search as well
+		psl, err := client.PolicySets.List(ctx, orgTest.Name, PolicySetListOptions{
+			Search: &psTest1.Name,
+		})
+		require.NoError(t, err)
+		assert.Contains(t, psl.Items, psTest1)
+		assert.NotContains(t, psl.Items, psTest2)
+		assert.Equal(t, 1, psl.CurrentPage)
+		assert.Equal(t, 1, psl.TotalCount)
+	})
+
+	t.Run("without a valid organization", func(t *testing.T) {
+		ps, err := client.PolicySets.List(ctx, badIdentifier, PolicySetListOptions{})
+		assert.Nil(t, ps)
+		assert.EqualError(t, err, "Invalid value for organization")
+	})
+}
+
+func TestPolicySetsCreate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	t.Run("with valid attributes", func(t *testing.T) {
+		ps, err := client.PolicySets.Create(ctx, orgTest.Name, PolicySetCreateOptions{
+			Name: String("a-policy-set"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, ps.Name, "a-policy-set")
+		assert.Equal(t, ps.Description, "")
+		assert.False(t, ps.Global)
+	})
+
+	t.Run("with all attributes provided", func(t *testing.T) {
+		options := PolicySetCreateOptions{
+			Name:        String("global"),
+			Description: String("Policies in this set will be checked in ALL workspaces!"),
+			Global:      Bool(true),
+		}
+		ps, err := client.PolicySets.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+		assert.Equal(t, &ps.Name, options.Name)
+		assert.Equal(t, &ps.Description, options.Description)
+		assert.True(t, ps.Global)
+	})
+
+	t.Run("with policies and workspaces provided", func(t *testing.T) {
+		pTest, _ := createPolicy(t, client, orgTest)
+		wTest, _ := createWorkspace(t, client, orgTest)
+		options := PolicySetCreateOptions{
+			Name:       String("populated-policy-set"),
+			Policies:   []*Policy{pTest},
+			Workspaces: []*Workspace{wTest},
+		}
+
+		ps, err := client.PolicySets.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+		assert.Equal(t, &ps.Name, options.Name)
+		assert.Equal(t, ps.PolicyCount, 1)
+		assert.Equal(t, ps.Policies[0].ID, pTest.ID)
+		assert.Equal(t, ps.WorkspaceCount, 1)
+		assert.Equal(t, ps.Workspaces[0].ID, wTest.ID)
+	})
+
+	t.Run("without a name provided", func(t *testing.T) {
+		ps, err := client.PolicySets.Create(ctx, orgTest.Name, PolicySetCreateOptions{})
+		assert.Nil(t, ps)
+		assert.EqualError(t, err, "Name is required")
+	})
+
+	t.Run("with an invalid name provided", func(t *testing.T) {
+		ps, err := client.PolicySets.Create(ctx, orgTest.Name, PolicySetCreateOptions{Name: String("nope!")})
+		assert.Nil(t, ps)
+		assert.EqualError(t, err, "Invalid value for name")
+	})
+
+	t.Run("without a valid organization", func(t *testing.T) {
+		ps, err := client.PolicySets.Create(ctx, badIdentifier, PolicySetCreateOptions{Name: String("policy-set")})
+		assert.Nil(t, ps)
+		assert.EqualError(t, err, "Invalid value for organization")
+	})
+}
+
+func TestPolicySetsRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{})
+	defer psTestCleanup()
+
+	t.Run("with a valid ID", func(t *testing.T) {
+		ps, err := client.PolicySets.Read(ctx, psTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, ps.ID, psTest.ID)
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		ps, err := client.PolicySets.Read(ctx, badIdentifier)
+		assert.Nil(t, ps)
+		assert.EqualError(t, err, "Invalid value for policy set ID")
+	})
+}
+
+func TestPolicySetsUpdate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{})
+	defer psTestCleanup()
+
+	t.Run("with valid attributes", func(t *testing.T) {
+		options := PolicySetUpdateOptions{
+			Name:        String("global"),
+			Description: String("Policies in this set will be checked in ALL workspaces!"),
+			Global:      Bool(true),
+		}
+		ps, err := client.PolicySets.Update(ctx, psTest.ID, options)
+		require.NoError(t, err)
+		assert.Equal(t, &ps.Name, options.Name)
+		assert.Equal(t, &ps.Description, options.Description)
+		assert.True(t, ps.Global)
+	})
+
+	t.Run("with invalid attributes", func(t *testing.T) {
+		options := PolicySetUpdateOptions{Name: String("nope!")}
+		ps, err := client.PolicySets.Update(ctx, psTest.ID, options)
+		assert.Nil(t, ps)
+		assert.EqualError(t, err, "Invalid value for name")
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		ps, err := client.PolicySets.Update(ctx, badIdentifier, PolicySetUpdateOptions{Global: Bool(true)})
+		assert.Nil(t, ps)
+		assert.EqualError(t, err, "Invalid value for policy set ID")
+	})
+}
+
+func TestPolicySetsAddPolicies(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{})
+	defer psTestCleanup()
+
+	pTest1, _ := createPolicy(t, client, orgTest)
+	pTest2, _ := createPolicy(t, client, orgTest)
+
+	t.Run("with policies provided", func(t *testing.T) {
+		err := client.PolicySets.AddPolicies(ctx, psTest.ID, PolicySetAddPoliciesOptions{
+			Policies: []*Policy{pTest1, pTest2},
+		})
+		require.NoError(t, err)
+		ps, _ := client.PolicySets.Read(ctx, psTest.ID)
+		assert.Equal(t, ps.PolicyCount, 2)
+
+		ids := []string{}
+		for _, policy := range ps.Policies {
+			ids = append(ids, policy.ID)
+		}
+		assert.Contains(t, ids, pTest1.ID)
+		assert.Contains(t, ids, pTest2.ID)
+	})
+
+	t.Run("without any policies provided", func(t *testing.T) {
+		err := client.PolicySets.AddPolicies(ctx, psTest.ID, PolicySetAddPoliciesOptions{
+			Policies: []*Policy{},
+		})
+		assert.EqualError(t, err, "Must provide at least one policy")
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.AddPolicies(ctx, badIdentifier, PolicySetAddPoliciesOptions{})
+		assert.EqualError(t, err, "Invalid value for policy set ID")
+	})
+}
+
+func TestPolicySetsRemovePolicies(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	pTest1, _ := createPolicy(t, client, orgTest)
+	pTest2, _ := createPolicy(t, client, orgTest)
+
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, []*Workspace{})
+	defer psTestCleanup()
+
+	t.Run("with policies provided", func(t *testing.T) {
+		err := client.PolicySets.RemovePolicies(ctx, psTest.ID, PolicySetRemovePoliciesOptions{
+			Policies: []*Policy{pTest1, pTest2},
+		})
+		require.NoError(t, err)
+		ps, _ := client.PolicySets.Read(ctx, psTest.ID)
+		assert.Equal(t, ps.PolicyCount, 0)
+		assert.Empty(t, ps.Policies)
+	})
+
+	t.Run("without any policies provided", func(t *testing.T) {
+		err := client.PolicySets.RemovePolicies(ctx, psTest.ID, PolicySetRemovePoliciesOptions{
+			Policies: []*Policy{},
+		})
+		assert.EqualError(t, err, "Must provide at least one policy")
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.RemovePolicies(ctx, badIdentifier, PolicySetRemovePoliciesOptions{})
+		assert.EqualError(t, err, "Invalid value for policy set ID")
+	})
+}
+
+func TestPolicySetsAttachToWorkspaces(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{})
+	defer psTestCleanup()
+
+	wTest1, _ := createWorkspace(t, client, orgTest)
+	wTest2, _ := createWorkspace(t, client, orgTest)
+
+	t.Run("with workspaces provided", func(t *testing.T) {
+		err := client.PolicySets.AttachToWorkspaces(ctx, psTest.ID, PolicySetAttachToWorkspacesOptions{
+			Workspaces: []*Workspace{wTest1, wTest2},
+		})
+		require.NoError(t, err)
+		ps, _ := client.PolicySets.Read(ctx, psTest.ID)
+		assert.Equal(t, ps.WorkspaceCount, 2)
+
+		ids := []string{}
+		for _, ws := range ps.Workspaces {
+			ids = append(ids, ws.ID)
+		}
+		assert.Contains(t, ids, wTest1.ID)
+		assert.Contains(t, ids, wTest2.ID)
+	})
+
+	t.Run("without any workspaces provided", func(t *testing.T) {
+		err := client.PolicySets.AttachToWorkspaces(ctx, psTest.ID, PolicySetAttachToWorkspacesOptions{
+			Workspaces: []*Workspace{},
+		})
+		assert.EqualError(t, err, "Must provide at least one workspace")
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.AttachToWorkspaces(ctx, badIdentifier, PolicySetAttachToWorkspacesOptions{})
+		assert.EqualError(t, err, "Invalid value for policy set ID")
+	})
+}
+
+func TestPolicySetsDetachFromWorkspaces(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest1, _ := createWorkspace(t, client, orgTest)
+	wTest2, _ := createWorkspace(t, client, orgTest)
+
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{wTest1, wTest2})
+	defer psTestCleanup()
+
+	t.Run("with workspaces provided", func(t *testing.T) {
+		err := client.PolicySets.DetachFromWorkspaces(ctx, psTest.ID, PolicySetDetachFromWorkspacesOptions{
+			Workspaces: []*Workspace{wTest1, wTest2},
+		})
+		require.NoError(t, err)
+		ps, _ := client.PolicySets.Read(ctx, psTest.ID)
+		assert.Equal(t, ps.WorkspaceCount, 0)
+		assert.Empty(t, ps.Workspaces)
+	})
+
+	t.Run("without any workspaces provided", func(t *testing.T) {
+		err := client.PolicySets.DetachFromWorkspaces(ctx, psTest.ID, PolicySetDetachFromWorkspacesOptions{
+			Workspaces: []*Workspace{},
+		})
+		assert.EqualError(t, err, "Must provide at least one workspace")
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.DetachFromWorkspaces(ctx, badIdentifier, PolicySetDetachFromWorkspacesOptions{})
+		assert.EqualError(t, err, "Invalid value for policy set ID")
+	})
+}
+
+func TestPolicySetsDelete(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	psTest, _ := createPolicySet(t, client, orgTest, []*Policy{}, []*Workspace{})
+
+	t.Run("with valid options", func(t *testing.T) {
+		err := client.PolicySets.Delete(ctx, psTest.ID)
+		require.NoError(t, err)
+
+		// Try loading the policy - it should fail.
+		_, err = client.PolicySets.Read(ctx, psTest.ID)
+		assert.Equal(t, err, ErrResourceNotFound)
+	})
+
+	t.Run("when the policy does not exist", func(t *testing.T) {
+		err := client.PolicySets.Delete(ctx, psTest.ID)
+		assert.Equal(t, err, ErrResourceNotFound)
+	})
+
+	t.Run("when the policy ID is invalid", func(t *testing.T) {
+		err := client.PolicySets.Delete(ctx, badIdentifier)
+		assert.EqualError(t, err, "Invalid value for policy set ID")
+	})
+}

--- a/policy_test.go
+++ b/policy_test.go
@@ -48,9 +48,7 @@ func TestPoliciesList(t *testing.T) {
 		// Search by one of the policy's names; we should get only that policy
 		// and pagination data should reflect the search as well
 		pl, err := client.Policies.List(ctx, orgTest.Name, PolicyListOptions{
-			ListOptions: ListOptions{
-				Search: pTest1.Name,
-			},
+			Search: &pTest1.Name,
 		})
 		require.NoError(t, err)
 		assert.Contains(t, pl.Items, pTest1)
@@ -182,7 +180,10 @@ func TestPoliciesRead(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	pTest, pTestCleanup := createPolicy(t, client, nil)
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	pTest, pTestCleanup := createPolicy(t, client, orgTest)
 	defer pTestCleanup()
 
 	t.Run("when the policy exists without content", func(t *testing.T) {

--- a/tfe.go
+++ b/tfe.go
@@ -93,6 +93,7 @@ type Client struct {
 	Plans                 Plans
 	Policies              Policies
 	PolicyChecks          PolicyChecks
+	PolicySets            PolicySets
 	Runs                  Runs
 	SSHKeys               SSHKeys
 	StateVersions         StateVersions
@@ -162,6 +163,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Plans = &plans{client: client}
 	client.Policies = &policies{client: client}
 	client.PolicyChecks = &policyChecks{client: client}
+	client.PolicySets = &policySets{client: client}
 	client.Runs = &runs{client: client}
 	client.SSHKeys = &sshKeys{client: client}
 	client.StateVersions = &stateVersions{client: client}


### PR DESCRIPTION
Now that policy sets have been enabled, we can add support for it to the API client. We might want to wait until we've finalized the feature in TFE before this is merged, but we can at least get the feedback loop started!