### PR TITLE
Add support for VCS policy sets

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,7 @@ tests:
 $ export TFE_ADDRESS=https://tfe.local
 $ export TFE_TOKEN=xxxxxxxxxxxxxxxxxxx
 $ export GITHUB_TOKEN=xxxxxxxxxxxxxxxx
+$ export GITHUB_IDENTIFIER=xxxxxxxxxxx
 ```
 
 In order for the tests relating to queuing and capacity to pass, FRQ should be

--- a/helper_test.go
+++ b/helper_test.go
@@ -222,7 +222,7 @@ func createOAuthClient(t *testing.T, client *Client, org *Organization) (*OAuthC
 
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken == "" {
-		t.Fatal("Export a valid GITHUB_TOKEN before running this test!")
+		t.Skip("Export a valid GITHUB_TOKEN before running this test!")
 	}
 
 	options := OAuthClientCreateOptions{

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -79,7 +79,7 @@ func TestOAuthClientsCreate(t *testing.T) {
 
 	githubToken := os.Getenv("GITHUB_TOKEN")
 	if githubToken == "" {
-		t.Fatal("Export a valid GITHUB_TOKEN before running this test!")
+		t.Skip("Export a valid GITHUB_TOKEN before running this test!")
 	}
 
 	orgTest, orgTestCleanup := createOrganization(t, client)

--- a/policy_set.go
+++ b/policy_set.go
@@ -28,10 +28,13 @@ type PolicySets interface {
 	// Update an existing policy set.
 	Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error)
 
-	// Add policies to a policy set.
+	// Add policies to a policy set. This function can only be used
+	// when there is no VCS repository associated with the policy set.
 	AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error
 
-	// Remove policies from a policy set.
+	// Remove policies from a policy set. This function can only be
+	// used when there is no VCS repository associated with the policy
+	// set.
 	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
 
 	// Add workspaces to a policy set.
@@ -61,7 +64,9 @@ type PolicySet struct {
 	Name           string    `jsonapi:"attr,name"`
 	Description    string    `jsonapi:"attr,description"`
 	Global         bool      `jsonapi:"attr,global"`
+	PoliciesPath   string    `jsonapi:"attr,policies-path,omitempty"`
 	PolicyCount    int       `jsonapi:"attr,policy-count"`
+	VCSRepo        *VCSRepo  `jsonapi:"attr,vcs-repo"`
 	WorkspaceCount int       `jsonapi:"attr,workspace-count"`
 	CreatedAt      time.Time `jsonapi:"attr,created-at,iso8601"`
 	UpdatedAt      time.Time `jsonapi:"attr,updated-at,iso8601"`
@@ -117,6 +122,18 @@ type PolicySetCreateOptions struct {
 
 	// The initial members of the policy set.
 	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
+
+	// The sub-path within the attached VCS repository to ingress. All
+	// files and directories outside of this sub-path will be ignored.
+	// This option may only be specified when a VCS repo is present.
+	PoliciesPath *string `jsonapi:"attr,policies-path,omitempty"`
+
+	// VCS repository information. When present, the policies and
+	// configuration will be sourced from the specified VCS repository
+	// instead of being defined within the policy set itself. Note that
+	// this option is mutually exclusive with the Policies option and
+	// both cannot be used at the same time.
+	VCSRepo *VCSRepoOptions `jsonapi:"attr,vcs-repo,omitempty"`
 
 	// The initial list of workspaces for which the policy set should be enforced.
 	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`

--- a/policy_set.go
+++ b/policy_set.go
@@ -28,13 +28,12 @@ type PolicySets interface {
 	// Update an existing policy set.
 	Update(ctx context.Context, policySetID string, options PolicySetUpdateOptions) (*PolicySet, error)
 
-	// Add policies to a policy set. This function can only be used
-	// when there is no VCS repository associated with the policy set.
+	// Add policies to a policy set. This function can only be used when
+	// there is no VCS repository associated with the policy set.
 	AddPolicies(ctx context.Context, policySetID string, options PolicySetAddPoliciesOptions) error
 
-	// Remove policies from a policy set. This function can only be
-	// used when there is no VCS repository associated with the policy
-	// set.
+	// Remove policies from a policy set. This function can only be used
+	// when there is no VCS repository associated with the policy set.
 	RemovePolicies(ctx context.Context, policySetID string, options PolicySetRemovePoliciesOptions) error
 
 	// Add workspaces to a policy set.
@@ -64,7 +63,7 @@ type PolicySet struct {
 	Name           string    `jsonapi:"attr,name"`
 	Description    string    `jsonapi:"attr,description"`
 	Global         bool      `jsonapi:"attr,global"`
-	PoliciesPath   string    `jsonapi:"attr,policies-path,omitempty"`
+	PoliciesPath   string    `jsonapi:"attr,policies-path"`
 	PolicyCount    int       `jsonapi:"attr,policy-count"`
 	VCSRepo        *VCSRepo  `jsonapi:"attr,vcs-repo"`
 	WorkspaceCount int       `jsonapi:"attr,workspace-count"`
@@ -120,13 +119,13 @@ type PolicySetCreateOptions struct {
 	// Whether or not the policy set is global.
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
-	// The initial members of the policy set.
-	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
-
 	// The sub-path within the attached VCS repository to ingress. All
 	// files and directories outside of this sub-path will be ignored.
 	// This option may only be specified when a VCS repo is present.
 	PoliciesPath *string `jsonapi:"attr,policies-path,omitempty"`
+
+	// The initial members of the policy set.
+	Policies []*Policy `jsonapi:"relation,policies,omitempty"`
 
 	// VCS repository information. When present, the policies and
 	// configuration will be sourced from the specified VCS repository

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -123,10 +123,6 @@ func TestPolicySetsCreate(t *testing.T) {
 	})
 
 	t.Run("with vcs policy set", func(t *testing.T) {
-		if ghToken := os.Getenv("GITHUB_TOKEN"); ghToken == "" {
-			t.Skip("Export a valid GITHUB_TOKEN before running this test")
-		}
-
 		githubIdentifier := os.Getenv("GITHUB_IDENTIFIER")
 		if githubIdentifier == "" {
 			t.Skip("Export a valid GITHUB_IDENTIFIER before running this test")


### PR DESCRIPTION
This adds support for the upcoming VCS policy sets feature.

This was a minimal change, requiring only the extra options in
PolicySetCreateOptions and PolicySet.