### PR TITLE
adding in private key for ado_server only

### DIFF
--- a/oauth_client.go
+++ b/oauth_client.go
@@ -122,6 +122,9 @@ type OAuthClientCreateOptions struct {
 
 	// The VCS provider being connected with.
 	ServiceProvider *ServiceProviderType `jsonapi:"attr,service-provider"`
+
+	// Private key associated with this vcs provider - only available for ado_server
+	PrivateKey *string `jsonapi:"attr,private-key"`
 }
 
 func (o OAuthClientCreateOptions) valid() error {
@@ -136,6 +139,9 @@ func (o OAuthClientCreateOptions) valid() error {
 	}
 	if o.ServiceProvider == nil {
 		return errors.New("service provider is required")
+	}
+	if o.PrivateKey != nil && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
+		return errors.New("Private Key can only be present with Azure DevOps Server service provider")
 	}
 	return nil
 }

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -224,3 +224,88 @@ func TestOAuthClientsDelete(t *testing.T) {
 		assert.EqualError(t, err, "invalid value for OAuth client ID")
 	})
 }
+
+func TestOAuthClientsCreateOptionsValid(t *testing.T) {
+
+	t.Run("with valid options", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:          String("https://api.github.com"),
+			HTTPURL:         String("https://github.com"),
+			OAuthToken:      String("NOTHING"),
+			ServiceProvider: ServiceProvider(ServiceProviderGithub),
+		}
+
+		err := options.valid()
+		assert.Nil(t, err)
+	})
+
+	t.Run("without an API URL", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			HTTPURL:         String("https://github.com"),
+			OAuthToken:      String("NOTHING"),
+			ServiceProvider: ServiceProvider(ServiceProviderGithub),
+		}
+
+		err := options.valid()
+		assert.EqualError(t, err, "API URL is required")
+	})
+
+	t.Run("without a HTTP URL", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:          String("https://api.github.com"),
+			OAuthToken:      String("NOTHING"),
+			ServiceProvider: ServiceProvider(ServiceProviderGithub),
+		}
+
+		err := options.valid()
+		assert.EqualError(t, err, "HTTP URL is required")
+	})
+
+	t.Run("without an OAuth token", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:          String("https://api.github.com"),
+			HTTPURL:         String("https://github.com"),
+			ServiceProvider: ServiceProvider(ServiceProviderGithub),
+		}
+
+		err := options.valid()
+		assert.EqualError(t, err, "OAuth token is required")
+	})
+
+	t.Run("without a service provider", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:     String("https://api.github.com"),
+			HTTPURL:    String("https://github.com"),
+			OAuthToken: String("NOTHING"),
+		}
+
+		err := options.valid()
+		assert.EqualError(t, err, "service provider is required")
+	})
+
+	t.Run("with private key and not ado_server options", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:          String("https://api.github.com"),
+			HTTPURL:         String("https://github.com"),
+			OAuthToken:      String("NOTHING"),
+			ServiceProvider: ServiceProvider(ServiceProviderGithub),
+			PrivateKey:      String("NOTHING"),
+		}
+
+		err := options.valid()
+		assert.EqualError(t, err, "Private Key can only be present with Azure DevOps Server service provider")
+	})
+
+	t.Run("with valid options including private key", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:          String("https://ado.example.com"),
+			HTTPURL:         String("https://ado.example.com"),
+			OAuthToken:      String("NOTHING"),
+			ServiceProvider: ServiceProvider(ServiceProviderAzureDevOpsServer),
+			PrivateKey:      String("NOTHING"),
+		}
+
+		err := options.valid()
+		assert.Nil(t, err)
+	})
+}


### PR DESCRIPTION
This adds in PrivateKey to the OAuthClientCreateOptions struct to allow users to include the RSA private key associated with the ado server.

This is only valid for Azure DevOps Server VCS provider and is validated.