### PR TITLE
Admin runs list (try 2)

### DIFF
--- a/admin_runs.go
+++ b/admin_runs.go
@@ -44,7 +44,7 @@ type AdminRunsListOptions struct {
 
 func (o AdminRunsListOptions) valid() error {
 	if o.RunStatus != nil && *o.RunStatus != "" {
-		validRunStatus := []string{"pending", "plan_queued", "planning", "planned", "confirmed", "apply_queued", "applying", "applied", "discarded", "errored", "canceled", "cost_estimating", "cost_estimated", "policy_checking", "policy_override", "policy_soft_failed", "policy_checked", "planned_and_finished"}
+		validRunStatus := []string{"pending", "plan_queued", "planning", "planned", "confirmed", "apply_queued", "applying", "applied", "discarded", "errored", "canceled", "cost_estimating", "cost_estimated", "policy_checking", "policy_override", "policy_soft_failed", "policy_checked", "planned_and_finished", "force_canceled"}
 		runStatus := strings.Split(*o.RunStatus, ",")
 
 		// iterate over our statuses

--- a/admin_runs.go
+++ b/admin_runs.go
@@ -1,0 +1,125 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminRuns = (*adminRuns)(nil)
+
+// AdminRuns Users Admin API contains endpoints to help site administrators manage
+// user accounts.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/admin runs.html
+type AdminRuns interface {
+	// List all the runs of the given installation.
+	List(ctx context.Context, options AdminRunsListOptions) (*AdminRunsList, error)
+
+	// Force-cancel a run by its ID.
+	ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error
+}
+
+// runs implements Users.
+type adminRuns struct {
+	client *Client
+}
+
+type adminRun struct {
+	ID                     string               `jsonapi:"primary,runs"`
+	Actions                *RunActions          `jsonapi:"attr,actions"`
+	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
+	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
+	HasChanges             bool                 `jsonapi:"attr,has-changes"`
+	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
+	Message                string               `jsonapi:"attr,message"`
+	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
+	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
+	Source                 RunSource            `jsonapi:"attr,source"`
+	Status                 RunStatus            `jsonapi:"attr,status"`
+	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
+
+	// Relations
+	Workspace    *Workspace    `jsonapi:"relation,workspace"`
+	Organization *Organization `jsonapi:"relation,workspace.organization"`
+}
+
+// AdminRunsList represents a list of runs.
+type AdminRunsList struct {
+	*Pagination
+	Items []*Run
+}
+
+// AdminRunsListOptions represents the options for listing runs.
+type AdminRunsListOptions struct {
+	ListOptions
+	RunStatus *string `url:"filter[status]"`
+	Query     *string `url:"q"`
+	Include   string  `url:"include"`
+}
+
+func (o AdminRunsListOptions) valid() error {
+	if *o.RunStatus != "" {
+		validRunStatus := []string{"pending", "plan_queued", "planning", "planned", "confirmed", "apply_queued", "applying", "applied", "discarded", "errored", "canceled", "cost_estimating", "cost_estimated", "policy_checking", "policy_override", "policy_soft_failed", "policy_checked", "planned_and_finished"}
+		runStatus := strings.Split(*o.RunStatus, ",")
+
+		// iterate over our statuses
+		for _, status := range runStatus {
+
+			// start with invalid
+			valid := false
+			for _, s := range validRunStatus {
+				if status == s {
+					// found a match, set to true and continue to the next status
+					valid = true
+					break
+				}
+			}
+
+			if valid == false {
+				return fmt.Errorf("invalid value %s for run status", status)
+			}
+		}
+	}
+	return nil
+}
+
+// List all the runs of the terraform enterprise installation.
+func (s *adminRuns) List(ctx context.Context, options AdminRunsListOptions) (*AdminRunsList, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("admin/runs")
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	rl := &AdminRunsList{}
+	err = s.client.do(ctx, req, rl)
+	if err != nil {
+		return nil, err
+	}
+
+	return rl, nil
+}
+
+// ForceCancel is used to forcefully cancel a run by its ID.
+func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error {
+	if !validStringID(&runID) {
+		return errors.New("invalid value for run ID")
+	}
+
+	u := fmt.Sprintf("admin/runs/%s/actions/force-cancel", url.QueryEscape(runID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/admin_runs.go
+++ b/admin_runs.go
@@ -57,13 +57,13 @@ type AdminRunsList struct {
 // AdminRunsListOptions represents the options for listing runs.
 type AdminRunsListOptions struct {
 	ListOptions
-	RunStatus *string `url:"filter[status]"`
+	RunStatus *string `url:"filter[status],omitempty"` // sending an empty param returns zero results
 	Query     *string `url:"q"`
 	Include   string  `url:"include"`
 }
 
 func (o AdminRunsListOptions) valid() error {
-	if *o.RunStatus != "" {
+	if o.RunStatus != nil && *o.RunStatus != "" {
 		validRunStatus := []string{"pending", "plan_queued", "planning", "planned", "confirmed", "apply_queued", "applying", "applied", "discarded", "errored", "canceled", "cost_estimating", "cost_estimated", "policy_checking", "policy_override", "policy_soft_failed", "policy_checked", "planned_and_finished"}
 		runStatus := strings.Split(*o.RunStatus, ",")
 

--- a/admin_runs.go
+++ b/admin_runs.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/url"
 	"strings"
-	"time"
 )
 
 // Compile-time proof of interface implementation.
@@ -27,25 +26,6 @@ type AdminRuns interface {
 // runs implements Users.
 type adminRuns struct {
 	client *Client
-}
-
-type adminRun struct {
-	ID                     string               `jsonapi:"primary,runs"`
-	Actions                *RunActions          `jsonapi:"attr,actions"`
-	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
-	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
-	HasChanges             bool                 `jsonapi:"attr,has-changes"`
-	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
-	Message                string               `jsonapi:"attr,message"`
-	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
-	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
-	Source                 RunSource            `jsonapi:"attr,source"`
-	Status                 RunStatus            `jsonapi:"attr,status"`
-	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
-
-	// Relations
-	Workspace    *Workspace    `jsonapi:"relation,workspace"`
-	Organization *Organization `jsonapi:"relation,workspace.organization"`
 }
 
 // AdminRunsList represents a list of runs.

--- a/admin_runs_test.go
+++ b/admin_runs_test.go
@@ -1,0 +1,53 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminRunsList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	wTest, wTestCleanup := createWorkspace(t, client, nil)
+	defer wTestCleanup()
+
+	rTest1, _ := createRun(t, client, wTest)
+	rTest2, _ := createRun(t, client, wTest)
+
+	t.Run("without list options", func(t *testing.T) {
+		rl, err := client.AdminRuns.List(ctx, AdminRunsListOptions{})
+		require.NoError(t, err)
+
+		found := []string{}
+		for _, r := range rl.Items {
+			found = append(found, r.ID)
+		}
+
+		assert.Contains(t, found, rTest1.ID)
+		assert.Contains(t, found, rTest2.ID)
+		assert.Equal(t, 1, rl.CurrentPage)
+		assert.Equal(t, 2, rl.TotalCount)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		t.Skip("paging not supported yet in API")
+
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		rl, err := client.AdminRuns.List(ctx, AdminRunsListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, rl.Items)
+		assert.Equal(t, 999, rl.CurrentPage)
+		assert.Equal(t, 2, rl.TotalCount)
+	})
+}

--- a/admin_runs_test.go
+++ b/admin_runs_test.go
@@ -10,6 +10,7 @@ import (
 
 func TestAdminRunsList(t *testing.T) {
 	client := testClient(t)
+
 	ctx := context.Background()
 
 	wTest, wTestCleanup := createWorkspace(t, client, nil)
@@ -30,12 +31,9 @@ func TestAdminRunsList(t *testing.T) {
 		assert.Contains(t, found, rTest1.ID)
 		assert.Contains(t, found, rTest2.ID)
 		assert.Equal(t, 1, rl.CurrentPage)
-		assert.Equal(t, 2, rl.TotalCount)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		t.Skip("paging not supported yet in API")
-
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
@@ -48,6 +46,5 @@ func TestAdminRunsList(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, rl.Items)
 		assert.Equal(t, 999, rl.CurrentPage)
-		assert.Equal(t, 2, rl.TotalCount)
 	})
 }

--- a/tfe.go
+++ b/tfe.go
@@ -132,6 +132,7 @@ type Client struct {
 	Users                      Users
 	Variables                  Variables
 	Workspaces                 Workspaces
+	AdminRuns                  AdminRuns
 }
 
 // NewClient creates a new Terraform Enterprise API client.
@@ -226,6 +227,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Users = &users{client: client}
 	client.Variables = &variables{client: client}
 	client.Workspaces = &workspaces{client: client}
+	client.AdminRuns = &adminRuns{client: client}
 
 	return client, nil
 }


### PR DESCRIPTION
## Description

This is an extension of #115 that fixes a handful of problems. I found that PR to be non-functioning.

All my code is in [this commit](https://github.com/hashicorp/go-tfe/commit/44e052d79b938c0e011a87f365be4d2fca4d2c55) and it fixes a few problems:

1. the code for validating filter statuses failed to check for nil
2. we need to omitempty the filter statuses because otherwise and empty filter status returns no results
3. Stop assuming that the 2 runs created by this test are the only ones return by the api. Otherwise you can't test against a TFE server that is used for anything else, including other test runs.

I also added a small feature to the testClient function that allows you to use insecure TLS. I find this very useful when trying to debug api requests. If desired I can remove that or move it to another PR.

## Testing plan

I verified that my branch is working by running `go test -v ./... -run TestAdminRunsList`.

## External links

- [API documentation](https://github.com/hashicorp/go-tfe/pull/115)
- #115 

## Output from tests

```
$ go test -v ./... -run TestAdminRunsList
=== RUN   TestAdminRunsList
=== RUN   TestAdminRunsList/without_list_options
=== RUN   TestAdminRunsList/with_list_options
--- PASS: TestAdminRunsList (5.28s)
    --- PASS: TestAdminRunsList/without_list_options (0.22s)
    --- PASS: TestAdminRunsList/with_list_options (0.34s)
PASS
ok  	github.com/hashicorp/go-tfe	5.614s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]


```