### PR TITLE
Add shallow Read/Update/Delete APIs to Workspace

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -25,14 +25,26 @@ type Workspaces interface {
 	// Read a workspace by its name.
 	Read(ctx context.Context, organization string, workspace string) (*Workspace, error)
 
+	// ReadById reads a workspace by its ID.
+	ReadByID(ctx context.Context, workspaceID string) (*Workspace, error)
+
 	// Update settings of an existing workspace.
 	Update(ctx context.Context, organization string, workspace string, options WorkspaceUpdateOptions) (*Workspace, error)
+
+	// UpdateById updates the settings of an existing workspace.
+	UpdateByID(ctx context.Context, workspaceID string, options WorkspaceUpdateOptions) (*Workspace, error)
 
 	// Delete a workspace by its name.
 	Delete(ctx context.Context, organization string, workspace string) error
 
+	// Delete a workspace by its ID.
+	DeleteByID(ctx context.Context, workspaceID string) error
+
 	// RemoveVCSConnection from a workspace.
 	RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error)
+
+	// RemoveVCSConnection from a workspace.
+	RemoveVCSConnectionByID(ctx context.Context, workspaceID string) (*Workspace, error)
 
 	// Lock a workspace by its ID.
 	Lock(ctx context.Context, workspaceID string, options WorkspaceLockOptions) (*Workspace, error)
@@ -263,6 +275,27 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 	return w, nil
 }
 
+// Read a workspace by its ID.
+func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspace, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Workspace{}
+	err = s.client.do(ctx, req, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
 // WorkspaceUpdateOptions represents the options for updating a workspace.
 type WorkspaceUpdateOptions struct {
 	// For internal use only!
@@ -339,6 +372,30 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 	return w, nil
 }
 
+// Update settings of an existing workspace by its ID.
+func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options WorkspaceUpdateOptions) (*Workspace, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Workspace{}
+	err = s.client.do(ctx, req, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
 // Delete a workspace by its name.
 func (s *workspaces) Delete(ctx context.Context, organization, workspace string) error {
 	if !validStringID(&organization) {
@@ -353,6 +410,21 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 		url.QueryEscape(organization),
 		url.QueryEscape(workspace),
 	)
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// Delete a workspace by its ID.
+func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
+	if !validStringID(&workspaceID) {
+		return errors.New("invalid value for workspace ID")
+	}
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -381,6 +453,28 @@ func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, work
 		url.QueryEscape(organization),
 		url.QueryEscape(workspace),
 	)
+
+	req, err := s.client.newRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	w := &Workspace{}
+	err = s.client.do(ctx, req, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
+// RemoveVCSConnection from a workspace by workspace ID.
+func (s *workspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceID string) (*Workspace, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
 
 	req, err := s.client.newRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
 	if err != nil {

--- a/workspace.go
+++ b/workspace.go
@@ -25,25 +25,25 @@ type Workspaces interface {
 	// Read a workspace by its name.
 	Read(ctx context.Context, organization string, workspace string) (*Workspace, error)
 
-	// ReadById reads a workspace by its ID.
+	// ReadByID reads a workspace by its ID.
 	ReadByID(ctx context.Context, workspaceID string) (*Workspace, error)
 
 	// Update settings of an existing workspace.
 	Update(ctx context.Context, organization string, workspace string, options WorkspaceUpdateOptions) (*Workspace, error)
 
-	// UpdateById updates the settings of an existing workspace.
+	// UpdateByID updates the settings of an existing workspace.
 	UpdateByID(ctx context.Context, workspaceID string, options WorkspaceUpdateOptions) (*Workspace, error)
 
 	// Delete a workspace by its name.
 	Delete(ctx context.Context, organization string, workspace string) error
 
-	// Delete a workspace by its ID.
+	// DeleteByID deletes a workspace by its ID.
 	DeleteByID(ctx context.Context, workspaceID string) error
 
 	// RemoveVCSConnection from a workspace.
 	RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error)
 
-	// RemoveVCSConnection from a workspace.
+	// RemoveVCSConnectionByID removes a VCS connection from a workspace.
 	RemoveVCSConnectionByID(ctx context.Context, workspaceID string) (*Workspace, error)
 
 	// Lock a workspace by its ID.
@@ -275,7 +275,7 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 	return w, nil
 }
 
-// Read a workspace by its ID.
+// ReadByID reads a workspace by its ID.
 func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspace, error) {
 	if !validStringID(&workspaceID) {
 		return nil, errors.New("invalid value for workspace ID")
@@ -372,7 +372,7 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 	return w, nil
 }
 
-// Update settings of an existing workspace by its ID.
+// UpdateByID updates the settings of an existing workspace.
 func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options WorkspaceUpdateOptions) (*Workspace, error) {
 	if !validStringID(&workspaceID) {
 		return nil, errors.New("invalid value for workspace ID")
@@ -418,7 +418,7 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 	return s.client.do(ctx, req, nil)
 }
 
-// Delete a workspace by its ID.
+// DeleteByID deletes a workspace by its ID.
 func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
 	if !validStringID(&workspaceID) {
 		return errors.New("invalid value for workspace ID")
@@ -468,7 +468,7 @@ func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, work
 	return w, nil
 }
 
-// RemoveVCSConnection from a workspace by workspace ID.
+// RemoveVCSConnectionByID removes a VCS connection from a workspace.
 func (s *workspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceID string) (*Workspace, error) {
 	if !validStringID(&workspaceID) {
 		return nil, errors.New("invalid value for workspace ID")

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -202,6 +202,47 @@ func TestWorkspacesRead(t *testing.T) {
 	})
 }
 
+func TestWorkspacesReadByID(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	t.Run("when the workspace exists", func(t *testing.T) {
+		w, err := client.Workspaces.ReadByID(ctx, wTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, wTest, w)
+
+		t.Run("permissions are properly decoded", func(t *testing.T) {
+			assert.True(t, w.Permissions.CanDestroy)
+		})
+
+		t.Run("relationships are properly decoded", func(t *testing.T) {
+			assert.Equal(t, orgTest.Name, w.Organization.Name)
+		})
+
+		t.Run("timestamps are properly decoded", func(t *testing.T) {
+			assert.NotEmpty(t, w.CreatedAt)
+		})
+	})
+
+	t.Run("when the workspace does not exist", func(t *testing.T) {
+		w, err := client.Workspaces.ReadByID(ctx, "nonexisting")
+		assert.Nil(t, w)
+		assert.Error(t, err)
+	})
+
+	t.Run("without a valid workspace ID", func(t *testing.T) {
+		w, err := client.Workspaces.ReadByID(ctx, badIdentifier)
+		assert.Nil(t, w)
+		assert.EqualError(t, err, "invalid value for workspace ID")
+	})
+}
+
 func TestWorkspacesUpdate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -282,6 +323,80 @@ func TestWorkspacesUpdate(t *testing.T) {
 	})
 }
 
+func TestWorkspacesUpdateByID(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, _ := createWorkspace(t, client, orgTest)
+
+	t.Run("when updating a subset of values", func(t *testing.T) {
+		options := WorkspaceUpdateOptions{
+			Name:             String(wTest.Name),
+			AutoApply:        Bool(true),
+			QueueAllRuns:     Bool(true),
+			TerraformVersion: String("0.10.0"),
+		}
+
+		wAfter, err := client.Workspaces.UpdateByID(ctx, wTest.ID, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, wTest.Name, wAfter.Name)
+		assert.NotEqual(t, wTest.AutoApply, wAfter.AutoApply)
+		assert.NotEqual(t, wTest.QueueAllRuns, wAfter.QueueAllRuns)
+		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
+		assert.Equal(t, wTest.WorkingDirectory, wAfter.WorkingDirectory)
+	})
+
+	t.Run("with valid options", func(t *testing.T) {
+		options := WorkspaceUpdateOptions{
+			Name:                String(randomString(t)),
+			AutoApply:           Bool(false),
+			FileTriggersEnabled: Bool(true),
+			QueueAllRuns:        Bool(false),
+			TerraformVersion:    String("0.11.1"),
+			TriggerPrefixes:     []string{"/modules", "/shared"},
+			WorkingDirectory:    String("baz/"),
+		}
+
+		w, err := client.Workspaces.UpdateByID(ctx, wTest.ID, options)
+		require.NoError(t, err)
+
+		// Get a refreshed view of the workspace from the API
+		refreshed, err := client.Workspaces.Read(ctx, orgTest.Name, *options.Name)
+		require.NoError(t, err)
+
+		for _, item := range []*Workspace{
+			w,
+			refreshed,
+		} {
+			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.AutoApply, item.AutoApply)
+			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
+			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
+			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
+			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
+			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
+		}
+	})
+
+	t.Run("when an error is returned from the api", func(t *testing.T) {
+		w, err := client.Workspaces.UpdateByID(ctx, wTest.ID, WorkspaceUpdateOptions{
+			TerraformVersion: String("nonexisting"),
+		})
+		assert.Nil(t, w)
+		assert.Error(t, err)
+	})
+
+	t.Run("without a valid workspace ID", func(t *testing.T) {
+		w, err := client.Workspaces.UpdateByID(ctx, badIdentifier, WorkspaceUpdateOptions{})
+		assert.Nil(t, w)
+		assert.EqualError(t, err, "invalid value for workspace ID")
+	})
+}
+
 func TestWorkspacesDelete(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -311,6 +426,30 @@ func TestWorkspacesDelete(t *testing.T) {
 	})
 }
 
+func TestWorkspacesDeleteByID(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, _ := createWorkspace(t, client, orgTest)
+
+	t.Run("with valid options", func(t *testing.T) {
+		err := client.Workspaces.DeleteByID(ctx, wTest.ID)
+		require.NoError(t, err)
+
+		// Try loading the workspace - it should fail.
+		_, err = client.Workspaces.ReadByID(ctx, wTest.ID)
+		assert.Equal(t, ErrResourceNotFound, err)
+	})
+
+	t.Run("without a valid workspace ID", func(t *testing.T) {
+		err := client.Workspaces.DeleteByID(ctx, badIdentifier)
+		assert.EqualError(t, err, "invalid value for workspace ID")
+	})
+}
+
 func TestWorkspacesRemoveVCSConnection(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -322,6 +461,22 @@ func TestWorkspacesRemoveVCSConnection(t *testing.T) {
 
 	t.Run("remove vcs integration", func(t *testing.T) {
 		w, err := client.Workspaces.RemoveVCSConnection(ctx, orgTest.Name, wTest.Name)
+		require.NoError(t, err)
+		assert.Equal(t, (*VCSRepo)(nil), w.VCSRepo)
+	})
+}
+
+func TestWorkspacesRemoveVCSConnectionByID(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, _ := createWorkspaceWithVCS(t, client, orgTest)
+
+	t.Run("remove vcs integration", func(t *testing.T) {
+		w, err := client.Workspaces.RemoveVCSConnectionByID(ctx, wTest.ID)
 		require.NoError(t, err)
 		assert.Equal(t, (*VCSRepo)(nil), w.VCSRepo)
 	})


### PR DESCRIPTION
Adds APIs for the newly added shallow workspace endpoints.

You can now read, update, and delete workspaces by their ID rather than always needing to nest the organization name and have the workspace's name.