### PR TITLE
Add admin organization API client

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -4,16 +4,16 @@
 
 If you are planning to run the full suite of tests or work on policy sets or registry modules, you'll need to set up repositories for them in GitHub.
 
-Your policy set repository will need the following: 
+Your policy set repository will need the following:
 1. A policy set stored in a subdirectory `policy-sets/foo`
 1. A branch other than master named `policies`
 
 Your registry module repository will need to be a [valid module](https://www.terraform.io/docs/cloud/registry/publish.html#preparing-a-module-repository).
-It will need the following: 
+It will need the following:
 1. To be named `terraform-<PROVIDER>-<NAME>`
 1. At least one valid SemVer tag in the format `x.y.z`
-[terraform-random-module](ttps://github.com/caseylang/terraform-random-module) is a good example repo. 
-   
+[terraform-random-module](ttps://github.com/caseylang/terraform-random-module) is a good example repo.
+
 ### 2. Set up environment variables
 
 ##### Required:
@@ -25,6 +25,7 @@ Tests are run against an actual backend so they require a valid backend address 
 1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running any tests that use VCS (OAuth clients, policy sets, etc).
 1. `GITHUB_POLICY_SET_IDENTIFIER` - GitHub policy set repository identifier in the format `username/repository`. Required for running policy set tests.
 1. `GITHUB_REGISTRY_MODULE_IDENTIFIER` - GitHub registry module repository identifier in the format `username/repository`. Required for running registry module tests.
+1. `ENABLE_TFE` - Some tests are only applicable to Terraform Enterprise or Terraform Cloud. By setting `ENABLE_TFE=1` you will enable enterprise only tests and disable cloud only tests. In CI `ENABLE_TFE` is not set so if you are writing enterprise only features you should manually test with `ENABLE_TFE=1` against a Terraform Enterprise instance.
 
 You can set your environment variables up however you prefer. The following are instructions for setting up environment variables using [envchain](https://github.com/sorah/envchain).
    1. Make sure you have envchain installed. [Instructions for this can be found in the envchain README](https://github.com/sorah/envchain#installation).
@@ -34,7 +35,7 @@ You can set your environment variables up however you prefer. The following are 
       envchain --set YOUR_NAMESPACE_HERE ENVIRONMENT_VARIABLE_HERE
       ```
       **OR**
-    
+
       Set all of the environment variables at once with the following command:
       ```sh
       envchain --set YOUR_NAMESPACE_HERE TFE_ADDRESS TFE_TOKEN GITHUB_TOKEN GITHUB_POLICY_SET_IDENTIFIER
@@ -72,5 +73,5 @@ $ envchain YOUR_NAMESPACE_HERE go test -run TestNotificationConfiguration -v ./.
 ##### Without envchain:
 ```sh
 $ go test -run TestNotificationConfiguration -v ./...
-```   
+```
 

--- a/TESTS.md
+++ b/TESTS.md
@@ -12,7 +12,7 @@ Your registry module repository will need to be a [valid module](https://www.ter
 It will need the following:
 1. To be named `terraform-<PROVIDER>-<NAME>`
 1. At least one valid SemVer tag in the format `x.y.z`
-[terraform-random-module](ttps://github.com/caseylang/terraform-random-module) is a good example repo.
+[terraform-random-module](https://github.com/caseylang/terraform-random-module) is a good example repo.
 
 ### 2. Set up environment variables
 

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -28,6 +28,9 @@ type AdminOrganizations interface {
 
 	// Update attributes of an existing organization via admin API.
 	Update(ctx context.Context, organization string, options AdminOrganizationUpdateOptions) (*AdminOrganization, error)
+
+	// Delete an organization by its name via admin API
+	Delete(ctx context.Context, organization string) error
 }
 
 // adminOrganizations implements AdminOrganizations.
@@ -156,4 +159,19 @@ func (s *adminOrganizations) Update(ctx context.Context, organization string, op
 	}
 
 	return org, nil
+}
+
+// Delete an organization by its name.
+func (s *adminOrganizations) Delete(ctx context.Context, organization string) error {
+	if !validStringID(&organization) {
+		return errors.New("invalid value for organization")
+	}
+
+	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
 }

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -2,6 +2,7 @@ package tfe
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/url"
 )
@@ -21,6 +22,12 @@ type AdminOrganizations interface {
 
 	// Update the module sharing partnerships that an organization has
 	UpdateModuleConsumers(ctx context.Context, organization string, options ModulePartnershipUpdateOptions) (*ModulePartnershipList, error)
+
+	// Read attributes of an existing organization via admin API.
+	Read(ctx context.Context, organization string) (*AdminOrganization, error)
+
+	// Update attributes of an existing organization via admin API.
+	Update(ctx context.Context, organization string, options AdminOrganizationUpdateOptions) (*AdminOrganization, error)
 }
 
 // adminOrganizations implements AdminOrganizations.
@@ -47,7 +54,35 @@ type ModulePartnershipUpdateOptions struct {
 	ModuleConsumingOrganizationIDs []*string `jsonapi:"attr,module-consuming-organization-ids"`
 }
 
+// AdminOrganization represents a Terraform Enterprise organization returned from the Admin API.
+type AdminOrganization struct {
+	Name string `jsonapi:"primary,organizations"`
+
+	AccessBetaTools                  bool   `jsonapi:"attr,access-beta-tools"`
+	ExternalID                       string `jsonapi:"attr,external-id"`
+	GlobalModuleSharing              bool   `jsonapi:"attr,global-module-sharing"`
+	IsDisabled                       bool   `jsonapi:"attr,is-disabled"`
+	NotificationEmail                string `jsonapi:"attr,notification-email"`
+	SsoEnabled                       bool   `jsonapi:"attr,sso-enabled"`
+	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
+	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
+}
+
+// AdminOrganizationUpdateOptions represents the admin options for updating an organization.
+// https://www.terraform.io/docs/cloud/api/admin/organizations.html#request-body
+type AdminOrganizationUpdateOptions struct {
+	AccessBetaTools                  *bool   `jsonapi:"attr,access-beta-tools,omitempty"`
+	GlobalModuleSharing              *bool   `jsonapi:"attr,global-module-sharing,omitempty"`
+	IsDisabled                       *bool   `jsonapi:"attr,is-disabled,omitempty"`
+	TerraformBuildWorkerApplyTimeout *string `jsonapi:"attr,terraform-build-worker-apply-timeout,omitempty"`
+	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
+}
+
 func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string) (*ModulePartnershipList, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+
 	u := fmt.Sprintf("admin/organizations/%s/module-consumers", url.QueryEscape(organization))
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
@@ -64,6 +99,10 @@ func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organizati
 }
 
 func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, options ModulePartnershipUpdateOptions) (*ModulePartnershipList, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+
 	u := fmt.Sprintf("admin/organizations/%s/module-consumers", url.QueryEscape(organization))
 	req, err := s.client.newRequest("PATCH", u, &options)
 	if err != nil {
@@ -77,4 +116,44 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 	}
 
 	return partnerships, nil
+}
+
+func (s *adminOrganizations) Read(ctx context.Context, organization string) (*AdminOrganization, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+
+	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	org := &AdminOrganization{}
+	err = s.client.do(ctx, req, org)
+	if err != nil {
+		return nil, err
+	}
+
+	return org, nil
+}
+
+func (s *adminOrganizations) Update(ctx context.Context, organization string, options AdminOrganizationUpdateOptions) (*AdminOrganization, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+
+	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	org := &AdminOrganization{}
+	err = s.client.do(ctx, req, org)
+	if err != nil {
+		return nil, err
+	}
+
+	return org, nil
 }

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -18,7 +18,8 @@ var _ AdminOrganizations = (*adminOrganizations)(nil)
 type AdminOrganizations interface {
 
 	// List the module sharing partnerships that an organization has
-	ListModuleConsumers(ctx context.Context, organization string) (*OrganizationList, error)
+	// TODO(kirch): Add pagination options to this API
+	ListModuleConsumers(ctx context.Context, organization string, options OrganizationListOptions) (*OrganizationList, error)
 
 	// Update the module sharing consumers that an organization has
 	UpdateModuleConsumers(ctx context.Context, organization string, consumers ModuleConsumers) error
@@ -72,13 +73,13 @@ type AdminOrganizationUpdateOptions struct {
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
 }
 
-func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string) (*OrganizationList, error) {
+func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options OrganizationListOptions) (*OrganizationList, error) {
 	if !validStringID(&organization) {
 		return nil, errors.New("invalid value for organization")
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -18,7 +18,7 @@ var _ AdminOrganizations = (*adminOrganizations)(nil)
 type AdminOrganizations interface {
 
 	// List the module sharing partnerships that an organization has
-	ListModuleConsumers(ctx context.Context, organization string) (*ModulePartnershipList, error)
+	ListModuleConsumers(ctx context.Context, organization string) (*OrganizationList, error)
 
 	// Update the module sharing partnerships that an organization has
 	UpdateModuleConsumers(ctx context.Context, organization string, options ModulePartnershipUpdateOptions) (*ModulePartnershipList, error)
@@ -81,24 +81,24 @@ type AdminOrganizationUpdateOptions struct {
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
 }
 
-func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string) (*ModulePartnershipList, error) {
+func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string) (*OrganizationList, error) {
 	if !validStringID(&organization) {
 		return nil, errors.New("invalid value for organization")
 	}
 
-	u := fmt.Sprintf("admin/organizations/%s/module-consumers", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	partnerships := &ModulePartnershipList{}
-	err = s.client.do(ctx, req, partnerships)
+	consumers := &OrganizationList{}
+	err = s.client.do(ctx, req, consumers)
 	if err != nil {
 		return nil, err
 	}
 
-	return partnerships, nil
+	return consumers, nil
 }
 
 func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, options ModulePartnershipUpdateOptions) (*ModulePartnershipList, error) {

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -18,7 +18,6 @@ var _ AdminOrganizations = (*adminOrganizations)(nil)
 type AdminOrganizations interface {
 
 	// List the module sharing partnerships that an organization has
-	// TODO(kirch): Add pagination options to this API
 	ListModuleConsumers(ctx context.Context, organization string, options OrganizationListOptions) (*OrganizationList, error)
 
 	// Update the module sharing consumers that an organization has

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -21,7 +21,7 @@ type AdminOrganizations interface {
 	ListModuleConsumers(ctx context.Context, organization string) (*OrganizationList, error)
 
 	// Update the module sharing consumers that an organization has
-	UpdateModuleConsumers(ctx context.Context, organization string, consumers ModuleConsumers) (*OrganizationList, error)
+	UpdateModuleConsumers(ctx context.Context, organization string, consumers ModuleConsumers) error
 
 	// Read attributes of an existing organization via admin API.
 	Read(ctx context.Context, organization string) (*AdminOrganization, error)
@@ -92,9 +92,9 @@ func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organizati
 	return partnerships, nil
 }
 
-func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, consumers ModuleConsumers) (*OrganizationList, error) {
+func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, consumers ModuleConsumers) error {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return errors.New("invalid value for organization")
 	}
 
 	options := []*modulePartnershipUpdateOption{}
@@ -107,16 +107,10 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
 	req, err := s.client.newRequest("PATCH", u, options)
 	if err != nil {
-		return nil, err
+		return err
 	}
 
-	partnerships := &OrganizationList{}
-	err = s.client.do(ctx, req, partnerships)
-	if err != nil {
-		return nil, err
-	}
-
-	return partnerships, nil
+	return s.client.do(ctx, req, nil)
 }
 
 func (s *adminOrganizations) Read(ctx context.Context, organization string) (*AdminOrganization, error) {

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -60,6 +60,7 @@ type AdminOrganization struct {
 	SsoEnabled                       bool   `jsonapi:"attr,sso-enabled"`
 	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
 	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
+	TerraformWorkerSudoEnabled       bool   `jsonapi:"attr,terraform-worker-sudo-enabled"`
 }
 
 // AdminOrganizationUpdateOptions represents the admin options for updating an organization.

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -1,0 +1,80 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminOrganizations = (*adminOrganizations)(nil)
+
+// AdminOrganizations describes all of the admin organization related methods that the Terraform
+// Enterprise API supports. Note that admin settings are only available in Terraform Enterprise.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/admin/organizations.html
+// Module sharing docs: https://www.terraform.io/docs/cloud/api/admin/module-sharing.html
+type AdminOrganizations interface {
+
+	// List the module sharing partnerships that an organization has
+	ListModuleConsumers(ctx context.Context, organization string) (*ModulePartnershipList, error)
+
+	// Update the module sharing partnerships that an organization has
+	UpdateModuleConsumers(ctx context.Context, organization string, options ModulePartnershipUpdateOptions) (*ModulePartnershipList, error)
+}
+
+// adminOrganizations implements AdminOrganizations.
+type adminOrganizations struct {
+	client *Client
+}
+
+// ModulePartnershipList represents the list of module sharing partnerships
+type ModulePartnershipList struct {
+	*Pagination
+	Items []*ModulePartnership
+}
+
+// ModulePartnership represents the module sharing partnership between two organizations
+type ModulePartnership struct {
+	ConsumingOrganizationID   *string `jsonapi:"attr,consuming-organization-id"`
+	ConsumingOrganizationName *string `jsonapi:"attr,consuming-organization-name"`
+	ProducingOrganizationID   *string `jsonapi:"attr,producing-organization-id"`
+	ProducingOrganizationName *string `jsonapi:"attr,producing-organization-name"`
+}
+
+// ModulePartnershipUpdateOptions represents the options for updating an organization's module sharing partnerships
+type ModulePartnershipUpdateOptions struct {
+	ModuleConsumingOrganizationIDs []*string `jsonapi:"attr,module-consuming-organization-ids"`
+}
+
+func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string) (*ModulePartnershipList, error) {
+	u := fmt.Sprintf("admin/organizations/%s/module-consumers", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	partnerships := &ModulePartnershipList{}
+	err = s.client.do(ctx, req, partnerships)
+	if err != nil {
+		return nil, err
+	}
+
+	return partnerships, nil
+}
+
+func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, options ModulePartnershipUpdateOptions) (*ModulePartnershipList, error) {
+	u := fmt.Sprintf("admin/organizations/%s/module-consumers", url.QueryEscape(organization))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	partnerships := &ModulePartnershipList{}
+	err = s.client.do(ctx, req, partnerships)
+	if err != nil {
+		return nil, err
+	}
+
+	return partnerships, nil
+}

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -38,3 +38,67 @@ func TestModulePartnershipsList(t *testing.T) {
 		assert.Empty(t, consumerList.Items)
 	})
 }
+
+func TestAdminOrganizations(t *testing.T) {
+
+	skipIfNotEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	org, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	t.Run("fetches and updates organization", func(t *testing.T) {
+		adminOrg, err := client.Admin.Organizations.Read(ctx, org.Name)
+		assert.NotNilf(t, adminOrg, "Org returned as nil")
+		assert.Nilf(t, err, "Failed to update org %v", err)
+
+		accessBetaTools := true
+		globalModuleSharing := true
+		isDisabled := false
+		terraformBuildWorkerApplyTimeout := "24h"
+		terraformBuildWorkerPlanTimeout := "24h"
+
+		opts := AdminOrganizationUpdateOptions{
+			AccessBetaTools:                  &accessBetaTools,
+			GlobalModuleSharing:              &globalModuleSharing,
+			IsDisabled:                       &isDisabled,
+			TerraformBuildWorkerApplyTimeout: &terraformBuildWorkerApplyTimeout,
+			TerraformBuildWorkerPlanTimeout:  &terraformBuildWorkerPlanTimeout,
+		}
+
+		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
+
+		assert.NotNilf(t, adminOrg, "Org returned as nil")
+		assert.Nilf(t, err, "Failed to update org %v", err)
+
+		assert.Equal(t, adminOrg.AccessBetaTools, accessBetaTools)
+		assert.Equal(t, adminOrg.GlobalModuleSharing, globalModuleSharing)
+		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
+		assert.Equal(t, adminOrg.TerraformBuildWorkerApplyTimeout, terraformBuildWorkerApplyTimeout)
+		assert.Equal(t, adminOrg.TerraformBuildWorkerPlanTimeout, terraformBuildWorkerPlanTimeout)
+
+		isDisabled = true
+		opts = AdminOrganizationUpdateOptions{
+			IsDisabled: &isDisabled,
+		}
+
+		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
+		assert.NotNilf(t, adminOrg, "Org returned as nil")
+		assert.Nilf(t, err, "Failed to update org %v", err)
+
+		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
+
+		isDisabled = false
+		opts = AdminOrganizationUpdateOptions{
+			IsDisabled: &isDisabled,
+		}
+
+		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
+		assert.NotNilf(t, adminOrg, "Org returned as nil")
+		assert.Nilf(t, err, "Failed to update org %v", err)
+
+		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
+	})
+}

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -202,6 +202,7 @@ func TestAdminOrganizations(t *testing.T) {
 		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
 		assert.Equal(t, adminOrg.TerraformBuildWorkerApplyTimeout, terraformBuildWorkerApplyTimeout)
 		assert.Equal(t, adminOrg.TerraformBuildWorkerPlanTimeout, terraformBuildWorkerPlanTimeout)
+		assert.Equal(t, adminOrg.TerraformWorkerSudoEnabled, false)
 
 		isDisabled = true
 		opts = AdminOrganizationUpdateOptions{

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -27,14 +27,20 @@ func TestModulePartnershipsList(t *testing.T) {
 		opts := ModulePartnershipUpdateOptions{
 			ModuleConsumingOrganizationIDs: []*string{&org2.ExternalID},
 		}
-		consumerList, _ = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
-		assert.Equal(t, org2.ExternalID, *consumerList.Items[0].ConsumingOrganizationID)
-		assert.Equal(t, org.ExternalID, *consumerList.Items[0].ProducingOrganizationID)
+		oldConsumerList, _ := client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Equal(t, org2.ExternalID, *oldConsumerList.Items[0].ConsumingOrganizationID)
+		assert.Equal(t, org.ExternalID, *oldConsumerList.Items[0].ProducingOrganizationID)
+
+		consumerList, _ = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		assert.Equal(t, org2.ExternalID, consumerList.Items[0].ExternalID)
 
 		opts = ModulePartnershipUpdateOptions{
 			ModuleConsumingOrganizationIDs: []*string{},
 		}
-		consumerList, _ = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		oldConsumerList, _ = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Empty(t, oldConsumerList.Items)
+
+		consumerList, _ = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Empty(t, consumerList.Items)
 	})
 }

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -8,6 +8,9 @@ import (
 )
 
 func TestModulePartnershipsList(t *testing.T) {
+
+	skipIfNotEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -47,7 +47,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 			&org2.Name,
 		}
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
-		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
@@ -59,7 +59,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 			&org3.Name,
 		}
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
-		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		assert.Nilf(t, err, "Failed to update consumers %v", err)
 		nameList = _toNameList(consumerList.Items)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
@@ -72,7 +72,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 			&org3.Name,
 		}
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
-		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
@@ -81,7 +81,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 
 		opts = ModuleConsumers{}
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
-		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -1,0 +1,37 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestModulePartnershipsList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	org, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	t.Run("creates and destroys consumers", func(t *testing.T) {
+		consumerList, _ := client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		assert.Empty(t, consumerList.Items)
+
+		org2, orgTestCleanup2 := createOrganization(t, client)
+		defer orgTestCleanup2()
+
+		opts := ModulePartnershipUpdateOptions{
+			ModuleConsumingOrganizationIDs: []*string{&org2.ExternalID},
+		}
+		consumerList, _ = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Equal(t, org2.ExternalID, *consumerList.Items[0].ConsumingOrganizationID)
+		assert.Equal(t, org.ExternalID, *consumerList.Items[0].ProducingOrganizationID)
+
+		opts = ModulePartnershipUpdateOptions{
+			ModuleConsumingOrganizationIDs: []*string{},
+		}
+		consumerList, _ = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Empty(t, consumerList.Items)
+	})
+}

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -46,25 +46,21 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 		opts := ModuleConsumers{
 			&org2.Name,
 		}
-		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to read update consumers %v", err)
-		nameList := _toNameList(consumerList.Items)
-		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
-		nameList = _toNameList(consumerList.Items)
+		nameList := _toNameList(consumerList.Items)
 		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
 
 		opts = ModuleConsumers{
 			&org2.Name,
 			&org3.Name,
 		}
-		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to read update consumers %v", err)
 		nameList = _toNameList(consumerList.Items)
-		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
-		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
@@ -75,10 +71,8 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 		opts = ModuleConsumers{
 			&org3.Name,
 		}
-		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to read update consumers %v", err)
-		nameList = _toNameList(consumerList.Items)
-		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
@@ -86,9 +80,8 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
 
 		opts = ModuleConsumers{}
-		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to read update consumers %v", err)
-		assert.Empty(t, consumerList.Items)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -18,7 +18,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 	defer orgTestCleanup()
 
 	t.Run("creates and destroys consumers", func(t *testing.T) {
-		consumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		consumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{})
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
 		assert.Empty(t, consumerList.Items)
 
@@ -49,7 +49,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
-		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{})
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
 		nameList := _toNameList(consumerList.Items)
 		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
@@ -62,7 +62,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 		assert.Nilf(t, err, "Failed to update consumers %v", err)
 		nameList = _toNameList(consumerList.Items)
 
-		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{})
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
 		nameList = _toNameList(consumerList.Items)
 		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
@@ -74,7 +74,7 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
-		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{})
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
 		nameList = _toNameList(consumerList.Items)
 		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
@@ -83,9 +83,66 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
-		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{})
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
 		assert.Empty(t, consumerList.Items)
+	})
+
+	t.Run("lists consumers with pagination options", func(t *testing.T) {
+		consumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{})
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
+		assert.Empty(t, consumerList.Items)
+
+		org2, orgTestCleanup2 := createOrganization(t, client)
+		defer orgTestCleanup2()
+		org3, orgTestCleanup3 := createOrganization(t, client)
+		defer orgTestCleanup3()
+
+		_listContains := func(name string, items []string) bool {
+			for _, item := range items {
+				if name == item {
+					return true
+				}
+			}
+			return false
+		}
+		_toNameList := func(orgs []*Organization) []string {
+			names := []string{}
+			for _, org := range orgs {
+				names = append(names, org.Name)
+			}
+			return names
+		}
+
+		opts := ModuleConsumers{
+			&org2.Name,
+			&org3.Name,
+		}
+		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Nilf(t, err, "Failed to update consumers %v", err)
+
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{
+			ListOptions{
+				PageSize:   1,
+				PageNumber: 1,
+			},
+		})
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
+		nameList1 := _toNameList(consumerList.Items)
+
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name, OrganizationListOptions{
+			ListOptions{
+				PageSize:   1,
+				PageNumber: 2,
+			},
+		})
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
+		nameList2 := _toNameList(consumerList.Items)
+
+		nameList := append(nameList1, nameList2...)
+
+		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
+		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
 	})
 }
 

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -49,6 +49,23 @@ func TestAdminOrganizations(t *testing.T) {
 	org, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
+	t.Run("deletes organization", func(t *testing.T) {
+		org2, org2TestCleanup := createOrganization(t, client)
+		cleanupFailed := false
+		var err error = nil
+		defer func() {
+			if cleanupFailed {
+				t.Error("Error destroying organization!", org.Name, err)
+				org2TestCleanup()
+			}
+		}()
+
+		err = client.Admin.Organizations.Delete(ctx, org2.Name)
+		if err != nil {
+			cleanupFailed = true
+		}
+	})
+
 	t.Run("fetches and updates organization", func(t *testing.T) {
 		adminOrg, err := client.Admin.Organizations.Read(ctx, org.Name)
 		assert.NotNilf(t, adminOrg, "Org returned as nil")

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestModulePartnershipsList(t *testing.T) {
+func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 
 	skipIfNotEnterprise(t)
 
@@ -18,29 +18,31 @@ func TestModulePartnershipsList(t *testing.T) {
 	defer orgTestCleanup()
 
 	t.Run("creates and destroys consumers", func(t *testing.T) {
-		consumerList, _ := client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		consumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
 		assert.Empty(t, consumerList.Items)
 
 		org2, orgTestCleanup2 := createOrganization(t, client)
 		defer orgTestCleanup2()
 
-		opts := ModulePartnershipUpdateOptions{
-			ModuleConsumingOrganizationIDs: []*string{&org2.ExternalID},
+		opts := ModuleConsumers{
+			&org2.Name,
 		}
-		oldConsumerList, _ := client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
-		assert.Equal(t, org2.ExternalID, *oldConsumerList.Items[0].ConsumingOrganizationID)
-		assert.Equal(t, org.ExternalID, *oldConsumerList.Items[0].ProducingOrganizationID)
+		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		assert.Equal(t, org2.Name, consumerList.Items[0].Name)
 
-		consumerList, _ = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
-		assert.Equal(t, org2.ExternalID, consumerList.Items[0].ExternalID)
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
+		assert.Equal(t, org2.Name, consumerList.Items[0].Name)
 
-		opts = ModulePartnershipUpdateOptions{
-			ModuleConsumingOrganizationIDs: []*string{},
-		}
-		oldConsumerList, _ = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
-		assert.Empty(t, oldConsumerList.Items)
+		opts = ModuleConsumers{}
+		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		assert.Empty(t, consumerList.Items)
 
-		consumerList, _ = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
 		assert.Empty(t, consumerList.Items)
 	})
 }

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -24,17 +24,66 @@ func TestAdminOrganizationModulePartnershipsList(t *testing.T) {
 
 		org2, orgTestCleanup2 := createOrganization(t, client)
 		defer orgTestCleanup2()
+		org3, orgTestCleanup3 := createOrganization(t, client)
+		defer orgTestCleanup3()
+
+		_listContains := func(name string, items []string) bool {
+			for _, item := range items {
+				if name == item {
+					return true
+				}
+			}
+			return false
+		}
+		_toNameList := func(orgs []*Organization) []string {
+			names := []string{}
+			for _, org := range orgs {
+				names = append(names, org.Name)
+			}
+			return names
+		}
 
 		opts := ModuleConsumers{
 			&org2.Name,
 		}
 		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to read update consumers %v", err)
-		assert.Equal(t, org2.Name, consumerList.Items[0].Name)
+		nameList := _toNameList(consumerList.Items)
+		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
 
 		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
 		assert.Nilf(t, err, "Failed to read org consumers %v", err)
-		assert.Equal(t, org2.Name, consumerList.Items[0].Name)
+		nameList = _toNameList(consumerList.Items)
+		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
+
+		opts = ModuleConsumers{
+			&org2.Name,
+			&org3.Name,
+		}
+		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		nameList = _toNameList(consumerList.Items)
+		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
+		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
+
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
+		nameList = _toNameList(consumerList.Items)
+		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
+		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
+
+		opts = ModuleConsumers{
+			&org3.Name,
+		}
+		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
+		assert.Nilf(t, err, "Failed to read update consumers %v", err)
+		nameList = _toNameList(consumerList.Items)
+		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
+
+		consumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org.Name)
+		assert.Nilf(t, err, "Failed to read org consumers %v", err)
+		nameList = _toNameList(consumerList.Items)
+		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
 
 		opts = ModuleConsumers{}
 		consumerList, err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,7 @@ github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/helper_test.go
+++ b/helper_test.go
@@ -27,6 +27,28 @@ func testClient(t *testing.T) *Client {
 	return client
 }
 
+// skips a test if ENABLE_TFE is not set to equal "1"
+// this is used to conditionally skip tests if not running against a Terraform
+// Enterprise instance. Effectively these tests will only run against a Terraform
+// Enterprise instance.
+func skipIfNotEnterprise(t *testing.T) {
+	enableTFE := os.Getenv("ENABLE_TFE")
+	if enableTFE != "1" {
+		t.Skip("Skipping Terraform Enterprise related test. Set ENABLE_TFE=1 to run.")
+	}
+}
+
+// skips a test if ENABLE_TFE is set to equal "1"
+// this is used to conditionally skip tests if running against a Terraform
+// Enterprise instance. Effectively these tests will only run against a Terraform
+// Cloud instance.
+func skipIfEnterprise(t *testing.T) {
+	enableTFE := os.Getenv("ENABLE_TFE")
+	if enableTFE == "1" {
+		t.Skip("Skipping Terraform Cloud related test. Set ENABLE_TFE=0 to run.")
+	}
+}
+
 func fetchTestAccountDetails(t *testing.T, client *Client) *TestAccountDetails {
 	if _testAccountDetails == nil {
 		_testAccountDetails = FetchTestAccountDetails(t, client)

--- a/organization.go
+++ b/organization.go
@@ -43,7 +43,7 @@ type Organizations interface {
 
 	// ModuleProducers shows the organizations that are producing modules that this organization can consume
 	// NOTE: this is a TFE only API and will fail if run against a non TFE instance
-	ModuleProducers(ctx context.Context, organization string) (*OrganizationList, error)
+	ModuleProducers(ctx context.Context, organization string, options OrganizationListOptions) (*OrganizationList, error)
 }
 
 // organizations implements Organizations.
@@ -376,13 +376,13 @@ func (s *organizations) RunQueue(ctx context.Context, organization string, optio
 }
 
 // ModuleProducers shows the organizations that are producing modules that this organization can consume
-func (s *organizations) ModuleProducers(ctx context.Context, organization string) (*OrganizationList, error) {
+func (s *organizations) ModuleProducers(ctx context.Context, organization string, options OrganizationListOptions) (*OrganizationList, error) {
 	if !validStringID(&organization) {
 		return nil, errors.New("invalid value for organization")
 	}
 
 	u := fmt.Sprintf("organizations/%s/relationships/module-producers", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/organization_test.go
+++ b/organization_test.go
@@ -407,15 +407,17 @@ func TestOrganizationsModuleProducers(t *testing.T) {
 
 		opts := ModuleConsumers{
 			&org2.Name,
-			&org3.Name,
 		}
 		err := client.Admin.Organizations.UpdateModuleConsumers(ctx, org.Name, opts)
 		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
-		producerList, err := client.Organizations.ModuleProducers(ctx, org.Name)
+		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org3.Name, opts)
+		assert.Nilf(t, err, "Failed to update consumers %v", err)
+
+		producerList, err := client.Organizations.ModuleProducers(ctx, org2.Name)
 		assert.Nilf(t, err, "Failed to read org producers %v", err)
 		nameList := _toNameList(producerList.Items)
-		assert.Truef(t, _listContains(org2.Name, nameList), "Expected %v to be in returned list", org2.Name)
+		assert.Truef(t, _listContains(org.Name, nameList), "Expected %v to be in returned list", org.Name)
 		assert.Truef(t, _listContains(org3.Name, nameList), "Expected %v to be in returned list", org3.Name)
 	})
 

--- a/organization_test.go
+++ b/organization_test.go
@@ -453,7 +453,7 @@ func TestOrganizationsModuleProducers(t *testing.T) {
 		assert.Nilf(t, err, "Failed to update consumers %v", err)
 
 		producerList1, err := client.Organizations.ModuleProducers(ctx, org2.Name, OrganizationListOptions{
-			ListOptions: ListOptions{
+			ListOptions{
 				PageNumber: 1,
 				PageSize:   1,
 			},
@@ -462,7 +462,7 @@ func TestOrganizationsModuleProducers(t *testing.T) {
 		nameList1 := _toNameList(producerList1.Items)
 
 		producerList2, err := client.Organizations.ModuleProducers(ctx, org2.Name, OrganizationListOptions{
-			ListOptions: ListOptions{
+			ListOptions{
 				PageNumber: 2,
 				PageSize:   1,
 			},

--- a/tfe.go
+++ b/tfe.go
@@ -108,6 +108,8 @@ type Client struct {
 	retryServerErrors bool
 	remoteAPIVersion  string
 
+	Admin Admin
+
 	AgentPools                 AgentPools
 	Applies                    Applies
 	ConfigurationVersions      ConfigurationVersions
@@ -138,6 +140,13 @@ type Client struct {
 	UserTokens                 UserTokens
 	Variables                  Variables
 	Workspaces                 Workspaces
+}
+
+// Admin is the the Terraform Enterprise Admin API. It provides access to site
+// wide admin settings. These are only available for Terraform Enterprise and
+// do not function against Terraform Cloud.
+type Admin struct {
+	Organizations AdminOrganizations
 }
 
 // NewClient creates a new Terraform Enterprise API client.
@@ -211,6 +220,11 @@ func NewClient(cfg *Config) (*Client, error) {
 	// Save the API version so we can return it from the RemoteAPIVersion
 	// method later.
 	client.remoteAPIVersion = meta.APIVersion
+
+	// Create Admin
+	client.Admin = Admin{
+		Organizations: &adminOrganizations{client: client},
+	}
 
 	// Create the services.
 	client.AgentPools = &agentPools{client: client}


### PR DESCRIPTION
## Description

Adds client methods for changing TFE admin organization module sharing partnerships.
Add test for module sharing interactions.

Add admin portion of the client for these interfaces and other existing admin API interfaces.

## Testing plan

1.  Run the included tests **against a TFE instance** (setup a local TFE instance using ONPREM_ENABLED=1, set appropriate TFE_ADDRESS and an admin TFE_TOKEN)

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/admin/module-sharing.html)

## Output from tests

```
12:04 $ ENABLE_TFE=1 go test -run TestAdminOrganization ./... -v -count=1
=== RUN   TestAdminOrganizationModulePartnershipsList
=== RUN   TestAdminOrganizationModulePartnershipsList/creates_and_destroys_consumers
--- PASS: TestAdminOrganizationModulePartnershipsList (2.35s)
    --- PASS: TestAdminOrganizationModulePartnershipsList/creates_and_destroys_consumers (1.39s)
=== RUN   TestAdminOrganizations
=== RUN   TestAdminOrganizations/deletes_organization
=== RUN   TestAdminOrganizations/fetches_and_updates_organization
--- PASS: TestAdminOrganizations (2.01s)
    --- PASS: TestAdminOrganizations/deletes_organization (0.53s)
    --- PASS: TestAdminOrganizations/fetches_and_updates_organization (0.72s)
PASS
ok  	github.com/hashicorp/go-tfe	4.368s


```
