### PR TITLE
Add Custom workspace access support / Team Access updates

### DIFF
--- a/team_access.go
+++ b/team_access.go
@@ -37,12 +37,44 @@ type teamAccesses struct {
 // AccessType represents a team access type.
 type AccessType string
 
-// List all available team access types.
+// RunsPermissionType represents the permissiontype to a workspace's runs.
+type RunsPermissionType string
+
+// VariablesPermissionType represents the permissiontype to a workspace's variables.
+type VariablesPermissionType string
+
+// StateVersionsPermissionType represents the permissiontype to a workspace's state versions.
+type StateVersionsPermissionType string
+
+// SentinelMocksPermissionType represents the permissiontype to a workspace's Sentinel mocks.
+type SentinelMocksPermissionType string
+
+// WorkspaceLockingPermissionType represents the permissiontype to lock or unlock a workspace.
+type WorkspaceLockingPermissionType bool
+
+// List all available team access types and permissions.
 const (
-	AccessAdmin AccessType = "admin"
-	AccessPlan  AccessType = "plan"
-	AccessRead  AccessType = "read"
-	AccessWrite AccessType = "write"
+	AccessAdmin  AccessType = "admin"
+	AccessPlan   AccessType = "plan"
+	AccessRead   AccessType = "read"
+	AccessWrite  AccessType = "write"
+	AccessCustom AccessType = "custom"
+
+	RunsPermissionRead  RunsPermissionType = "read"
+	RunsPermissionPlan  RunsPermissionType = "plan"
+	RunsPermissionApply RunsPermissionType = "apply"
+
+	VariablesPermissionNone  VariablesPermissionType = "none"
+	VariablesPermissionRead  VariablesPermissionType = "read"
+	VariablesPermissionWrite VariablesPermissionType = "write"
+
+	StateVersionsPermissionNone        StateVersionsPermissionType = "none"
+	StateVersionsPermissionReadOutputs StateVersionsPermissionType = "read-outputs"
+	StateVersionsPermissionRead        StateVersionsPermissionType = "read"
+	StateVersionsPermissionWrite       StateVersionsPermissionType = "write"
+
+	SentinelMocksPermissionNone SentinelMocksPermissionType = "none"
+	SentinelMocksPermissionRead SentinelMocksPermissionType = "read"
 )
 
 // TeamAccessList represents a list of team accesses.
@@ -53,8 +85,13 @@ type TeamAccessList struct {
 
 // TeamAccess represents the workspace access for a team.
 type TeamAccess struct {
-	ID     string     `jsonapi:"primary,team-workspaces"`
-	Access AccessType `jsonapi:"attr,access"`
+	ID               string                      `jsonapi:"primary,team-workspaces"`
+	Access           AccessType                  `jsonapi:"attr,access"`
+	Runs             RunsPermissionType          `jsonapi:"attr,runs"`
+	Variables        VariablesPermissionType     `jsonapi:"attr,variables"`
+	StateVersions    StateVersionsPermissionType `jsonapi:"attr,state-versions"`
+	SentinelMocks    SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks"`
+	WorkspaceLocking bool                        `jsonapi:"attr,workspace-locking"`
 
 	// Relations
 	Team      *Team      `jsonapi:"relation,team"`
@@ -104,6 +141,14 @@ type TeamAccessAddOptions struct {
 
 	// The type of access to grant.
 	Access *AccessType `jsonapi:"attr,access"`
+
+	// Custom workspace access permissions. These can only be edited when Access is 'custom'; otherwise, they are
+	// read-only and reflect the Access level's implicit permissions.
+	Runs             *RunsPermissionType          `jsonapi:"attr,runs,omitempty"`
+	Variables        *VariablesPermissionType     `jsonapi:"attr,variables,omitempty"`
+	StateVersions    *StateVersionsPermissionType `jsonapi:"attr,state-versions,omitempty"`
+	SentinelMocks    *SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks,omitempty"`
+	WorkspaceLocking *bool                        `jsonapi:"attr,workspace-locking,omitempty"`
 
 	// The team to add to the workspace
 	Team *Team `jsonapi:"relation,team"`

--- a/team_access_test.go
+++ b/team_access_test.go
@@ -234,6 +234,36 @@ func TestTeamAccessesRead(t *testing.T) {
 	})
 }
 
+func TestTeamAccessesUpdate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
+	defer tmTestCleanup()
+
+	taTest, taTestCleanup := createTeamAccess(t, client, tmTest, wTest, nil)
+	defer taTestCleanup()
+
+	t.Run("with valid attributes", func(t *testing.T) {
+		options := TeamAccessUpdateOptions{
+			Access: Access(AccessCustom),
+			Runs:   RunsPermission(RunsPermissionPlan),
+		}
+
+		ta, err := client.TeamAccess.Update(ctx, taTest.ID, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, ta.Access, AccessCustom)
+		assert.Equal(t, ta.Runs, RunsPermissionPlan)
+	})
+}
+
 func TestTeamAccessesRemove(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()

--- a/team_access_test.go
+++ b/team_access_test.go
@@ -92,6 +92,8 @@ func TestTeamAccessesAdd(t *testing.T) {
 		}
 
 		ta, err := client.TeamAccess.Add(ctx, options)
+		defer client.TeamAccess.Remove(ctx, ta.ID)
+
 		require.NoError(t, err)
 
 		// Get a refreshed view from the API.
@@ -107,7 +109,50 @@ func TestTeamAccessesAdd(t *testing.T) {
 		}
 	})
 
+	t.Run("with valid custom options", func(t *testing.T) {
+		options := TeamAccessAddOptions{
+			Access:        Access(AccessCustom),
+			Runs:          RunsPermission(RunsPermissionRead),
+			StateVersions: StateVersionsPermission(StateVersionsPermissionNone),
+			Team:          tmTest,
+			Workspace:     wTest,
+		}
+
+		ta, err := client.TeamAccess.Add(ctx, options)
+		defer client.TeamAccess.Remove(ctx, ta.ID)
+
+		require.NoError(t, err)
+
+		// Get a refreshed view from the API.
+		refreshed, err := client.TeamAccess.Read(ctx, ta.ID)
+		require.NoError(t, err)
+
+		for _, item := range []*TeamAccess{
+			ta,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, *options.Access, item.Access)
+		}
+	})
+
+	t.Run("with invalid custom options", func(t *testing.T) {
+		options := TeamAccessAddOptions{
+			Access:    Access(AccessRead),
+			Runs:      RunsPermission(RunsPermissionApply),
+			Team:      tmTest,
+			Workspace: wTest,
+		}
+
+		_, err := client.TeamAccess.Add(ctx, options)
+
+		assert.EqualError(t, err, "invalid attribute\n\nRuns is read-only when access level is 'read'; use the 'custom' access level to set this attribute.")
+	})
+
 	t.Run("when the team already has access", func(t *testing.T) {
+		_, taTestCleanup := createTeamAccess(t, client, tmTest, wTest, nil)
+		defer taTestCleanup()
+
 		options := TeamAccessAddOptions{
 			Access:    Access(AccessAdmin),
 			Team:      tmTest,
@@ -158,6 +203,14 @@ func TestTeamAccessesRead(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, AccessAdmin, ta.Access)
+
+		t.Run("permission attributes are decoded", func(t *testing.T) {
+			assert.Equal(t, RunsPermissionApply, ta.Runs)
+			assert.Equal(t, VariablesPermissionWrite, ta.Variables)
+			assert.Equal(t, StateVersionsPermissionWrite, ta.StateVersions)
+			assert.Equal(t, SentinelMocksPermissionRead, ta.SentinelMocks)
+			assert.Equal(t, true, ta.WorkspaceLocking)
+		})
 
 		t.Run("team relationship is decoded", func(t *testing.T) {
 			assert.NotEmpty(t, ta.Team)

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -5,6 +5,26 @@ func Access(v AccessType) *AccessType {
 	return &v
 }
 
+// RunsPermission returns a pointer to the given team runs permission type.
+func RunsPermission(v RunsPermissionType) *RunsPermissionType {
+	return &v
+}
+
+// VariablesPermission returns a pointer to the given team variables permission type.
+func VariablesPermission(v VariablesPermissionType) *VariablesPermissionType {
+	return &v
+}
+
+// StateVersionsPermission returns a pointer to the given team state versions permission type.
+func StateVersionsPermission(v StateVersionsPermissionType) *StateVersionsPermissionType {
+	return &v
+}
+
+// SentinelMocksPermission returns a pointer to the given team Sentinel mocks permission type.
+func SentinelMocksPermission(v SentinelMocksPermissionType) *SentinelMocksPermissionType {
+	return &v
+}
+
 // AuthPolicy returns a pointer to the given authentication poliy.
 func AuthPolicy(v AuthPolicyType) *AuthPolicyType {
 	return &v


### PR DESCRIPTION
## Description

* Adds support for Custom workspace access, a new feature in the [Team Access API](https://www.terraform.io/docs/cloud/api/team-access.html).
* Also adds support for updating Team Access

## Output from tests

```
» go test -v -run 'TestTeamAccesses'
=== RUN   TestTeamAccessesList
=== RUN   TestTeamAccessesList/with_valid_options
=== RUN   TestTeamAccessesList/with_list_options
=== RUN   TestTeamAccessesList/without_list_options
=== RUN   TestTeamAccessesList/without_a_valid_workspace_ID
--- PASS: TestTeamAccessesList (3.22s)
    --- SKIP: TestTeamAccessesList/with_valid_options (0.19s)
        team_access_test.go:38: paging not supported yet in API
    --- SKIP: TestTeamAccessesList/with_list_options (0.00s)
        team_access_test.go:44: paging not supported yet in API
    --- PASS: TestTeamAccessesList/without_list_options (0.00s)
    --- PASS: TestTeamAccessesList/without_a_valid_workspace_ID (0.00s)
=== RUN   TestTeamAccessesAdd
=== RUN   TestTeamAccessesAdd/with_valid_options
=== RUN   TestTeamAccessesAdd/with_valid_custom_options
=== RUN   TestTeamAccessesAdd/with_invalid_custom_options
=== RUN   TestTeamAccessesAdd/when_the_team_already_has_access
=== RUN   TestTeamAccessesAdd/when_options_is_missing_access
=== RUN   TestTeamAccessesAdd/when_options_is_missing_team
=== RUN   TestTeamAccessesAdd/when_options_is_missing_workspace
--- PASS: TestTeamAccessesAdd (3.79s)
    --- PASS: TestTeamAccessesAdd/with_valid_options (0.51s)
    --- PASS: TestTeamAccessesAdd/with_valid_custom_options (0.52s)
    --- PASS: TestTeamAccessesAdd/with_invalid_custom_options (0.23s)
    --- PASS: TestTeamAccessesAdd/when_the_team_already_has_access (1.16s)
    --- PASS: TestTeamAccessesAdd/when_options_is_missing_access (0.00s)
    --- PASS: TestTeamAccessesAdd/when_options_is_missing_team (0.00s)
    --- PASS: TestTeamAccessesAdd/when_options_is_missing_workspace (0.00s)
=== RUN   TestTeamAccessesRead
=== RUN   TestTeamAccessesRead/when_the_team_access_exists
=== RUN   TestTeamAccessesRead/when_the_team_access_exists/permission_attributes_are_decoded
=== RUN   TestTeamAccessesRead/when_the_team_access_exists/team_relationship_is_decoded
=== RUN   TestTeamAccessesRead/when_the_team_access_exists/workspace_relationship_is_decoded
=== RUN   TestTeamAccessesRead/when_the_team_access_does_not_exist
=== RUN   TestTeamAccessesRead/without_a_valid_team_access_ID
--- PASS: TestTeamAccessesRead (2.28s)
    --- PASS: TestTeamAccessesRead/when_the_team_access_exists (0.17s)
        --- PASS: TestTeamAccessesRead/when_the_team_access_exists/permission_attributes_are_decoded (0.00s)
        --- PASS: TestTeamAccessesRead/when_the_team_access_exists/team_relationship_is_decoded (0.00s)
        --- PASS: TestTeamAccessesRead/when_the_team_access_exists/workspace_relationship_is_decoded (0.00s)
    --- PASS: TestTeamAccessesRead/when_the_team_access_does_not_exist (0.17s)
    --- PASS: TestTeamAccessesRead/without_a_valid_team_access_ID (0.00s)
=== RUN   TestTeamAccessesUpdate
=== RUN   TestTeamAccessesUpdate/with_valid_attributes
--- PASS: TestTeamAccessesUpdate (2.91s)
    --- PASS: TestTeamAccessesUpdate/with_valid_attributes (0.18s)
=== RUN   TestTeamAccessesRemove
=== RUN   TestTeamAccessesRemove/with_valid_options
=== RUN   TestTeamAccessesRemove/when_the_team_access_does_not_exist
=== RUN   TestTeamAccessesRemove/when_the_team_access_ID_is_invalid
--- PASS: TestTeamAccessesRemove (2.75s)
    --- PASS: TestTeamAccessesRemove/with_valid_options (0.49s)
    --- PASS: TestTeamAccessesRemove/when_the_team_access_does_not_exist (0.31s)
    --- PASS: TestTeamAccessesRemove/when_the_team_access_ID_is_invalid (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     15.376s
```
