### PR TITLE
Allow creation of variables with no value

### DIFF
--- a/variable.go
+++ b/variable.go
@@ -129,9 +129,6 @@ func (o VariableCreateOptions) valid() error {
 	if !validString(o.Key) {
 		return errors.New("key is required")
 	}
-	if !validString(o.Value) {
-		return errors.New("value is required")
-	}
 	if o.Category == nil {
 		return errors.New("category is required")
 	}

--- a/variable_test.go
+++ b/variable_test.go
@@ -107,6 +107,18 @@ func TestVariablesCreate(t *testing.T) {
 		assert.EqualError(t, err, "key is required")
 	})
 
+	t.Run("when options has an empty key", func(t *testing.T) {
+		options := VariableCreateOptions{
+			Key:       String(""),
+			Value:     String(randomString(t)),
+			Category:  Category(CategoryTerraform),
+			Workspace: wTest,
+		}
+
+		_, err := client.Variables.Create(ctx, options)
+		assert.EqualError(t, err, "key is required")
+	})
+
 	t.Run("when options is missing value", func(t *testing.T) {
 		options := VariableCreateOptions{
 			Key:       String(randomString(t)),
@@ -114,8 +126,22 @@ func TestVariablesCreate(t *testing.T) {
 			Workspace: wTest,
 		}
 
-		_, err := client.Variables.Create(ctx, options)
-		assert.EqualError(t, err, "value is required")
+		v, err := client.Variables.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, "", v.Value)
+	})
+
+	t.Run("when options has an empty string value", func(t *testing.T) {
+		options := VariableCreateOptions{
+			Key:       String(randomString(t)),
+			Value:     String(""),
+			Category:  Category(CategoryTerraform),
+			Workspace: wTest,
+		}
+
+		v, err := client.Variables.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, *options.Value, v.Value)
 	})
 
 	t.Run("when options is missing category", func(t *testing.T) {


### PR DESCRIPTION
An empty string and null are both valid values for a variable according to the [API docs](https://www.terraform.io/docs/enterprise/api/variables.html) and testing done by @sudomateo.

A null value in the API results in an empty string being stored and returned from the server.