### PR TITLE
Manage team members via organization membership

### DIFF
--- a/organization_membership.go
+++ b/organization_membership.go
@@ -56,6 +56,7 @@ type OrganizationMembershipList struct {
 type OrganizationMembership struct {
 	ID     string                       `jsonapi:"primary,organization-memberships"`
 	Status OrganizationMembershipStatus `jsonapi:"attr,status"`
+	Email  string                       `jsonapi:"attr,email"`
 
 	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`

--- a/team.go
+++ b/team.go
@@ -51,7 +51,8 @@ type Team struct {
 	UserCount          int                 `jsonapi:"attr,users-count"`
 
 	// Relations
-	Users []*User `jsonapi:"relation,users"`
+	Users                  []*User                   `jsonapi:"relation,users"`
+	OrganizationMemberhips []*OrganizationMembership `jsonapi:"relation,organization-memberships"`
 }
 
 // OrganizationAccess represents the team's permissions on its organization

--- a/team.go
+++ b/team.go
@@ -51,8 +51,8 @@ type Team struct {
 	UserCount          int                 `jsonapi:"attr,users-count"`
 
 	// Relations
-	Users                  []*User                   `jsonapi:"relation,users"`
-	OrganizationMemberhips []*OrganizationMembership `jsonapi:"relation,organization-memberships"`
+	Users                   []*User                   `jsonapi:"relation,users"`
+	OrganizationMemberships []*OrganizationMembership `jsonapi:"relation,organization-memberships"`
 }
 
 // OrganizationAccess represents the team's permissions on its organization

--- a/tfe.go
+++ b/tfe.go
@@ -32,7 +32,7 @@ const (
 	DefaultAddress = "https://app.terraform.io"
 	// DefaultBasePath on which the API is served.
 	DefaultBasePath = "/api/v2/"
-	// No-op API endpoint used to configure the rate limiter
+	// PingEndpoint is a no-op API endpoint used to configure the rate limiter
 	PingEndpoint = "ping"
 )
 


### PR DESCRIPTION
This PR adds support for team membership management via organization membership resources as opposed to usernames.

This change enables administrators to manage members by email as well as setup team assignments while the invitation for the new member is pending.

Prereq #112 

https://app.asana.com/0/1128360243090396/1169252625472641