### PR TITLE
Add pull request template + small README fix

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,27 @@
+## Description
+
+_Describe why you're making this change._
+
+## Testing plan
+
+1.  _Describe how to replicate_
+1.  _the conditions_
+1.  _under which your code performs its purpose,_
+1.  _including example code to run where necessary._
+
+## External links
+
+_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
+
+- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
+- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)
+
+## Output from tests
+
+_Please run the tests locally for any files you changes and include the output here._
+
+```
+$ go test
+
+...
+```

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ and token.
 1. `TFE_TOKEN` - A [user API token](https://www.terraform.io/docs/cloud/users-teams-organizations/users.html#api-tokens) for the Terraform Cloud or Terraform Enterprise instance being used for testing.
 
 ##### Optional:
-1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running OAuth client tests.
+1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running any tests that use VCS (OAuth clients, policy sets, etc).
 1. `GITHUB_POLICY_SET_IDENTIFIER` - GitHub policy set repository identifier in the format `username/repository`. Required for running policy set tests.
 
 You can set your environment variables up however you prefer. The following are instructions for setting up environment variables using [envchain](https://github.com/sorah/envchain).


### PR DESCRIPTION
## Description

We don't have a pull request template for this repo yet, so I thought it would be a good idea to add one. 

There was also a small mistake in the README that I fixed. 

## Testing plan

1. This is a documentation change, so just read over the template to make sure it looks right.

## External links

There are no relevant external links but here's what one would look like:
- [GitHub pull request template documentation](https://help.github.com/en/github/building-a-strong-community/creating-a-pull-request-template-for-your-repository)

## Output from tests

This is a documentation only change, so no tests to run, but I've left this so you can see what the template would look like. 

```
$ go test
...
```