### PR TITLE
Allow access to JSON version of state, and allow access to output variables that aren't strings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hashicorp/go-tfe
+module github.com/sfc-gh-ahess/go-tfe
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect

--- a/state_version_output.go
+++ b/state_version_output.go
@@ -1,7 +1,9 @@
 package tfe
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"net/url"
@@ -17,6 +19,8 @@ var _ StateVersionOutputs = (*stateVersionOutputs)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/state-version-outputs.html
 type StateVersionOutputs interface {
 	Read(ctx context.Context, outputID string) (*StateVersionOutput, error)
+
+	ReadSimpler(ctx context.Context, outputID string) (*StateVersionOutputAllKinds, error)
 }
 
 type stateVersionOutputs struct {
@@ -30,6 +34,15 @@ type StateVersionOutput struct {
 	Type      string `jsonapi:"attr,type"`
 	Value     string `jsonapi:"attr,value"`
 }
+
+type StateVersionOutputAllKinds struct {
+	ID        string `jsonapi:"primary,state-version-outputs"`
+	Name      string `jsonapi:"attr,name"`
+	Sensitive bool   `jsonapi:"attr,sensitive"`
+	Type      string `jsonapi:"attr,type"`
+	Value     interface{} `jsonapi:"attr,value"`
+}
+
 
 func (s *stateVersionOutputs) Read(ctx context.Context, outputID string) (*StateVersionOutput, error) {
 	if !validStringID(&outputID) {
@@ -46,6 +59,59 @@ func (s *stateVersionOutputs) Read(ctx context.Context, outputID string) (*State
 	err = s.client.do(ctx, req, so)
 	if err != nil {
 		return nil, err
+	}
+
+	return so, nil
+}
+
+// This is here because the original implementation, above, does not support State Outputs that are not strings, and errors when you try to read one.
+// State outputs can also be arrays, as in our use case.  So we support the interface{} type for any data type, and the 'type' field can be used to determine what kind of data you have.
+// The underlying JSON API parser does not support this type of changeable output, or so it would seem, so we shall use a more raw approach.
+func (s *stateVersionOutputs) ReadSimpler(ctx context.Context, outputID string) (*StateVersionOutputAllKinds, error) {
+	if !validStringID(&outputID) {
+		return nil, errors.New("invalid value for run ID")
+	}
+
+	u := fmt.Sprintf("state-version-outputs/%s", url.QueryEscape(outputID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	err = s.client.do(ctx, req, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	// Convert to a json map
+	var result map[string]interface{}
+	err = json.Unmarshal(buf.Bytes(), &result)
+	if err != nil {
+		return nil, err
+	}
+
+	// Create a new value to hold our output
+	so := &StateVersionOutputAllKinds{}
+	so.ID = outputID
+
+	// Read in the data from the json.
+	// Look for an object called Data, and below that, attributes..
+	if data, ok := result["data"].(map[string]interface{}); ok {
+		if attr, ok := data["attributes"].(map[string]interface{}); ok {
+			if name, ok := attr["name"].(string); ok {
+				so.Name = name
+			}
+			if sensitive, ok := attr["name"].(bool); ok {
+				so.Sensitive = sensitive
+			}
+			if tp, ok := attr["type"].(string); ok {
+				so.Type = tp
+			}
+			if value, ok := attr["value"]; ok {
+				so.Value = value
+			}
+		}
 	}
 
 	return so, nil


### PR DESCRIPTION
This PR represents two changes to the go-tfe library:
1. It provides a method for retrieving the JSON state of a workspace
2. It provides a mechanism for accessing state outputs that are not strings.  The built-in StateVersionOutputs assumes all outputs are strings, and panics when an array or other non-string output is encountered, which Terraform does support.
