### PR TITLE
Add additional organization entitlements

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -101,8 +101,12 @@ type Capacity struct {
 // Entitlements represents the entitlements of an organization.
 type Entitlements struct {
 	ID                    string `jsonapi:"primary,entitlement-sets"`
+	Agents                bool   `jsonapi:"attr,agents"`
+	AuditLogging          bool   `jsonapi:"attr,audit-logging"`
+	CostEstimation        bool   `jsonapi:"attr,cost-estimation"`
 	Operations            bool   `jsonapi:"attr,operations"`
 	PrivateModuleRegistry bool   `jsonapi:"attr,private-module-registry"`
+	SSO                   bool   `jsonapi:"attr,sso"`
 	Sentinel              bool   `jsonapi:"attr,sentinel"`
 	StateStorage          bool   `jsonapi:"attr,state-storage"`
 	Teams                 bool   `jsonapi:"attr,teams"`

--- a/organization_test.go
+++ b/organization_test.go
@@ -261,8 +261,12 @@ func TestOrganizationsEntitlements(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, entitlements.ID)
+		assert.True(t, entitlements.Agents)
+		assert.True(t, entitlements.AuditLogging)
+		assert.True(t, entitlements.CostEstimation)
 		assert.True(t, entitlements.Operations)
 		assert.True(t, entitlements.PrivateModuleRegistry)
+		assert.True(t, entitlements.SSO)
 		assert.True(t, entitlements.Sentinel)
 		assert.True(t, entitlements.StateStorage)
 		assert.True(t, entitlements.Teams)


### PR DESCRIPTION
## Description

Adds additional entitlements which were added to the API since the original struct was written.

Note that not all attributes that exist today were added here; some attributes are all but deprecated as they are always true now, for legacy reasons (the configuration designer is an example). 