### PR TITLE
Fix race condition with run creation in tests

### DIFF
--- a/run_test.go
+++ b/run_test.go
@@ -112,7 +112,7 @@ func TestRunsRead(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	rTest, rTestCleanup := createPlannedRun(t, client, nil)
+	rTest, rTestCleanup := createCostEstimatedRun(t, client, nil)
 	defer rTestCleanup()
 
 	t.Run("when the run exists", func(t *testing.T) {


### PR DESCRIPTION
# Description

This fixes a race condition causing the following error in CI:

```
Failed
=== RUN   TestRunsRead/when_the_run_exists
    --- FAIL: TestRunsRead/when_the_run_exists (0.06s)
        run_test.go:121:
            	Error Trace:	run_test.go:121
            	Error:      	Not equal:

            - Status: (tfe.RunStatus) (len=7) "planned",
            + Status: (tfe.RunStatus) (len=15) "cost_estimating",
```

The issue is that Terraform Cloud was recently changed to enable Cost
Estimation by default, and these helper functions make big assumptions
about the state of a run when returned. They behave more like
"createAtLeastPlannedRun" (the run is indeed planned but this doesn't
mean that the end state is planned!)

These helpers should more appropriately create an organization with the
right circumstances to return the correct run final run state - that is,
createPlannedRun should not return a run for an org with cost estimation
enabled.

But as a quick fix, we instead take the easy way out and just change the
test to expect that cost estimation is enabled.

## Testing plan

Does CI pass?