### PR TITLE
[Internal only] Switch to docker mirror

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ test_results_dir: &test_results_dir /tmp/test_results
 jobs:
   run-tests:
     docker:
-      - image: circleci/golang:1.12.1
+      - image: docker.mirror.hashicorp.services/circleci/golang:1.12.1
         environment:
           TEST_RESULTS_DIR: *test_results_dir
 


### PR DESCRIPTION
## Description

Instead of using dockerhub (which will enforce rate limiting on anonymous image pulls starting Nov 1st), we're moving projects to our mirror at `docker.mirror.hashicorp.services`. LMK if you have any q's, otherwise feel free to approve and merge on your own! 
## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

## Output from tests

_Please run the tests locally for any files you changes and include the output here._

```
$ go test

...
```
