### PR TITLE
Add policy set version

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -4,22 +4,24 @@
 
 If you are planning to run the full suite of tests or work on policy sets or registry modules, you'll need to set up repositories for them in GitHub.
 
-Your policy set repository will need the following: 
+Your policy set repository will need the following:
 1. A policy set stored in a subdirectory `policy-sets/foo`
 1. A branch other than master named `policies`
 
 Your registry module repository will need to be a [valid module](https://www.terraform.io/docs/cloud/registry/publish.html#preparing-a-module-repository).
-It will need the following: 
+It will need the following:
 1. To be named `terraform-<PROVIDER>-<NAME>`
 1. At least one valid SemVer tag in the format `x.y.z`
-[terraform-random-module](ttps://github.com/caseylang/terraform-random-module) is a good example repo. 
-   
+[terraform-random-module](ttps://github.com/caseylang/terraform-random-module) is a good example repo.
+
 ### 2. Set up environment variables
 
 ##### Required:
 Tests are run against an actual backend so they require a valid backend address and token.
 1. `TFE_ADDRESS` - URL of a Terraform Cloud or Terraform Enterprise instance to be used for testing, including scheme. Example: `https://tfe.local`
 1. `TFE_TOKEN` - A [user API token](https://www.terraform.io/docs/cloud/users-teams-organizations/users.html#api-tokens) for the Terraform Cloud or Terraform Enterprise instance being used for testing.
+
+Note that many tests create organizations. However, in Terraform Cloud these organizations will have the "Free" pricing plan that does not support creation of features such as Sentinel policy sets and cost estimates. If you want to run tests that use those paid features, please use a Terraform Enterprise server instead of Terraform Cloud.
 
 ##### Optional:
 1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running any tests that use VCS (OAuth clients, policy sets, etc).
@@ -34,16 +36,15 @@ You can set your environment variables up however you prefer. The following are 
       envchain --set YOUR_NAMESPACE_HERE ENVIRONMENT_VARIABLE_HERE
       ```
       **OR**
-    
+
       Set all of the environment variables at once with the following command:
       ```sh
       envchain --set YOUR_NAMESPACE_HERE TFE_ADDRESS TFE_TOKEN GITHUB_TOKEN GITHUB_POLICY_SET_IDENTIFIER
       ```
 
-### 3. Make sure run queue settings are correct
+### 3. (Optional) Make sure cost estimates are enabled on your Terraform Enterprise server if you want to test runs with cost estimates.
 
-In order for the tests relating to queuing and capacity to pass, FRQ (fair run queuing) should be
-enabled with a limit of 2 concurrent runs per organization on the Terraform Cloud or Terraform Enterprise instance you are using for testing.
+If you want to run the tests in cost_estimate_test.go on a Terraform Enterprise server, please enable cost estimates on the Site Administration > Cost Estimation page of the TFE UI. See https://www.terraform.io/docs/enterprise/admin/integration.html#cost-estimation-integration.
 
 ### 4. Run the tests
 
@@ -73,4 +74,3 @@ $ envchain YOUR_NAMESPACE_HERE go test -run TestNotificationConfiguration -v ./.
 ```sh
 $ go test -run TestNotificationConfiguration -v ./...
 ```   
-

--- a/examples/policysets/README.md
+++ b/examples/policysets/README.md
@@ -1,0 +1,23 @@
+# Policy Sets Example
+This example illustrates how to create a Sentinel policy set and a policy set version. It also shows how to upload a policy set containing a policy set definition file and an actual policy to the upload URL of the policy set version. These files are loaded from this [directory](../../test-fixtures/policy-set-version).
+
+## Installation
+Run `go install .`
+
+## Running
+Export the `TFE_ADDRESS`, `TFE_TOKEN`, and `TFE_ORGANIZATION` environment variables. Be sure to specify an organization that has a pricing plan that supports Sentinel policy sets.
+
+Then run `$GOPATH/bin/policysets`.
+
+You should see output like this:
+```
+2020/11/09 10:35:46 The policy set ID is:polset-vqzQART8KsoW3Yjq
+2020/11/09 10:35:46 The policy set version Type is: policy-set-versions
+2020/11/09 10:35:46 The policy set version ID is: polsetver-yjV8gjDNAZm7JJyN
+2020/11/09 10:35:46 The linked policy set ID is: polset-vqzQART8KsoW3Yjq
+2020/11/09 10:35:46 The upload link is:https://tfe.hashidemos.io/_archivist/v1/object/dmF1bHQ6djE6bHoyN2RUTFFSVEFSOFhUT0l1UElQUmZLN20wTENxWVRIcUdNMXRxNzhKTDJnWCtPcjVhWFdTRS8wSE9jdTYxWTArejlXOEhXY1J1bWVkclp6bUdwVW1wTkRXUEJyU0VpMVllZ1ozVHQ5cmgveFhMS25BT09vcC9wcy9MVWRCQjI1SXcrZUNtUmdQRU9Oc0JsWm9MN2ZqSmhpU2FMbng0UWI2NU1nYloreTBiclJpdmlJMzJYckNmU2NwRXNIQVB6VGs4WFMwWWY5NS9vYjlJcUZXUklpa0F6alRlZTl3bkd4b1VDRnpqSElhQkZvWE5tNmFYaFh5NXpGM095ckFockk3d2w2TldWWHRaMzFTdXE5b0xJUzkrUA
+2020/11/09 10:35:46 The upload status is: pending
+2020/11/09 10:35:46 The upload URL is:https://tfe.hashidemos.io/_archivist/v1/object/dmF1bHQ6djE6bHoyN2RUTFFSVEFSOFhUT0l1UElQUmZLN20wTENxWVRIcUdNMXRxNzhKTDJnWCtPcjVhWFdTRS8wSE9jdTYxWTArejlXOEhXY1J1bWVkclp6bUdwVW1wTkRXUEJyU0VpMVllZ1ozVHQ5cmgveFhMS25BT09vcC9wcy9MVWRCQjI1SXcrZUNtUmdQRU9Oc0JsWm9MN2ZqSmhpU2FMbng0UWI2NU1nYloreTBiclJpdmlJMzJYckNmU2NwRXNIQVB6VGs4WFMwWWY5NS9vYjlJcUZXUklpa0F6alRlZTl3bkd4b1VDRnpqSElhQkZvWE5tNmFYaFh5NXpGM095ckFockk3d2w2TldWWHRaMzFTdXE5b0xJUzkrUA
+2020/11/09 10:35:46 The upload status is: ready
+2020/11/09 10:35:46 Successfully deleted policy set polset-vqzQART8KsoW3Yjq
+```

--- a/examples/policysets/main.go
+++ b/examples/policysets/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"log"
+	"os"
 	"time"
 
 	tfe "github.com/hashicorp/go-tfe"
@@ -10,7 +11,8 @@ import (
 
 func main() {
 	config := &tfe.Config{
-		Token: "insert-your-token-here",
+		Address:    os.Getenv("TFE_ADDRESS"),
+		Token:      os.Getenv("TFE_TOKEN"),
 	}
 
 	client, err := tfe.NewClient(config)
@@ -22,7 +24,7 @@ func main() {
 	ctx := context.Background()
 
 	// Create a new policy set
-	ps, err := client.PolicySets.Create(ctx, "org-name", tfe.PolicySetCreateOptions{
+	ps, err := client.PolicySets.Create(ctx, os.Getenv("TFE_ORGANIZATION"), tfe.PolicySetCreateOptions{
 		Name: tfe.String("my-policy-set-tst"),
 	})
 	if err != nil {

--- a/examples/policysets/main.go
+++ b/examples/policysets/main.go
@@ -1,0 +1,79 @@
+package main
+
+import (
+	"context"
+	"log"
+	"time"
+
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+func main() {
+	config := &tfe.Config{
+		Token: "insert-your-token-here",
+	}
+
+	client, err := tfe.NewClient(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a context
+	ctx := context.Background()
+
+	// Create a new policy set
+	ps, err := client.PolicySets.Create(ctx, "org-name", tfe.PolicySetCreateOptions{
+		Name: tfe.String("my-policy-set-tst"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		log.Print("The policy set ID is:", ps.ID, "\n")
+	}
+
+	// Create a policy set version
+	psv, err := client.PolicySetVersions.Create(ctx, ps.ID, tfe.PolicySetVersionCreateOptions{})
+	if err != nil {
+		log.Println("Failed creating policy set version")
+		log.Fatal(err)
+	} else {
+		log.Print("The policy set version ID is:", psv.ID, "\n")
+		log.Print("The linked policy set ID is:", psv.PolicySet.ID, "\n")
+	}
+
+	// Upload a policy set version tar ball
+	uploadLink := ""
+	for k, v := range *psv.Links {
+		if k == "upload" {
+			uploadLink = v.(string)
+		}
+	}
+
+	// Log upload URL
+	log.Print("The upload URL is:", uploadLink, "\n")
+
+	// Upload a policy set to the upload link
+	err = client.PolicySetVersions.Upload(ctx, uploadLink, "../../test-fixtures/policy-set-version")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Try to read the policy set version
+	for i := 0; ; i++ {
+		psv, err = client.PolicySetVersions.Read(ctx, psv.ID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		if psv.Status == tfe.PolicySetVersionUploaded {
+			break
+		}
+
+		if i > 10 {
+			log.Fatal("Timeout waiting for the policy set version to be uploaded")
+		}
+
+		time.Sleep(1 * time.Second)
+	}
+
+}

--- a/examples/policysets/main.go
+++ b/examples/policysets/main.go
@@ -37,17 +37,15 @@ func main() {
 		log.Println("Failed creating policy set version")
 		log.Fatal(err)
 	} else {
-		log.Print("The policy set version ID is:", psv.ID, "\n")
-		log.Print("The linked policy set ID is:", psv.PolicySet.ID, "\n")
+		log.Print("The policy set version Type is: ", psv.Data.Type, "\n")
+		log.Print("The policy set version ID is: ", psv.Data.ID, "\n")
+		log.Print("The linked policy set ID is: ", psv.Data.Relationships.PolicySet.Data.ID, "\n")
+		log.Print("The upload link is:", psv.Data.Links.Upload, "\n")
+		log.Print("The upload status is: ", psv.Data.Attributes.Status)
 	}
 
-	// Upload a policy set version tar ball
-	uploadLink := ""
-	for k, v := range *psv.Links {
-		if k == "upload" {
-			uploadLink = v.(string)
-		}
-	}
+	// Get the upload Link
+	uploadLink := psv.Data.Links.Upload
 
 	// Log upload URL
 	log.Print("The upload URL is:", uploadLink, "\n")
@@ -60,12 +58,14 @@ func main() {
 
 	// Try to read the policy set version
 	for i := 0; ; i++ {
-		psv, err = client.PolicySetVersions.Read(ctx, psv.ID)
+		psv, err = client.PolicySetVersions.Read(ctx, psv.Data.ID)
 		if err != nil {
 			log.Fatal(err)
+		} else {
+			log.Print("The upload status is: ", psv.Data.Attributes.Status)
 		}
 
-		if psv.Status == tfe.PolicySetVersionUploaded {
+		if psv.Data.Attributes.Status == tfe.PolicySetVersionReady {
 			break
 		}
 

--- a/examples/policysets/main.go
+++ b/examples/policysets/main.go
@@ -78,4 +78,12 @@ func main() {
 		time.Sleep(1 * time.Second)
 	}
 
+	// Delete the policy set
+	// Note that there is no API to delete policy set versions
+	err = client.PolicySets.Delete(ctx, ps.ID)
+	if err != nil {
+		log.Fatal(err)
+	} else {
+		log.Println("Successfully deleted policy set", ps.ID)
+	}
 }

--- a/helper_test.go
+++ b/helper_test.go
@@ -175,7 +175,7 @@ func createPolicySetVersion(t *testing.T, client *Client, ps *PolicySet) (*Polic
 	}
 
 	return psv, func() {
-		// There currently isn't a way to delete a state, so we
+		// There currently isn't a way to delete a policy set version, so we
 		// can only cleanup by deleting the policy set.
 		if psCleanup != nil {
 			psCleanup()
@@ -188,12 +188,7 @@ func createUploadedPolicySetVersion(t *testing.T, client *Client, ps *PolicySet)
 
 	ctx := context.Background()
 
-	uploadLink := ""
-	for k, v := range *(psv.Links) {
-		if k == "upload" {
-			uploadLink = v.(string)
-		}
-	}
+	uploadLink := psv.Data.Links.Upload
 
 	err := client.PolicySetVersions.Upload(ctx, uploadLink, "test-fixtures/policy-set-version")
 	if err != nil {
@@ -202,13 +197,13 @@ func createUploadedPolicySetVersion(t *testing.T, client *Client, ps *PolicySet)
 	}
 
 	for i := 0; ; i++ {
-		psv, err = client.PolicySetVersions.Read(ctx, psv.ID)
+		psv, err = client.PolicySetVersions.Read(ctx, psv.Data.ID)
 		if err != nil {
 			psvCleanup()
 			t.Fatal(err)
 		}
 
-		if psv.Status == PolicySetVersionUploaded {
+		if psv.Data.Attributes.Status == PolicySetVersionReady {
 			break
 		}
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -910,6 +910,9 @@ func createWorkspace(t *testing.T, client *Client, org *Organization) (*Workspac
 	}
 
 	return w, func() {
+		// Sleep to avoid error caused by deleting workspace too quickly
+		time.Sleep(1 * time.Second)
+
 		if err := client.Workspaces.Delete(ctx, org.Name, w.Name); err != nil {
 			t.Errorf("Error destroying workspace! WARNING: Dangling resources\n"+
 				"may exist! The full error is shown below.\n\n"+

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -47,7 +47,7 @@ type PolicySetVersionStatus string
 const (
 	PolicySetVersionErrored  PolicySetVersionStatus = "errored"
 	PolicySetVersionPending  PolicySetVersionStatus = "pending"
-	PolicySetVersionReady PolicySetVersionStatus = "ready"
+	PolicySetVersionReady    PolicySetVersionStatus = "ready"
 )
 
 // PolicySetVersionSource represents a source of a policy set version.
@@ -71,7 +71,7 @@ type PolicySetVersionData struct {
 	ID               string                 `json:"id"`
 	Attributes       *PSVAttributes         `json:"attributes"`
 	Relationships    *PSVRelationships      `json:"relationships"`
-	Links            *PSVLinks            `json:"links"`
+	Links            *PSVLinks              `json:"links"`
 }
 
 type PSVAttributes struct {

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	slug "github.com/hashicorp/go-slug"
-	jsonapi "github.com/svanharmelen/jsonapi"
 )
 
 // Compile-time proof of interface implementation.
@@ -48,7 +47,7 @@ type PolicySetVersionStatus string
 const (
 	PolicySetVersionErrored  PolicySetVersionStatus = "errored"
 	PolicySetVersionPending  PolicySetVersionStatus = "pending"
-	PolicySetVersionUploaded PolicySetVersionStatus = "uploaded"
+	PolicySetVersionReady PolicySetVersionStatus = "ready"
 )
 
 // PolicySetVersionSource represents a source of a policy set version.
@@ -63,23 +62,43 @@ const (
 	PolicySetVersionSourceTerraform PolicySetVersionSource = "terraform"
 )
 
-// PolicySetVersion is a representation of an uploaded policy set
-// in TFE for non-VCS-backed policy sets. A  policy set must have at
-// least one policy set version before it can be used.
 type PolicySetVersion struct {
-	ID               string                 `jsonapi:"primary,policy-set-versions"`
-	Source           PolicySetVersionSource `jsonapi:"attr,source"`
-	Status           PolicySetVersionStatus `jsonapi:"attr,status"`
-	StatusTimestamps *PSVStatusTimestamps   `jsonapi:"attr,status-timestamps"`
-	Error            string                 `jsonapi:"attr,error"`
-	CreatedAt        time.Time              `jsonapi:"attr,created-at,iso8601"`
-	UpdatedAt        time.Time              `jsonapi:"attr,updated-at,iso8601"`
+	Data             *PolicySetVersionData  `json:"data"`
+}
 
-	// Relations
-	PolicySet        *PolicySet             `jsonapi:"relation,policy-set"`
+type PolicySetVersionData struct {
+	Type             string                 `json:"type"`
+	ID               string                 `json:"id"`
+	Attributes       *PSVAttributes         `json:"attributes"`
+	Relationships    *PSVRelationships      `json:"relationships"`
+	Links            *PSVLinks            `json:"links"`
+}
 
-	// Links
-	Links            *jsonapi.Links         `json:"links,omitempty"`
+type PSVAttributes struct {
+	Source           PolicySetVersionSource `json:"source"`
+	Status           PolicySetVersionStatus `json:"status"`
+	StatusTimestamps *PSVStatusTimestamps   `json:"status-timestamps"`
+	Error            string                 `json:"error"`
+	CreatedAt        time.Time              `json:"created-at"`
+	UpdatedAt        time.Time              `json:"updated-at"`
+}
+
+type PSVRelationships struct {
+	PolicySet *PolicySetRelationship `json:"policy-set"`
+}
+
+type PolicySetRelationship struct {
+	Data *PolicySetData     `json:"data"`
+}
+
+type PolicySetData struct {
+	Type string  `json:"type"`
+	ID   string  `json:"id"`
+}
+
+type PSVLinks struct {
+	Self   string `json:"self"`
+	Upload string `json:"upload"`
 }
 
 // PSVStatusTimestamps holds the timestamps for individual policy set version

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -1,0 +1,171 @@
+package tfe
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"os"
+	"time"
+
+	slug "github.com/hashicorp/go-slug"
+	jsonapi "github.com/svanharmelen/jsonapi"
+)
+
+// Compile-time proof of interface implementation.
+var _ PolicySetVersions = (*policySetVersions)(nil)
+
+// PolicySetVersions describes all the policy set version related
+// methods that the Terraform Enterprise API supports.
+//
+// TFE API docs:
+// https://www.terraform.io/docs/enterprise/api/policy-sets.html
+type PolicySetVersions interface {
+
+	// Create is used to create a new policy set version. The created
+	// policy set version will be usable once data is uploaded to it.
+	Create(ctx context.Context, policySetID string, options PolicySetVersionCreateOptions) (*PolicySetVersion, error)
+
+	// Read a policy set version by its ID.
+	Read(ctx context.Context, psvID string) (*PolicySetVersion, error)
+
+	// Upload package with Sentinel policies and modules. It requires
+	// the upload URL from a policy set version and the full path to the
+	// policy set files on disk.
+	Upload(ctx context.Context, url string, path string) error
+}
+
+// policySetVersions implements PolicySetVersions.
+type policySetVersions struct {
+	client *Client
+}
+
+// PolicySetVersionStatus represents a policy set version status.
+type PolicySetVersionStatus string
+
+//List all available policy set version statuses.
+const (
+	PolicySetVersionErrored  PolicySetVersionStatus = "errored"
+	PolicySetVersionPending  PolicySetVersionStatus = "pending"
+	PolicySetVersionUploaded PolicySetVersionStatus = "uploaded"
+)
+
+// PolicySetVersionSource represents a source of a policy set version.
+type PolicySetVersionSource string
+
+// List all available policy set version sources.
+const (
+	PolicySetVersionSourceAPI       PolicySetVersionSource = "tfe-api"
+	PolicySetVersionSourceBitbucket PolicySetVersionSource = "bitbucket"
+	PolicySetVersionSourceGithub    PolicySetVersionSource = "github"
+	PolicySetVersionSourceGitlab    PolicySetVersionSource = "gitlab"
+	PolicySetVersionSourceTerraform PolicySetVersionSource = "terraform"
+)
+
+// PolicySetVersion is a representation of an uploaded policy set
+// in TFE for non-VCS-backed policy sets. A  policy set must have at
+// least one policy set version before it can be used.
+type PolicySetVersion struct {
+	ID               string                 `jsonapi:"primary,policy-set-versions"`
+	Source           PolicySetVersionSource `jsonapi:"attr,source"`
+	Status           PolicySetVersionStatus `jsonapi:"attr,status"`
+	StatusTimestamps *PSVStatusTimestamps   `jsonapi:"attr,status-timestamps"`
+	Error            string                 `jsonapi:"attr,error"`
+	CreatedAt        time.Time              `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt        time.Time              `jsonapi:"attr,updated-at,iso8601"`
+
+	// Relations
+	PolicySet        *PolicySet             `jsonapi:"relation,policy-set"`
+
+	// Links
+	Links            *jsonapi.Links         `json:"links,omitempty"`
+}
+
+// PSVStatusTimestamps holds the timestamps for individual policy set version
+// statuses.
+type PSVStatusTimestamps struct {
+	ReadyAt    time.Time `json:"ready-at"`
+	PendingAt  time.Time `json:"pending-at"`
+	ErroredAt  time.Time `json:"errored-at"`
+}
+
+// PolicySetVersionCreateOptions represents the options for creating a
+// policy set version.
+type PolicySetVersionCreateOptions struct {
+	// For internal use only!
+	ID string `jsonapi:"primary,policy-set-versions"`
+}
+
+// Create is used to create a new policy set version. The created
+// policy set version will be usable once data is uploaded to it.
+func (s *policySetVersions) Create(ctx context.Context, policySetID string, options PolicySetVersionCreateOptions) (*PolicySetVersion, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("invalid value for policy set ID")
+	}
+
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
+
+	u := fmt.Sprintf("policy-sets/%s/versions", url.QueryEscape(policySetID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	psv := &PolicySetVersion{}
+	err = s.client.do(ctx, req, psv)
+	if err != nil {
+		return nil, err
+	}
+
+	return psv, nil
+}
+
+// Read a policy set version by its ID.
+func (s *policySetVersions) Read(ctx context.Context, psvID string) (*PolicySetVersion, error) {
+	if !validStringID(&psvID) {
+		return nil, errors.New("invalid value for policy set version ID")
+	}
+
+	u := fmt.Sprintf("policy-set-versions/%s", url.QueryEscape(psvID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	psv := &PolicySetVersion{}
+	err = s.client.do(ctx, req, psv)
+	if err != nil {
+		return nil, err
+	}
+
+	return psv, nil
+}
+
+// Upload package with Sentinel policies and modules. It requires the
+// upload URL from a policy set version and the full path to the policy set
+// files on disk.
+func (s *policySetVersions) Upload(ctx context.Context, url, path string) error {
+	file, err := os.Stat(path)
+	if err != nil {
+		return err
+	}
+	if !file.Mode().IsDir() {
+		return errors.New("path needs to be an existing directory")
+	}
+
+	body := bytes.NewBuffer(nil)
+
+	_, err = slug.Pack(path, body, true)
+	if err != nil {
+		return err
+	}
+
+	req, err := s.client.newRequest("PUT", url, body)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/policy_set_version_test.go
+++ b/policy_set_version_test.go
@@ -24,24 +24,19 @@ func TestPolicySetVersionsCreate(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get a refreshed view of the policy set version.
-		refreshed, err := client.PolicySetVersions.Read(ctx, psv.ID)
+		refreshed, err := client.PolicySetVersions.Read(ctx, psv.Data.ID)
 		require.NoError(t, err)
 
 		for _, item := range []*PolicySetVersion{
 			psv,
 			refreshed,
 		} {
-			assert.NotEmpty(t, item.ID)
-			assert.Empty(t, item.Error)
-			assert.Equal(t, item.Source, PolicySetVersionSourceAPI)
-			assert.Equal(t, item.Status, PolicySetVersionPending)
+			assert.NotEmpty(t, item.Data.ID)
+			assert.Empty(t, item.Data.Attributes.Error)
+			assert.Equal(t, item.Data.Attributes.Source, PolicySetVersionSourceAPI)
+			assert.Equal(t, item.Data.Attributes.Status, PolicySetVersionPending)
 
-			uploadLink := ""
-			for k, v := range *(item.Links) {
-				if k == "upload" {
-					uploadLink = v.(string)
-				}
-			}
+			uploadLink := item.Data.Links.Upload
 			assert.NotEmpty(t, uploadLink)
 		}
 	})
@@ -62,7 +57,7 @@ func TestPolicySetVersionsRead(t *testing.T) {
 	defer psvTestCleanup()
 
 	t.Run("when the policy set version exists", func(t *testing.T) {
-		psv, err := client.PolicySetVersions.Read(ctx, psvTest.ID)
+		psv, err := client.PolicySetVersions.Read(ctx, psvTest.Data.ID)
 		require.NoError(t, err)
 
 		assert.Equal(t, psvTest, psv)
@@ -90,12 +85,7 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 
-		uploadLink := ""
-		for k, v := range *(psv.Links) {
-			if k == "upload" {
-				uploadLink = v.(string)
-			}
-		}
+		uploadLink := psv.Data.Links.Upload
 
 		err := client.PolicySetVersions.Upload(
 			ctx,
@@ -107,10 +97,10 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 		// We do this in a small loop, because it can take a second
 		// before the upload is finished.
 		for i := 0; ; i++ {
-			refreshed, err := client.PolicySetVersions.Read(ctx, psv.ID)
+			refreshed, err := client.PolicySetVersions.Read(ctx, psv.Data.ID)
 			require.NoError(t, err)
 
-			if refreshed.Status == PolicySetVersionUploaded {
+			if refreshed.Data.Attributes.Status == PolicySetVersionReady {
 				break
 			}
 
@@ -124,12 +114,7 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 
 	t.Run("without a valid upload URL", func(t *testing.T) {
 
-		uploadLink := ""
-		for k, v := range *(psv.Links) {
-			if k == "upload" {
-				uploadLink = v.(string)
-			}
-		}
+		uploadLink := psv.Data.Links.Upload
 
 		err := client.PolicySetVersions.Upload(
 			ctx,
@@ -141,12 +126,7 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 
 	t.Run("without a valid path", func(t *testing.T) {
 
-		uploadLink := ""
-		for k, v := range *(psv.Links) {
-			if k == "upload" {
-				uploadLink = v.(string)
-			}
-		}
+		uploadLink := psv.Data.Links.Upload
 
 		err := client.PolicySetVersions.Upload(
 			ctx,

--- a/policy_set_version_test.go
+++ b/policy_set_version_test.go
@@ -1,0 +1,158 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestPolicySetVersionsCreate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil)
+	defer psTestCleanup()
+
+	t.Run("with valid options", func(t *testing.T) {
+		psv, err := client.PolicySetVersions.Create(ctx,
+			psTest.ID,
+			PolicySetVersionCreateOptions{},
+		)
+		require.NoError(t, err)
+
+		// Get a refreshed view of the policy set version.
+		refreshed, err := client.PolicySetVersions.Read(ctx, psv.ID)
+		require.NoError(t, err)
+
+		for _, item := range []*PolicySetVersion{
+			psv,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Empty(t, item.Error)
+			assert.Equal(t, item.Source, PolicySetVersionSourceAPI)
+			assert.Equal(t, item.Status, PolicySetVersionPending)
+
+			uploadLink := ""
+			for k, v := range *(item.Links) {
+				if k == "upload" {
+					uploadLink = v.(string)
+				}
+			}
+			assert.NotEmpty(t, uploadLink)
+		}
+	})
+
+	t.Run("when policy set ID is invalid", func(t *testing.T) {
+		options := PolicySetVersionCreateOptions{}
+
+		_, err := client.PolicySetVersions.Create(ctx, badIdentifier, options)
+		assert.EqualError(t, err, "invalid value for policy set ID")
+	})
+}
+
+func TestPolicySetVersionsRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	psvTest, psvTestCleanup := createPolicySetVersion(t, client, nil)
+	defer psvTestCleanup()
+
+	t.Run("when the policy set version exists", func(t *testing.T) {
+		psv, err := client.PolicySetVersions.Read(ctx, psvTest.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, psvTest, psv)
+	})
+
+	t.Run("when the policy set version does not exist", func(t *testing.T) {
+		psv, err := client.PolicySetVersions.Read(ctx, "nonexisting")
+		assert.Nil(t, psv)
+		assert.Equal(t, err, ErrResourceNotFound)
+	})
+
+	t.Run("with invalid policy set version id", func(t *testing.T) {
+		psv, err := client.PolicySetVersions.Read(ctx, badIdentifier)
+		assert.Nil(t, psv)
+		assert.EqualError(t, err, "invalid value for policy set version ID")
+	})
+}
+
+func TestPolicySetVersionsUpload(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	psv, psvCleanup := createPolicySetVersion(t, client, nil)
+	defer psvCleanup()
+
+	t.Run("with valid options", func(t *testing.T) {
+
+		uploadLink := ""
+		for k, v := range *(psv.Links) {
+			if k == "upload" {
+				uploadLink = v.(string)
+			}
+		}
+
+		err := client.PolicySetVersions.Upload(
+			ctx,
+			uploadLink,
+			"test-fixtures/policy-set-version",
+		)
+		require.NoError(t, err)
+
+		// We do this in a small loop, because it can take a second
+		// before the upload is finished.
+		for i := 0; ; i++ {
+			refreshed, err := client.PolicySetVersions.Read(ctx, psv.ID)
+			require.NoError(t, err)
+
+			if refreshed.Status == PolicySetVersionUploaded {
+				break
+			}
+
+			if i > 10 {
+				t.Fatal("Timeout waiting for the policy set version to be uploaded")
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+	})
+
+	t.Run("without a valid upload URL", func(t *testing.T) {
+
+		uploadLink := ""
+		for k, v := range *(psv.Links) {
+			if k == "upload" {
+				uploadLink = v.(string)
+			}
+		}
+
+		err := client.PolicySetVersions.Upload(
+			ctx,
+			uploadLink[:len(uploadLink)-10]+"nonexisting",
+			"test-fixtures/policy-set-version",
+		)
+		assert.Error(t, err)
+	})
+
+	t.Run("without a valid path", func(t *testing.T) {
+
+		uploadLink := ""
+		for k, v := range *(psv.Links) {
+			if k == "upload" {
+				uploadLink = v.(string)
+			}
+		}
+
+		err := client.PolicySetVersions.Upload(
+			ctx,
+			uploadLink,
+			"nonexisting",
+		)
+		assert.Error(t, err)
+	})
+}

--- a/test-fixtures/policy-set-version/enforce-mandatory-tags.sentinel
+++ b/test-fixtures/policy-set-version/enforce-mandatory-tags.sentinel
@@ -1,0 +1,27 @@
+# This policy uses the Sentinel tfplan import to require that all EC2 instances
+# have all mandatory tags.
+# Note that the comparison is case-sensitive since AWS tags are case-sensitive.
+
+# Import common-functions/tfplan-functions/tfplan-functions.sentinel
+# with alias "plan"
+import "tfplan-functions" as plan
+
+# List of mandatory tags
+### List of mandatory tags ###
+mandatory_tags = [
+  "Department",
+  "Billable",
+]
+
+# Get all EC2 instances
+allEC2Instances = plan.find_resources("aws_instance")
+
+# Filter to EC2 instances with violations
+# Warnings will be printed for all violations since the last parameter is true
+violatingEC2Instances = plan.filter_attribute_not_contains_list(allEC2Instances,
+                        "tags", mandatory_tags, true)
+
+# Main rule
+main = rule {
+  length(violatingEC2Instances["messages"]) is 0
+}

--- a/test-fixtures/policy-set-version/sentinel.hcl
+++ b/test-fixtures/policy-set-version/sentinel.hcl
@@ -1,0 +1,8 @@
+policy "enforce-mandatory-tags" {
+  source = "./enforce-mandatory-tags.sentinel"
+  enforcement_level = "hard-mandatory"
+}
+
+module "tfplan-functions" {
+  source = "https://raw.githubusercontent.com/hashicorp/terraform-guides/master/governance/third-generation/common-functions/tfplan-functions/tfplan-functions.sentinel"
+}

--- a/tfe.go
+++ b/tfe.go
@@ -123,6 +123,7 @@ type Client struct {
 	PolicyChecks               PolicyChecks
 	PolicySetParameters        PolicySetParameters
 	PolicySets                 PolicySets
+	PolicySetVersions          PolicySetVersions
 	RegistryModules            RegistryModules
 	Runs                       Runs
 	RunTriggers                RunTriggers
@@ -225,6 +226,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Policies = &policies{client: client}
 	client.PolicyChecks = &policyChecks{client: client}
 	client.PolicySetParameters = &policySetParameters{client: client}
+	client.PolicySetVersions = &policySetVersions{client: client}
 	client.PolicySets = &policySets{client: client}
 	client.RegistryModules = &registryModules{client: client}
 	client.Runs = &runs{client: client}
@@ -594,6 +596,11 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 	// Items and Pagination struct fields.
 	if !items.IsValid() || !pagination.IsValid() {
 		return jsonapi.UnmarshalPayload(resp.Body, v)
+		// One alternative based on https://github.com/google/jsonapi/issues/68#issuecomment-275572468
+		//payload := new(jsonapi.OnePayload)
+		//return json.NewDecoder(resp.Body).Decode(payload)
+		// Second alternative based on https://github.com/google/jsonapi/issues/68#issuecomment-275572468
+		//return json.NewDecoder(resp.Body).Decode(v)
 	}
 
 	// Return an error if v.Items is not a slice.


### PR DESCRIPTION
## Description

This PR adds support for [policy set versions](https://www.terraform.io/docs/cloud/api/policy-sets.html#create-a-policy-set-version). This was requested by a significant HashiCorp customer who wants to be able to use the TFE provider to manage non-VCS-backed policy sets for which they currently have to use the TFE API itself to create policy set versions and then upload their actual policy sets to the upload URL of the policy set versions. After this PR is approved, I plan on doing one against the [TFE provider](https://github.com/hashicorp/terraform-provider-tfe) itself that will use the new policy_set_version.go class that I have added in this PR.

I encountered some complications in adding this resource because the upload link for policy set versions is returned under the links collection of the JSON document returned by the API that creates policy set versions. Unfortunately, the [jsonapi](https://github.com/google/jsonapi) package that the go-tfe library uses does not support unmarshalling those links with structure tags the way it supports unmarshalling relationships.  See https://github.com/google/jsonapi/blob/master/README.md#links, https://github.com/google/jsonapi/issues/93, and https://github.com/google/jsonapi/issues/68. While the last proposes a solution and references a working example in https://github.com/google/jsonapi/blob/master/request_test.go#L694, that example does not actually include demarshalling a structure that uses jsonapi structure tags.  And the JSONAPILinks example given in https://github.com/google/jsonapi/blob/master/README.md#links would appear to only help with marshalling links into a structure.

I addressed this problem in the following ways:

1. I used json structure tags instead of jsonapi structure tags in policy_set_version.go
2. I added special processing to the do() function in tfe.go to handle structures that do not have any jsonapi structure tags. When that is the case, instead of returning `jsonapi.UnmarshalPayload(resp.Body, v)`, the function returns `json.NewDecoder(resp.Body).Decode(v)`.
3. To support that special processing, I also added logic to the do() method of tfe.go similar to that in the serializeRequestBody() function of tfe.go to determine whether v is a Slice or a Ptr and count the number of jsonapi and json fields in v.

Since all other response structures currently used have at least one jsonapi structure tag, only policy set versions are affected by the changes in items 2 and 3.

I also added a policy set with one policy set definition file and one policy under test-fixutres/policy-set-version. This is used by the TestPolicySetVersionsUpload() function of policy_set_version_test.go and by main.go of examples/policysets.

I added a new example to create policy sets and policy set versions under examples/policysets. Note that this reads the `TFE_ADDRESS`, `TFE_TOKEN`, and `TFE_ORGANIZATION` environment variables, avoiding the need to edit the file to set hard-coded files. Similar changes could be made to examples/organizations/main.go and examples/workspaces/main.go, but I am not making them in this PR.

## Testing plan

You can test the new code in two ways:
1. Export environment variables described in TESTS.md and then run `go test -run TestPolicySetVersion -v ./...`
1. Run `go install .` from the root directory of go-tfe, navigate to the examples/policysets directory, run `go install .` again, export the `TFE_ADDRESS`, `TFE_TOKEN`, and `TFE_ORGANIZATION` environment variables, and then run `$GOPATH/bin/policysets`.

## External links
- [jsonapi package](https://github.com/google/jsonapi)
- [jsonapi Links](https://github.com/google/jsonapi/blob/master/README.md#links)
- [jsonapi issue 93](https://github.com/google/jsonapi/issues/93)
- [jsonapi issue 68](https://github.com/google/jsonapi/issues/68)

## Output from tests

Here are the results of testing against policy_set_version_test.go:
```
$go test -run TestPolicySetVersion -v ./...                               
=== RUN   TestPolicySetVersionsCreate
=== RUN   TestPolicySetVersionsCreate/with_valid_options
=== RUN   TestPolicySetVersionsCreate/when_policy_set_ID_is_invalid
--- PASS: TestPolicySetVersionsCreate (0.89s)
    --- PASS: TestPolicySetVersionsCreate/with_valid_options (0.17s)
    --- PASS: TestPolicySetVersionsCreate/when_policy_set_ID_is_invalid (0.00s)
=== RUN   TestPolicySetVersionsRead
=== RUN   TestPolicySetVersionsRead/when_the_policy_set_version_exists
=== RUN   TestPolicySetVersionsRead/when_the_policy_set_version_does_not_exist
=== RUN   TestPolicySetVersionsRead/with_invalid_policy_set_version_id
--- PASS: TestPolicySetVersionsRead (0.71s)
    --- PASS: TestPolicySetVersionsRead/when_the_policy_set_version_exists (0.06s)
    --- PASS: TestPolicySetVersionsRead/when_the_policy_set_version_does_not_exist (0.04s)
    --- PASS: TestPolicySetVersionsRead/with_invalid_policy_set_version_id (0.00s)
=== RUN   TestPolicySetVersionsUpload
=== RUN   TestPolicySetVersionsUpload/with_valid_options
=== RUN   TestPolicySetVersionsUpload/without_a_valid_upload_URL
=== RUN   TestPolicySetVersionsUpload/without_a_valid_path
--- PASS: TestPolicySetVersionsUpload (2.01s)
    --- PASS: TestPolicySetVersionsUpload/with_valid_options (1.27s)
    --- PASS: TestPolicySetVersionsUpload/without_a_valid_upload_URL (0.02s)
    --- PASS: TestPolicySetVersionsUpload/without_a_valid_path (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	3.782s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/policysets	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
```

Here are results from running `$GOPATH/bin/policysets` from examples/policysets:
```
$$GOPATH/bin/policysets
2020/11/09 10:35:46 The policy set ID is:polset-vqzQART8KsoW3Yjq
2020/11/09 10:35:46 The policy set version Type is: policy-set-versions
2020/11/09 10:35:46 The policy set version ID is: polsetver-yjV8gjDNAZm7JJyN
2020/11/09 10:35:46 The linked policy set ID is: polset-vqzQART8KsoW3Yjq
2020/11/09 10:35:46 The upload link is:https://roger-ptfe.hashidemos.io/_archivist/v1/object/dmF1bHQ6djE6bHoyN2RUTFFSVEFSOFhUT0l1UElQUmZLN20wTENxWVRIcUdNMXRxNzhKTDJnWCtPcjVhWFdTRS8wSE9jdTYxWTArejlXOEhXY1J1bWVkclp6bUdwVW1wTkRXUEJyU0VpMVllZ1ozVHQ5cmgveFhMS25BT09vcC9wcy9MVWRCQjI1SXcrZUNtUmdQRU9Oc0JsWm9MN2ZqSmhpU2FMbng0UWI2NU1nYloreTBiclJpdmlJMzJYckNmU2NwRXNIQVB6VGs4WFMwWWY5NS9vYjlJcUZXUklpa0F6alRlZTl3bkd4b1VDRnpqSElhQkZvWE5tNmFYaFh5NXpGM095ckFockk3d2w2TldWWHRaMzFTdXE5b0xJUzkrUA
2020/11/09 10:35:46 The upload status is: pending
2020/11/09 10:35:46 The upload URL is:https://roger-ptfe.hashidemos.io/_archivist/v1/object/dmF1bHQ6djE6bHoyN2RUTFFSVEFSOFhUT0l1UElQUmZLN20wTENxWVRIcUdNMXRxNzhKTDJnWCtPcjVhWFdTRS8wSE9jdTYxWTArejlXOEhXY1J1bWVkclp6bUdwVW1wTkRXUEJyU0VpMVllZ1ozVHQ5cmgveFhMS25BT09vcC9wcy9MVWRCQjI1SXcrZUNtUmdQRU9Oc0JsWm9MN2ZqSmhpU2FMbng0UWI2NU1nYloreTBiclJpdmlJMzJYckNmU2NwRXNIQVB6VGs4WFMwWWY5NS9vYjlJcUZXUklpa0F6alRlZTl3bkd4b1VDRnpqSElhQkZvWE5tNmFYaFh5NXpGM095ckFockk3d2w2TldWWHRaMzFTdXE5b0xJUzkrUA
2020/11/09 10:35:46 The upload status is: ready
2020/11/09 10:35:46 Successfully deleted policy set polset-vqzQART8KsoW3Yjq
```

I also ran the complete test suite with `go test -v -count=1 ./... -timeout=30m > testresult.txt` and have attached output in which all tests did pass:
[testresults-passed.txt](https://github.com/hashicorp/go-tfe/files/5511607/testresults-passed.txt)

However, I also noticed that some unrelated tests sometimes failed, giving errors when deleting workspaces. Those workspaces ultimately disappeared, but I believe because the organizations containing them were deleted. I reduced the frequency of these failures by adding a 1 second sleep at the beginning of the orgCleanup() function returned by the createWorkspace() function of helper_test.go. This seems to help by giving TFE a bit more time after previous operations done against workspaces before deleting them and does not make the testing take much longer.

Here is an example of the type of error I had been seeing:
```
=== RUN   TestRunsCancel
=== RUN   TestRunsCancel/when_the_run_exists
=== RUN   TestRunsCancel/when_the_run_does_not_exist
=== RUN   TestRunsCancel/with_invalid_run_ID
--- FAIL: TestRunsCancel (2.25s)
    --- PASS: TestRunsCancel/when_the_run_exists (0.04s)
    --- PASS: TestRunsCancel/when_the_run_does_not_exist (0.03s)
    --- PASS: TestRunsCancel/with_invalid_run_ID (0.00s)
    helper_test.go:914: Error destroying workspace! WARNING: Dangling resources
        may exist! The full error is shown below.
        
        Workspace: 8978ed66-2f5f-e28c-b304-5ca6ef12ef7d
        Error: internal server error
```

Note that I switched back to the master branch and saw the exact same errors.  So, I know that my code changes did not introduce these sporadic workspace deletion errors.