### PR TITLE
Add timestamp fields for planned runs

### DIFF
--- a/run.go
+++ b/run.go
@@ -122,13 +122,14 @@ type RunPermissions struct {
 
 // RunStatusTimestamps holds the timestamps for individual run statuses.
 type RunStatusTimestamps struct {
-	ErroredAt       time.Time `json:"errored-at"`
-	FinishedAt      time.Time `json:"finished-at"`
-	QueuedAt        time.Time `json:"queued-at"`
-	StartedAt       time.Time `json:"started-at"`
-	PlannedAt       time.Time `json:"planned-at"`
-	PlanningAt      time.Time `json:"planning-at"`
-	PlanQueuabledAt time.Time `json:"plan-queueable-at"`
+	ErroredAt            time.Time `json:"errored-at"`
+	FinishedAt           time.Time `json:"finished-at"`
+	QueuedAt             time.Time `json:"queued-at"`
+	StartedAt            time.Time `json:"started-at"`
+	PlannedAt            time.Time `json:"planned-at"`
+	PlannedAndFinishedAt time.Time `json:"planned-and-finished-at"`
+	PlanningAt           time.Time `json:"planning-at"`
+	PlanQueuabledAt      time.Time `json:"plan-queueable-at"`
 }
 
 // RunListOptions represents the options for listing runs.

--- a/run.go
+++ b/run.go
@@ -126,9 +126,11 @@ type RunStatusTimestamps struct {
 	FinishedAt           time.Time `json:"finished-at"`
 	QueuedAt             time.Time `json:"queued-at"`
 	StartedAt            time.Time `json:"started-at"`
+	ApplyingAt           time.Time `json:"applying-at"`
+	AppliedAt            time.Time `json:"applied-at"`
+	PlanningAt           time.Time `json:"planning-at"`
 	PlannedAt            time.Time `json:"planned-at"`
 	PlannedAndFinishedAt time.Time `json:"planned-and-finished-at"`
-	PlanningAt           time.Time `json:"planning-at"`
 	PlanQueuabledAt      time.Time `json:"plan-queueable-at"`
 }
 

--- a/run.go
+++ b/run.go
@@ -122,10 +122,13 @@ type RunPermissions struct {
 
 // RunStatusTimestamps holds the timestamps for individual run statuses.
 type RunStatusTimestamps struct {
-	ErroredAt  time.Time `json:"errored-at"`
-	FinishedAt time.Time `json:"finished-at"`
-	QueuedAt   time.Time `json:"queued-at"`
-	StartedAt  time.Time `json:"started-at"`
+	ErroredAt       time.Time `json:"errored-at"`
+	FinishedAt      time.Time `json:"finished-at"`
+	QueuedAt        time.Time `json:"queued-at"`
+	StartedAt       time.Time `json:"started-at"`
+	PlannedAt       time.Time `json:"planned-at"`
+	PlanningAt      time.Time `json:"planning-at"`
+	PlanQueuabledAt time.Time `json:"plan-queueable-at"`
 }
 
 // RunListOptions represents the options for listing runs.


### PR DESCRIPTION
For planned runs, there are a few extra timestamp fields that were missing. I'm not sure when these were added but, like the others, if they are not returned by the API, they will just be 0 values.