### PR TITLE
add new cost estimation status and utility for testing API versions

### DIFF
--- a/cost_estimate.go
+++ b/cost_estimate.go
@@ -33,13 +33,14 @@ type costEstimates struct {
 // CostEstimateStatus represents a costEstimate state.
 type CostEstimateStatus string
 
-//List all available costEstimate statuses.
+// List all available costEstimate statuses.
 const (
-	CostEstimateCanceled CostEstimateStatus = "canceled"
-	CostEstimateErrored  CostEstimateStatus = "errored"
-	CostEstimateFinished CostEstimateStatus = "finished"
-	CostEstimatePending  CostEstimateStatus = "pending"
-	CostEstimateQueued   CostEstimateStatus = "queued"
+	CostEstimateCanceled              CostEstimateStatus = "canceled"
+	CostEstimateErrored               CostEstimateStatus = "errored"
+	CostEstimateFinished              CostEstimateStatus = "finished"
+	CostEstimatePending               CostEstimateStatus = "pending"
+	CostEstimateQueued                CostEstimateStatus = "queued"
+	CostEstimateSkippedDueToTargeting CostEstimateStatus = "skipped_due_to_targeting"
 )
 
 // CostEstimate represents a Terraform Enterprise costEstimate.
@@ -58,11 +59,12 @@ type CostEstimate struct {
 
 // CostEstimateStatusTimestamps holds the timestamps for individual costEstimate statuses.
 type CostEstimateStatusTimestamps struct {
-	CanceledAt time.Time `json:"canceled-at"`
-	ErroredAt  time.Time `json:"errored-at"`
-	FinishedAt time.Time `json:"finished-at"`
-	PendingAt  time.Time `json:"pending-at"`
-	QueuedAt   time.Time `json:"queued-at"`
+	CanceledAt              time.Time `json:"canceled-at"`
+	ErroredAt               time.Time `json:"errored-at"`
+	FinishedAt              time.Time `json:"finished-at"`
+	PendingAt               time.Time `json:"pending-at"`
+	QueuedAt                time.Time `json:"queued-at"`
+	SkippedDueToTargetingAt time.Time `json:"skipped-due-to-targeting-at"`
 }
 
 // Read a costEstimate by its ID.

--- a/tfe.go
+++ b/tfe.go
@@ -259,6 +259,15 @@ func (c *Client) RemoteAPIVersion() string {
 	return c.remoteAPIVersion
 }
 
+// SetFakeRemoteAPIVersion allows setting a given string as the client's remoteAPIVersion,
+// overriding the value pulled from the API header during client initialization.
+//
+// This is intended for use in tests, when you may want to configure your TFE client to
+// return something different than the actual API version in order to test error handling.
+func (c *Client) SetFakeRemoteAPIVersion(fakeAPIVersion string) {
+	c.remoteAPIVersion = fakeAPIVersion
+}
+
 // RetryServerErrors configures the retry HTTP check to also retry
 // unexpected errors or requests that failed with a server error.
 func (c *Client) RetryServerErrors(retry bool) {

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -73,6 +73,12 @@ func TestClient_newClient(t *testing.T) {
 		if want := "34.21.9"; client.RemoteAPIVersion() != want {
 			t.Errorf("unexpected remote API version %q; want %q", client.RemoteAPIVersion(), want)
 		}
+
+		client.SetFakeRemoteAPIVersion("1.0")
+
+		if want := "1.0"; client.RemoteAPIVersion() != want {
+			t.Errorf("unexpected remote API version %q; want %q", client.RemoteAPIVersion(), want)
+		}
 	})
 }
 


### PR DESCRIPTION
## Description

This includes two small changes:

1. Adds a new allowed status for cost estimations, `skipped_due_to_targeting`, for cost estimation checks that have been skipped because the run is using remote targeting.
2. Adds a utility method, `SetFakeRemoteAPIVersion`, to allow other packages using `Client.RemoteAPIVersion` to more easily test their error handling of different API versions.

## External links

- [the original PR which added `Client.RemoteAPIVersion`](https://github.com/hashicorp/go-tfe/pull/120)
- [PR to add remote targeting support to Terraform](https://github.com/hashicorp/terraform/pull/24834)

## Output from tests

Client changes:

```
$ go test -run TestClient -v ./...

=== RUN   TestClient_newClient
=== RUN   TestClient_newClient/uses_env_vars_if_values_are_missing
=== RUN   TestClient_newClient/fails_if_token_is_empty
=== RUN   TestClient_newClient/makes_a_new_client_with_good_settings
--- PASS: TestClient_newClient (0.00s)
    --- PASS: TestClient_newClient/uses_env_vars_if_values_are_missing (0.00s)
    --- PASS: TestClient_newClient/fails_if_token_is_empty (0.00s)
    --- PASS: TestClient_newClient/makes_a_new_client_with_good_settings (0.00s)
=== RUN   TestClient_defaultConfig
=== RUN   TestClient_defaultConfig/with_no_environment_variables
=== RUN   TestClient_defaultConfig/with_environment_variables
--- PASS: TestClient_defaultConfig (0.00s)
    --- PASS: TestClient_defaultConfig/with_no_environment_variables (0.00s)
    --- PASS: TestClient_defaultConfig/with_environment_variables (0.00s)
=== RUN   TestClient_headers
--- PASS: TestClient_headers (0.00s)
=== RUN   TestClient_userAgent
--- PASS: TestClient_userAgent (0.00s)
=== RUN   TestClient_configureLimiter
--- PASS: TestClient_configureLimiter (0.00s)
=== RUN   TestClient_retryHTTPCheck
--- PASS: TestClient_retryHTTPCheck (0.00s)
=== RUN   TestClient_retryHTTPBackoff
--- PASS: TestClient_retryHTTPBackoff (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	2.289s
```

Cost estimate changes:

```
$ go test -run TestCostEstimates -v ./...

=== RUN   TestCostEstimatesRead
=== RUN   TestCostEstimatesRead/when_the_costEstimate_exists
=== RUN   TestCostEstimatesRead/when_the_costEstimate_does_not_exist
=== RUN   TestCostEstimatesRead/with_invalid_costEstimate_ID
--- PASS: TestCostEstimatesRead (48.38s)
    --- PASS: TestCostEstimatesRead/when_the_costEstimate_exists (0.28s)
    --- PASS: TestCostEstimatesRead/when_the_costEstimate_does_not_exist (0.26s)
    --- PASS: TestCostEstimatesRead/with_invalid_costEstimate_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	49.836s
```
