### PR TITLE
Add Context to CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,7 +6,7 @@ version: 2
 test_results_dir: &test_results_dir /tmp/test_results
 
 jobs:
-  build:
+  run-tests:
     docker:
       - image: circleci/golang:1.12.1
         environment:
@@ -32,3 +32,11 @@ jobs:
 
       - store_test_results:
           path: *test_results_dir
+
+
+workflows:
+  version: 2
+  my-workflow:
+    jobs:
+      - run-tests:
+          context: core-team-access


### PR DESCRIPTION
Adding this Context prevents non-HashiCorp collaborators from accessing protected env vars. A side effect of this is that OSS collaborator PRs will not run in Circle, and will need to be run manually by an internal maintainer.