### PR TITLE
Specify Go 1.12 in mod

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -11,3 +11,5 @@ require (
 	github.com/svanharmelen/jsonapi v0.0.0-20180618144545-0c0828c3f16d
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )
+
+go 1.12


### PR DESCRIPTION
Adding explicit Go version in `go.mod`.

> The go directive in a go.mod file now indicates the version of the language used by the files within that module.

https://golang.org/doc/go1.12#modules