### PR TITLE
fixing nil check for validString check

### DIFF
--- a/oauth_client.go
+++ b/oauth_client.go
@@ -140,7 +140,7 @@ func (o OAuthClientCreateOptions) valid() error {
 	if o.ServiceProvider == nil {
 		return errors.New("service provider is required")
 	}
-	if o.PrivateKey != nil && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
+	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
 		return errors.New("Private Key can only be present with Azure DevOps Server service provider")
 	}
 	return nil

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -282,6 +282,18 @@ func TestOAuthClientsCreateOptionsValid(t *testing.T) {
 		assert.EqualError(t, err, "service provider is required")
 	})
 
+	t.Run("without private key and not ado_server options", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:          String("https://api.github.com"),
+			HTTPURL:         String("https://github.com"),
+			OAuthToken:      String("NOTHING"),
+			ServiceProvider: ServiceProvider(ServiceProviderGitlabEE),
+		}
+
+		err := options.valid()
+		assert.Nil(t, err)
+	})
+
 	t.Run("with private key and not ado_server options", func(t *testing.T) {
 		options := OAuthClientCreateOptions{
 			APIURL:          String("https://api.github.com"),

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -294,6 +294,19 @@ func TestOAuthClientsCreateOptionsValid(t *testing.T) {
 		assert.Nil(t, err)
 	})
 
+	t.Run("with empty private key and not ado_server options", func(t *testing.T) {
+		options := OAuthClientCreateOptions{
+			APIURL:          String("https://api.github.com"),
+			HTTPURL:         String("https://github.com"),
+			OAuthToken:      String("NOTHING"),
+			ServiceProvider: ServiceProvider(ServiceProviderGitlabEE),
+			PrivateKey:      String(""),
+		}
+
+		err := options.valid()
+		assert.Nil(t, err)
+	})
+
 	t.Run("with private key and not ado_server options", func(t *testing.T) {
 		options := OAuthClientCreateOptions{
 			APIURL:          String("https://api.github.com"),


### PR DESCRIPTION
So, o.PrivateKey references a memory address it seems, not a string value so it's never nil.

