### PR TITLE
[DRAFT] Add support for destination type of email to notification configurations

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -90,25 +90,29 @@ func createUploadedConfigurationVersion(t *testing.T, client *Client, w *Workspa
 	return cv, cvCleanup
 }
 
-func createNotificationConfiguration(t *testing.T, client *Client, w *Workspace) (*NotificationConfiguration, func()) {
+func createNotificationConfiguration(t *testing.T, client *Client, w *Workspace, options *NotificationConfigurationCreateOptions) (*NotificationConfiguration, func()) {
 	var wCleanup func()
 
 	if w == nil {
 		w, wCleanup = createWorkspace(t, client, nil)
 	}
 
-	ctx := context.Background()
-	nc, err := client.NotificationConfigurations.Create(
-		ctx,
-		w.ID,
-		NotificationConfigurationCreateOptions{
+	if options == nil {
+		options = &NotificationConfigurationCreateOptions{
 			DestinationType: NotificationDestination(NotificationDestinationTypeGeneric),
 			Enabled:         Bool(false),
 			Name:            String(randomString(t)),
 			Token:           String(randomString(t)),
 			URL:             String("http://example.com"),
 			Triggers:        []string{NotificationTriggerCreated},
-		},
+		}
+	}
+
+	ctx := context.Background()
+	nc, err := client.NotificationConfigurations.Create(
+		ctx,
+		w.ID,
+		*options,
 	)
 	if err != nil {
 		t.Fatal(err)

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -58,8 +58,9 @@ type NotificationDestinationType string
 
 // List of available notification destination types.
 const (
-	NotificationDestinationTypeSlack   NotificationDestinationType = "slack"
+	NotificationDestinationTypeEmail   NotificationDestinationType = "email"
 	NotificationDestinationTypeGeneric NotificationDestinationType = "generic"
+	NotificationDestinationTypeSlack   NotificationDestinationType = "slack"
 )
 
 // NotificationConfigurationList represents a list of Notification
@@ -80,10 +81,14 @@ type NotificationConfiguration struct {
 	Token             string                      `jsonapi:"attr,token"`
 	Triggers          []string                    `jsonapi:"attr,triggers"`
 	UpdatedAt         time.Time                   `jsonapi:"attr,updated-at,iso8601"`
-	URL               string                      `jsonapi:"attr,url"`
+	URL               string                      `jsonapi:"attr,url,omitempty"`
+
+	// EmailAddresses is only available for TFE users. It is not available in TFC.
+	EmailAddresses []string `jsonapi:"attr,email-addresses,omitempty"`
 
 	// Relations
 	Subscribable *Workspace `jsonapi:"relation,subscribable"`
+	EmailUsers   []*User    `jsonapi:"relation,users,omitempty"`
 }
 
 // DeliveryResponse represents a notification configuration delivery response.
@@ -141,11 +146,18 @@ type NotificationConfigurationCreateOptions struct {
 	// The token of the notification configuration
 	Token *string `jsonapi:"attr,token,omitempty"`
 
-	// The destination type of the notification configuration
+	// The list of run events that will trigger notifications.
 	Triggers []string `jsonapi:"attr,triggers,omitempty"`
 
 	// The url of the notification configuration
-	URL *string `jsonapi:"attr,url"`
+	URL *string `jsonapi:"attr,url,omitempty"`
+
+	// The list of email addresses that will receive notification emails.
+	// EmailAddresses is only available for TFE users. It is not available in TFC.
+	EmailAddresses []string `jsonapi:"attr,email-addresses,omitempty"`
+
+	// The list of users belonging to the organization that will receive notification emails.
+	EmailUsers []*User `jsonapi:"relation,users,omitempty"`
 }
 
 func (o NotificationConfigurationCreateOptions) valid() error {
@@ -158,8 +170,11 @@ func (o NotificationConfigurationCreateOptions) valid() error {
 	if !validString(o.Name) {
 		return errors.New("name is required")
 	}
-	if !validString(o.URL) {
-		return errors.New("url is required")
+
+	if *o.DestinationType == NotificationDestinationTypeGeneric || *o.DestinationType == NotificationDestinationTypeSlack {
+		if o.URL == nil {
+			return errors.New("url is required")
+		}
 	}
 	return nil
 }
@@ -191,7 +206,7 @@ func (s *notificationConfigurations) Create(ctx context.Context, workspaceID str
 	return nc, nil
 }
 
-// Read a notitification configuration by its ID.
+// Read a notification configuration by its ID.
 func (s *notificationConfigurations) Read(ctx context.Context, notificationConfigurationID string) (*NotificationConfiguration, error) {
 	if !validStringID(&notificationConfigurationID) {
 		return nil, errors.New("invalid value for notification configuration ID")
@@ -227,11 +242,18 @@ type NotificationConfigurationUpdateOptions struct {
 	// The token of the notification configuration
 	Token *string `jsonapi:"attr,token,omitempty"`
 
-	// The destination type of the notification configuration
+	// The list of run events that will trigger notifications.
 	Triggers []string `jsonapi:"attr,triggers,omitempty"`
 
 	// The url of the notification configuration
 	URL *string `jsonapi:"attr,url,omitempty"`
+
+	// The list of email addresses that will receive notification emails.
+	// EmailAddresses is only available for TFE users. It is not available in TFC.
+	EmailAddresses []string `jsonapi:"attr,email-addresses,omitempty"`
+
+	// The list of users belonging to the organization that will receive notification emails.
+	EmailUsers []*User `jsonapi:"relation,users,omitempty"`
 }
 
 // Updates a notification configuration with the given options.


### PR DESCRIPTION
## Description

This PR adds support for the `email` destination type to notification configurations. 

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example code to run where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

## Output from tests

```
$ envchain go-tfe go test -run TestNotificationConfiguration -v ./...
=== RUN   TestNotificationConfigurationList
=== RUN   TestNotificationConfigurationList/with_a_valid_workspace
=== RUN   TestNotificationConfigurationList/with_list_options
=== RUN   TestNotificationConfigurationList/without_a_valid_workspace
--- PASS: TestNotificationConfigurationList (1.86s)
    --- SKIP: TestNotificationConfigurationList/with_a_valid_workspace (0.16s)
        notification_configuration_test.go:31: paging not supported yet in API
    --- SKIP: TestNotificationConfigurationList/with_list_options (0.00s)
        notification_configuration_test.go:37: paging not supported yet in API
    --- PASS: TestNotificationConfigurationList/without_a_valid_workspace (0.00s)
=== RUN   TestNotificationConfigurationCreate
=== RUN   TestNotificationConfigurationCreate/with_all_required_values
=== RUN   TestNotificationConfigurationCreate/without_a_required_value
=== RUN   TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_generic
=== RUN   TestNotificationConfigurationCreate/without_a_valid_workspace
=== RUN   TestNotificationConfigurationCreate/with_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationCreate/without_email_users_when_destination_type_is_email
--- PASS: TestNotificationConfigurationCreate (2.01s)
    --- PASS: TestNotificationConfigurationCreate/with_all_required_values (0.15s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_generic (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_valid_workspace (0.00s)
    --- PASS: TestNotificationConfigurationCreate/with_email_users_when_destination_type_is_email (0.18s)
    --- PASS: TestNotificationConfigurationCreate/without_email_users_when_destination_type_is_email (0.21s)
=== RUN   TestNotificationConfigurationRead
=== RUN   TestNotificationConfigurationRead/with_a_valid_ID
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationRead (1.76s)
    --- PASS: TestNotificationConfigurationRead/with_a_valid_ID (0.12s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist (0.11s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationUpdate
=== RUN   TestNotificationConfigurationUpdate/with_options
=== RUN   TestNotificationConfigurationUpdate/with_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationUpdate/without_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationUpdate/without_options
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationUpdate (3.76s)
    --- PASS: TestNotificationConfigurationUpdate/with_options (0.34s)
    --- PASS: TestNotificationConfigurationUpdate/with_email_users_when_destination_type_is_email (0.30s)
    --- PASS: TestNotificationConfigurationUpdate/without_email_users_when_destination_type_is_email (0.19s)
    --- PASS: TestNotificationConfigurationUpdate/without_options (0.22s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist (0.11s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationDelete
=== RUN   TestNotificationConfigurationDelete/with_a_valid_ID
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationDelete (1.86s)
    --- PASS: TestNotificationConfigurationDelete/with_a_valid_ID (0.27s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist (0.19s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationVerify
=== RUN   TestNotificationConfigurationVerify/with_a_valid_ID
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationVerify (2.03s)
    --- PASS: TestNotificationConfigurationVerify/with_a_valid_ID (0.21s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists (0.10s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
```
