### PR TITLE
Add subscribable workspace relation on notification configurations

### DIFF
--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -81,6 +81,9 @@ type NotificationConfiguration struct {
 	Triggers          []string                    `jsonapi:"attr,triggers"`
 	UpdatedAt         time.Time                   `jsonapi:"attr,updated-at,iso8601"`
 	URL               string                      `jsonapi:"attr,url"`
+
+	// Relations
+	Subscribable *Workspace `jsonapi:"relation,subscribable"`
 }
 
 // DeliveryResponse represents a notification configuration delivery response.


### PR DESCRIPTION
## Description

I'm currently working on [phase one of deprecating  workspace_external_id/workspace_external_ids](https://github.com/terraform-providers/terraform-provider-tfe/pull/182) in the TFE provider. In order to make sure users migrating to the new attributes don't have unnecessary diffs, I need access to the workspace associated with a given notification configuration so that I can set both the new and old attributes on resource read. This PR adds that relation to the notification configuration struct. 

The subscribable relation is polymorphic but currently doesn't include anything that isn't a workspace, so I've opted to implement it here as if it wasn't polymorphic (like I did for the sourceable relation on run triggers previously). This relation will need to be implemented different in the future when we allow other things to have notification configurations.

A number of other resource include these relations in their structs, including run triggers, policy sets, oauth clients, and more. 

## Testing plan

I'm just adding a relation that already gets returned by the API, so nothing to test here. 

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/notification-configurations.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/182)

## Output from tests

```
$ envchain go-tfe go test -run TestNotificationConfiguration -v ./...
=== RUN   TestNotificationConfigurationList
=== RUN   TestNotificationConfigurationList/with_a_valid_workspace
=== RUN   TestNotificationConfigurationList/with_list_options
=== RUN   TestNotificationConfigurationList/without_a_valid_workspace
--- PASS: TestNotificationConfigurationList (2.10s)
    --- SKIP: TestNotificationConfigurationList/with_a_valid_workspace (0.16s)
        notification_configuration_test.go:31: paging not supported yet in API
    --- SKIP: TestNotificationConfigurationList/with_list_options (0.00s)
        notification_configuration_test.go:37: paging not supported yet in API
    --- PASS: TestNotificationConfigurationList/without_a_valid_workspace (0.00s)
=== RUN   TestNotificationConfigurationCreate
=== RUN   TestNotificationConfigurationCreate/with_all_required_values
=== RUN   TestNotificationConfigurationCreate/without_a_required_value
=== RUN   TestNotificationConfigurationCreate/without_a_valid_workspace
--- PASS: TestNotificationConfigurationCreate (1.38s)
    --- PASS: TestNotificationConfigurationCreate/with_all_required_values (0.28s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_valid_workspace (0.00s)
=== RUN   TestNotificationConfigurationRead
=== RUN   TestNotificationConfigurationRead/with_a_valid_ID
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationRead (1.82s)
    --- PASS: TestNotificationConfigurationRead/with_a_valid_ID (0.15s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist (0.11s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationUpdate
=== RUN   TestNotificationConfigurationUpdate/with_options
=== RUN   TestNotificationConfigurationUpdate/without_options
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationUpdate (2.38s)
    --- PASS: TestNotificationConfigurationUpdate/with_options (0.24s)
    --- PASS: TestNotificationConfigurationUpdate/without_options (0.45s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist (0.12s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationDelete
=== RUN   TestNotificationConfigurationDelete/with_a_valid_ID
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationDelete (1.65s)
    --- PASS: TestNotificationConfigurationDelete/with_a_valid_ID (0.22s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist (0.18s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationVerify
=== RUN   TestNotificationConfigurationVerify/with_a_valid_ID
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationVerify (1.86s)
    --- PASS: TestNotificationConfigurationVerify/with_a_valid_ID (0.22s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists (0.11s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     16.818s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
```
