### PR TITLE
Add support for managing User Tokens

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -135,6 +135,7 @@ type Client struct {
 	TeamMembers                TeamMembers
 	TeamTokens                 TeamTokens
 	Users                      Users
+	UserTokens                 UserTokens
 	Variables                  Variables
 	Workspaces                 Workspaces
 }
@@ -239,6 +240,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.TeamMembers = &teamMembers{client: client}
 	client.TeamTokens = &teamTokens{client: client}
 	client.Users = &users{client: client}
+	client.UserTokens = &userTokens{client: client}
 	client.Variables = &variables{client: client}
 	client.Workspaces = &workspaces{client: client}
 

--- a/user_token.go
+++ b/user_token.go
@@ -24,7 +24,7 @@ type UserTokens interface {
 	Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error)
 
 	// Read a user token by its ID.
-	Read(ctx context.Context, userID string) (*UserToken, error)
+	Read(ctx context.Context, tokenID string) (*UserToken, error)
 
 	// Delete a user token by its ID.
 	Delete(ctx context.Context, tokenID string) error
@@ -100,12 +100,12 @@ func (s *userTokens) List(ctx context.Context, userID string) (*UserTokenList, e
 }
 
 // Read a user token by its ID.
-func (s *userTokens) Read(ctx context.Context, userID string) (*UserToken, error) {
-	if !validStringID(&userID) {
+func (s *userTokens) Read(ctx context.Context, tokenID string) (*UserToken, error) {
+	if !validStringID(&tokenID) {
 		return nil, errors.New("invalid value for user ID")
 	}
 
-	u := fmt.Sprintf("users/%s/authentication-token", url.QueryEscape(userID))
+	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/user_token.go
+++ b/user_token.go
@@ -84,7 +84,6 @@ func (s *userTokens) List(ctx context.Context, userID string) (*UserTokenList, e
 	}
 
 	u := fmt.Sprintf("users/%s/authentication-tokens", url.QueryEscape(userID))
-	// req, err := s.client.newRequest("GET", u, &options)
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/user_token.go
+++ b/user_token.go
@@ -1,0 +1,136 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ UserTokens = (*userTokens)(nil)
+
+// UserTokens describes all the user token related methods that the
+// Terraform Cloud/Enterprise API supports.
+//
+// TFE API docs:
+// https://www.terraform.io/docs/enterprise/api/user-tokens.html
+type UserTokens interface {
+	// List all the tokens of the given user ID.
+	List(ctx context.Context, userID string) (*UserTokenList, error)
+
+	// Create a new user token
+	Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error)
+
+	// Read a user token by its ID.
+	Read(ctx context.Context, userID string) (*UserToken, error)
+
+	// Delete a user token by its ID.
+	Delete(ctx context.Context, userID string) error
+}
+
+// userTokens implements UserTokens.
+type userTokens struct {
+	client *Client
+}
+
+// UserTokenList is a list of tokens for the given user ID.
+type UserTokenList struct {
+	*Pagination
+	Items []*UserToken
+}
+
+// UserToken represents a Terraform Enterprise user token.
+type UserToken struct {
+	ID          string    `jsonapi:"primary,authentication-tokens"`
+	CreatedAt   time.Time `jsonapi:"attr,created-at,iso8601"`
+	Description string    `jsonapi:"attr,description"`
+	LastUsedAt  time.Time `jsonapi:"attr,last-used-at,iso8601"`
+	Token       string    `jsonapi:"attr,token"`
+}
+
+// UserTokenCreateOptions the options for creating a user token.
+type UserTokenCreateOptions struct {
+	// Description of the token
+	Description string `jsonapi:"attr,description,omitempty"`
+}
+
+// Create a new user token, replacing any existing token.
+func (s *userTokens) Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error) {
+	if !validStringID(&userID) {
+		return nil, errors.New("invalid value for user ID")
+	}
+
+	u := fmt.Sprintf("users/%s/authentication-tokens", url.QueryEscape(userID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ut := &UserToken{}
+	err = s.client.do(ctx, req, ut)
+	if err != nil {
+		return nil, err
+	}
+
+	return ut, err
+}
+
+// List shows existing user tokens
+func (s *userTokens) List(ctx context.Context, userID string) (*UserTokenList, error) {
+	if !validStringID(&userID) {
+		return nil, errors.New("invalid value for user ID")
+	}
+
+	u := fmt.Sprintf("users/%s/authentication-tokens", url.QueryEscape(userID))
+	// req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tl := &UserTokenList{}
+	err = s.client.do(ctx, req, tl)
+	if err != nil {
+		return nil, err
+	}
+
+	return tl, err
+}
+
+// Read a user token by its ID.
+func (s *userTokens) Read(ctx context.Context, userID string) (*UserToken, error) {
+	if !validStringID(&userID) {
+		return nil, errors.New("invalid value for user ID")
+	}
+
+	u := fmt.Sprintf("users/%s/authentication-token", url.QueryEscape(userID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	tt := &UserToken{}
+	err = s.client.do(ctx, req, tt)
+	if err != nil {
+		return nil, err
+	}
+
+	return tt, err
+}
+
+// Delete a user token by its ID.
+func (s *userTokens) Delete(ctx context.Context, tokenID string) error {
+	if !validStringID(&tokenID) {
+		return errors.New("invalid value for user ID")
+	}
+
+	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/user_token.go
+++ b/user_token.go
@@ -56,7 +56,7 @@ type UserTokenCreateOptions struct {
 	Description string `jsonapi:"attr,description,omitempty"`
 }
 
-// Create a new user token, replacing any existing token.
+// Create a new user token
 func (s *userTokens) Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error) {
 	if !validStringID(&userID) {
 		return nil, errors.New("invalid value for user ID")

--- a/user_token.go
+++ b/user_token.go
@@ -44,7 +44,7 @@ type UserTokenList struct {
 // UserToken represents a Terraform Enterprise user token.
 type UserToken struct {
 	ID          string    `jsonapi:"primary,authentication-tokens"`
-	GeneratedAt time.Time `jsonapi:"attr,created-at,iso8601"`
+	CreatedAt   time.Time `jsonapi:"attr,created-at,iso8601"`
 	Description string    `jsonapi:"attr,description"`
 	LastUsedAt  time.Time `jsonapi:"attr,last-used-at,iso8601"`
 	Token       string    `jsonapi:"attr,token"`

--- a/user_token.go
+++ b/user_token.go
@@ -27,7 +27,7 @@ type UserTokens interface {
 	Read(ctx context.Context, userID string) (*UserToken, error)
 
 	// Delete a user token by its ID.
-	Delete(ctx context.Context, userID string) error
+	Delete(ctx context.Context, tokenID string) error
 }
 
 // userTokens implements UserTokens.

--- a/user_token.go
+++ b/user_token.go
@@ -20,8 +20,8 @@ type UserTokens interface {
 	// List all the tokens of the given user ID.
 	List(ctx context.Context, userID string) (*UserTokenList, error)
 
-	// Create a new user token
-	Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error)
+	// Generate a new user token
+	Generate(ctx context.Context, userID string, options UserTokenGenerateOptions) (*UserToken, error)
 
 	// Read a user token by its ID.
 	Read(ctx context.Context, tokenID string) (*UserToken, error)
@@ -44,20 +44,20 @@ type UserTokenList struct {
 // UserToken represents a Terraform Enterprise user token.
 type UserToken struct {
 	ID          string    `jsonapi:"primary,authentication-tokens"`
-	CreatedAt   time.Time `jsonapi:"attr,created-at,iso8601"`
+	GeneratedAt time.Time `jsonapi:"attr,created-at,iso8601"`
 	Description string    `jsonapi:"attr,description"`
 	LastUsedAt  time.Time `jsonapi:"attr,last-used-at,iso8601"`
 	Token       string    `jsonapi:"attr,token"`
 }
 
-// UserTokenCreateOptions the options for creating a user token.
-type UserTokenCreateOptions struct {
+// UserTokenGenerateOptions the options for creating a user token.
+type UserTokenGenerateOptions struct {
 	// Description of the token
 	Description string `jsonapi:"attr,description,omitempty"`
 }
 
-// Create a new user token
-func (s *userTokens) Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error) {
+// Generate a new user token
+func (s *userTokens) Generate(ctx context.Context, userID string, options UserTokenGenerateOptions) (*UserToken, error) {
 	if !validStringID(&userID) {
 		return nil, errors.New("invalid value for user ID")
 	}
@@ -101,7 +101,7 @@ func (s *userTokens) List(ctx context.Context, userID string) (*UserTokenList, e
 // Read a user token by its ID.
 func (s *userTokens) Read(ctx context.Context, tokenID string) (*UserToken, error) {
 	if !validStringID(&tokenID) {
-		return nil, errors.New("invalid value for user ID")
+		return nil, errors.New("invalid value for token ID")
 	}
 
 	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))
@@ -122,7 +122,7 @@ func (s *userTokens) Read(ctx context.Context, tokenID string) (*UserToken, erro
 // Delete a user token by its ID.
 func (s *userTokens) Delete(ctx context.Context, tokenID string) error {
 	if !validStringID(&tokenID) {
-		return errors.New("invalid value for user ID")
+		return errors.New("invalid value for token ID")
 	}
 
 	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))

--- a/user_token_test.go
+++ b/user_token_test.go
@@ -1,0 +1,58 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserTokens_Basic(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+	user, err := client.Users.ReadCurrent(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	token, cleanupFunc := createToken(t, client, user)
+	defer cleanupFunc()
+
+	t.Run("listing existing tokens", func(t *testing.T) {
+		ctx := context.Background()
+		tl, err := client.UserTokens.List(ctx, user.ID)
+		require.NoError(t, err)
+		var found bool
+		for _, j := range tl.Items {
+			if j.ID == token.ID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Fatalf("token (%s) not found in token list", token.ID)
+		}
+	})
+}
+
+func createToken(t *testing.T, client *Client, user *User) (*UserToken, func()) {
+	t.Helper()
+	ctx := context.Background()
+	if user == nil {
+		t.Fatal("Nil user in createToken")
+	}
+	token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
+		Description: fmt.Sprintf("go-tfe-user-token-test-%s", randomString(t)),
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return token, func() {
+		if err := client.UserTokens.Delete(ctx, token.ID); err != nil {
+			t.Errorf("Error destroying token! WARNING: Dangling resources\n"+
+				"may exist! The full error is shown below.\n\n"+
+				"Token: %s\nError: %s", token.ID, err)
+		}
+	}
+}

--- a/user_token_test.go
+++ b/user_token_test.go
@@ -38,8 +38,8 @@ func TestUserTokens_List(t *testing.T) {
 	})
 }
 
-// TestUserTokens_Create tests basic creation of user tokens
-func TestUserTokens_Create(t *testing.T) {
+// TestUserTokens_Generate tests basic creation of user tokens
+func TestUserTokens_Generate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 	user, err := client.Users.ReadCurrent(ctx)
@@ -59,7 +59,7 @@ func TestUserTokens_Create(t *testing.T) {
 	}(t)
 
 	t.Run("create token with no description", func(t *testing.T) {
-		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{})
+		token, err := client.UserTokens.Generate(ctx, user.ID, UserTokenGenerateOptions{})
 		tokens = append(tokens, token.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -67,7 +67,7 @@ func TestUserTokens_Create(t *testing.T) {
 	})
 
 	t.Run("create token with description", func(t *testing.T) {
-		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
+		token, err := client.UserTokens.Generate(ctx, user.ID, UserTokenGenerateOptions{
 			Description: fmt.Sprintf("go-tfe-user-token-test-%s", randomString(t)),
 		})
 		tokens = append(tokens, token.ID)
@@ -109,7 +109,7 @@ func createToken(t *testing.T, client *Client, user *User) (*UserToken, func()) 
 	if user == nil {
 		t.Fatal("Nil user in createToken")
 	}
-	token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
+	token, err := client.UserTokens.Generate(ctx, user.ID, UserTokenGenerateOptions{
 		Description: fmt.Sprintf("go-tfe-user-token-test-%s", randomString(t)),
 	})
 	if err != nil {


### PR DESCRIPTION
## Description

Add support for [User Tokens Endpoints][user-tokens]. This was originally copied from `team_tokens.go` and modified to fit the differences between the endpoints. Marking `WIP` until I figure out the pagination bit for listing tokens.

## Output from tests

_Please run the tests locally for any files you changes and include the output here._

```
$ go test ./... -run TestUserTokens -v
=== RUN   TestUserTokens_List
=== RUN   TestUserTokens_List/listing_existing_tokens
--- PASS: TestUserTokens_List (0.81s)
    --- PASS: TestUserTokens_List/listing_existing_tokens (0.13s)
=== RUN   TestUserTokens_Create
=== RUN   TestUserTokens_Create/create_token_with_no_description
=== RUN   TestUserTokens_Create/create_token_with_description
--- PASS: TestUserTokens_Create (0.61s)
    --- PASS: TestUserTokens_Create/create_token_with_no_description (0.08s)
    --- PASS: TestUserTokens_Create/create_token_with_description (0.08s)
=== RUN   TestUserTokens_Read
=== RUN   TestUserTokens_Read/read_token
--- PASS: TestUserTokens_Read (0.63s)
    --- PASS: TestUserTokens_Read/read_token (0.07s)
PASS
ok      github.com/hashicorp/go-tfe     2.266s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
...
```

[user-tokens]: https://www.terraform.io/docs/cloud/api/user-tokens.html