### PR TITLE
Add ID to struct to maintain consistency with the module registry API

### DIFF
--- a/registry_module.go
+++ b/registry_module.go
@@ -227,6 +227,8 @@ func (r *registryModules) CreateVersion(ctx context.Context, organization string
 
 // RegistryModuleCreateWithVCSConnectionOptions is used when creating a registry module with a VCS repo
 type RegistryModuleCreateWithVCSConnectionOptions struct {
+        ID string `jsonapi:"primary,registry-modules"`
+
 	// VCS repository information
 	VCSRepo *RegistryModuleVCSRepoOptions `jsonapi:"attr,vcs-repo"`
 }
@@ -262,6 +264,9 @@ func (r *registryModules) CreateWithVCSConnection(ctx context.Context, options R
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
+
+        // Make sure we don't send a user provided ID.
+        options.ID = ""
 
 	req, err := r.client.newRequest("POST", "registry-modules", &options)
 	if err != nil {


### PR DESCRIPTION
## Description

Adds the appropriate value of `"type": "registry-modules"` that is required by the module registry API (linked below).

## Testing plan

1.  Create a TF config with the following setup
    
    ```
    terraform {
      required_providers {
        tfe = {
          source = "hashicorp/tfe"
          version = "0.21.0"
        }
      }
    }

    resource "tfe_registry_module" "null_test" {
      vcs_repo {
        display_identifier = "org/repo"
        identifier = "org/repo"
        oauth_token_id = var.oauth_token_id
      }
    }
    ```

1. Set an environment variable of `TF_LOG=TRACE`.
1. Queue a run and note that the API call that is made does not include the required value for `data.type`:

   ```
   {
     "data": {
       "type": "",
       "attributes": {
         "vcs-repo": {
           "identifier": "justinretzolk/terraform-null-test",
           "oauth-token-id": "ot-XXXXXXXXXXX",
           "display-identifier": "justinretzolk/terraform-null-test"
         }
       }
     }
   }
   ```

1. Build the `tfe` provider with the changes in this PR.
1. Reinit as needed and re-run the same test.
1. Note that the API call now has the appropriate value for `data.type`:

   ```
   {
     "data": {
       "type": "registry-modules",
       "attributes": {
         "vcs-repo": {
           "identifier": "justinretzolk/terraform-null-test",
           "oauth-token-id": "ot-XXXXXXXXXXX",
           "display-identifier": "justinretzolk/terraform-null-test"
         }
       }
     }
   }
   ```

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/modules.html#publish-a-module-from-a-vcs)

*Note:* Credit to @sudomateo for helping with the code spelunking and additional guidance. 
