### PR TITLE
Add Azure DevOps Server, Azure DevOps Services, and Bitbucket Server Legacy as OAuth Client ServiceProviders

### DIFF
--- a/oauth_client.go
+++ b/oauth_client.go
@@ -40,13 +40,18 @@ type ServiceProviderType string
 
 // List of available VCS types.
 const (
-	ServiceProviderBitbucket       ServiceProviderType = "bitbucket_hosted"
+	ServiceProviderAzureDevOpsServer   ServiceProviderType = "ado_server"
+	ServiceProviderAzureDevOpsServices ServiceProviderType = "ado_services"
+	ServiceProviderBitbucket           ServiceProviderType = "bitbucket_hosted"
+	// Bitbucket Server v5.4.0 and above
 	ServiceProviderBitbucketServer ServiceProviderType = "bitbucket_server"
-	ServiceProviderGithub          ServiceProviderType = "github"
-	ServiceProviderGithubEE        ServiceProviderType = "github_enterprise"
-	ServiceProviderGitlab          ServiceProviderType = "gitlab_hosted"
-	ServiceProviderGitlabCE        ServiceProviderType = "gitlab_community_edition"
-	ServiceProviderGitlabEE        ServiceProviderType = "gitlab_enterprise_edition"
+	// Bitbucket Server v5.3.0 and below
+	ServiceProviderBitbucketServerLegacy ServiceProviderType = "bitbucket_server_legacy"
+	ServiceProviderGithub                ServiceProviderType = "github"
+	ServiceProviderGithubEE              ServiceProviderType = "github_enterprise"
+	ServiceProviderGitlab                ServiceProviderType = "gitlab_hosted"
+	ServiceProviderGitlabCE              ServiceProviderType = "gitlab_community_edition"
+	ServiceProviderGitlabEE              ServiceProviderType = "gitlab_enterprise_edition"
 )
 
 // OAuthClientList represents a list of OAuth clients.


### PR DESCRIPTION
In order to support Azure DevOps Server and Azure DevOps Services in terraform-provider-tfe, we need to add them here as a ServiceProviders. I also added Bitbucket Server Legacy and some comments explaining the difference between the two Bitbucket Servers. 