### PR TITLE
Fix Cost Estimation tests

### DIFF
--- a/cost_estimate_test.go
+++ b/cost_estimate_test.go
@@ -2,7 +2,6 @@ package tfe
 
 import (
 	"context"
-	"io/ioutil"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -27,7 +26,7 @@ func TestCostEstimatesRead(t *testing.T) {
 	require.NoError(t, err)
 
 	wTest, _ := createWorkspace(t, client, orgTest)
-	rTest, _ := createPlannedRun(t, client, wTest)
+	rTest, _ := createCostEstimatedRun(t, client, wTest)
 
 	t.Run("when the costEstimate exists", func(t *testing.T) {
 		ce, err := client.CostEstimates.Read(ctx, rTest.CostEstimate.ID)
@@ -45,48 +44,6 @@ func TestCostEstimatesRead(t *testing.T) {
 	t.Run("with invalid costEstimate ID", func(t *testing.T) {
 		ce, err := client.CostEstimates.Read(ctx, badIdentifier)
 		assert.Nil(t, ce)
-		assert.EqualError(t, err, "invalid value for cost estimation ID")
-	})
-}
-
-func TestCostEstimatesLogs(t *testing.T) {
-	client := testClient(t)
-	ctx := context.Background()
-
-	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
-
-	// Enable cost estimation for the test organization.
-	orgTest, err := client.Organizations.Update(
-		ctx,
-		orgTest.Name,
-		OrganizationUpdateOptions{
-			CostEstimationEnabled: Bool(true),
-		},
-	)
-	require.NoError(t, err)
-
-	wTest, _ := createWorkspace(t, client, orgTest)
-	rTest, _ := createPlannedRun(t, client, wTest)
-
-	t.Run("when the log exists", func(t *testing.T) {
-		ce, err := client.CostEstimates.Read(ctx, rTest.CostEstimate.ID)
-		require.NoError(t, err)
-
-		logReader, err := client.CostEstimates.Logs(ctx, ce.ID)
-		require.NotNil(t, logReader)
-		require.NoError(t, err)
-
-		logs, err := ioutil.ReadAll(logReader)
-		require.NoError(t, err)
-
-		t.Skip("log output is likely to change")
-		assert.Contains(t, string(logs), "SKU")
-	})
-
-	t.Run("when the log does not exist", func(t *testing.T) {
-		logs, err := client.CostEstimates.Logs(ctx, "nonexisting")
-		assert.Nil(t, logs)
-		assert.Error(t, err)
+		assert.EqualError(t, err, "invalid value for cost estimate ID")
 	})
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -349,10 +349,35 @@ func createPlannedRun(t *testing.T, client *Client, w *Workspace) (*Run, func())
 
 		if i > 45 {
 			rCleanup()
-			t.Fatal("Timeout waiting for run to be applied")
+			t.Fatal("Timeout waiting for run to be planned")
 		}
 
 		time.Sleep(1 * time.Second)
+	}
+}
+
+func createCostEstimatedRun(t *testing.T, client *Client, w *Workspace) (*Run, func()) {
+	r, rCleanup := createRun(t, client, w)
+
+	var err error
+	ctx := context.Background()
+	for i := 0; ; i++ {
+		r, err = client.Runs.Read(ctx, r.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		switch r.Status {
+		case RunCostEstimated, RunPolicyChecked, RunPolicyOverride:
+			return r, rCleanup
+		}
+
+		if i > 45 {
+			rCleanup()
+			t.Fatal("Timeout waiting for run to be cost estimated")
+		}
+
+		time.Sleep(2 * time.Second)
 	}
 }
 


### PR DESCRIPTION
1. cost-estimates don’t have logs
2. we need to wait for cost-estimate to be available
3. error response text was wrong

These tests were failing due to changes to the permissions model in TFC. Even with that fixed there were still some remaining issues with the tests failing.