### PR TITLE
Policy set vcs update

### DIFF
--- a/policy_set.go
+++ b/policy_set.go
@@ -209,6 +209,18 @@ type PolicySetUpdateOptions struct {
 
 	// Whether or not the policy set is global.
 	Global *bool `jsonapi:"attr,global,omitempty"`
+
+	// The sub-path within the attached VCS repository to ingress. All
+	// files and directories outside of this sub-path will be ignored.
+	// This option may only be specified when a VCS repo is present.
+	PoliciesPath *string `jsonapi:"attr,policies-path,omitempty"`
+
+	// VCS repository information. When present, the policies and
+	// configuration will be sourced from the specified VCS repository
+	// instead of being defined within the policy set itself. Note that
+	// this option is mutually exclusive with the Policies option and
+	// both cannot be used at the same time.
+	VCSRepo *VCSRepoOptions `jsonapi:"attr,vcs-repo,omitempty"`
 }
 
 func (o PolicySetUpdateOptions) valid() error {

--- a/policy_set.go
+++ b/policy_set.go
@@ -218,8 +218,9 @@ type PolicySetUpdateOptions struct {
 	// VCS repository information. When present, the policies and
 	// configuration will be sourced from the specified VCS repository
 	// instead of being defined within the policy set itself. Note that
-	// this option is mutually exclusive with the Policies option and
-	// both cannot be used at the same time.
+	// specifying this option may only be used on policy sets with no
+	// directly-attached policies (*PolicySet.Policies). Specifying this
+	// option when policies are already present will result in an error.
 	VCSRepo *VCSRepoOptions `jsonapi:"attr,vcs-repo,omitempty"`
 }
 


### PR DESCRIPTION
This PR adds updates to policy sets VCS options and policy path.
Issue #105 

Added test to TestPolicySetCreate `with_vcs_policy_updated`
```
=== RUN   TestPolicySetsCreate
=== RUN   TestPolicySetsCreate/with_vcs_policy_set
=== RUN   TestPolicySetsCreate/with_vcs_policy_updated
=== RUN   TestPolicySetsCreate/without_a_name_provided
=== RUN   TestPolicySetsCreate/with_an_invalid_name_provided
=== RUN   TestPolicySetsCreate/without_a_valid_organization
--- PASS: TestPolicySetsCreate (5.55s)
    --- PASS: TestPolicySetsCreate/with_vcs_policy_set (2.10s)
    --- PASS: TestPolicySetsCreate/with_vcs_policy_updated (2.64s)
    --- PASS: TestPolicySetsCreate/without_a_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/with_an_invalid_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/without_a_valid_organization (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     6.898s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]```
