### PR TITLE
run: Allow setting target addresses when creating a run

### DIFF
--- a/run.go
+++ b/run.go
@@ -98,6 +98,7 @@ type Run struct {
 	Source                 RunSource            `jsonapi:"attr,source"`
 	Status                 RunStatus            `jsonapi:"attr,status"`
 	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	TargetAddrs            []string             `jsonapi:"attr,target_addrs,omitempty"`
 
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
@@ -184,6 +185,19 @@ type RunCreateOptions struct {
 
 	// Specifies the workspace where the run will be executed.
 	Workspace *Workspace `jsonapi:"relation,workspace"`
+
+	// If non-empty, requests that Terraform should create a plan including
+	// actions only for the given objects (specified using resource address
+	// syntax) and the objects they depend on.
+	//
+	// This capability is provided for exceptional circumstances only, such as
+	// recovering from mistakes or working around existing Terraform
+	// limitations. Terraform will generally mention the -target command line
+	// option in its error messages describing situations where setting this
+	// argument may be appropriate. This argument should not be used as part
+	// of routine workflow and Terraform will emit warnings reminding about
+	// this whenever this property is set.
+	TargetAddrs []string `jsonapi:"attr,target_addrs,omitempty"`
 }
 
 func (o RunCreateOptions) valid() error {

--- a/run.go
+++ b/run.go
@@ -98,7 +98,7 @@ type Run struct {
 	Source                 RunSource            `jsonapi:"attr,source"`
 	Status                 RunStatus            `jsonapi:"attr,status"`
 	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
-	TargetAddrs            []string             `jsonapi:"attr,target_addrs,omitempty"`
+	TargetAddrs            []string             `jsonapi:"attr,target-addrs,omitempty"`
 
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
@@ -197,7 +197,7 @@ type RunCreateOptions struct {
 	// argument may be appropriate. This argument should not be used as part
 	// of routine workflow and Terraform will emit warnings reminding about
 	// this whenever this property is set.
-	TargetAddrs []string `jsonapi:"attr,target_addrs,omitempty"`
+	TargetAddrs []string `jsonapi:"attr,target-addrs,omitempty"`
 }
 
 func (o RunCreateOptions) valid() error {

--- a/run_test.go
+++ b/run_test.go
@@ -96,13 +96,15 @@ func TestRunsCreate(t *testing.T) {
 
 	t.Run("with additional attributes", func(t *testing.T) {
 		options := RunCreateOptions{
-			Message:   String("yo"),
-			Workspace: wTest,
+			Message:     String("yo"),
+			Workspace:   wTest,
+			TargetAddrs: []string{"null_resource.example"},
 		}
 
 		r, err := client.Runs.Create(ctx, options)
 		require.NoError(t, err)
 		assert.Equal(t, *options.Message, r.Message)
+		assert.Equal(t, options.TargetAddrs, r.TargetAddrs)
 	})
 }
 


### PR DESCRIPTION
Addresses given in this new property will ultimately translate to additional -target arguments when running Terraform CLI remotely in the Terraform Cloud and Enterprise execution environments.

The new attribute this is adding will roll out in Terraform Cloud and Enterprise asynchronously from us merging this, so callers should use the mechanism from #120 to sniff for API minor version v2.3 to detect availability of this feature until it is fully deployed.
