### PR TITLE
Add the new operations field to the Workspace struct

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -289,25 +289,6 @@ func (c *Client) configureLimiter() error {
 	return nil
 }
 
-// ListOptions is used to specify pagination options when making API requests.
-// Pagination allows breaking up large result sets into chunks, or "pages".
-type ListOptions struct {
-	// The page number to request. The results vary based on the PageSize.
-	PageNumber int `url:"page[number],omitempty"`
-
-	// The number of elements returned in a single page.
-	PageSize int `url:"page[size],omitempty"`
-}
-
-// Pagination is used to return the pagination details of an API request.
-type Pagination struct {
-	CurrentPage  int `json:"current-page"`
-	PreviousPage int `json:"prev-page"`
-	NextPage     int `json:"next-page"`
-	TotalPages   int `json:"total-pages"`
-	TotalCount   int `json:"total-count"`
-}
-
 // newRequest creates an API request. A relative URL path can be provided in
 // path, in which case it is resolved relative to the apiVersionPath of the
 // Client. Relative URL paths should always be specified without a preceding
@@ -477,6 +458,25 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 	pagination.Set(reflect.ValueOf(p))
 
 	return nil
+}
+
+// ListOptions is used to specify pagination options when making API requests.
+// Pagination allows breaking up large result sets into chunks, or "pages".
+type ListOptions struct {
+	// The page number to request. The results vary based on the PageSize.
+	PageNumber int `url:"page[number],omitempty"`
+
+	// The number of elements returned in a single page.
+	PageSize int `url:"page[size],omitempty"`
+}
+
+// Pagination is used to return the pagination details of an API request.
+type Pagination struct {
+	CurrentPage  int `json:"current-page"`
+	PreviousPage int `json:"prev-page"`
+	NextPage     int `json:"next-page"`
+	TotalPages   int `json:"total-pages"`
+	TotalCount   int `json:"total-count"`
 }
 
 func parsePagination(body io.Reader) (*Pagination, error) {

--- a/workspace.go
+++ b/workspace.go
@@ -66,6 +66,7 @@ type Workspace struct {
 	Locked               bool                  `jsonapi:"attr,locked"`
 	MigrationEnvironment string                `jsonapi:"attr,migration-environment"`
 	Name                 string                `jsonapi:"attr,name"`
+	Operations           bool                  `jsonapi:"attr,operations"`
 	Permissions          *WorkspacePermissions `jsonapi:"attr,permissions"`
 	TerraformVersion     string                `jsonapi:"attr,terraform-version"`
 	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`


### PR DESCRIPTION
This new field will be used in future versions of TFE to determine if operations for this workspace should run locally or remote.

FYI: I didn't add any tests yet that use this new field as the TFE API doesn't actually provide the field yet and will initially always return `true`. But by adding this field now, I can already use it in the `remote` backend to prepare that for the remote state storage only feature.