### PR TITLE
Add CreatedBy relationship to Run

### DIFF
--- a/run.go
+++ b/run.go
@@ -25,6 +25,9 @@ type Runs interface {
 	// Read a run by its ID.
 	Read(ctx context.Context, runID string) (*Run, error)
 
+	// ReadWithOptions reads a run by its ID using the options supplied
+	ReadWithOptions(ctx context.Context, runID string, options *RunReadOptions) (*Run, error)
+
 	// Apply a run by its ID.
 	Apply(ctx context.Context, runID string, options RunApplyOptions) error
 
@@ -236,12 +239,22 @@ func (s *runs) Create(ctx context.Context, options RunCreateOptions) (*Run, erro
 
 // Read a run by its ID.
 func (s *runs) Read(ctx context.Context, runID string) (*Run, error) {
+	return s.ReadWithOptions(ctx, runID, nil)
+}
+
+// RunReadOptions represents the options for reading a run.
+type RunReadOptions struct {
+	Include string `url:"include"`
+}
+
+// Read a run by its ID with the given options.
+func (s *runs) ReadWithOptions(ctx context.Context, runID string, options *RunReadOptions) (*Run, error) {
 	if !validStringID(&runID) {
 		return nil, errors.New("invalid value for run ID")
 	}
 
 	u := fmt.Sprintf("runs/%s", url.QueryEscape(runID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/run.go
+++ b/run.go
@@ -107,6 +107,7 @@ type Run struct {
 	Apply                *Apply                `jsonapi:"relation,apply"`
 	ConfigurationVersion *ConfigurationVersion `jsonapi:"relation,configuration-version"`
 	CostEstimate         *CostEstimate         `jsonapi:"relation,cost-estimate"`
+	CreatedBy            *User                 `jsonapi:"relation,created-by"`
 	Plan                 *Plan                 `jsonapi:"relation,plan"`
 	PolicyChecks         []*PolicyCheck        `jsonapi:"relation,policy-checks"`
 	Workspace            *Workspace            `jsonapi:"relation,workspace"`

--- a/run_test.go
+++ b/run_test.go
@@ -146,6 +146,26 @@ func TestRunsRead(t *testing.T) {
 	})
 }
 
+func TestRunsReadWithOptions(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	rTest, rTestCleanup := createRun(t, client, nil)
+	defer rTestCleanup()
+
+	t.Run("when the run exists", func(t *testing.T) {
+		curOpts := &RunReadOptions{
+			Include: "created_by",
+		}
+
+		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, curOpts)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, r.CreatedBy)
+		assert.NotEmpty(t, r.CreatedBy.Username)
+	})
+}
+
 func TestRunsApply(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Description

* Adds `Run.CreatedBy` field, populated from the `created-by` relationship.
* Adds a `Runs.ReadWithOptions` to accommodate options like an `?include=` parameter in fetching a single run. The API keeps backward compatibility and matches what we do for StateVersions.

Closes #21 

## Output from tests

```
» go test -v ./... -timeout=30m -run TestRunsReadWithOptions
=== RUN   TestRunsReadWithOptions
=== RUN   TestRunsReadWithOptions/when_the_run_exists
--- PASS: TestRunsReadWithOptions (4.00s)
    --- PASS: TestRunsReadWithOptions/when_the_run_exists (0.25s)
PASS
ok      github.com/hashicorp/go-tfe     4.663s
```