### PR TITLE
Add test account helper

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -27,32 +27,9 @@ func testClient(t *testing.T) *Client {
 	return client
 }
 
-// TestAccountDetails represents the info fetched from
-// /api/v2/account/details so we can determine the user
-// that is running the tests from the token being used.
-type TestAccountDetails struct {
-	ID       string `json:"id" jsonapi:"primary,users"`
-	Username string `jsonapi:"attr,username"`
-	Email    string `jsonapi:"attr,email"`
-}
-
-// fetchTestAccountDetails returns the username and external ID
-// of the user running the test
 func fetchTestAccountDetails(t *testing.T, client *Client) *TestAccountDetails {
 	if _testAccountDetails == nil {
-		tad := &TestAccountDetails{}
-		req, err := client.newRequest("GET", "account/details", nil)
-		if err != nil {
-			t.Fatalf("could not create request for user details: %v", err)
-		}
-
-		ctx := context.Background()
-		err = client.do(ctx, req, tad)
-		if err != nil {
-			t.Fatalf("could not fetch test user details: %v", err)
-		}
-		_testAccountDetails = tad
-		return tad
+		_testAccountDetails = FetchTestAccountDetails(t, client)
 	}
 	return _testAccountDetails
 }

--- a/team_member_test.go
+++ b/team_member_test.go
@@ -15,8 +15,10 @@ func TestTeamMembersList(t *testing.T) {
 	tmTest, tmTestCleanup := createTeam(t, client, nil)
 	defer tmTestCleanup()
 
+	testAcct := fetchTestAccountDetails(t, client)
+
 	options := TeamMemberAddOptions{
-		Usernames: []string{"admin"},
+		Usernames: []string{testAcct.Username},
 	}
 	err := client.TeamMembers.Add(ctx, tmTest.ID, options)
 	require.NoError(t, err)
@@ -28,7 +30,7 @@ func TestTeamMembersList(t *testing.T) {
 
 		found := false
 		for _, user := range users {
-			if user.Username == "admin" {
+			if user.Username == testAcct.Username {
 				found = true
 				break
 			}
@@ -51,9 +53,11 @@ func TestTeamMembersAdd(t *testing.T) {
 	tmTest, tmTestCleanup := createTeam(t, client, nil)
 	defer tmTestCleanup()
 
+	testAcct := fetchTestAccountDetails(t, client)
+
 	t.Run("with valid options", func(t *testing.T) {
 		options := TeamMemberAddOptions{
-			Usernames: []string{"admin"},
+			Usernames: []string{testAcct.Username},
 		}
 
 		err := client.TeamMembers.Add(ctx, tmTest.ID, options)
@@ -64,7 +68,7 @@ func TestTeamMembersAdd(t *testing.T) {
 
 		found := false
 		for _, user := range users {
-			if user.Username == "admin" {
+			if user.Username == testAcct.Username {
 				found = true
 				break
 			}
@@ -100,15 +104,17 @@ func TestTeamMembersRemove(t *testing.T) {
 	tmTest, tmTestCleanup := createTeam(t, client, nil)
 	defer tmTestCleanup()
 
+	testAcct := fetchTestAccountDetails(t, client)
+
 	options := TeamMemberAddOptions{
-		Usernames: []string{"admin"},
+		Usernames: []string{testAcct.Username},
 	}
 	err := client.TeamMembers.Add(ctx, tmTest.ID, options)
 	require.NoError(t, err)
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := TeamMemberRemoveOptions{
-			Usernames: []string{"admin"},
+			Usernames: []string{testAcct.Username},
 		}
 
 		err := client.TeamMembers.Remove(ctx, tmTest.ID, options)

--- a/testing.go
+++ b/testing.go
@@ -1,0 +1,36 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+)
+
+// TestAccountDetails represents the basic account information
+// of a TFE/TFC user.
+//
+// See FetchTestAccountDetails for more information.
+type TestAccountDetails struct {
+	ID       string `json:"id" jsonapi:"primary,users"`
+	Username string `jsonapi:"attr,username"`
+	Email    string `jsonapi:"attr,email"`
+}
+
+// FetchTestAccountDetails returns TestAccountDetails
+// of the user running the tests.
+//
+// Use this helper to fetch the username and email
+// address associated with the token used to run the tests.
+func FetchTestAccountDetails(t *testing.T, client *Client) *TestAccountDetails {
+	tad := &TestAccountDetails{}
+	req, err := client.newRequest("GET", "account/details", nil)
+	if err != nil {
+		t.Fatalf("could not create account details request: %v", err)
+	}
+
+	ctx := context.Background()
+	err = client.do(ctx, req, tad)
+	if err != nil {
+		t.Fatalf("could not fetch test user details: %v", err)
+	}
+	return tad
+}


### PR DESCRIPTION
This PR adds a test helper to fetch the account details of the user running the tests. Calls out to `/api/v2/account/details` to determine the user ID, username and email associated with `TFE_TOKEN`.

