### PR TITLE
Avoid HTML responses for rate discovery

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -251,13 +251,8 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 
 // configureLimiter configures the rate limiter.
 func (c *Client) configureLimiter() error {
-	u, err := c.baseURL.Parse("/")
-	if err != nil {
-		return err
-	}
-
 	// Create a new request.
-	req, err := http.NewRequest("GET", u.String(), nil)
+	req, err := http.NewRequest("GET", c.baseURL.String(), nil)
 	if err != nil {
 		return err
 	}
@@ -266,6 +261,8 @@ func (c *Client) configureLimiter() error {
 	for k, v := range c.headers {
 		req.Header[k] = v
 	}
+
+	req.Header.Set("Accept", "application/vnd.api+json")
 
 	// Make a single request to retrieve the rate limit headers.
 	resp, err := c.http.HTTPClient.Do(req)


### PR DESCRIPTION
The library requests [full blown HTML login page](https://gist.github.com/radeksimko/4c022ce6e74a7c60347d9e264e8905ed) of TFE during its initialization, just to discover rate limit. That seems like a lot of data for that context.

I first thought I'd just set the `Accept` header, but TFE's homepage responds 500 for such request (probably worth a separate issue/PR to TFE).

I think there's no reason to call `/` anyway, when we already have a valid API endpoint. That endpoint (in its base form) will respond 404, but still return the expected rate limit header.