### PR TITLE
Update the rate limit retries

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -164,8 +164,8 @@ func NewClient(cfg *Config) (*Client, error) {
 			ErrorHandler: retryablehttp.PassthroughErrorHandler,
 			HTTPClient:   config.HTTPClient,
 			RetryWaitMin: 100 * time.Millisecond,
-			RetryWaitMax: 300 * time.Millisecond,
-			RetryMax:     5,
+			RetryWaitMax: 400 * time.Millisecond,
+			RetryMax:     30,
 		},
 	}
 


### PR DESCRIPTION
After doing some more heavy testing, it turned out that having a higher
value here doesn't actually cause any downsides as the backoff algorithm
doesn't take the attempt number into account. So making this number higher
only makes it much less likely anyone will ever hit the limit.