### PR TITLE
Implement Admin Runs List API

### DIFF
--- a/admin_run.go
+++ b/admin_run.go
@@ -1,0 +1,48 @@
+package tfe
+
+import (
+	"context"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminRuns = (*adminRuns)(nil)
+
+// AdminRuns describes all the admin run related methods that the Terraform Enterprise
+// API supports.
+//
+// TFE API docs:
+// https://www.terraform.io/docs/enterprise/api/admin/runs.html
+type AdminRuns interface {
+	// List all runs in the Terraform Enterprise installation.
+	List(ctx context.Context, options AdminRunListOptions) (*RunList, error)
+}
+
+type adminRuns struct {
+	client *Client
+}
+
+//AdminRunListOptions represents the options for listing runs.
+type AdminRunListOptions struct {
+	ListOptions
+	Q      *string   `url:"q,omitempty"`
+	Status RunStatus `url:"filter[status],omitempty"`
+}
+
+// List all runs in the Terraform Enterprise installation.
+func (s *adminRuns) List(ctx context.Context, options AdminRunListOptions) (*RunList, error) {
+
+	u := "admin/runs"
+
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	rl := &RunList{}
+	err = s.client.do(ctx, req, rl)
+	if err != nil {
+		return nil, err
+	}
+
+	return rl, nil
+}

--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -1,0 +1,54 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminRunsList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	wTest, wTestCleanup := createWorkspace(t, client, nil)
+	defer wTestCleanup()
+
+	rTest1, _ := createRun(t, client, wTest)
+	rTest2, _ := createRun(t, client, wTest)
+
+	t.Run("without list options", func(t *testing.T) {
+		rl, err := client.AdminRuns.List(ctx, AdminRunListOptions{})
+		require.NoError(t, err)
+
+		found := []string{}
+		for _, r := range rl.Items {
+			found = append(found, r.ID)
+		}
+
+		assert.Contains(t, found, rTest1.ID)
+		assert.Contains(t, found, rTest2.ID)
+		assert.Equal(t, 1, rl.CurrentPage)
+		assert.Equal(t, 2, rl.TotalCount)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		t.Skip("paging not supported yet in API")
+
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		rl, err := client.AdminRuns.List(ctx, AdminRunListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, rl.Items)
+		assert.Equal(t, 999, rl.CurrentPage)
+		assert.Equal(t, 2, rl.TotalCount)
+	})
+
+}

--- a/tfe.go
+++ b/tfe.go
@@ -125,6 +125,8 @@ type Client struct {
 	Users                      Users
 	Variables                  Variables
 	Workspaces                 Workspaces
+
+	AdminRuns AdminRuns
 }
 
 // NewClient creates a new Terraform Enterprise API client.
@@ -214,6 +216,8 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Users = &users{client: client}
 	client.Variables = &variables{client: client}
 	client.Workspaces = &workspaces{client: client}
+
+	client.AdminRuns = &adminRuns{client: client}
 
 	return client, nil
 }


### PR DESCRIPTION
I'm not sure is this how hashicorp wants to implement the Admin API.

I think I should improve the test a bit. But the `q` parameter test is a bit tricky to test. I don't have a TFE instance to run my test against.