### PR TITLE
Add support for run triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Currently the following endpoints are supported:
 - [x] [Policy Checks](https://www.terraform.io/docs/enterprise/api/policy-checks.html)
 - [ ] [Registry Modules](https://www.terraform.io/docs/enterprise/api/modules.html)
 - [x] [Runs](https://www.terraform.io/docs/enterprise/api/run.html)
+- [x] [Run Triggers](https://www.terraform.io/docs/cloud/api/run-triggers.html)
 - [x] [SSH Keys](https://www.terraform.io/docs/enterprise/api/ssh-keys.html)
 - [x] [State Versions](https://www.terraform.io/docs/enterprise/api/state-versions.html)
 - [x] [Team Access](https://www.terraform.io/docs/enterprise/api/team-access.html)

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -1,0 +1,177 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ RunTriggers = (*runTriggers)(nil)
+
+// RunTriggers describes all the Run Trigger
+// related methods that the Terraform Cloud API supports.
+//
+// TFE API docs:
+// https://www.terraform.io/docs/cloud/api/run-triggers.html
+type RunTriggers interface {
+	// List all the run triggers within a workspace.
+	List(ctx context.Context, workspaceID string, options RunTriggerListOptions) (*RunTriggerList, error)
+
+	// Create a new run trigger with the given options.
+	Create(ctx context.Context, workspaceID string, options RunTriggerCreateOptions) (*RunTrigger, error)
+
+	// Read a run trigger by its ID.
+	Read(ctx context.Context, RunTriggerID string) (*RunTrigger, error)
+
+	// Delete a run trigger by its ID.
+	Delete(ctx context.Context, RunTriggerID string) error
+}
+
+// runTriggers implements RunTriggers.
+type runTriggers struct {
+	client *Client
+}
+
+// RunTriggerList represents a list of Run Triggers
+type RunTriggerList struct {
+	*Pagination
+	Items []*RunTrigger
+}
+
+// RunTrigger represents a run trigger.
+type RunTrigger struct {
+	ID             string    `jsonapi:"primary,run-triggers"`
+	CreatedAt      time.Time `jsonapi:"attr,created-at,iso8601"`
+	SourceableName string    `jsonapi:"attr,sourceable-name"`
+	WorkspaceName  string    `jsonapi:"attr,workspace-name"`
+
+	// Relations
+	// TODO: this will eventually need to be polymorphic
+	Sourceable *Workspace `jsonapi:"relation,sourceable"`
+	Workspace  *Workspace `jsonapi:"relation,workspace"`
+}
+
+// RunTriggerListOptions represents the options for listing
+// run triggers.
+type RunTriggerListOptions struct {
+	ListOptions
+	RunTriggerType *string `url:"filter[run-trigger][type]"`
+}
+
+func (o RunTriggerListOptions) valid() error {
+	if !validString(o.RunTriggerType) {
+		return errors.New("run-trigger type is required")
+	}
+	if *o.RunTriggerType != "inbound" && *o.RunTriggerType != "outbound" {
+		return errors.New("invalid value for run-trigger type")
+	}
+	return nil
+}
+
+// List all the run triggers associated with a workspace.
+func (s *runTriggers) List(ctx context.Context, workspaceID string, options RunTriggerListOptions) (*RunTriggerList, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("GET", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	rtl := &RunTriggerList{}
+	err = s.client.do(ctx, req, rtl)
+	if err != nil {
+		return nil, err
+	}
+
+	return rtl, nil
+}
+
+// RunTriggerCreateOptions represents the options for
+// creating a new run trigger.
+type RunTriggerCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,run-triggers"`
+
+	// The source workspace
+	Sourceable *Workspace `jsonapi:"relation,sourceable"`
+}
+
+func (o RunTriggerCreateOptions) valid() error {
+	if o.Sourceable == nil {
+		return errors.New("sourceable is required")
+	}
+	return nil
+}
+
+// Creates a run trigger with the given options.
+func (s *runTriggers) Create(ctx context.Context, workspaceID string, options RunTriggerCreateOptions) (*RunTrigger, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	rt := &RunTrigger{}
+	err = s.client.do(ctx, req, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	return rt, nil
+}
+
+// Read a run trigger by its ID.
+func (s *runTriggers) Read(ctx context.Context, runTriggerID string) (*RunTrigger, error) {
+	if !validStringID(&runTriggerID) {
+		return nil, errors.New("invalid value for run trigger ID")
+	}
+
+	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rt := &RunTrigger{}
+	err = s.client.do(ctx, req, rt)
+	if err != nil {
+		return nil, err
+	}
+
+	return rt, nil
+}
+
+// Delete a run trigger by its ID.
+func (s *runTriggers) Delete(ctx context.Context, runTriggerID string) error {
+	if !validStringID(&runTriggerID) {
+		return errors.New("invalid value for run trigger ID")
+	}
+
+	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/run_trigger_test.go
+++ b/run_trigger_test.go
@@ -1,0 +1,217 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRunTriggerList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	sourceable1Test, sourceable1TestCleanup := createWorkspace(t, client, orgTest)
+	defer sourceable1TestCleanup()
+
+	sourceable2Test, sourceable2TestCleanup := createWorkspace(t, client, orgTest)
+	defer sourceable2TestCleanup()
+
+	rtTest1, _ := createRunTrigger(t, client, wTest, sourceable1Test)
+	rtTest2, _ := createRunTrigger(t, client, wTest, sourceable2Test)
+
+	t.Run("without list options", func(t *testing.T) {
+		rtl, err := client.RunTriggers.List(
+			ctx,
+			wTest.ID,
+			RunTriggerListOptions{
+				RunTriggerType: String("inbound"),
+			},
+		)
+		require.NoError(t, err)
+		assert.Contains(t, rtl.Items, rtTest1)
+		assert.Contains(t, rtl.Items, rtTest2)
+		assert.Equal(t, 1, rtl.CurrentPage)
+		assert.Equal(t, 2, rtl.TotalCount)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		rtl, err := client.RunTriggers.List(
+			ctx,
+			wTest.ID,
+			RunTriggerListOptions{
+				ListOptions: ListOptions{
+					PageNumber: 999,
+					PageSize:   100,
+				},
+				RunTriggerType: String("inbound"),
+			},
+		)
+		require.NoError(t, err)
+		assert.Empty(t, rtl.Items)
+		assert.Equal(t, 999, rtl.CurrentPage)
+		assert.Equal(t, 2, rtl.TotalCount)
+	})
+
+	t.Run("without a valid workspace", func(t *testing.T) {
+		rtl, err := client.RunTriggers.List(
+			ctx,
+			badIdentifier,
+			RunTriggerListOptions{
+				RunTriggerType: String("inbound"),
+			},
+		)
+		assert.Nil(t, rtl)
+		assert.EqualError(t, err, "invalid value for workspace ID")
+	})
+
+	t.Run("without run-trigger type", func(t *testing.T) {
+		rtl, err := client.RunTriggers.List(
+			ctx,
+			wTest.ID,
+			RunTriggerListOptions{},
+		)
+		assert.Nil(t, rtl)
+		assert.EqualError(t, err, "run-trigger type is required")
+	})
+
+	t.Run("with invalid run-trigger type", func(t *testing.T) {
+		rtl, err := client.RunTriggers.List(
+			ctx,
+			wTest.ID,
+			RunTriggerListOptions{
+				RunTriggerType: String("invalid"),
+			},
+		)
+		assert.Nil(t, rtl)
+		assert.EqualError(t, err, "invalid value for run-trigger type")
+	})
+}
+
+func TestRunTriggerCreate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	sourceableTest, sourceableTestCleanup := createWorkspace(t, client, orgTest)
+	defer sourceableTestCleanup()
+
+	t.Run("with all required values", func(t *testing.T) {
+		options := RunTriggerCreateOptions{
+			Sourceable: sourceableTest,
+		}
+
+		_, err := client.RunTriggers.Create(ctx, wTest.ID, options)
+		require.NoError(t, err)
+	})
+
+	t.Run("without a required value", func(t *testing.T) {
+		options := RunTriggerCreateOptions{}
+
+		rt, err := client.RunTriggers.Create(ctx, wTest.ID, options)
+		assert.Nil(t, rt)
+		assert.EqualError(t, err, "sourceable is required")
+	})
+
+	t.Run("without a valid workspace", func(t *testing.T) {
+		rt, err := client.RunTriggers.Create(ctx, badIdentifier, RunTriggerCreateOptions{})
+		assert.Nil(t, rt)
+		assert.EqualError(t, err, "invalid value for workspace ID")
+	})
+
+	t.Run("when an error is returned from the api", func(t *testing.T) {
+		// There are many cases that would cause the server to return an error
+		// on run trigger creation. This tests one of them: setting workspace
+		// and sourceable to the same workspace
+		options := RunTriggerCreateOptions{
+			Sourceable: sourceableTest,
+		}
+
+		rt, err := client.RunTriggers.Create(ctx, sourceableTest.ID, options)
+		assert.Nil(t, rt)
+		assert.Error(t, err)
+	})
+}
+
+func TestRunTriggerRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	sourceableTest, sourceableTestCleanup := createWorkspace(t, client, orgTest)
+	defer sourceableTestCleanup()
+
+	rtTest, rtTestCleanup := createRunTrigger(t, client, wTest, sourceableTest)
+	defer rtTestCleanup()
+
+	t.Run("with a valid ID", func(t *testing.T) {
+		rt, err := client.RunTriggers.Read(ctx, rtTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, rtTest.ID, rt.ID)
+	})
+
+	t.Run("when the run trigger does not exist", func(t *testing.T) {
+		_, err := client.RunTriggers.Read(ctx, "nonexisting")
+		assert.Equal(t, err, ErrResourceNotFound)
+	})
+
+	t.Run("when the run trigger ID is invalid", func(t *testing.T) {
+		_, err := client.RunTriggers.Read(ctx, badIdentifier)
+		assert.EqualError(t, err, "invalid value for run trigger ID")
+	})
+}
+
+func TestRunTriggerDelete(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	sourceableTest, sourceableTestCleanup := createWorkspace(t, client, orgTest)
+	defer sourceableTestCleanup()
+
+	// No need to cleanup here, as this test will delete this run trigger
+	rtTest, _ := createRunTrigger(t, client, wTest, sourceableTest)
+
+	t.Run("with a valid ID", func(t *testing.T) {
+		err := client.RunTriggers.Delete(ctx, rtTest.ID)
+		require.NoError(t, err)
+
+		_, err = client.RunTriggers.Read(ctx, rtTest.ID)
+		assert.Equal(t, err, ErrResourceNotFound)
+	})
+
+	t.Run("when the run trigger does not exist", func(t *testing.T) {
+		err := client.RunTriggers.Delete(ctx, "nonexisting")
+		assert.Equal(t, err, ErrResourceNotFound)
+	})
+
+	t.Run("when the run trigger ID is invalid", func(t *testing.T) {
+		err := client.RunTriggers.Delete(ctx, badIdentifier)
+		assert.EqualError(t, err, "invalid value for run trigger ID")
+	})
+}

--- a/tfe.go
+++ b/tfe.go
@@ -122,6 +122,7 @@ type Client struct {
 	PolicySetParameters        PolicySetParameters
 	PolicySets                 PolicySets
 	Runs                       Runs
+	RunTriggers                RunTriggers
 	SSHKeys                    SSHKeys
 	StateVersions              StateVersions
 	Teams                      Teams
@@ -215,6 +216,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.PolicySetParameters = &policySetParameters{client: client}
 	client.PolicySets = &policySets{client: client}
 	client.Runs = &runs{client: client}
+	client.RunTriggers = &runTriggers{client: client}
 	client.SSHKeys = &sshKeys{client: client}
 	client.StateVersions = &stateVersions{client: client}
 	client.Teams = &teams{client: client}


### PR DESCRIPTION
## Description

This PR adds support for the new run triggers endpoints (create/delete/list/show). 

I ran into problems trying to figure out how to make the sourceable polymorphic. The jsonapi package we use doesn't seem to support it. I think we'll have to do something custom, use a different jsonapi package or modify the api to deal with the polymorphic relationship differently. Since we are currently only supporting sourceables that are workspaces right now, I've made them workspaces here for now. 

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/run-triggers.html)
- [TFC documentation](https://www.terraform.io/docs/cloud/workspaces/run-triggers.html)

## Output from acceptance tests

```
envchain go-tfe go test ./... -timeout=30m
--- FAIL: TestOrganizationsRead (1.25s)
    --- FAIL: TestOrganizationsRead/when_the_org_exists (0.19s)
        --- FAIL: TestOrganizationsRead/when_the_org_exists/timestamps_are_populated (0.00s)
            organization_test.go:112: 
                        Error Trace:    organization_test.go:112
                        Error:          Should NOT be empty, but was 0001-01-01 00:00:00 +0000 UTC
                        Test:           TestOrganizationsRead/when_the_org_exists/timestamps_are_populated
--- FAIL: TestOrganizationsCapacity (11.09s)
    --- FAIL: TestOrganizationsCapacity/without_queued_runs (0.26s)
        require.go:794: 
                Error Trace:    organization_test.go:219
                Error:          Received unexpected error:
                                resource not found
                Test:           TestOrganizationsCapacity/without_queued_runs
    --- FAIL: TestOrganizationsCapacity/with_queued_runs (7.72s)
        require.go:794: 
                Error Trace:    organization_test.go:233
                Error:          Received unexpected error:
                                resource not found
                Test:           TestOrganizationsCapacity/with_queued_runs
--- FAIL: TestOrganizationsRunQueue (11.98s)
    --- FAIL: TestOrganizationsRunQueue/without_queued_runs (0.35s)
        require.go:794: 
                Error Trace:    organization_test.go:296
                Error:          Received unexpected error:
                                resource not found
                Test:           TestOrganizationsRunQueue/without_queued_runs
    --- FAIL: TestOrganizationsRunQueue/with_queued_runs (0.27s)
        require.go:794: 
                Error Trace:    organization_test.go:310
                Error:          Received unexpected error:
                                resource not found
                Test:           TestOrganizationsRunQueue/with_queued_runs
    --- FAIL: TestOrganizationsRunQueue/without_queue_options (0.36s)
        require.go:794: 
                Error Trace:    organization_test.go:325
                Error:          Received unexpected error:
                                resource not found
                Test:           TestOrganizationsRunQueue/without_queue_options
    --- FAIL: TestOrganizationsRunQueue/with_queue_options (0.35s)
        require.go:794: 
                Error Trace:    organization_test.go:350
                Error:          Received unexpected error:
                                resource not found
                Test:           TestOrganizationsRunQueue/with_queue_options
--- FAIL: TestTeamMembersList (1.81s)
    require.go:794: 
                Error Trace:    team_member_test.go:22
                Error:          Received unexpected error:
                                bad request
                                
                                admin is not a member of the organization
                Test:           TestTeamMembersList
--- FAIL: TestTeamMembersAdd (1.74s)
    --- FAIL: TestTeamMembersAdd/with_valid_options (0.37s)
        require.go:794: 
                Error Trace:    team_member_test.go:60
                Error:          Received unexpected error:
                                bad request
                                
                                admin is not a member of the organization
                Test:           TestTeamMembersAdd/with_valid_options
--- FAIL: TestTeamMembersRemove (1.73s)
    require.go:794: 
                Error Trace:    team_member_test.go:107
                Error:          Received unexpected error:
                                bad request
                                
                                admin is not a member of the organization
                Test:           TestTeamMembersRemove
--- FAIL: TestUsersUpdate (3.15s)
    --- FAIL: TestUsersUpdate/with_a_new_email_address (0.59s)
        user_test.go:69: 
                Error Trace:    user_test.go:69
                Error:          Not equal: 
                                expected: "newtestemail@hashicorp.com"
                                actual  : ""
                                
                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -newtestemail@hashicorp.com
                                +
                Test:           TestUsersUpdate/with_a_new_email_address
FAIL
FAIL    github.com/hashicorp/go-tfe     1063.331s
```