### PR TITLE
Retry 500 server errors by default after successful initialization

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,10 +1,9 @@
 module github.com/hashicorp/go-tfe
 
 require (
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.0.0
-	github.com/hashicorp/go-cleanhttp v0.5.0
-	github.com/hashicorp/go-retryablehttp v0.5.2
+	github.com/hashicorp/go-cleanhttp v0.5.1
+	github.com/hashicorp/go-retryablehttp v0.6.4
 	github.com/hashicorp/go-slug v0.4.1
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -4,10 +4,12 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
 github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
-github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-retryablehttp v0.5.2 h1:AoISa4P4IsW0/m4T6St8Yw38gTl5GtBAgfkhYh1xAz4=
-github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-cleanhttp v0.5.1 h1:dH3aiDG9Jvb5r5+bYHsikaOUIpcM0xvgMXVoDkXMzJM=
+github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-hclog v0.9.2 h1:CG6TE5H9/JXsFWJCfoIVpKFIkFe6ysEuHirp4DxCsHI=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-retryablehttp v0.6.4 h1:BbgctKO892xEyOXnGiaAwIoSq1QZ/SS4AhjoAh9DnfY=
+github.com/hashicorp/go-retryablehttp v0.6.4/go.mod h1:vAew36LZh98gCBJNLH42IQ1ER/9wtLZZ8meHqQvEYWY=
 github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
@@ -15,6 +17,7 @@ github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/b
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.2.2/go.mod h1:a8OnRcib4nhh0OaRAV+Yts87kKdq0PP7pXfy6kDkUVs=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d h1:Z4EH+5EffvBEhh37F0C0DnpklTMh00JOkjW5zK3ofBI=

--- a/tfe.go
+++ b/tfe.go
@@ -175,10 +175,11 @@ func NewClient(cfg *Config) (*Client, error) {
 
 	// Create the client.
 	client := &Client{
-		baseURL:      baseURL,
-		token:        config.Token,
-		headers:      config.Headers,
-		retryLogHook: config.RetryLogHook,
+		baseURL:           baseURL,
+		token:             config.Token,
+		headers:           config.Headers,
+		retryLogHook:      config.RetryLogHook,
+		retryServerErrors: true,
 	}
 
 	client.http = &retryablehttp.Client{

--- a/tfe.go
+++ b/tfe.go
@@ -175,11 +175,10 @@ func NewClient(cfg *Config) (*Client, error) {
 
 	// Create the client.
 	client := &Client{
-		baseURL:           baseURL,
-		token:             config.Token,
-		headers:           config.Headers,
-		retryLogHook:      config.RetryLogHook,
-		retryServerErrors: true,
+		baseURL:      baseURL,
+		token:        config.Token,
+		headers:      config.Headers,
+		retryLogHook: config.RetryLogHook,
 	}
 
 	client.http = &retryablehttp.Client{
@@ -196,6 +195,10 @@ func NewClient(cfg *Config) (*Client, error) {
 	if err := client.configureLimiter(); err != nil {
 		return nil, err
 	}
+
+	// Once rate limits have been established, default to retrying requests on
+	// server errors.
+	client.RetryServerErrors(true)
 
 	// Create the services.
 	client.Applies = &applies{client: client}

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -316,14 +316,14 @@ func TestClient_retryHTTPCheck(t *testing.T) {
 		},
 		"err-no-server-errors": {
 			err:      connErr,
-			checkOK:  false,
-			checkErr: connErr,
+			checkOK:  true,
+			checkErr: nil,
 		},
 		"err-with-server-errors": {
 			err:               connErr,
 			retryServerErrors: true,
 			checkOK:           true,
-			checkErr:          connErr,
+			checkErr:          nil,
 		},
 	}
 
@@ -337,7 +337,7 @@ func TestClient_retryHTTPCheck(t *testing.T) {
 
 		client.RetryServerErrors(tc.retryServerErrors)
 
-		checkOK, checkErr := client.retryHTTPCheck(ctx, tc.resp, tc.err)
+		checkOK, checkErr := client.http.CheckRetry(ctx, tc.resp, tc.err)
 		if checkOK != tc.checkOK {
 			t.Fatalf("test %s expected checkOK %t, got: %t", name, tc.checkOK, checkOK)
 		}


### PR DESCRIPTION
This new default means that the TFE provider will retry requests which result in 5xx errors, but still fail on initialization if the instance is unreachable. This should improve robustness to intermittent network failures, without making it more difficult to diagnose incorrectly configured networks or TFE instances.