### PR TITLE
team: add "visibility" field

### DIFF
--- a/team.go
+++ b/team.go
@@ -47,6 +47,7 @@ type Team struct {
 	ID                 string              `jsonapi:"primary,teams"`
 	Name               string              `jsonapi:"attr,name"`
 	OrganizationAccess *OrganizationAccess `jsonapi:"attr,organization-access"`
+	Visibility         string              `jsonapi:"attr,visibility"`
 	Permissions        *TeamPermissions    `jsonapi:"attr,permissions"`
 	UserCount          int                 `jsonapi:"attr,users-count"`
 
@@ -103,6 +104,9 @@ type TeamCreateOptions struct {
 
 	// The team's organization access
 	OrganizationAccess *OrganizationAccessOptions `jsonapi:"attr,organization-access,omitempty"`
+
+	// The team's visibility ("secret", "organization")
+	Visibility *string `jsonapi:"attr,visibility,omitempty"`
 }
 
 // OrganizationAccessOptions represents the organization access options of a team.
@@ -177,6 +181,9 @@ type TeamUpdateOptions struct {
 
 	// The team's organization access
 	OrganizationAccess *OrganizationAccessOptions `jsonapi:"attr,organization-access,omitempty"`
+
+	// The team's visibility ("secret", "organization")
+	Visibility *string `jsonapi:"attr,visibility,omitempty"`
 }
 
 // Update a team by its ID.

--- a/team_test.go
+++ b/team_test.go
@@ -113,6 +113,10 @@ func TestTeamsRead(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, tmTest, tm)
 
+		t.Run("visibility is returned", func(t *testing.T) {
+			assert.Equal(t, "secret", tm.Visibility)
+		})
+
 		t.Run("permissions are properly decoded", func(t *testing.T) {
 			assert.True(t, tm.Permissions.CanDestroy)
 		})
@@ -152,6 +156,7 @@ func TestTeamsUpdate(t *testing.T) {
 			OrganizationAccess: &OrganizationAccessOptions{
 				ManagePolicies:    Bool(false),
 				ManageVCSSettings: Bool(true)},
+			Visibility: String("organization"),
 		}
 
 		tm, err := client.Teams.Update(ctx, tmTest.ID, options)
@@ -165,6 +170,10 @@ func TestTeamsUpdate(t *testing.T) {
 			refreshed,
 		} {
 			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t,
+				*options.Visibility,
+				item.Visibility,
+			)
 			assert.Equal(t,
 				*options.OrganizationAccess.ManagePolicies,
 				item.OrganizationAccess.ManagePolicies,


### PR DESCRIPTION
Adds the `visibility` field from the [Teams API](https://www.terraform.io/docs/cloud/api/teams.html). I'm planning to follow up and add this to http://github.com/terraform-providers/terraform-provider-tfe.

I ran the teams tests against a Terraform Enterprise instance:

```
$ go test -v -timeout 30s github.com/hashicorp/go-tfe -run TestTeams

=== RUN   TestTeamsList
=== RUN   TestTeamsList/without_list_options
    TestTeamsList/without_list_options: team_test.go:29: paging not supported yet in API
=== RUN   TestTeamsList/with_list_options
    TestTeamsList/with_list_options: team_test.go:35: paging not supported yet in API
=== RUN   TestTeamsList/without_a_valid_organization
--- PASS: TestTeamsList (1.72s)
    --- SKIP: TestTeamsList/without_list_options (0.22s)
    --- SKIP: TestTeamsList/with_list_options (0.00s)
    --- PASS: TestTeamsList/without_a_valid_organization (0.00s)
=== RUN   TestTeamsCreate
=== RUN   TestTeamsCreate/with_valid_options
=== RUN   TestTeamsCreate/when_options_is_missing_name
=== RUN   TestTeamsCreate/when_options_has_an_invalid_organization
--- PASS: TestTeamsCreate (1.03s)
    --- PASS: TestTeamsCreate/with_valid_options (0.42s)
    --- PASS: TestTeamsCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestTeamsCreate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestTeamsRead
=== RUN   TestTeamsRead/when_the_team_exists
=== RUN   TestTeamsRead/when_the_team_exists/visibility_is_returned
=== RUN   TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded
=== RUN   TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded
=== RUN   TestTeamsRead/when_the_team_does_not_exist
=== RUN   TestTeamsRead/without_a_valid_team_ID
--- PASS: TestTeamsRead (1.25s)
    --- PASS: TestTeamsRead/when_the_team_exists (0.21s)
        --- PASS: TestTeamsRead/when_the_team_exists/visibility_is_returned (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded (0.00s)
    --- PASS: TestTeamsRead/when_the_team_does_not_exist (0.20s)
    --- PASS: TestTeamsRead/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsUpdate
=== RUN   TestTeamsUpdate/with_valid_options
=== RUN   TestTeamsUpdate/when_the_team_does_not_exist
=== RUN   TestTeamsUpdate/without_a_valid_team_ID
--- PASS: TestTeamsUpdate (1.56s)
    --- PASS: TestTeamsUpdate/with_valid_options (0.41s)
    --- PASS: TestTeamsUpdate/when_the_team_does_not_exist (0.21s)
    --- PASS: TestTeamsUpdate/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsDelete
=== RUN   TestTeamsDelete/with_valid_options
=== RUN   TestTeamsDelete/without_valid_team_ID
--- PASS: TestTeamsDelete (1.11s)
    --- PASS: TestTeamsDelete/with_valid_options (0.32s)
    --- PASS: TestTeamsDelete/without_valid_team_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	6.765s
```