### PR TITLE
Note that the user token but be for a user named admin

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Your policy set repository will need the following:
 Tests are run against an actual backend so they require a valid backend address
 and token.
 1. `TFE_ADDRESS` - URL of a Terraform Cloud or Terraform Enterprise instance to be used for testing, including scheme. Example: `https://tfe.local`
-1. `TFE_TOKEN` - A [user API token](https://www.terraform.io/docs/cloud/users-teams-organizations/users.html#api-tokens) for the Terraform Cloud or Terraform Enterprise instance being used for testing.
+1. `TFE_TOKEN` - A [user API token](https://www.terraform.io/docs/cloud/users-teams-organizations/users.html#api-tokens) for the Terraform Cloud or Terraform Enterprise instance being used for testing. **Must be a user named `admin`**
 
 ##### Optional:
 1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running OAuth client tests.


### PR DESCRIPTION
Small README update that the user token must be for the user named `admin`.