### PR TITLE
Feature: Admin/Users list

### DIFF
--- a/admin_users.go
+++ b/admin_users.go
@@ -1,0 +1,75 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminUsers = (*adminUsers)(nil)
+
+// AdminUsers Users Admin API contains endpoints to help site administrators manage
+// user accounts.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/admin/users.html
+type AdminUsers interface {
+	// List all the users of the given installation.
+	List(ctx context.Context, options AdminUsersListOptions) (*AdminUsersList, error)
+}
+
+// users implements Users.
+type adminUsers struct {
+	client *Client
+}
+
+// AdminUser represents a Terraform Enterprise user.
+type AdminUser struct {
+	ID               string          `jsonapi:"primary,users"`
+	AvatarURL        string          `jsonapi:"attr,avatar-url"`
+	Email            string          `jsonapi:"attr,email"`
+	IsServiceAccount bool            `jsonapi:"attr,is-service-account"`
+	TwoFactor        *AdminTwoFactor `jsonapi:"attr,two-factor"`
+	UnconfirmedEmail string          `jsonapi:"attr,unconfirmed-email"`
+	Username         string          `jsonapi:"attr,username"`
+	V2Only           bool            `jsonapi:"attr,v2-only"`
+
+	// Relations
+	// AuthenticationTokens *AuthenticationTokens `jsonapi:"relation,authentication-tokens"`
+	Organizations []*Organization `jsonapi:"relation,organizations"`
+}
+
+// AdminTwoFactor represents the organization permissions.
+type AdminTwoFactor struct {
+	Enabled  bool `json:"enabled"`
+	Verified bool `json:"verified"`
+}
+
+// AdminUsersList represents a list of users.
+type AdminUsersList struct {
+	*Pagination
+	Items []*AdminUser
+}
+
+// AdminUsersListOptions represents the options for listing users.
+type AdminUsersListOptions struct {
+	ListOptions
+
+	Include string `url:"include"`
+}
+
+// List all the users of the terraform enterprise installation.
+func (s *adminUsers) List(ctx context.Context, options AdminUsersListOptions) (*AdminUsersList, error) {
+	u := fmt.Sprintf("admin/users")
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	rl := &AdminUsersList{}
+	err = s.client.do(ctx, req, rl)
+	if err != nil {
+		return nil, err
+	}
+
+	return rl, nil
+}

--- a/admin_users_test.go
+++ b/admin_users_test.go
@@ -1,0 +1,46 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminUsersList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("without list options", func(t *testing.T) {
+		rl, err := client.AdminUsers.List(ctx, AdminUsersListOptions{})
+		require.NoError(t, err)
+
+		u, err := client.Users.ReadCurrent(ctx)
+
+		found := []string{}
+		for _, r := range rl.Items {
+			found = append(found, r.ID)
+		}
+
+		assert.Contains(t, found, u.ID)
+		assert.Equal(t, 1, rl.CurrentPage)
+		assert.Equal(t, 1, rl.TotalCount)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		rl, err := client.AdminUsers.List(ctx, AdminUsersListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, rl.Items)
+		assert.Equal(t, 999, rl.CurrentPage)
+		assert.Equal(t, 2, rl.TotalCount)
+	})
+}

--- a/tfe.go
+++ b/tfe.go
@@ -132,6 +132,7 @@ type Client struct {
 	Users                      Users
 	Variables                  Variables
 	Workspaces                 Workspaces
+	AdminUsers                 AdminUsers
 }
 
 // NewClient creates a new Terraform Enterprise API client.
@@ -226,6 +227,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Users = &users{client: client}
 	client.Variables = &variables{client: client}
 	client.Workspaces = &workspaces{client: client}
+	client.AdminUsers = &adminUsers{client: client}
 
 	return client, nil
 }


### PR DESCRIPTION
Hi! I needed the admin/users endpoint to automatically sync all users of an organization to a team in a cronjob, so I've added it here.

I've verified this works as you'd expect.

Though, I did notice that not every admin token is created equally- I am admin but my token kept returning `unauthorized`, I asked another admin to create a token and that did work. Not sure what that was about.