### PR TITLE
Enable GO111MODULES in the tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,8 +17,6 @@ jobs:
     steps:
       - checkout
       
-      - run: go get -v -t -d ./...
-      
       - run:
           name: Make test results directory
           command: mkdir -p $TEST_RESULTS_DIR
@@ -26,6 +24,7 @@ jobs:
       - run:
           name: Run tests
           command: |
+              export GO111MODULE=on
               gotestsum --format short-verbose --junitfile \
               $TEST_RESULTS_DIR/tests.xml -- -timeout=40m
           no_output_timeout: 1800


### PR DESCRIPTION
## Description

The tests were failing because they didn't actually honor our `go.mod` versions and picked up a version of `go-retryablehttp` that used a Go 1.13+ errors tool.

## Testing plan

1.  Tests pass (or at least, they compile enough to fail)