### PR TITLE
Update tests to be inline with the expected response

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -261,7 +261,6 @@ func (c *Client) configureLimiter() error {
 	for k, v := range c.headers {
 		req.Header[k] = v
 	}
-
 	req.Header.Set("Accept", "application/vnd.api+json")
 
 	// Make a single request to retrieve the rate limit headers.

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -12,7 +12,9 @@ import (
 
 func TestClient_newClient(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
 		w.Header().Set("X-RateLimit-Limit", "30")
+		w.WriteHeader(404) // We query the configured base URL which should return a 404.
 	}))
 	defer ts.Close()
 
@@ -96,7 +98,9 @@ func TestClient_headers(t *testing.T) {
 		testedCalls++
 
 		if testedCalls == 1 {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
 			w.Header().Set("X-RateLimit-Limit", "30")
+			w.WriteHeader(404) // We query the configured base URL which should return a 404.
 			return
 		}
 
@@ -157,7 +161,9 @@ func TestClient_userAgent(t *testing.T) {
 		testedCalls++
 
 		if testedCalls == 1 {
+			w.Header().Set("Content-Type", "application/vnd.api+json")
 			w.Header().Set("X-RateLimit-Limit", "30")
+			w.WriteHeader(404) // We query the configured base URL which should return a 404.
 			return
 		}
 
@@ -199,7 +205,9 @@ func TestClient_userAgent(t *testing.T) {
 func TestClient_configureLimiter(t *testing.T) {
 	rateLimit := ""
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
 		w.Header().Set("X-RateLimit-Limit", rateLimit)
+		w.WriteHeader(404) // We query the configured base URL which should return a 404.
 	}))
 	defer ts.Close()
 


### PR DESCRIPTION
We updated the call to get the rate limit header from the server, so
these changes also update the tests to return the expected response.