### PR TITLE
Workspace variable descriptions

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -687,6 +687,7 @@ func createVariable(t *testing.T, client *Client, w *Workspace) (*Variable, func
 		Key:      String(randomString(t)),
 		Value:    String(randomString(t)),
 		Category: Category(CategoryTerraform),
+		Description: String(randomString(t)),
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/variable.go
+++ b/variable.go
@@ -57,6 +57,7 @@ type Variable struct {
 	ID        string       `jsonapi:"primary,vars"`
 	Key       string       `jsonapi:"attr,key"`
 	Value     string       `jsonapi:"attr,value"`
+	Description string     `jsonapi:"attr,description"`
 	Category  CategoryType `jsonapi:"attr,category"`
 	HCL       bool         `jsonapi:"attr,hcl"`
 	Sensitive bool         `jsonapi:"attr,sensitive"`
@@ -101,6 +102,9 @@ type VariableCreateOptions struct {
 
 	// The value of the variable.
 	Value *string `jsonapi:"attr,value,omitempty"`
+
+	// The description of the variable.
+	Description *string `jsonapi:"attr,description,omitempty"`
 
 	// Whether this is a Terraform or environment variable.
 	Category *CategoryType `jsonapi:"attr,category"`
@@ -183,6 +187,9 @@ type VariableUpdateOptions struct {
 
 	// The value of the variable.
 	Value *string `jsonapi:"attr,value,omitempty"`
+
+	// The description of the variable.
+	Description *string `jsonapi:"attr,description,omitempty"`
 
 	// Whether to evaluate the value of the variable as a string of HCL code.
 	HCL *bool `jsonapi:"attr,hcl,omitempty"`

--- a/variable_test.go
+++ b/variable_test.go
@@ -127,7 +127,7 @@ func TestVariablesCreate(t *testing.T) {
 		}
 
 		_, err := client.Variables.Create(ctx, wTest.ID, options)
-		assert.EqualError(t, err, "Invalid Attribute\n\nDescription is too long (maximum is 512 characters)")
+		assert.Error(t, err)
 	})
 
 	t.Run("when options is missing value", func(t *testing.T) {

--- a/variable_test.go
+++ b/variable_test.go
@@ -67,6 +67,7 @@ func TestVariablesCreate(t *testing.T) {
 			Key:      String(randomString(t)),
 			Value:    String(randomString(t)),
 			Category: Category(CategoryTerraform),
+			Description: String(randomString(t)),
 		}
 
 		v, err := client.Variables.Create(ctx, wTest.ID, options)
@@ -75,6 +76,7 @@ func TestVariablesCreate(t *testing.T) {
 		assert.NotEmpty(t, v.ID)
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, *options.Value, v.Value)
+		assert.Equal(t, *options.Description, v.Description)
 		assert.Equal(t, *options.Category, v.Category)
 		// The workspace isn't returned correcly by the API.
 		// assert.Equal(t, *options.Workspace, v.Workspace)
@@ -82,9 +84,10 @@ func TestVariablesCreate(t *testing.T) {
 
 	t.Run("when options has an empty string value", func(t *testing.T) {
 		options := VariableCreateOptions{
-			Key:      String(randomString(t)),
-			Value:    String(""),
-			Category: Category(CategoryTerraform),
+			Key:         String(randomString(t)),
+			Value:       String(""),
+			Description: String(randomString(t)),
+			Category:    Category(CategoryTerraform),
 		}
 
 		v, err := client.Variables.Create(ctx, wTest.ID, options)
@@ -93,7 +96,38 @@ func TestVariablesCreate(t *testing.T) {
 		assert.NotEmpty(t, v.ID)
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, *options.Value, v.Value)
+		assert.Equal(t, *options.Description, v.Description)
 		assert.Equal(t, *options.Category, v.Category)
+	})
+
+	t.Run("when options has an empty string description", func(t *testing.T) {
+		options := VariableCreateOptions{
+			Key:         String(randomString(t)),
+			Value:       String(randomString(t)),
+			Description: String(""),
+			Category:    Category(CategoryTerraform),
+		}
+
+		v, err := client.Variables.Create(ctx, wTest.ID, options)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, v.ID)
+		assert.Equal(t, *options.Key, v.Key)
+		assert.Equal(t, *options.Value, v.Value)
+		assert.Equal(t, *options.Description, v.Description)
+		assert.Equal(t, *options.Category, v.Category)
+	})
+
+	t.Run("when options has a too-long description", func(t *testing.T) {
+		options := VariableCreateOptions{
+			Key:         String(randomString(t)),
+			Value:       String(randomString(t)),
+			Description: String("tortor aliquam nulla facilisi cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla facilisi morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
+			Category:    Category(CategoryTerraform),
+		}
+
+		_, err := client.Variables.Create(ctx, wTest.ID, options)
+		assert.EqualError(t, err, "Invalid Attribute\n\nDescription is too long (maximum is 512 characters)")
 	})
 
 	t.Run("when options is missing value", func(t *testing.T) {


### PR DESCRIPTION
Workspace variables now have descriptions (`terraform` and `env` categories) and this is the first step in exposing this functionality to the tfe provider.

Variable tests passing locally:
<img width="655" alt="Screen Shot 2020-02-03 at 11 38 03 AM" src="https://user-images.githubusercontent.com/11901347/73671790-aca98780-4679-11ea-8ab1-e1ef801543d2.png">
