### PR TITLE
Add SpeculativeEnabled attribute to workspace

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -189,9 +189,9 @@ type WorkspaceCreateOptions struct {
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
 
 	// Whether this workspace allows speculative plans. Setting this to false
-	// prevents Terraform Cloud from running plans on pull requests, which can
-	// improve security if the VCS repository is public or includes untrusted
-	// contributors.
+	// prevents Terraform Cloud or the Terraform Enterprise instance from
+	// running plans on pull requests, which can improve security if the VCS
+	// repository is public or includes untrusted contributors.
 	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace. Upon creating a
@@ -336,9 +336,9 @@ type WorkspaceUpdateOptions struct {
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
 
 	// Whether this workspace allows speculative plans. Setting this to false
-	// prevents Terraform Cloud from running plans on pull requests, which can
-	// improve security if the VCS repository is public or includes untrusted
-	// contributors.
+	// prevents Terraform Cloud or the Terraform Enterprise instance from
+	// running plans on pull requests, which can improve security if the VCS
+	// repository is public or includes untrusted contributors.
 	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace.

--- a/workspace.go
+++ b/workspace.go
@@ -88,6 +88,7 @@ type Workspace struct {
 	Operations           bool                  `jsonapi:"attr,operations"`
 	Permissions          *WorkspacePermissions `jsonapi:"attr,permissions"`
 	QueueAllRuns         bool                  `jsonapi:"attr,queue-all-runs"`
+	SpeculativeEnabled   bool                  `jsonapi:"attr,speculative-enabled"`
 	TerraformVersion     string                `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes      []string              `jsonapi:"attr,trigger-prefixes"`
 	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`
@@ -186,6 +187,12 @@ type WorkspaceCreateOptions struct {
 	// Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
+
+	// Whether this workspace allows speculative plans. Setting this to false
+	// prevents Terraform Cloud from running plans on pull requests, which can
+	// improve security if the VCS repository is public or includes untrusted
+	// contributors.
+	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace. Upon creating a
 	// workspace, the latest version is selected unless otherwise specified.
@@ -327,6 +334,12 @@ type WorkspaceUpdateOptions struct {
 	// Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
+
+	// Whether this workspace allows speculative plans. Setting this to false
+	// prevents Terraform Cloud from running plans on pull requests, which can
+	// improve security if the VCS repository is public or includes untrusted
+	// contributors.
+	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace.
 	TerraformVersion *string `jsonapi:"attr,terraform-version,omitempty"`

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -91,6 +91,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			FileTriggersEnabled: Bool(true),
 			Operations:          Bool(true),
 			QueueAllRuns:        Bool(true),
+			SpeculativeEnabled:  Bool(true),
 			TerraformVersion:    String("0.11.0"),
 			TriggerPrefixes:     []string{"/modules", "/shared"},
 			WorkingDirectory:    String("bar/"),
@@ -113,6 +114,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
+			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
@@ -280,6 +282,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			FileTriggersEnabled: Bool(true),
 			Operations:          Bool(false),
 			QueueAllRuns:        Bool(false),
+			SpeculativeEnabled:  Bool(true),
 			TerraformVersion:    String("0.11.1"),
 			TriggerPrefixes:     []string{"/modules", "/shared"},
 			WorkingDirectory:    String("baz/"),
@@ -301,6 +304,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
+			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
@@ -363,6 +367,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 			FileTriggersEnabled: Bool(true),
 			Operations:          Bool(false),
 			QueueAllRuns:        Bool(false),
+			SpeculativeEnabled:  Bool(true),
 			TerraformVersion:    String("0.11.1"),
 			TriggerPrefixes:     []string{"/modules", "/shared"},
 			WorkingDirectory:    String("baz/"),
@@ -384,6 +389,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
+			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)


### PR DESCRIPTION
## Description

This change allows to read and set the `SpeculativeEnabled` property on workspaces. I would like to add support for that property to [terraform-provider-tfe](https://github.com/terraform-providers/terraform-provider-tfe), and adding it here is the first step.

Fixes #133

## Testing plan

The tests have been updated to test this in the same way that `FileTriggersEnabled` is tested.
`FileTriggersEnabled` also defaults to `true` during workspace creation and is thus quite comparable.

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/workspaces.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/210)

## Output from tests

```
$ go test -run TestWorkspaces -v ./...
=== RUN   TestWorkspacesList
=== RUN   TestWorkspacesList/without_list_options
=== RUN   TestWorkspacesList/with_list_options
=== RUN   TestWorkspacesList/when_searching_a_known_workspace
=== RUN   TestWorkspacesList/when_searching_an_unknown_workspace
=== RUN   TestWorkspacesList/without_a_valid_organization
--- PASS: TestWorkspacesList (3.11s)
    --- PASS: TestWorkspacesList/without_list_options (0.17s)
    --- PASS: TestWorkspacesList/with_list_options (0.48s)
    --- PASS: TestWorkspacesList/when_searching_a_known_workspace (0.19s)
    --- PASS: TestWorkspacesList/when_searching_an_unknown_workspace (0.63s)
    --- PASS: TestWorkspacesList/without_a_valid_organization (0.00s)
=== RUN   TestWorkspacesCreate
=== RUN   TestWorkspacesCreate/with_valid_options
=== RUN   TestWorkspacesCreate/when_options_is_missing_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_organization
=== RUN   TestWorkspacesCreate/when_an_error_is_returned_from_the_api
--- PASS: TestWorkspacesCreate (0.98s)
    --- PASS: TestWorkspacesCreate/with_valid_options (0.29s)
    --- PASS: TestWorkspacesCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_organization (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_error_is_returned_from_the_api (0.12s)
=== RUN   TestWorkspacesRead
=== RUN   TestWorkspacesRead/when_the_workspace_exists
=== RUN   TestWorkspacesRead/when_the_workspace_exists/permissions_are_properly_decoded
=== RUN   TestWorkspacesRead/when_the_workspace_exists/relationships_are_properly_decoded
=== RUN   TestWorkspacesRead/when_the_workspace_exists/timestamps_are_properly_decoded
=== RUN   TestWorkspacesRead/when_the_workspace_does_not_exist
=== RUN   TestWorkspacesRead/when_the_organization_does_not_exist
=== RUN   TestWorkspacesRead/without_a_valid_organization
=== RUN   TestWorkspacesRead/without_a_valid_workspace
--- PASS: TestWorkspacesRead (1.90s)
    --- PASS: TestWorkspacesRead/when_the_workspace_exists (0.13s)
        --- PASS: TestWorkspacesRead/when_the_workspace_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesRead/when_the_workspace_exists/relationships_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesRead/when_the_workspace_exists/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestWorkspacesRead/when_the_workspace_does_not_exist (0.13s)
    --- PASS: TestWorkspacesRead/when_the_organization_does_not_exist (0.42s)
    --- PASS: TestWorkspacesRead/without_a_valid_organization (0.00s)
    --- PASS: TestWorkspacesRead/without_a_valid_workspace (0.00s)
=== RUN   TestWorkspacesReadByID
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists/permissions_are_properly_decoded
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists/relationships_are_properly_decoded
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists/timestamps_are_properly_decoded
=== RUN   TestWorkspacesReadByID/when_the_workspace_does_not_exist
=== RUN   TestWorkspacesReadByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesReadByID (1.45s)
    --- PASS: TestWorkspacesReadByID/when_the_workspace_exists (0.14s)
        --- PASS: TestWorkspacesReadByID/when_the_workspace_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesReadByID/when_the_workspace_exists/relationships_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesReadByID/when_the_workspace_exists/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestWorkspacesReadByID/when_the_workspace_does_not_exist (0.12s)
    --- PASS: TestWorkspacesReadByID/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesUpdate
=== RUN   TestWorkspacesUpdate/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdate/with_valid_options
=== RUN   TestWorkspacesUpdate/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_organization
--- PASS: TestWorkspacesUpdate (1.34s)
    --- PASS: TestWorkspacesUpdate/when_updating_a_subset_of_values (0.16s)
    --- PASS: TestWorkspacesUpdate/with_valid_options (0.30s)
    --- PASS: TestWorkspacesUpdate/when_an_error_is_returned_from_the_api (0.12s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestWorkspacesUpdateByID
=== RUN   TestWorkspacesUpdateByID/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdateByID/with_valid_options
=== RUN   TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdateByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUpdateByID (1.52s)
    --- PASS: TestWorkspacesUpdateByID/when_updating_a_subset_of_values (0.19s)
    --- PASS: TestWorkspacesUpdateByID/with_valid_options (0.35s)
    --- PASS: TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api (0.14s)
    --- PASS: TestWorkspacesUpdateByID/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesDelete
=== RUN   TestWorkspacesDelete/with_valid_options
=== RUN   TestWorkspacesDelete/when_organization_is_invalid
=== RUN   TestWorkspacesDelete/when_workspace_is_invalid
--- PASS: TestWorkspacesDelete (1.46s)
    --- PASS: TestWorkspacesDelete/with_valid_options (0.63s)
    --- PASS: TestWorkspacesDelete/when_organization_is_invalid (0.00s)
    --- PASS: TestWorkspacesDelete/when_workspace_is_invalid (0.00s)
=== RUN   TestWorkspacesDeleteByID
=== RUN   TestWorkspacesDeleteByID/with_valid_options
=== RUN   TestWorkspacesDeleteByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesDeleteByID (1.44s)
    --- PASS: TestWorkspacesDeleteByID/with_valid_options (0.62s)
    --- PASS: TestWorkspacesDeleteByID/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesRemoveVCSConnection
    TestWorkspacesRemoveVCSConnection: helper_test.go:269: Export a valid GITHUB_TOKEN before running this test!
--- SKIP: TestWorkspacesRemoveVCSConnection (0.58s)
=== RUN   TestWorkspacesRemoveVCSConnectionByID
    TestWorkspacesRemoveVCSConnectionByID: helper_test.go:269: Export a valid GITHUB_TOKEN before running this test!
--- SKIP: TestWorkspacesRemoveVCSConnectionByID (0.55s)
=== RUN   TestWorkspacesLock
=== RUN   TestWorkspacesLock/with_valid_options
=== RUN   TestWorkspacesLock/when_workspace_is_already_locked
=== RUN   TestWorkspacesLock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesLock (1.09s)
    --- PASS: TestWorkspacesLock/with_valid_options (0.18s)
    --- PASS: TestWorkspacesLock/when_workspace_is_already_locked (0.12s)
    --- PASS: TestWorkspacesLock/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesUnlock
=== RUN   TestWorkspacesUnlock/with_valid_options
=== RUN   TestWorkspacesUnlock/when_workspace_is_already_unlocked
=== RUN   TestWorkspacesUnlock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUnlock (1.21s)
    --- PASS: TestWorkspacesUnlock/with_valid_options (0.16s)
    --- PASS: TestWorkspacesUnlock/when_workspace_is_already_unlocked (0.14s)
    --- PASS: TestWorkspacesUnlock/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesForceUnlock
=== RUN   TestWorkspacesForceUnlock/with_valid_options
=== RUN   TestWorkspacesForceUnlock/when_workspace_is_already_unlocked
=== RUN   TestWorkspacesForceUnlock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesForceUnlock (1.20s)
    --- PASS: TestWorkspacesForceUnlock/with_valid_options (0.16s)
    --- PASS: TestWorkspacesForceUnlock/when_workspace_is_already_unlocked (0.13s)
    --- PASS: TestWorkspacesForceUnlock/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesAssignSSHKey
=== RUN   TestWorkspacesAssignSSHKey/with_valid_options
=== RUN   TestWorkspacesAssignSSHKey/without_an_SSH_key_ID
=== RUN   TestWorkspacesAssignSSHKey/without_a_valid_SSH_key_ID
=== RUN   TestWorkspacesAssignSSHKey/without_a_valid_workspace_ID
--- PASS: TestWorkspacesAssignSSHKey (1.33s)
    --- PASS: TestWorkspacesAssignSSHKey/with_valid_options (0.18s)
    --- PASS: TestWorkspacesAssignSSHKey/without_an_SSH_key_ID (0.00s)
    --- PASS: TestWorkspacesAssignSSHKey/without_a_valid_SSH_key_ID (0.00s)
    --- PASS: TestWorkspacesAssignSSHKey/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesUnassignSSHKey
=== RUN   TestWorkspacesUnassignSSHKey/with_valid_options
=== RUN   TestWorkspacesUnassignSSHKey/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUnassignSSHKey (1.51s)
    --- PASS: TestWorkspacesUnassignSSHKey/with_valid_options (0.17s)
    --- PASS: TestWorkspacesUnassignSSHKey/without_a_valid_workspace_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	20.777s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
```