### PR TITLE
Add support for the IP Ranges API

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Currently the following endpoints are supported:
 - [x] [Applies](https://www.terraform.io/docs/cloud/api/applies.html)
 - [x] [Configuration Versions](https://www.terraform.io/docs/cloud/api/configuration-versions.html)
 - [x] [Cost Estimates](https://www.terraform.io/docs/cloud/api/cost-estimates.html)
-- [ ] [IP Ranges](https://www.terraform.io/docs/cloud/api/ip-ranges.html)
+- [x] [IP Ranges](https://www.terraform.io/docs/cloud/api/ip-ranges.html)
 - [x] [Notification Configurations](https://www.terraform.io/docs/cloud/api/notification-configurations.html)
 - [x] [OAuth Clients](https://www.terraform.io/docs/cloud/api/oauth-clients.html)
 - [x] [OAuth Tokens](https://www.terraform.io/docs/cloud/api/oauth-tokens.html)

--- a/ip_ranges.go
+++ b/ip_ranges.go
@@ -1,0 +1,96 @@
+package tfe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+// Compile-time proof of interface implementation.
+var _ IPRanges = (*ipRanges)(nil)
+
+// IP Ranges provides a list of Terraform Cloud and Enterprise's IP ranges.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/ip-ranges.html
+type IPRanges interface {
+	// Retrieve TFC IP ranges. If `modifiedSince` is not an empty string
+	// then it will only return the IP ranges changes since that date.
+	// The format for `modifiedSince` can be found here:
+	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
+	Read(ctx context.Context, modifiedSince string) (*IPRange, error)
+}
+
+type ipRanges struct {
+	client *Client
+}
+
+type IPRange struct {
+	// List of IP ranges in CIDR notation used for connections from user site to Terraform Cloud APIs
+	API []string `json:"api"`
+	// List of IP ranges in CIDR notation used for notifications
+	Notifications []string `json:"notifications"`
+	// List of IP ranges in CIDR notation used for outbound requests from Sentinel policies
+	Sentinel []string `json:"sentinel"`
+	// List of IP ranges in CIDR notation used for connecting to VCS providers
+	VCS []string `json:"vcs"`
+}
+
+func (i *ipRanges) Read(ctx context.Context, modifiedSince string) (*IPRange, error) {
+	i.client.baseURL.Path = "/api/"
+	req, err := i.client.newRequest("GET", "meta/ip-ranges", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if modifiedSince != "" {
+		req.Header.Add("If-Modified-Since", modifiedSince)
+	}
+
+	ir := &IPRange{}
+	err = i.customDo(ctx, req, ir)
+	if err != nil {
+		return nil, err
+	}
+
+	return ir, nil
+}
+
+// The IP ranges API is not returning jsonapi like every other endpoint
+// which means we need to handle it differently.
+func (i *ipRanges) customDo(ctx context.Context, req *retryablehttp.Request, ir *IPRange) error {
+	// Wait will block until the limiter can obtain a new token
+	// or returns an error if the given context is canceled.
+	if err := i.client.limiter.Wait(ctx); err != nil {
+		return err
+	}
+
+	// Add the context to the request.
+	req = req.WithContext(ctx)
+
+	// Execute the request and check the response.
+	resp, err := i.client.http.Do(req)
+	if err != nil {
+		// If we got an error, and the context has been canceled,
+		// the context's error is probably more useful.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 && resp.StatusCode >= 400 {
+		return fmt.Errorf("Error HTTP response while retrieving IP ranges: %d", resp.StatusCode)
+	} else if resp.StatusCode == 304 {
+		return nil
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(ir)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/ip_ranges_test.go
+++ b/ip_ranges_test.go
@@ -1,0 +1,34 @@
+package tfe
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
+)
+
+func TestIPRangesRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("without modifiedSince", func(t *testing.T) {
+		r, err := client.IPRanges.Read(ctx, "")
+		require.NoError(t, err)
+		assert.NotEmpty(t, r.API)
+		assert.NotEmpty(t, r.Notifications)
+		assert.NotEmpty(t, r.Sentinel)
+		assert.NotEmpty(t, r.VCS)
+	})
+
+	t.Run("with future modifiedSince", func(t *testing.T) {
+		ts := time.Now().Add(48 * time.Hour)
+		modifiedSince := ts.Format("Mon, 02 Jan 2006 00:00:00 GMT")
+		r, err := client.IPRanges.Read(ctx, modifiedSince)
+		require.NoError(t, err)
+		assert.Empty(t, r.API)
+		assert.Empty(t, r.Notifications)
+		assert.Empty(t, r.Sentinel)
+		assert.Empty(t, r.VCS)
+	})
+}

--- a/state_outputs.go
+++ b/state_outputs.go
@@ -1,0 +1,52 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ StateOutputs = (*stateOutputs)(nil)
+
+//State version outputs are the output values from a Terraform state file.
+//They include the name and value of the output, as well as a sensitive boolean
+//if the value should be hidden by default in UIs.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/state-version-outputs.html
+type StateOutputs interface {
+	Read(ctx context.Context, outputID string) (*StateOutput, error)
+}
+
+type stateOutputs struct {
+	client *Client
+}
+
+type StateOutput struct {
+	ID        string `jsonapi:"primary,state-version-outputs"`
+	Name      string `jsonapi:"attr,name"`
+	Sensitive bool   `jsonapi:"attr,sensitive"`
+	Type      string `jsonapi:"attr,type"`
+	Value     string `jsonapi:"attr,value"`
+}
+
+func (s *stateOutputs) Read(ctx context.Context, outputID string) (*StateOutput, error) {
+	if !validStringID(&outputID) {
+		return nil, errors.New("invalid value for run ID")
+	}
+
+	u := fmt.Sprintf("state-version-outputs/%s", url.QueryEscape(outputID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	so := &StateOutput{}
+	err = s.client.do(ctx, req, so)
+	if err != nil {
+		return nil, err
+	}
+
+	return so, nil
+}

--- a/state_outputs_test.go
+++ b/state_outputs_test.go
@@ -1,0 +1,42 @@
+package tfe
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestStateOutputsRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	wTest1, wTest1Cleanup := createWorkspace(t, client, nil)
+	defer wTest1Cleanup()
+
+	_, svTestCleanup := createStateVersion(t, client, 0, wTest1)
+	defer svTestCleanup()
+
+	sv, err := client.StateVersions.Current(ctx, wTest1.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output := sv.Outputs[0]
+
+	t.Run("when a state output exists", func(t *testing.T) {
+		so, err := client.StateOutputs.Read(ctx, output.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, so.ID, output.ID)
+		assert.Equal(t, so.Name, output.Name)
+		assert.Equal(t, so.Value, output.Value)
+	})
+
+	t.Run("when a state output does not exist", func(t *testing.T) {
+		so, err := client.StateOutputs.Read(ctx, "wsout-J2zM24JPAAAAAAAA")
+		assert.Nil(t, so)
+		assert.Equal(t, ErrResourceNotFound, err)
+	})
+
+}

--- a/state_version.go
+++ b/state_version.go
@@ -55,7 +55,8 @@ type StateVersion struct {
 	VCSCommitURL string    `jsonapi:"attr,vcs-commit-url"`
 
 	// Relations
-	Run *Run `jsonapi:"relation,run"`
+	Run     *Run           `jsonapi:"relation,run"`
+	Outputs []*StateOutput `jsonapi:"relation,outputs"`
 }
 
 // StateVersionListOptions represents the options for listing state versions.
@@ -166,7 +167,7 @@ func (s *stateVersions) Read(ctx context.Context, svID string) (*StateVersion, e
 		return nil, errors.New("invalid value for state version ID")
 	}
 
-	u := fmt.Sprintf("state-versions/%s", url.QueryEscape(svID))
+	u := fmt.Sprintf("state-versions/%s?include=outputs", url.QueryEscape(svID))
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -187,7 +188,7 @@ func (s *stateVersions) Current(ctx context.Context, workspaceID string) (*State
 		return nil, errors.New("invalid value for workspace ID")
 	}
 
-	u := fmt.Sprintf("workspaces/%s/current-state-version", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/current-state-version?include=outputs", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/state_version_test.go
+++ b/state_version_test.go
@@ -43,6 +43,14 @@ func TestStateVersionsList(t *testing.T) {
 			sv.DownloadURL = ""
 		}
 
+		// outputs are populated only once the state has been parsed by TFC
+		// which can cause the tests to fail if it doesn't happen fast enough.
+		for idx, _ := range svl.Items {
+			svl.Items[idx].Outputs = nil
+		}
+		svTest1.Outputs = nil
+		svTest2.Outputs = nil
+
 		assert.Contains(t, svl.Items, svTest1)
 		assert.Contains(t, svl.Items, svTest2)
 		assert.Equal(t, 1, svl.CurrentPage)
@@ -263,6 +271,11 @@ func TestStateVersionsRead(t *testing.T) {
 		// again during the GET.
 		svTest.DownloadURL, sv.DownloadURL = "", ""
 
+		// outputs are populated only once the state has been parsed by TFC
+		// which can cause the tests to fail if it doesn't happen fast enough.
+		svTest.Outputs = nil
+		sv.Outputs = nil
+
 		assert.Equal(t, svTest, sv)
 	})
 
@@ -300,6 +313,11 @@ func TestStateVersionsCurrent(t *testing.T) {
 		// in this test - once at creation of the configuration version, and
 		// again during the GET.
 		svTest.DownloadURL, sv.DownloadURL = "", ""
+
+		// outputs are populated only once the state has been parsed by TFC
+		// which can cause the tests to fail if it doesn't happen fast enough.
+		svTest.Outputs = nil
+		sv.Outputs = nil
 
 		assert.Equal(t, svTest, sv)
 	})

--- a/test-fixtures/state-version/terraform.tfstate
+++ b/test-fixtures/state-version/terraform.tfstate
@@ -1,31 +1,29 @@
 {
-    "version": 3,
-    "terraform_version": "0.11.8",
-    "serial": 1,
-    "lineage": "741c4949-60b9-5bb1-5bf8-b14f4bb14af3",
-    "modules": [
+  "version": 4,
+  "terraform_version": "0.12.29",
+  "serial": 2,
+  "lineage": "b2b54b23-e7ea-5500-7b15-fcb68c1d92bb",
+  "outputs": {
+    "test_output": {
+      "value": "9023256633839603543",
+      "type": "string"
+    }
+  },
+  "resources": [
+    {
+      "mode": "managed",
+      "type": "null_resource",
+      "name": "test",
+      "provider": "provider.null",
+      "instances": [
         {
-            "path": [
-                "root"
-            ],
-            "outputs": {},
-            "resources": {
-                "null_resource.test": {
-                    "type": "null_resource",
-                    "depends_on": [],
-                    "primary": {
-                        "id": "8959853686594715514",
-                        "attributes": {
-                            "id": "8959853686594715514"
-                        },
-                        "meta": {},
-                        "tainted": false
-                    },
-                    "deposed": [],
-                    "provider": "provider.null"
-                }
-            },
-            "depends_on": []
+          "schema_version": 0,
+          "attributes": {
+            "id": "9023256633839603543",
+            "triggers": null
+          }
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/tfe.go
+++ b/tfe.go
@@ -111,6 +111,7 @@ type Client struct {
 	Applies                    Applies
 	ConfigurationVersions      ConfigurationVersions
 	CostEstimates              CostEstimates
+	IPRanges                   IPRanges
 	NotificationConfigurations NotificationConfigurations
 	OAuthClients               OAuthClients
 	OAuthTokens                OAuthTokens
@@ -214,6 +215,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Applies = &applies{client: client}
 	client.ConfigurationVersions = &configurationVersions{client: client}
 	client.CostEstimates = &costEstimates{client: client}
+	client.IPRanges = &ipRanges{client: client}
 	client.NotificationConfigurations = &notificationConfigurations{client: client}
 	client.OAuthClients = &oAuthClients{client: client}
 	client.OAuthTokens = &oAuthTokens{client: client}

--- a/tfe.go
+++ b/tfe.go
@@ -127,6 +127,7 @@ type Client struct {
 	Runs                       Runs
 	RunTriggers                RunTriggers
 	SSHKeys                    SSHKeys
+	StateOutputs               StateOutputs
 	StateVersions              StateVersions
 	Teams                      Teams
 	TeamAccess                 TeamAccesses
@@ -229,6 +230,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Runs = &runs{client: client}
 	client.RunTriggers = &runTriggers{client: client}
 	client.SSHKeys = &sshKeys{client: client}
+	client.StateOutputs = &stateOutputs{client: client}
 	client.StateVersions = &stateVersions{client: client}
 	client.Teams = &teams{client: client}
 	client.TeamAccess = &teamAccesses{client: client}


### PR DESCRIPTION
test output:

```
❯ go test ./... -v -run TestIPRangesRead
=== RUN   TestIPRangesRead
=== RUN   TestIPRangesRead/without_modifiedSince
=== RUN   TestIPRangesRead/with_future_modifiedSince
--- PASS: TestIPRangesRead (2.79s)
    --- PASS: TestIPRangesRead/without_modifiedSince (0.24s)
    --- PASS: TestIPRangesRead/with_future_modifiedSince (0.26s)
PASS
ok      github.com/hashicorp/go-tfe     3.025s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
```