### PR TITLE
Add Organization Access on teams

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -418,7 +418,8 @@ func createTeam(t *testing.T, client *Client, org *Organization) (*Team, func())
 
 	ctx := context.Background()
 	tm, err := client.Teams.Create(ctx, org.Name, TeamCreateOptions{
-		Name: String(randomString(t)),
+		Name:               String(randomString(t)),
+		OrganizationAccess: &OrganizationAccessOptions{ManagePolicies: Bool(true)},
 	})
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
This adds support for the new Organization Access feature on teams (https://www.terraform.io/docs/enterprise/users-teams-organizations/teams.html#managing-organization-access). As a side effect, I've also added Team.Update for updating teams as well as fixed an erroneous validation that kept users from being able to specify a team name with a space in it.