### PR TITLE
Omarismail/errors cleanup

### DIFF
--- a/agent_pool.go
+++ b/agent_pool.go
@@ -59,7 +59,7 @@ type AgentPoolListOptions struct {
 // List all the agent pools of the given organization.
 func (s *agentPools) List(ctx context.Context, organization string, options AgentPoolListOptions) (*AgentPoolList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/agent-pools", url.QueryEscape(organization))
@@ -88,10 +88,10 @@ type AgentPoolCreateOptions struct {
 
 func (o AgentPoolCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	return nil
 }
@@ -99,7 +99,7 @@ func (o AgentPoolCreateOptions) valid() error {
 // Create a new agent pool with the given options.
 func (s *agentPools) Create(ctx context.Context, organization string, options AgentPoolCreateOptions) (*AgentPool, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	if err := options.valid(); err != nil {
@@ -156,7 +156,7 @@ type AgentPoolUpdateOptions struct {
 
 func (o AgentPoolUpdateOptions) valid() error {
 	if o.Name != nil && !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	return nil
 }

--- a/agent_pool_test.go
+++ b/agent_pool_test.go
@@ -45,7 +45,7 @@ func TestAgentPoolsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		pools, err := client.AgentPools.List(ctx, badIdentifier, AgentPoolListOptions{})
 		assert.Nil(t, pools)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -79,7 +79,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 	t.Run("when options is missing name", func(t *testing.T) {
 		k, err := client.AgentPools.Create(ctx, "foo", AgentPoolCreateOptions{})
 		assert.Nil(t, k)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with an invalid organization", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 			Name: String("cool-pool"),
 		})
 		assert.Nil(t, pool)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 

--- a/agent_pool_test.go
+++ b/agent_pool_test.go
@@ -45,7 +45,7 @@ func TestAgentPoolsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		pools, err := client.AgentPools.List(ctx, badIdentifier, AgentPoolListOptions{})
 		assert.Nil(t, pools)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -79,7 +79,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 	t.Run("when options is missing name", func(t *testing.T) {
 		k, err := client.AgentPools.Create(ctx, "foo", AgentPoolCreateOptions{})
 		assert.Nil(t, k)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with an invalid organization", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 			Name: String("cool-pool"),
 		})
 		assert.Nil(t, pool)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,31 @@
+package tfe
+
+import (
+	"errors"
+)
+
+// Generic errors applicable to all resources.
+var (
+	// ErrWorkspaceLocked is returned when trying to lock a
+	// locked workspace.
+	ErrWorkspaceLocked = errors.New("workspace already locked")
+
+	// ErrWorkspaceNotLocked is returned when trying to unlock
+	// a unlocked workspace.
+	ErrWorkspaceNotLocked = errors.New("workspace already unlocked")
+
+	// ErrUnauthorized is returned when a receiving a 401.
+	ErrUnauthorized = errors.New("unauthorized")
+
+	// ErrResourceNotFound is returned when a receiving a 404.
+	ErrResourceNotFound = errors.New("resource not found")
+
+	// ErrRequiredName is returned when a name option is not present.
+	ErrRequiredName = errors.New("name is required")
+
+	// ErrInvalidName is returned when the name option is has invalid value.
+	ErrInvalidName = errors.New("invalid value for name")
+
+	// ErrInvalidOrg is returned when the organization option has an invalid value.
+	ErrInvalidOrg = errors.New("invalid value for organization")
+)

--- a/errors.go
+++ b/errors.go
@@ -23,7 +23,7 @@ var (
 	// ErrRequiredName is returned when a name option is not present.
 	ErrRequiredName = errors.New("name is required")
 
-	// ErrInvalidName is returned when the name option is has invalid value.
+	// ErrInvalidName is returned when the name option has invalid value.
 	ErrInvalidName = errors.New("invalid value for name")
 
 	// ErrInvalidOrg is returned when the organization option has an invalid value.

--- a/ip_ranges.go
+++ b/ip_ranges.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+
 	"github.com/hashicorp/go-retryablehttp"
 )
 

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -168,7 +168,7 @@ func (o NotificationConfigurationCreateOptions) valid() error {
 		return errors.New("enabled is required")
 	}
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 
 	if *o.DestinationType == NotificationDestinationTypeGeneric || *o.DestinationType == NotificationDestinationTypeSlack {

--- a/notification_configuration_test.go
+++ b/notification_configuration_test.go
@@ -106,7 +106,7 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 
 		nc, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
 		assert.Nil(t, nc)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("without a required value URL when destination type is generic", func(t *testing.T) {

--- a/notification_configuration_test.go
+++ b/notification_configuration_test.go
@@ -106,7 +106,7 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 
 		nc, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
 		assert.Nil(t, nc)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("without a required value URL when destination type is generic", func(t *testing.T) {

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -88,7 +88,7 @@ type OAuthClientListOptions struct {
 // List all the OAuth clients for a given organization.
 func (s *oAuthClients) List(ctx context.Context, organization string, options OAuthClientListOptions) (*OAuthClientList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
@@ -149,7 +149,7 @@ func (o OAuthClientCreateOptions) valid() error {
 // Create an OAuth client to connect an organization and a VCS provider.
 func (s *oAuthClients) Create(ctx context.Context, organization string, options OAuthClientCreateOptions) (*OAuthClient, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
 		return nil, err

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -69,7 +69,7 @@ func TestOAuthClientsList(t *testing.T) {
 
 		ocl, err := client.OAuthClients.List(ctx, badIdentifier, options)
 		assert.Nil(t, ocl)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -115,7 +115,7 @@ func TestOAuthClientsCreate(t *testing.T) {
 		}
 
 		_, err := client.OAuthClients.Create(ctx, badIdentifier, options)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("without an API URL", func(t *testing.T) {

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -69,7 +69,7 @@ func TestOAuthClientsList(t *testing.T) {
 
 		ocl, err := client.OAuthClients.List(ctx, badIdentifier, options)
 		assert.Nil(t, ocl)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -115,7 +115,7 @@ func TestOAuthClientsCreate(t *testing.T) {
 		}
 
 		_, err := client.OAuthClients.Create(ctx, badIdentifier, options)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("without an API URL", func(t *testing.T) {

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -62,7 +62,7 @@ type OAuthTokenListOptions struct {
 // List all the OAuth tokens for a given organization.
 func (s *oAuthTokens) List(ctx context.Context, organization string, options OAuthTokenListOptions) (*OAuthTokenList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-tokens", url.QueryEscape(organization))

--- a/oauth_token_test.go
+++ b/oauth_token_test.go
@@ -70,7 +70,7 @@ func TestOAuthTokensList(t *testing.T) {
 
 		otl, err := client.OAuthTokens.List(ctx, badIdentifier, options)
 		assert.Nil(t, otl)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 

--- a/oauth_token_test.go
+++ b/oauth_token_test.go
@@ -70,7 +70,7 @@ func TestOAuthTokensList(t *testing.T) {
 
 		otl, err := client.OAuthTokens.List(ctx, badIdentifier, options)
 		assert.Nil(t, otl)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 

--- a/organization.go
+++ b/organization.go
@@ -182,10 +182,10 @@ type OrganizationCreateOptions struct {
 
 func (o OrganizationCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	if !validString(o.Email) {
 		return errors.New("email is required")
@@ -219,7 +219,7 @@ func (s *organizations) Create(ctx context.Context, options OrganizationCreateOp
 // Read an organization by its name.
 func (s *organizations) Read(ctx context.Context, organization string) (*Organization, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
@@ -267,7 +267,7 @@ type OrganizationUpdateOptions struct {
 // Update attributes of an existing organization.
 func (s *organizations) Update(ctx context.Context, organization string, options OrganizationUpdateOptions) (*Organization, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	// Make sure we don't send a user provided ID.
@@ -291,7 +291,7 @@ func (s *organizations) Update(ctx context.Context, organization string, options
 // Delete an organization by its name.
 func (s *organizations) Delete(ctx context.Context, organization string) error {
 	if !validStringID(&organization) {
-		return errors.New("invalid value for organization")
+		return ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
@@ -306,7 +306,7 @@ func (s *organizations) Delete(ctx context.Context, organization string) error {
 // Capacity shows the currently used capacity of an organization.
 func (s *organizations) Capacity(ctx context.Context, organization string) (*Capacity, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/capacity", url.QueryEscape(organization))
@@ -327,7 +327,7 @@ func (s *organizations) Capacity(ctx context.Context, organization string) (*Cap
 // Entitlements shows the entitlements of an organization.
 func (s *organizations) Entitlements(ctx context.Context, organization string) (*Entitlements, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/entitlement-set", url.QueryEscape(organization))
@@ -353,7 +353,7 @@ type RunQueueOptions struct {
 // RunQueue shows the current run queue of an organization.
 func (s *organizations) RunQueue(ctx context.Context, organization string, options RunQueueOptions) (*RunQueue, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/runs/queue", url.QueryEscape(organization))

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -74,7 +74,7 @@ type OrganizationMembershipListOptions struct {
 // List all the organization memberships of the given organization.
 func (s *organizationMemberships) List(ctx context.Context, organization string, options OrganizationMembershipListOptions) (*OrganizationMembershipList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
@@ -111,7 +111,7 @@ func (o OrganizationMembershipCreateOptions) valid() error {
 // Create an organization membership with the given options.
 func (s *organizationMemberships) Create(ctx context.Context, organization string, options OrganizationMembershipCreateOptions) (*OrganizationMembership, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
 		return nil, err

--- a/organization_membership_test.go
+++ b/organization_membership_test.go
@@ -72,7 +72,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		ml, err := client.OrganizationMemberships.List(ctx, badIdentifier, OrganizationMembershipListOptions{})
 		assert.Nil(t, ml)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -112,7 +112,7 @@ func TestOrganizationMembershipsCreate(t *testing.T) {
 		})
 
 		assert.Nil(t, mem)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when an error is returned from the api", func(t *testing.T) {

--- a/organization_membership_test.go
+++ b/organization_membership_test.go
@@ -72,7 +72,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		ml, err := client.OrganizationMemberships.List(ctx, badIdentifier, OrganizationMembershipListOptions{})
 		assert.Nil(t, ml)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -112,7 +112,7 @@ func TestOrganizationMembershipsCreate(t *testing.T) {
 		})
 
 		assert.Nil(t, mem)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when an error is returned from the api", func(t *testing.T) {

--- a/organization_test.go
+++ b/organization_test.go
@@ -78,7 +78,7 @@ func TestOrganizationsCreate(t *testing.T) {
 		_, err := client.Organizations.Create(ctx, OrganizationCreateOptions{
 			Email: String("foo@bar.com"),
 		})
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with invalid name", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestOrganizationsCreate(t *testing.T) {
 			Email: String("foo@bar.com"),
 		})
 		assert.Nil(t, org)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 }
 
@@ -117,7 +117,7 @@ func TestOrganizationsRead(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Read(ctx, badIdentifier)
 		assert.Nil(t, org)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestOrganizationsUpdate(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Update(ctx, badIdentifier, OrganizationUpdateOptions{})
 		assert.Nil(t, org)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when only updating a subset of fields", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestOrganizationsDelete(t *testing.T) {
 
 	t.Run("with invalid name", func(t *testing.T) {
 		err := client.Organizations.Delete(ctx, badIdentifier)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -240,7 +240,7 @@ func TestOrganizationsCapacity(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Read(ctx, badIdentifier)
 		assert.Nil(t, org)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {
@@ -276,7 +276,7 @@ func TestOrganizationsEntitlements(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		entitlements, err := client.Organizations.Entitlements(ctx, badIdentifier)
 		assert.Nil(t, entitlements)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {
@@ -364,7 +364,7 @@ func TestOrganizationsRunQueue(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Read(ctx, badIdentifier)
 		assert.Nil(t, org)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {

--- a/organization_test.go
+++ b/organization_test.go
@@ -78,7 +78,7 @@ func TestOrganizationsCreate(t *testing.T) {
 		_, err := client.Organizations.Create(ctx, OrganizationCreateOptions{
 			Email: String("foo@bar.com"),
 		})
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with invalid name", func(t *testing.T) {
@@ -87,7 +87,7 @@ func TestOrganizationsCreate(t *testing.T) {
 			Email: String("foo@bar.com"),
 		})
 		assert.Nil(t, org)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 }
 
@@ -117,7 +117,7 @@ func TestOrganizationsRead(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Read(ctx, badIdentifier)
 		assert.Nil(t, org)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {
@@ -168,7 +168,7 @@ func TestOrganizationsUpdate(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Update(ctx, badIdentifier, OrganizationUpdateOptions{})
 		assert.Nil(t, org)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when only updating a subset of fields", func(t *testing.T) {
@@ -199,7 +199,7 @@ func TestOrganizationsDelete(t *testing.T) {
 
 	t.Run("with invalid name", func(t *testing.T) {
 		err := client.Organizations.Delete(ctx, badIdentifier)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -240,7 +240,7 @@ func TestOrganizationsCapacity(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Read(ctx, badIdentifier)
 		assert.Nil(t, org)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {
@@ -276,7 +276,7 @@ func TestOrganizationsEntitlements(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		entitlements, err := client.Organizations.Entitlements(ctx, badIdentifier)
 		assert.Nil(t, entitlements)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {
@@ -364,7 +364,7 @@ func TestOrganizationsRunQueue(t *testing.T) {
 	t.Run("with invalid name", func(t *testing.T) {
 		org, err := client.Organizations.Read(ctx, badIdentifier)
 		assert.Nil(t, org)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {

--- a/organization_token.go
+++ b/organization_token.go
@@ -2,7 +2,6 @@ package tfe
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 	"time"
@@ -44,7 +43,7 @@ type OrganizationToken struct {
 // Generate a new organization token, replacing any existing token.
 func (s *organizationTokens) Generate(ctx context.Context, organization string) (*OrganizationToken, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
@@ -65,7 +64,7 @@ func (s *organizationTokens) Generate(ctx context.Context, organization string) 
 // Read an organization token.
 func (s *organizationTokens) Read(ctx context.Context, organization string) (*OrganizationToken, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
@@ -86,7 +85,7 @@ func (s *organizationTokens) Read(ctx context.Context, organization string) (*Or
 // Delete an organization token.
 func (s *organizationTokens) Delete(ctx context.Context, organization string) error {
 	if !validStringID(&organization) {
-		return errors.New("invalid value for organization")
+		return ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))

--- a/organization_token_test.go
+++ b/organization_token_test.go
@@ -33,7 +33,7 @@ func TestOrganizationTokensGenerate(t *testing.T) {
 	t.Run("without valid organization", func(t *testing.T) {
 		ot, err := client.OrganizationTokens.Generate(ctx, badIdentifier)
 		assert.Nil(t, ot)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -63,7 +63,7 @@ func TestOrganizationTokensRead(t *testing.T) {
 	t.Run("without valid organization", func(t *testing.T) {
 		ot, err := client.OrganizationTokens.Read(ctx, badIdentifier)
 		assert.Nil(t, ot)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -88,6 +88,6 @@ func TestOrganizationTokensDelete(t *testing.T) {
 
 	t.Run("without valid organization", func(t *testing.T) {
 		err := client.OrganizationTokens.Delete(ctx, badIdentifier)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }

--- a/organization_token_test.go
+++ b/organization_token_test.go
@@ -33,7 +33,7 @@ func TestOrganizationTokensGenerate(t *testing.T) {
 	t.Run("without valid organization", func(t *testing.T) {
 		ot, err := client.OrganizationTokens.Generate(ctx, badIdentifier)
 		assert.Nil(t, ot)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -63,7 +63,7 @@ func TestOrganizationTokensRead(t *testing.T) {
 	t.Run("without valid organization", func(t *testing.T) {
 		ot, err := client.OrganizationTokens.Read(ctx, badIdentifier)
 		assert.Nil(t, ot)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -88,6 +88,6 @@ func TestOrganizationTokensDelete(t *testing.T) {
 
 	t.Run("without valid organization", func(t *testing.T) {
 		err := client.OrganizationTokens.Delete(ctx, badIdentifier)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }

--- a/policy.go
+++ b/policy.go
@@ -90,7 +90,7 @@ type PolicyListOptions struct {
 // List all the policies for a given organization
 func (s *policies) List(ctx context.Context, organization string, options PolicyListOptions) (*PolicyList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/policies", url.QueryEscape(organization))
@@ -131,10 +131,10 @@ type EnforcementOptions struct {
 
 func (o PolicyCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	if o.Enforce == nil {
 		return errors.New("enforce is required")
@@ -153,7 +153,7 @@ func (o PolicyCreateOptions) valid() error {
 // Create a policy and associate it with an organization.
 func (s *policies) Create(ctx context.Context, organization string, options PolicyCreateOptions) (*Policy, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
 		return nil, err

--- a/policy_set.go
+++ b/policy_set.go
@@ -87,7 +87,7 @@ type PolicySetListOptions struct {
 // List all the policies for a given organization.
 func (s *policySets) List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
@@ -140,10 +140,10 @@ type PolicySetCreateOptions struct {
 
 func (o PolicySetCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	return nil
 }
@@ -151,7 +151,7 @@ func (o PolicySetCreateOptions) valid() error {
 // Create a policy set and associate it with an organization.
 func (s *policySets) Create(ctx context.Context, organization string, options PolicySetCreateOptions) (*PolicySet, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
 		return nil, err
@@ -226,7 +226,7 @@ type PolicySetUpdateOptions struct {
 
 func (o PolicySetUpdateOptions) valid() error {
 	if o.Name != nil && !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	return nil
 }

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -63,7 +63,7 @@ func TestPolicySetsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		ps, err := client.PolicySets.List(ctx, badIdentifier, PolicySetListOptions{})
 		assert.Nil(t, ps)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -199,7 +199,7 @@ func TestPolicySetsCreate(t *testing.T) {
 	t.Run("without a name provided", func(t *testing.T) {
 		ps, err := client.PolicySets.Create(ctx, orgTest.Name, PolicySetCreateOptions{})
 		assert.Nil(t, ps)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with an invalid name provided", func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestPolicySetsCreate(t *testing.T) {
 			Name: String("nope!"),
 		})
 		assert.Nil(t, ps)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestPolicySetsCreate(t *testing.T) {
 			Name: String("policy-set"),
 		})
 		assert.Nil(t, ps)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -271,7 +271,7 @@ func TestPolicySetsUpdate(t *testing.T) {
 			Name: String("nope!"),
 		})
 		assert.Nil(t, ps)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("without a valid ID", func(t *testing.T) {

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -63,7 +63,7 @@ func TestPolicySetsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		ps, err := client.PolicySets.List(ctx, badIdentifier, PolicySetListOptions{})
 		assert.Nil(t, ps)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -199,7 +199,7 @@ func TestPolicySetsCreate(t *testing.T) {
 	t.Run("without a name provided", func(t *testing.T) {
 		ps, err := client.PolicySets.Create(ctx, orgTest.Name, PolicySetCreateOptions{})
 		assert.Nil(t, ps)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with an invalid name provided", func(t *testing.T) {
@@ -207,7 +207,7 @@ func TestPolicySetsCreate(t *testing.T) {
 			Name: String("nope!"),
 		})
 		assert.Nil(t, ps)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestPolicySetsCreate(t *testing.T) {
 			Name: String("policy-set"),
 		})
 		assert.Nil(t, ps)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -271,7 +271,7 @@ func TestPolicySetsUpdate(t *testing.T) {
 			Name: String("nope!"),
 		})
 		assert.Nil(t, ps)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("without a valid ID", func(t *testing.T) {

--- a/policy_test.go
+++ b/policy_test.go
@@ -62,7 +62,7 @@ func TestPoliciesList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		ps, err := client.Policies.List(ctx, badIdentifier, PolicyListOptions{})
 		assert.Nil(t, ps)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -114,7 +114,7 @@ func TestPoliciesCreate(t *testing.T) {
 			},
 		})
 		assert.Nil(t, p)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("when options is missing name", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestPoliciesCreate(t *testing.T) {
 			},
 		})
 		assert.Nil(t, p)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("when options is missing an enforcement", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestPoliciesCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, p)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 

--- a/policy_test.go
+++ b/policy_test.go
@@ -62,7 +62,7 @@ func TestPoliciesList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		ps, err := client.Policies.List(ctx, badIdentifier, PolicyListOptions{})
 		assert.Nil(t, ps)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -114,7 +114,7 @@ func TestPoliciesCreate(t *testing.T) {
 			},
 		})
 		assert.Nil(t, p)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("when options is missing name", func(t *testing.T) {
@@ -127,7 +127,7 @@ func TestPoliciesCreate(t *testing.T) {
 			},
 		})
 		assert.Nil(t, p)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("when options is missing an enforcement", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestPoliciesCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, p)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -119,10 +119,10 @@ type RegistryModuleCreateOptions struct {
 
 func (o RegistryModuleCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	if !validString(o.Provider) {
 		return errors.New("provider is required")
@@ -136,7 +136,7 @@ func (o RegistryModuleCreateOptions) valid() error {
 // Create a new registry module without a VCS repo
 func (r *registryModules) Create(ctx context.Context, organization string, options RegistryModuleCreateOptions) (*RegistryModule, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
 		return nil, err
@@ -184,13 +184,13 @@ func (o RegistryModuleCreateVersionOptions) valid() error {
 // Create a new registry module version
 func (r *registryModules) CreateVersion(ctx context.Context, organization string, name string, provider string, options RegistryModuleCreateVersionOptions) (*RegistryModuleVersion, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if !validString(&name) {
-		return nil, errors.New("name is required")
+		return nil, ErrRequiredName
 	}
 	if !validStringID(&name) {
-		return nil, errors.New("invalid value for name")
+		return nil, ErrInvalidName
 	}
 	if !validString(&provider) {
 		return nil, errors.New("provider is required")
@@ -227,7 +227,7 @@ func (r *registryModules) CreateVersion(ctx context.Context, organization string
 
 // RegistryModuleCreateWithVCSConnectionOptions is used when creating a registry module with a VCS repo
 type RegistryModuleCreateWithVCSConnectionOptions struct {
-        ID string `jsonapi:"primary,registry-modules"`
+	ID string `jsonapi:"primary,registry-modules"`
 
 	// VCS repository information
 	VCSRepo *RegistryModuleVCSRepoOptions `jsonapi:"attr,vcs-repo"`
@@ -265,8 +265,8 @@ func (r *registryModules) CreateWithVCSConnection(ctx context.Context, options R
 		return nil, err
 	}
 
-        // Make sure we don't send a user provided ID.
-        options.ID = ""
+	// Make sure we don't send a user provided ID.
+	options.ID = ""
 
 	req, err := r.client.newRequest("POST", "registry-modules", &options)
 	if err != nil {
@@ -285,13 +285,13 @@ func (r *registryModules) CreateWithVCSConnection(ctx context.Context, options R
 // Read a specific registry module
 func (r *registryModules) Read(ctx context.Context, organization string, name string, provider string) (*RegistryModule, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if !validString(&name) {
-		return nil, errors.New("name is required")
+		return nil, ErrRequiredName
 	}
 	if !validStringID(&name) {
-		return nil, errors.New("invalid value for name")
+		return nil, ErrInvalidName
 	}
 	if !validString(&provider) {
 		return nil, errors.New("provider is required")
@@ -323,13 +323,13 @@ func (r *registryModules) Read(ctx context.Context, organization string, name st
 // Delete is used to delete the entire registry module
 func (r *registryModules) Delete(ctx context.Context, organization string, name string) error {
 	if !validStringID(&organization) {
-		return errors.New("invalid value for organization")
+		return ErrInvalidOrg
 	}
 	if !validString(&name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(&name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 
 	u := fmt.Sprintf(
@@ -348,13 +348,13 @@ func (r *registryModules) Delete(ctx context.Context, organization string, name 
 // DeleteProvider is used to delete the specific registry module provider
 func (r *registryModules) DeleteProvider(ctx context.Context, organization string, name string, provider string) error {
 	if !validStringID(&organization) {
-		return errors.New("invalid value for organization")
+		return ErrInvalidOrg
 	}
 	if !validString(&name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(&name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	if !validString(&provider) {
 		return errors.New("provider is required")
@@ -380,13 +380,13 @@ func (r *registryModules) DeleteProvider(ctx context.Context, organization strin
 // DeleteVersion is used to delete the specific registry module version
 func (r *registryModules) DeleteVersion(ctx context.Context, organization string, name string, provider string, version string) error {
 	if !validStringID(&organization) {
-		return errors.New("invalid value for organization")
+		return ErrInvalidOrg
 	}
 	if !validString(&name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(&name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	if !validString(&provider) {
 		return errors.New("provider is required")

--- a/registry_module_test.go
+++ b/registry_module_test.go
@@ -4,11 +4,9 @@ import (
 	"context"
 	"os"
 	"strings"
-
-	//"fmt"
-	"github.com/stretchr/testify/assert"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -53,7 +51,7 @@ func TestRegistryModulesCreate(t *testing.T) {
 			}
 			rm, err := client.RegistryModules.Create(ctx, orgTest.Name, options)
 			assert.Nil(t, rm)
-			assert.EqualError(t, err, "name is required")
+			assert.Equal(t, err, ErrRequiredName)
 		})
 
 		t.Run("with an invalid name", func(t *testing.T) {
@@ -63,7 +61,7 @@ func TestRegistryModulesCreate(t *testing.T) {
 			}
 			rm, err := client.RegistryModules.Create(ctx, orgTest.Name, options)
 			assert.Nil(t, rm)
-			assert.EqualError(t, err, "invalid value for name")
+			assert.Equal(t, err, ErrInvalidName)
 		})
 
 		t.Run("without a provider", func(t *testing.T) {
@@ -93,7 +91,7 @@ func TestRegistryModulesCreate(t *testing.T) {
 		}
 		rm, err := client.RegistryModules.Create(ctx, badIdentifier, options)
 		assert.Nil(t, rm)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -150,7 +148,7 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 		}
 		rmv, err := client.RegistryModules.CreateVersion(ctx, orgTest.Name, "", registryModuleTest.Provider, options)
 		assert.Nil(t, rmv)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
@@ -159,7 +157,7 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 		}
 		rmv, err := client.RegistryModules.CreateVersion(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider, options)
 		assert.Nil(t, rmv)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -186,7 +184,7 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 		}
 		rmv, err := client.RegistryModules.CreateVersion(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider, options)
 		assert.Nil(t, rmv)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 }
@@ -326,13 +324,13 @@ func TestRegistryModulesRead(t *testing.T) {
 	t.Run("without a name", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, orgTest.Name, "", registryModuleTest.Provider)
 		assert.Nil(t, rm)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider)
 		assert.Nil(t, rm)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -350,7 +348,7 @@ func TestRegistryModulesRead(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider)
 		assert.Nil(t, rm)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the registry module does not exist", func(t *testing.T) {
@@ -380,17 +378,17 @@ func TestRegistryModulesDelete(t *testing.T) {
 
 	t.Run("without a name", func(t *testing.T) {
 		err := client.RegistryModules.Delete(ctx, orgTest.Name, "")
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		err := client.RegistryModules.Delete(ctx, orgTest.Name, badIdentifier)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
 		err := client.RegistryModules.Delete(ctx, badIdentifier, registryModuleTest.Name)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the registry module does not exist", func(t *testing.T) {
@@ -421,12 +419,12 @@ func TestRegistryModulesDeleteProvider(t *testing.T) {
 
 	t.Run("without a name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteProvider(ctx, orgTest.Name, "", registryModuleTest.Provider)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteProvider(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -441,7 +439,7 @@ func TestRegistryModulesDeleteProvider(t *testing.T) {
 
 	t.Run("without a valid organization", func(t *testing.T) {
 		err := client.RegistryModules.DeleteProvider(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the registry module name and provider do not exist", func(t *testing.T) {
@@ -487,12 +485,12 @@ func TestRegistryModulesDeleteVersion(t *testing.T) {
 
 	t.Run("without a name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteVersion(ctx, orgTest.Name, "", registryModuleTest.Provider, registryModuleTest.VersionStatuses[0].Version)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteVersion(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider, registryModuleTest.VersionStatuses[0].Version)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -517,7 +515,7 @@ func TestRegistryModulesDeleteVersion(t *testing.T) {
 
 	t.Run("without a valid organization", func(t *testing.T) {
 		err := client.RegistryModules.DeleteVersion(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider, registryModuleTest.VersionStatuses[0].Version)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when the registry module name, provider, and version do not exist", func(t *testing.T) {

--- a/registry_module_test.go
+++ b/registry_module_test.go
@@ -51,7 +51,7 @@ func TestRegistryModulesCreate(t *testing.T) {
 			}
 			rm, err := client.RegistryModules.Create(ctx, orgTest.Name, options)
 			assert.Nil(t, rm)
-			assert.Equal(t, err, ErrRequiredName)
+			assert.EqualError(t, err, ErrRequiredName.Error())
 		})
 
 		t.Run("with an invalid name", func(t *testing.T) {
@@ -61,7 +61,7 @@ func TestRegistryModulesCreate(t *testing.T) {
 			}
 			rm, err := client.RegistryModules.Create(ctx, orgTest.Name, options)
 			assert.Nil(t, rm)
-			assert.Equal(t, err, ErrInvalidName)
+			assert.EqualError(t, err, ErrInvalidName.Error())
 		})
 
 		t.Run("without a provider", func(t *testing.T) {
@@ -91,7 +91,7 @@ func TestRegistryModulesCreate(t *testing.T) {
 		}
 		rm, err := client.RegistryModules.Create(ctx, badIdentifier, options)
 		assert.Nil(t, rm)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -148,7 +148,7 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 		}
 		rmv, err := client.RegistryModules.CreateVersion(ctx, orgTest.Name, "", registryModuleTest.Provider, options)
 		assert.Nil(t, rmv)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
@@ -157,7 +157,7 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 		}
 		rmv, err := client.RegistryModules.CreateVersion(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider, options)
 		assert.Nil(t, rmv)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -184,7 +184,7 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 		}
 		rmv, err := client.RegistryModules.CreateVersion(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider, options)
 		assert.Nil(t, rmv)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 }
@@ -324,13 +324,13 @@ func TestRegistryModulesRead(t *testing.T) {
 	t.Run("without a name", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, orgTest.Name, "", registryModuleTest.Provider)
 		assert.Nil(t, rm)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider)
 		assert.Nil(t, rm)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -348,7 +348,7 @@ func TestRegistryModulesRead(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider)
 		assert.Nil(t, rm)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the registry module does not exist", func(t *testing.T) {
@@ -378,17 +378,17 @@ func TestRegistryModulesDelete(t *testing.T) {
 
 	t.Run("without a name", func(t *testing.T) {
 		err := client.RegistryModules.Delete(ctx, orgTest.Name, "")
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		err := client.RegistryModules.Delete(ctx, orgTest.Name, badIdentifier)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
 		err := client.RegistryModules.Delete(ctx, badIdentifier, registryModuleTest.Name)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the registry module does not exist", func(t *testing.T) {
@@ -419,12 +419,12 @@ func TestRegistryModulesDeleteProvider(t *testing.T) {
 
 	t.Run("without a name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteProvider(ctx, orgTest.Name, "", registryModuleTest.Provider)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteProvider(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -439,7 +439,7 @@ func TestRegistryModulesDeleteProvider(t *testing.T) {
 
 	t.Run("without a valid organization", func(t *testing.T) {
 		err := client.RegistryModules.DeleteProvider(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the registry module name and provider do not exist", func(t *testing.T) {
@@ -485,12 +485,12 @@ func TestRegistryModulesDeleteVersion(t *testing.T) {
 
 	t.Run("without a name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteVersion(ctx, orgTest.Name, "", registryModuleTest.Provider, registryModuleTest.VersionStatuses[0].Version)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("with an invalid name", func(t *testing.T) {
 		err := client.RegistryModules.DeleteVersion(ctx, orgTest.Name, badIdentifier, registryModuleTest.Provider, registryModuleTest.VersionStatuses[0].Version)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("without a provider", func(t *testing.T) {
@@ -515,7 +515,7 @@ func TestRegistryModulesDeleteVersion(t *testing.T) {
 
 	t.Run("without a valid organization", func(t *testing.T) {
 		err := client.RegistryModules.DeleteVersion(ctx, badIdentifier, registryModuleTest.Name, registryModuleTest.Provider, registryModuleTest.VersionStatuses[0].Version)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the registry module name, provider, and version do not exist", func(t *testing.T) {

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -57,7 +57,7 @@ type SSHKeyListOptions struct {
 // List all the SSH keys for a given organization
 func (s *sshKeys) List(ctx context.Context, organization string, options SSHKeyListOptions) (*SSHKeyList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/ssh-keys", url.QueryEscape(organization))
@@ -89,7 +89,7 @@ type SSHKeyCreateOptions struct {
 
 func (o SSHKeyCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validString(o.Value) {
 		return errors.New("value is required")
@@ -100,7 +100,7 @@ func (o SSHKeyCreateOptions) valid() error {
 // Create an SSH key and associate it with an organization.
 func (s *sshKeys) Create(ctx context.Context, organization string, options SSHKeyCreateOptions) (*SSHKey, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	if err := options.valid(); err != nil {

--- a/ssh_key_test.go
+++ b/ssh_key_test.go
@@ -49,7 +49,7 @@ func TestSSHKeysList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		kl, err := client.SSHKeys.List(ctx, badIdentifier, SSHKeyListOptions{})
 		assert.Nil(t, kl)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -87,7 +87,7 @@ func TestSSHKeysCreate(t *testing.T) {
 			Value: String(randomString(t)),
 		})
 		assert.Nil(t, k)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("when options is missing value", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestSSHKeysCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, k)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 

--- a/ssh_key_test.go
+++ b/ssh_key_test.go
@@ -49,7 +49,7 @@ func TestSSHKeysList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		kl, err := client.SSHKeys.List(ctx, badIdentifier, SSHKeyListOptions{})
 		assert.Nil(t, kl)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -87,7 +87,7 @@ func TestSSHKeysCreate(t *testing.T) {
 			Value: String(randomString(t)),
 		})
 		assert.Nil(t, k)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("when options is missing value", func(t *testing.T) {
@@ -103,7 +103,7 @@ func TestSSHKeysCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, k)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 

--- a/state_version_output_test.go
+++ b/state_version_output_test.go
@@ -2,10 +2,11 @@ package tfe
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 const waitForStateVersionOutputs = 500 * time.Millisecond

--- a/team.go
+++ b/team.go
@@ -79,7 +79,7 @@ type TeamListOptions struct {
 // List all the teams of the given organization.
 func (s *teams) List(ctx context.Context, organization string, options TeamListOptions) (*TeamList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
@@ -121,7 +121,7 @@ type OrganizationAccessOptions struct {
 
 func (o TeamCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	return nil
 }
@@ -129,7 +129,7 @@ func (o TeamCreateOptions) valid() error {
 // Create a new team with the given options.
 func (s *teams) Create(ctx context.Context, organization string, options TeamCreateOptions) (*Team, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
 		return nil, err

--- a/team_test.go
+++ b/team_test.go
@@ -51,7 +51,7 @@ func TestTeamsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		tl, err := client.Teams.List(ctx, badIdentifier, TeamListOptions{})
 		assert.Nil(t, tl)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -86,7 +86,7 @@ func TestTeamsCreate(t *testing.T) {
 	t.Run("when options is missing name", func(t *testing.T) {
 		tm, err := client.Teams.Create(ctx, "foo", TeamCreateOptions{})
 		assert.Nil(t, tm)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("when options has an invalid organization", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestTeamsCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, tm)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 

--- a/team_test.go
+++ b/team_test.go
@@ -51,7 +51,7 @@ func TestTeamsList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		tl, err := client.Teams.List(ctx, badIdentifier, TeamListOptions{})
 		assert.Nil(t, tl)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -86,7 +86,7 @@ func TestTeamsCreate(t *testing.T) {
 	t.Run("when options is missing name", func(t *testing.T) {
 		tm, err := client.Teams.Create(ctx, "foo", TeamCreateOptions{})
 		assert.Nil(t, tm)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("when options has an invalid organization", func(t *testing.T) {
@@ -94,7 +94,7 @@ func TestTeamsCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, tm)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 

--- a/team_token_test.go
+++ b/team_token_test.go
@@ -62,7 +62,7 @@ func TestTeamTokensRead(t *testing.T) {
 	t.Run("without valid organization", func(t *testing.T) {
 		tt, err := client.OrganizationTokens.Read(ctx, badIdentifier)
 		assert.Nil(t, tt)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 

--- a/team_token_test.go
+++ b/team_token_test.go
@@ -62,7 +62,7 @@ func TestTeamTokensRead(t *testing.T) {
 	t.Run("without valid organization", func(t *testing.T) {
 		tt, err := client.OrganizationTokens.Read(ctx, badIdentifier)
 		assert.Nil(t, tt)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 

--- a/tfe.go
+++ b/tfe.go
@@ -37,20 +37,6 @@ const (
 	PingEndpoint = "ping"
 )
 
-var (
-	// ErrWorkspaceLocked is returned when trying to lock a
-	// locked workspace.
-	ErrWorkspaceLocked = errors.New("workspace already locked")
-	// ErrWorkspaceNotLocked is returned when trying to unlock
-	// a unlocked workspace.
-	ErrWorkspaceNotLocked = errors.New("workspace already unlocked")
-
-	// ErrUnauthorized is returned when a receiving a 401.
-	ErrUnauthorized = errors.New("unauthorized")
-	// ErrResourceNotFound is returned when a receiving a 404.
-	ErrResourceNotFound = errors.New("resource not found")
-)
-
 // RetryLogHook allows a function to run before each retry.
 type RetryLogHook func(attemptNum int, resp *http.Response)
 

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -5,14 +5,14 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"github.com/hashicorp/go-retryablehttp"
-	"github.com/svanharmelen/jsonapi"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"testing"
 	"time"
 
+	"github.com/hashicorp/go-retryablehttp"
+	"github.com/svanharmelen/jsonapi"
 	"golang.org/x/time/rate"
 )
 

--- a/workspace.go
+++ b/workspace.go
@@ -147,7 +147,7 @@ type WorkspaceListOptions struct {
 // List all the workspaces within an organization.
 func (s *workspaces) List(ctx context.Context, organization string, options WorkspaceListOptions) (*WorkspaceList, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
@@ -250,10 +250,10 @@ type VCSRepoOptions struct {
 
 func (o WorkspaceCreateOptions) valid() error {
 	if !validString(o.Name) {
-		return errors.New("name is required")
+		return ErrRequiredName
 	}
 	if !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	if o.Operations != nil && o.ExecutionMode != nil {
 		return errors.New("operations is deprecated and cannot be specified when execution mode is used")
@@ -271,7 +271,7 @@ func (o WorkspaceCreateOptions) valid() error {
 // Create is used to create a new workspace.
 func (s *workspaces) Create(ctx context.Context, organization string, options WorkspaceCreateOptions) (*Workspace, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
 		return nil, err
@@ -298,7 +298,7 @@ func (s *workspaces) Create(ctx context.Context, organization string, options Wo
 // Read a workspace by its name.
 func (s *workspaces) Read(ctx context.Context, organization, workspace string) (*Workspace, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
 		return nil, errors.New("invalid value for workspace")
@@ -418,7 +418,7 @@ type WorkspaceUpdateOptions struct {
 
 func (o WorkspaceUpdateOptions) valid() error {
 	if o.Name != nil && !validStringID(o.Name) {
-		return errors.New("invalid value for name")
+		return ErrInvalidName
 	}
 	if o.Operations != nil && o.ExecutionMode != nil {
 		return errors.New("operations is deprecated and cannot be specified when execution mode is used")
@@ -433,7 +433,7 @@ func (o WorkspaceUpdateOptions) valid() error {
 // Update settings of an existing workspace.
 func (s *workspaces) Update(ctx context.Context, organization, workspace string, options WorkspaceUpdateOptions) (*Workspace, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
 		return nil, errors.New("invalid value for workspace")
@@ -491,7 +491,7 @@ func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options
 // Delete a workspace by its name.
 func (s *workspaces) Delete(ctx context.Context, organization, workspace string) error {
 	if !validStringID(&organization) {
-		return errors.New("invalid value for organization")
+		return ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
 		return errors.New("invalid value for workspace")
@@ -534,7 +534,7 @@ type workspaceRemoveVCSConnectionOptions struct {
 // RemoveVCSConnection from a workspace.
 func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
 		return nil, errors.New("invalid value for workspace")

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -73,7 +73,7 @@ func TestWorkspacesList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		wl, err := client.Workspaces.List(ctx, badIdentifier, WorkspaceListOptions{})
 		assert.Nil(t, wl)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("with organization included", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestWorkspacesCreate(t *testing.T) {
 	t.Run("when options is missing name", func(t *testing.T) {
 		w, err := client.Workspaces.Create(ctx, "foo", WorkspaceCreateOptions{})
 		assert.Nil(t, w)
-		assert.Equal(t, err, ErrRequiredName)
+		assert.EqualError(t, err, ErrRequiredName.Error())
 	})
 
 	t.Run("when options has an invalid name", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			Name: String(badIdentifier),
 		})
 		assert.Nil(t, w)
-		assert.Equal(t, err, ErrInvalidName)
+		assert.EqualError(t, err, ErrInvalidName.Error())
 	})
 
 	t.Run("when options has an invalid organization", func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, w)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when options includes both an operations value and an enforcement mode value", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestWorkspacesRead(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		w, err := client.Workspaces.Read(ctx, badIdentifier, wTest.Name)
 		assert.Nil(t, w)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("without a valid workspace", func(t *testing.T) {
@@ -405,7 +405,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 	t.Run("when options has an invalid organization", func(t *testing.T) {
 		w, err := client.Workspaces.Update(ctx, badIdentifier, wTest.Name, WorkspaceUpdateOptions{})
 		assert.Nil(t, w)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
 
@@ -512,7 +512,7 @@ func TestWorkspacesDelete(t *testing.T) {
 
 	t.Run("when organization is invalid", func(t *testing.T) {
 		err := client.Workspaces.Delete(ctx, badIdentifier, wTest.Name)
-		assert.Equal(t, err, ErrInvalidOrg)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when workspace is invalid", func(t *testing.T) {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -73,7 +73,7 @@ func TestWorkspacesList(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		wl, err := client.Workspaces.List(ctx, badIdentifier, WorkspaceListOptions{})
 		assert.Nil(t, wl)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("with organization included", func(t *testing.T) {
@@ -140,7 +140,7 @@ func TestWorkspacesCreate(t *testing.T) {
 	t.Run("when options is missing name", func(t *testing.T) {
 		w, err := client.Workspaces.Create(ctx, "foo", WorkspaceCreateOptions{})
 		assert.Nil(t, w)
-		assert.EqualError(t, err, "name is required")
+		assert.Equal(t, err, ErrRequiredName)
 	})
 
 	t.Run("when options has an invalid name", func(t *testing.T) {
@@ -148,7 +148,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			Name: String(badIdentifier),
 		})
 		assert.Nil(t, w)
-		assert.EqualError(t, err, "invalid value for name")
+		assert.Equal(t, err, ErrInvalidName)
 	})
 
 	t.Run("when options has an invalid organization", func(t *testing.T) {
@@ -156,7 +156,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, w)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when options includes both an operations value and an enforcement mode value", func(t *testing.T) {
@@ -246,7 +246,7 @@ func TestWorkspacesRead(t *testing.T) {
 	t.Run("without a valid organization", func(t *testing.T) {
 		w, err := client.Workspaces.Read(ctx, badIdentifier, wTest.Name)
 		assert.Nil(t, w)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("without a valid workspace", func(t *testing.T) {
@@ -405,7 +405,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 	t.Run("when options has an invalid organization", func(t *testing.T) {
 		w, err := client.Workspaces.Update(ctx, badIdentifier, wTest.Name, WorkspaceUpdateOptions{})
 		assert.Nil(t, w)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 }
 
@@ -512,7 +512,7 @@ func TestWorkspacesDelete(t *testing.T) {
 
 	t.Run("when organization is invalid", func(t *testing.T) {
 		err := client.Workspaces.Delete(ctx, badIdentifier, wTest.Name)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.Equal(t, err, ErrInvalidOrg)
 	})
 
 	t.Run("when workspace is invalid", func(t *testing.T) {


### PR DESCRIPTION
## Description

The purpose of this PR is to clean up a bit of error handling. 

Having dedicated errors variables instead of using hard coded strings avoids doing [shotgun surgery](https://refactoring.guru/smells/shotgun-surgery). If we want to improve the error handling (a later followup to this), we will need to change strings in every location. But now, by having one variable, we can change that one string and it applies everywhere.

This change does three things:
1. creates an errors.go file that holds these variables.
2. Moves the errors from `tfe.go` into `errors.go`.
3. find all and replace where the errors for validation are used. 
4. Drive by clean up in making sure the imports for all files follows the pattern of: first is standard library and the following that is external pacakges.
5. fix some formatting indentation 

## Follow up

This does not change all errors, just a few of them. A follow up PR will go through all errors and organize them in this manner. 

## Testing plan

Run the tests and make sure they all pass. 
