### PR TITLE
add Include to WorkspacesListOptions

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -134,6 +134,9 @@ type WorkspaceListOptions struct {
 
 	// A search string (partial workspace name) used to filter the results.
 	Search *string `url:"search[name],omitempty"`
+
+	// A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
+	Include *string `url:"include"`
 }
 
 // List all the workspaces within an organization.

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -75,6 +75,18 @@ func TestWorkspacesList(t *testing.T) {
 		assert.Nil(t, wl)
 		assert.EqualError(t, err, "invalid value for organization")
 	})
+
+	t.Run("with organization included", func(t *testing.T) {
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+			Include: String("organization"),
+		})
+
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, wl.Items)
+		assert.NotNil(t, wl.Items[0].Organization)
+		assert.NotEmpty(t, wl.Items[0].Organization.Email)
+	})
 }
 
 func TestWorkspacesCreate(t *testing.T) {


### PR DESCRIPTION
## Description

The api for listing workspaces allows including related resources, but there was no way to make use of it via this library.

## Testing plan

1. new test case written

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources)

## Output from tests

```
$ go test -run TestWorkspacesList ./...
ok  	github.com/hashicorp/go-tfe	2.601s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
```

