### PR TITLE
Support Workspaces' allow-destroy-plan attribute

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -78,6 +78,7 @@ type Workspace struct {
 	ID                   string                `jsonapi:"primary,workspaces"`
 	Actions              *WorkspaceActions     `jsonapi:"attr,actions"`
 	AgentPoolID          string                `jsonapi:"attr,agent-pool-id"`
+	AllowDestroyPlan     bool                  `jsonapi:"attr,allow-destroy-plan"`
 	AutoApply            bool                  `jsonapi:"attr,auto-apply"`
 	CanQueueDestroyPlan  bool                  `jsonapi:"attr,can-queue-destroy-plan"`
 	CreatedAt            time.Time             `jsonapi:"attr,created-at,iso8601"`
@@ -172,6 +173,9 @@ type WorkspaceCreateOptions struct {
 	// belonging to the workspace's organization. This value must not be specified
 	// if execution-mode is set to remote or local or if operations is set to true.
 	AgentPoolID *string `jsonapi:"attr,agent-pool-id,omitempty"`
+
+	// Whether destroy plans can be queued on the workspace.
+	AllowDestroyPlan *bool `jsonapi:"attr,allow-destroy-plan,omitempty"`
 
 	// Whether to automatically apply changes when a Terraform plan is successful.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
@@ -345,6 +349,9 @@ type WorkspaceUpdateOptions struct {
 	// belonging to the workspace's organization. This value must not be specified
 	// if execution-mode is set to remote or local or if operations is set to true.
 	AgentPoolID *string `jsonapi:"attr,agent-pool-id,omitempty"`
+
+	// Whether destroy plans can be queued on the workspace.
+	AllowDestroyPlan *bool `jsonapi:"attr,allow-destroy-plan,omitempty"`
 
 	// Whether to automatically apply changes when a Terraform plan is successful.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -99,6 +99,7 @@ func TestWorkspacesCreate(t *testing.T) {
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceCreateOptions{
 			Name:                String("foo"),
+			AllowDestroyPlan:    Bool(false),
 			AutoApply:           Bool(true),
 			FileTriggersEnabled: Bool(true),
 			Operations:          Bool(true),
@@ -122,6 +123,7 @@ func TestWorkspacesCreate(t *testing.T) {
 		} {
 			assert.NotEmpty(t, item.ID)
 			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.AllowDestroyPlan, item.AllowDestroyPlan)
 			assert.Equal(t, *options.AutoApply, item.AutoApply)
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)
@@ -305,6 +307,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
 			Name:             String(wTest.Name),
+			AllowDestroyPlan: Bool(false),
 			AutoApply:        Bool(true),
 			Operations:       Bool(true),
 			QueueAllRuns:     Bool(true),
@@ -315,6 +318,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, wTest.Name, wAfter.Name)
+		assert.NotEqual(t, wTest.AllowDestroyPlan, wAfter.AllowDestroyPlan)
 		assert.NotEqual(t, wTest.AutoApply, wAfter.AutoApply)
 		assert.NotEqual(t, wTest.QueueAllRuns, wAfter.QueueAllRuns)
 		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
@@ -324,6 +328,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
 			Name:                String(randomString(t)),
+			AllowDestroyPlan:    Bool(true),
 			AutoApply:           Bool(false),
 			FileTriggersEnabled: Bool(true),
 			Operations:          Bool(false),
@@ -346,6 +351,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			refreshed,
 		} {
 			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.AllowDestroyPlan, item.AllowDestroyPlan)
 			assert.Equal(t, *options.AutoApply, item.AutoApply)
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)
@@ -411,6 +417,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
 			Name:             String(wTest.Name),
+			AllowDestroyPlan: Bool(false),
 			AutoApply:        Bool(true),
 			Operations:       Bool(true),
 			QueueAllRuns:     Bool(true),
@@ -421,6 +428,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, wTest.Name, wAfter.Name)
+		assert.NotEqual(t, wTest.AllowDestroyPlan, wAfter.AllowDestroyPlan)
 		assert.NotEqual(t, wTest.AutoApply, wAfter.AutoApply)
 		assert.NotEqual(t, wTest.QueueAllRuns, wAfter.QueueAllRuns)
 		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
@@ -430,6 +438,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
 			Name:                String(randomString(t)),
+			AllowDestroyPlan:    Bool(true),
 			AutoApply:           Bool(false),
 			FileTriggersEnabled: Bool(true),
 			Operations:          Bool(false),
@@ -452,6 +461,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 			refreshed,
 		} {
 			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.AllowDestroyPlan, item.AllowDestroyPlan)
 			assert.Equal(t, *options.AutoApply, item.AutoApply)
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)


### PR DESCRIPTION
## Description

Add support for a workspace's [`allow-destroy-plan` option](https://www.terraform.io/docs/cloud/api/workspaces.html)