### PR TITLE
Allow setting run comment

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -440,11 +440,18 @@ func (c *Client) newRequest(method, path string, v interface{}) (*retryablehttp.
 		reqHeaders.Set("Content-Type", "application/vnd.api+json")
 
 		if v != nil {
-			modelValue := reflect.ValueOf(v).Elem()
+
+			var modelType reflect.Type
+			if reflect.TypeOf(v).Kind() == reflect.Slice {
+				modelType = reflect.TypeOf(v).Elem().Elem()
+			} else {
+				modelType = reflect.ValueOf(v).Elem().Type()
+			}
+
 			jsonApiFields := 0
 			jsonFields := 0
-			for i := 0; i < modelValue.NumField(); i++ {
-				structField := modelValue.Type().Field(i)
+			for i := 0; i < modelType.NumField(); i++ {
+				structField := modelType.Field(i)
 				if structField.Tag.Get("jsonapi") != "" {
 					jsonApiFields++
 				}

--- a/tfe.go
+++ b/tfe.go
@@ -440,14 +440,25 @@ func (c *Client) newRequest(method, path string, v interface{}) (*retryablehttp.
 		reqHeaders.Set("Content-Type", "application/vnd.api+json")
 
 		if v != nil {
-
+			// The body can be a slice of pointers or a pointer. In either
+			// case we want to choose the serialization type based on the
+			// individual record type. To determine that type, we need
+			// to either follow the pointer or examine the slice element type.
+			// There are other theoretical possiblities (e. g. maps,
+			// non-pointers) but they wouldn't work anyway because the
+			// json-api library doesn't support serializing other things.
 			var modelType reflect.Type
 			if reflect.TypeOf(v).Kind() == reflect.Slice {
 				modelType = reflect.TypeOf(v).Elem().Elem()
+				// TODO: return an error if the element type isn't a pointer
 			} else {
+				// TODO: return an error for everything other than a slice
+				// or a pointer
 				modelType = reflect.ValueOf(v).Elem().Type()
 			}
 
+			// Infer whether the request uses jsonapi or regular json
+			// serialization based on how the fields are tagged.
 			jsonApiFields := 0
 			jsonFields := 0
 			for i := 0; i < modelType.NumField(); i++ {
@@ -460,6 +471,10 @@ func (c *Client) newRequest(method, path string, v interface{}) (*retryablehttp.
 				}
 			}
 			if jsonApiFields > 0 && jsonFields > 0 {
+				// Defining a struct with both json and jsonapi tags doesn't
+				// make sense, because a struct can only be serialized
+				// as one or another. If this does happen, it's a bug
+				// in the library that should be fixed at development time
 				return nil, errors.New("go-tfe bug: struct can't use both json and jsonapi attributes")
 			}
 

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -324,6 +324,37 @@ func TestClient_requestBodySerialization(t *testing.T) {
 		}
 	})
 
+	t.Run("non-pointer request", func(t *testing.T) {
+		body := InvalidBody{}
+		_, _, err := createRequest(body)
+		if err == nil || err.Error() != "go-tfe bug: DELETE/PATCH/POST body must be nil, ptr, or ptr slice" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("slice of non-pointer request", func(t *testing.T) {
+		body := []InvalidBody{{}}
+		_, _, err := createRequest(body)
+		if err == nil || err.Error() != "go-tfe bug: DELETE/PATCH/POST body must be nil, ptr, or ptr slice" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("map request", func(t *testing.T) {
+		body := make(map[string]string)
+		_, _, err := createRequest(body)
+		if err == nil || err.Error() != "go-tfe bug: DELETE/PATCH/POST body must be nil, ptr, or ptr slice" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("string request", func(t *testing.T) {
+		body := "foo"
+		_, _, err := createRequest(body)
+		if err == nil || err.Error() != "go-tfe bug: DELETE/PATCH/POST body must be nil, ptr, or ptr slice" {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	})
 }
 
 func createRequest(v interface{}) (*retryablehttp.Request, []byte, error) {


### PR DESCRIPTION
## Description

Almost every TFE API endpoint uses [jsonapi](https://jsonapi.org/), but a handful of endpoints expect plain JSON objects. Previously, requests to those endpoints would fail because the request would be formatted as a jsonapi request, and the endpoint expected a plain JSON object.

This change extends the request logic to inspect the tags of the request body object. If the fields are tagged with `jsonapi`, it uses the existing logic. Otherwise, it serializes the request body as a plain JSOn object.

## Testing plan

1. Ensure that applying/discarding runs with a comment works and the comment appears
1. Ensure that locking a workspace with a comment works and the comment appears
