### PR TITLE
Fixup tests

### DIFF
--- a/organization_test.go
+++ b/organization_test.go
@@ -204,6 +204,7 @@ func TestOrganizationsDelete(t *testing.T) {
 }
 
 func TestOrganizationsCapacity(t *testing.T) {
+	t.Skip("Capacity queues are not available in the API")
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -281,6 +282,7 @@ func TestOrganizationsEntitlements(t *testing.T) {
 }
 
 func TestOrganizationsRunQueue(t *testing.T) {
+	t.Skip("Capacity queues are not available in the API")
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/organization_test.go
+++ b/organization_test.go
@@ -109,7 +109,8 @@ func TestOrganizationsRead(t *testing.T) {
 
 		t.Run("timestamps are populated", func(t *testing.T) {
 			assert.NotEmpty(t, org.CreatedAt)
-			assert.NotEmpty(t, org.TrialExpiresAt)
+			// By default accounts are in the free tier and are not in a trial
+			assert.Empty(t, org.TrialExpiresAt)
 		})
 	})
 

--- a/user_test.go
+++ b/user_test.go
@@ -65,8 +65,18 @@ func TestUsersUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		u, err := client.Users.ReadCurrent(ctx)
+
+		email := ""
+		if u.UnconfirmedEmail != "" {
+			email = u.UnconfirmedEmail
+		} else if u.Email != "" {
+			email = u.Email
+		} else {
+			t.Fatalf("cannot test with user %q because both email and unconfirmed email are empty", u.ID)
+		}
+
 		assert.NoError(t, err)
-		assert.Equal(t, "newtestemail@hashicorp.com", u.UnconfirmedEmail)
+		assert.Equal(t, "newtestemail@hashicorp.com", email)
 	})
 
 	t.Run("with invalid email address", func(t *testing.T) {


### PR DESCRIPTION
This PR has 3 minor fixups:

- Organizations are not automatically in a trial upon creation so for CI (and most (all?) local test cases trial expiration will be null).
- The user update runs against the user running the tests so they will likely have a confirmed email so we fall back from `UnconfirmedEmail` to `Email` and failing if for some reason both are empty.
- Capacity is not available from the API so skipping for now (cc @beekus)