### PR TITLE
Admin Organizations API Client

### DIFF
--- a/TESTS.md
+++ b/TESTS.md
@@ -25,6 +25,7 @@ Tests are run against an actual backend so they require a valid backend address 
 1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running any tests that use VCS (OAuth clients, policy sets, etc).
 1. `GITHUB_POLICY_SET_IDENTIFIER` - GitHub policy set repository identifier in the format `username/repository`. Required for running policy set tests.
 1. `GITHUB_REGISTRY_MODULE_IDENTIFIER` - GitHub registry module repository identifier in the format `username/repository`. Required for running registry module tests.
+1. `ENABLE_TFE` - Some tests are only applicable to Terraform Enterprise or Terraform Cloud. By setting `ENABLE_TFE=1` you will enable enterprise only tests and disable cloud only tests. In CI `ENABLE_TFE` is not set so if you are writing enterprise only features you should manually test with `ENABLE_TFE=1` against a Terraform Enterprise instance.
 
 You can set your environment variables up however you prefer. The following are instructions for setting up environment variables using [envchain](https://github.com/sorah/envchain).
    1. Make sure you have envchain installed. [Instructions for this can be found in the envchain README](https://github.com/sorah/envchain#installation).

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -43,6 +43,9 @@ type AdminOrganization struct {
 	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
 	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
 	TerraformWorkerSudoEnabled       bool   `jsonapi:"attr,terraform-worker-sudo-enabled"`
+
+	// Relations
+	Owners []*User `jsonapi:"relation,owners"`
 }
 
 // AdminOrganizationUpdateOptions represents the admin options for updating an organization.
@@ -67,6 +70,10 @@ type AdminOrganizationListOptions struct {
 	// A query string used to filter organizations.
 	// Any organizations with a name or notification email partially matching this value will be returned.
 	Query *string `url:"q,omitempty"`
+
+	// A list of relations to include. See available resources
+	// https://www.terraform.io/docs/cloud/api/admin/organizations.html#available-related-resources
+	Include *string `url:"include"`
 }
 
 // List all the organizations visible to the current user.

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -1,0 +1,111 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminOrganizations = (*adminOrganizations)(nil)
+
+// AdminOrganizations describes all of the admin organization related methods that the Terraform
+// Enterprise API supports. Note that admin settings are only available in Terraform Enterprise.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/admin/organizations.html
+type AdminOrganizations interface {
+	// Read attributes of an existing organization via admin API.
+	Read(ctx context.Context, organization string) (*AdminOrganization, error)
+
+	// Update attributes of an existing organization via admin API.
+	Update(ctx context.Context, organization string, options AdminOrganizationUpdateOptions) (*AdminOrganization, error)
+
+	// Delete an organization by its name via admin API
+	Delete(ctx context.Context, organization string) error
+}
+
+// adminOrganizations implements AdminOrganizations.
+type adminOrganizations struct {
+	client *Client
+}
+
+// AdminOrganization represents a Terraform Enterprise organization returned from the Admin API.
+type AdminOrganization struct {
+	Name string `jsonapi:"primary,organizations"`
+
+	AccessBetaTools                  bool   `jsonapi:"attr,access-beta-tools"`
+	ExternalID                       string `jsonapi:"attr,external-id"`
+	GlobalModuleSharing              bool   `jsonapi:"attr,global-module-sharing"`
+	IsDisabled                       bool   `jsonapi:"attr,is-disabled"`
+	NotificationEmail                string `jsonapi:"attr,notification-email"`
+	SsoEnabled                       bool   `jsonapi:"attr,sso-enabled"`
+	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
+	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
+	TerraformWorkerSudoEnabled       bool   `jsonapi:"attr,terraform-worker-sudo-enabled"`
+}
+
+// AdminOrganizationUpdateOptions represents the admin options for updating an organization.
+// https://www.terraform.io/docs/cloud/api/admin/organizations.html#request-body
+type AdminOrganizationUpdateOptions struct {
+	AccessBetaTools                  *bool   `jsonapi:"attr,access-beta-tools,omitempty"`
+	GlobalModuleSharing              *bool   `jsonapi:"attr,global-module-sharing,omitempty"`
+	IsDisabled                       *bool   `jsonapi:"attr,is-disabled,omitempty"`
+	TerraformBuildWorkerApplyTimeout *string `jsonapi:"attr,terraform-build-worker-apply-timeout,omitempty"`
+	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
+}
+
+func (s *adminOrganizations) Read(ctx context.Context, organization string) (*AdminOrganization, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+
+	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	org := &AdminOrganization{}
+	err = s.client.do(ctx, req, org)
+	if err != nil {
+		return nil, err
+	}
+
+	return org, nil
+}
+
+func (s *adminOrganizations) Update(ctx context.Context, organization string, options AdminOrganizationUpdateOptions) (*AdminOrganization, error) {
+	if !validStringID(&organization) {
+		return nil, errors.New("invalid value for organization")
+	}
+
+	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	org := &AdminOrganization{}
+	err = s.client.do(ctx, req, org)
+	if err != nil {
+		return nil, err
+	}
+
+	return org, nil
+}
+
+// Delete an organization by its name.
+func (s *adminOrganizations) Delete(ctx context.Context, organization string) error {
+	if !validStringID(&organization) {
+		return errors.New("invalid value for organization")
+	}
+
+	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -65,7 +65,7 @@ type AdminOrganizationListOptions struct {
 	ListOptions
 
 	// A query string used to filter organizations.
-	// It can be name or notification email.
+	// Any organizations with a name or notification email partially matching this value will be returned.
 	Query *string `url:"q,omitempty"`
 }
 

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -35,7 +35,6 @@ type AdminOrganization struct {
 
 	AccessBetaTools                  bool   `jsonapi:"attr,access-beta-tools"`
 	ExternalID                       string `jsonapi:"attr,external-id"`
-	GlobalModuleSharing              bool   `jsonapi:"attr,global-module-sharing"`
 	IsDisabled                       bool   `jsonapi:"attr,is-disabled"`
 	NotificationEmail                string `jsonapi:"attr,notification-email"`
 	SsoEnabled                       bool   `jsonapi:"attr,sso-enabled"`
@@ -48,7 +47,6 @@ type AdminOrganization struct {
 // https://www.terraform.io/docs/cloud/api/admin/organizations.html#request-body
 type AdminOrganizationUpdateOptions struct {
 	AccessBetaTools                  *bool   `jsonapi:"attr,access-beta-tools,omitempty"`
-	GlobalModuleSharing              *bool   `jsonapi:"attr,global-module-sharing,omitempty"`
 	IsDisabled                       *bool   `jsonapi:"attr,is-disabled,omitempty"`
 	TerraformBuildWorkerApplyTimeout *string `jsonapi:"attr,terraform-build-worker-apply-timeout,omitempty"`
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -55,6 +55,7 @@ type AdminOrganizationUpdateOptions struct {
 	IsDisabled                       *bool   `jsonapi:"attr,is-disabled,omitempty"`
 	TerraformBuildWorkerApplyTimeout *string `jsonapi:"attr,terraform-build-worker-apply-timeout,omitempty"`
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
+	TerraformWorkerSudoEnabled       bool    `jsonapi:"attr,terraform-worker-sudo-enabled,omitempty"`
 }
 
 // AdminOrganizationList represents a list of organizations via Admin API.

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -2,7 +2,6 @@ package tfe
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 )
@@ -57,7 +56,7 @@ type AdminOrganizationUpdateOptions struct {
 
 func (s *adminOrganizations) Read(ctx context.Context, organization string) (*AdminOrganization, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
@@ -77,7 +76,7 @@ func (s *adminOrganizations) Read(ctx context.Context, organization string) (*Ad
 
 func (s *adminOrganizations) Update(ctx context.Context, organization string, options AdminOrganizationUpdateOptions) (*AdminOrganization, error) {
 	if !validStringID(&organization) {
-		return nil, errors.New("invalid value for organization")
+		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
@@ -98,7 +97,7 @@ func (s *adminOrganizations) Update(ctx context.Context, organization string, op
 // Delete an organization by its name.
 func (s *adminOrganizations) Delete(ctx context.Context, organization string) error {
 	if !validStringID(&organization) {
-		return errors.New("invalid value for organization")
+		return ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -1,0 +1,165 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminOrganizations_Read(t *testing.T) {
+	skipIfNotEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("it fails to read an organization with an invalid id", func(t *testing.T) {
+		adminOrg, err := client.Admin.Organizations.Read(ctx, "")
+		require.Error(t, err)
+		assert.EqualError(t, err, "invalid value for organization")
+		assert.Nil(t, adminOrg)
+	})
+
+	t.Run("it fails to read an organization with an bad org name", func(t *testing.T) {
+		orgName := fmt.Sprintf("bad-%s", randomString(t))
+		adminOrg, err := client.Admin.Organizations.Read(ctx, orgName)
+		require.Error(t, err)
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
+		assert.Nil(t, adminOrg)
+	})
+
+	t.Run("it reads an organization successfully", func(t *testing.T) {
+		org, orgTestCleanup := createOrganization(t, client)
+		defer orgTestCleanup()
+
+		adminOrg, err := client.Admin.Organizations.Read(ctx, org.Name)
+		assert.NoError(t, err)
+		assert.NotNilf(t, adminOrg, "Organization is not nil")
+		assert.Equal(t, adminOrg.Name, org.Name)
+
+		// attributes part of an AdminOrganization response that are not null
+		assert.NotNilf(t, adminOrg.AccessBetaTools, "AccessBetaTools is not nil")
+		assert.NotNilf(t, adminOrg.ExternalID, "ExternalID is not nil")
+		assert.NotNilf(t, adminOrg.GlobalModuleSharing, "GlobalModuleSharing is not nil")
+		assert.NotNilf(t, adminOrg.IsDisabled, "IsDisabled is not nil")
+		assert.NotNilf(t, adminOrg.NotificationEmail, "NotificationEmail is not nil")
+		assert.NotNilf(t, adminOrg.SsoEnabled, "SsoEnabled is not nil")
+		assert.NotNilf(t, adminOrg.TerraformWorkerSudoEnabled, "TerraformWorkerSudoEnabledis not nil")
+	})
+}
+
+func TestAdminOrganizations_Delete(t *testing.T) {
+	skipIfNotEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("it fails to delete an organization with an invalid id", func(t *testing.T) {
+		err := client.Admin.Organizations.Delete(ctx, "")
+		require.Error(t, err)
+		assert.EqualError(t, err, "invalid value for organization")
+	})
+
+	t.Run("it fails to delete an organization with an bad org name", func(t *testing.T) {
+		orgName := fmt.Sprintf("bad-%s", randomString(t))
+		err := client.Admin.Organizations.Delete(ctx, orgName)
+		require.Error(t, err)
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
+	})
+
+	t.Run("it deletes an organization successfully", func(t *testing.T) {
+		originalOrg, _ := createOrganization(t, client)
+
+		adminOrg, err := client.Admin.Organizations.Read(ctx, originalOrg.Name)
+		assert.NoError(t, err)
+		assert.NotNilf(t, adminOrg, "Organization is not nil")
+		assert.Equal(t, adminOrg.Name, originalOrg.Name)
+
+		err = client.Admin.Organizations.Delete(ctx, adminOrg.Name)
+		assert.NoError(t, err)
+
+		// Cannot find deleted org
+		_, err = client.Admin.Organizations.Read(ctx, originalOrg.Name)
+		assert.Error(t, err)
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
+	})
+}
+
+func TestAdminOrganizations_Update(t *testing.T) {
+	skipIfNotEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("it fails to update an organization with an invalid id", func(t *testing.T) {
+		_, err := client.Admin.Organizations.Update(ctx, "", AdminOrganizationUpdateOptions{})
+		require.Error(t, err)
+		assert.EqualError(t, err, "invalid value for organization")
+	})
+
+	t.Run("it fails to update an organization with an bad org name", func(t *testing.T) {
+		orgName := fmt.Sprintf("bad-%s", randomString(t))
+		_, err := client.Admin.Organizations.Update(ctx, orgName, AdminOrganizationUpdateOptions{})
+		require.Error(t, err)
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
+	})
+
+	t.Run("fetches and updates organization", func(t *testing.T) {
+		org, orgTestCleanup := createOrganization(t, client)
+		defer orgTestCleanup()
+
+		adminOrg, err := client.Admin.Organizations.Read(ctx, org.Name)
+		assert.NoError(t, err)
+		assert.NotNilf(t, adminOrg, "Org returned as nil")
+
+		accessBetaTools := true
+		globalModuleSharing := true
+		isDisabled := false
+		terraformBuildWorkerApplyTimeout := "24h"
+		terraformBuildWorkerPlanTimeout := "24h"
+
+		opts := AdminOrganizationUpdateOptions{
+			AccessBetaTools:                  &accessBetaTools,
+			GlobalModuleSharing:              &globalModuleSharing,
+			IsDisabled:                       &isDisabled,
+			TerraformBuildWorkerApplyTimeout: &terraformBuildWorkerApplyTimeout,
+			TerraformBuildWorkerPlanTimeout:  &terraformBuildWorkerPlanTimeout,
+		}
+
+		fmt.Println(org.Name)
+		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
+		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
+		assert.NoError(t, err)
+
+		assert.Equal(t, accessBetaTools, adminOrg.AccessBetaTools)
+		assert.Equal(t, globalModuleSharing, adminOrg.GlobalModuleSharing)
+		assert.Equal(t, isDisabled, adminOrg.IsDisabled)
+		assert.Equal(t, terraformBuildWorkerApplyTimeout, adminOrg.TerraformBuildWorkerApplyTimeout)
+		assert.Equal(t, terraformBuildWorkerPlanTimeout, adminOrg.TerraformBuildWorkerPlanTimeout)
+		assert.Equal(t, false, adminOrg.TerraformWorkerSudoEnabled)
+
+		isDisabled = true
+		opts = AdminOrganizationUpdateOptions{
+			IsDisabled: &isDisabled,
+		}
+
+		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
+		assert.NoError(t, err)
+		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
+
+		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
+
+		isDisabled = false
+		opts = AdminOrganizationUpdateOptions{
+			IsDisabled: &isDisabled,
+		}
+
+		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
+		assert.NoError(t, err)
+		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
+
+		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
+	})
+}

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -51,6 +51,17 @@ func TestAdminOrganizations_List(t *testing.T) {
 		assert.Equal(t, 1, adminOrgList.CurrentPage)
 		assert.Equal(t, 0, adminOrgList.TotalCount)
 	})
+
+	t.Run("with owners included", func(t *testing.T) {
+		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{
+			Include: String("owners"),
+		})
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, adminOrgList.Items)
+		assert.NotNil(t, adminOrgList.Items[0].Owners)
+		assert.NotEmpty(t, adminOrgList.Items[0].Owners[0].Email)
+	})
 }
 
 func TestAdminOrganizations_Read(t *testing.T) {

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 func TestAdminOrganizations_Read(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfCloud(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -42,7 +42,6 @@ func TestAdminOrganizations_Read(t *testing.T) {
 		// attributes part of an AdminOrganization response that are not null
 		assert.NotNilf(t, adminOrg.AccessBetaTools, "AccessBetaTools is not nil")
 		assert.NotNilf(t, adminOrg.ExternalID, "ExternalID is not nil")
-		assert.NotNilf(t, adminOrg.GlobalModuleSharing, "GlobalModuleSharing is not nil")
 		assert.NotNilf(t, adminOrg.IsDisabled, "IsDisabled is not nil")
 		assert.NotNilf(t, adminOrg.NotificationEmail, "NotificationEmail is not nil")
 		assert.NotNilf(t, adminOrg.SsoEnabled, "SsoEnabled is not nil")
@@ -51,7 +50,7 @@ func TestAdminOrganizations_Read(t *testing.T) {
 }
 
 func TestAdminOrganizations_Delete(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfCloud(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -88,7 +87,7 @@ func TestAdminOrganizations_Delete(t *testing.T) {
 }
 
 func TestAdminOrganizations_Update(t *testing.T) {
-	skipIfNotEnterprise(t)
+	skipIfCloud(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -115,14 +114,12 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		assert.NotNilf(t, adminOrg, "Org returned as nil")
 
 		accessBetaTools := true
-		globalModuleSharing := true
 		isDisabled := false
 		terraformBuildWorkerApplyTimeout := "24h"
 		terraformBuildWorkerPlanTimeout := "24h"
 
 		opts := AdminOrganizationUpdateOptions{
 			AccessBetaTools:                  &accessBetaTools,
-			GlobalModuleSharing:              &globalModuleSharing,
 			IsDisabled:                       &isDisabled,
 			TerraformBuildWorkerApplyTimeout: &terraformBuildWorkerApplyTimeout,
 			TerraformBuildWorkerPlanTimeout:  &terraformBuildWorkerPlanTimeout,
@@ -133,7 +130,6 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, accessBetaTools, adminOrg.AccessBetaTools)
-		assert.Equal(t, globalModuleSharing, adminOrg.GlobalModuleSharing)
 		assert.Equal(t, isDisabled, adminOrg.IsDisabled)
 		assert.Equal(t, terraformBuildWorkerApplyTimeout, adminOrg.TerraformBuildWorkerApplyTimeout)
 		assert.Equal(t, terraformBuildWorkerPlanTimeout, adminOrg.TerraformBuildWorkerPlanTimeout)

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -172,12 +172,14 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		isDisabled := false
 		terraformBuildWorkerApplyTimeout := "24h"
 		terraformBuildWorkerPlanTimeout := "24h"
+		terraformWorkerSudoEnabled := true
 
 		opts := AdminOrganizationUpdateOptions{
 			AccessBetaTools:                  &accessBetaTools,
 			IsDisabled:                       &isDisabled,
 			TerraformBuildWorkerApplyTimeout: &terraformBuildWorkerApplyTimeout,
 			TerraformBuildWorkerPlanTimeout:  &terraformBuildWorkerPlanTimeout,
+			TerraformWorkerSudoEnabled:       terraformWorkerSudoEnabled,
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
@@ -188,7 +190,7 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		assert.Equal(t, isDisabled, adminOrg.IsDisabled)
 		assert.Equal(t, terraformBuildWorkerApplyTimeout, adminOrg.TerraformBuildWorkerApplyTimeout)
 		assert.Equal(t, terraformBuildWorkerPlanTimeout, adminOrg.TerraformBuildWorkerPlanTimeout)
-		assert.Equal(t, false, adminOrg.TerraformWorkerSudoEnabled)
+		assert.Equal(t, terraformWorkerSudoEnabled, adminOrg.TerraformWorkerSudoEnabled)
 
 		isDisabled = true
 		opts = AdminOrganizationUpdateOptions{

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -15,10 +15,10 @@ func TestAdminOrganizations_List(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	t.Run("with no list options", func(t *testing.T) {
-		org, orgTestCleanup := createOrganization(t, client)
-		defer orgTestCleanup()
+	org, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
 
+	t.Run("with no list options", func(t *testing.T) {
 		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{})
 		require.NoError(t, err)
 
@@ -27,7 +27,8 @@ func TestAdminOrganizations_List(t *testing.T) {
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		org, orgTestCleanup := createOrganization(t, client)
+		// creating second org so that the query can only find the main org
+		_, orgTestCleanup := createOrganization(t, client)
 		defer orgTestCleanup()
 
 		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{
@@ -39,10 +40,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 		assert.Equal(t, 1, adminOrgList.TotalCount)
 	})
 
-	t.Run("with list options and bad query", func(t *testing.T) {
-		org, orgTestCleanup := createOrganization(t, client)
-		defer orgTestCleanup()
-
+	t.Run("with list options and org name that doesn't exist", func(t *testing.T) {
 		randomName := "random-org-name"
 
 		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{
@@ -68,8 +66,8 @@ func TestAdminOrganizations_Read(t *testing.T) {
 		assert.Nil(t, adminOrg)
 	})
 
-	t.Run("it fails to read an organization with an bad org name", func(t *testing.T) {
-		orgName := fmt.Sprintf("bad-%s", randomString(t))
+	t.Run("it returns ErrResourceNotFound for an organization that doesn't exist", func(t *testing.T) {
+		orgName := fmt.Sprintf("non-existing-%s", randomString(t))
 		adminOrg, err := client.Admin.Organizations.Read(ctx, orgName)
 		require.Error(t, err)
 		assert.EqualError(t, err, ErrResourceNotFound.Error())
@@ -107,8 +105,8 @@ func TestAdminOrganizations_Delete(t *testing.T) {
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
-	t.Run("it fails to delete an organization with an bad org name", func(t *testing.T) {
-		orgName := fmt.Sprintf("bad-%s", randomString(t))
+	t.Run("it returns ErrResourceNotFound during an attempt to delete an organization that doesn't exist", func(t *testing.T) {
+		orgName := fmt.Sprintf("non-existing-%s", randomString(t))
 		err := client.Admin.Organizations.Delete(ctx, orgName)
 		require.Error(t, err)
 		assert.EqualError(t, err, ErrResourceNotFound.Error())
@@ -144,8 +142,8 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
-	t.Run("it fails to update an organization with an bad org name", func(t *testing.T) {
-		orgName := fmt.Sprintf("bad-%s", randomString(t))
+	t.Run("it returns ErrResourceNotFound for during an update on an organization that doesn't exist", func(t *testing.T) {
+		orgName := fmt.Sprintf("non-existing-%s", randomString(t))
 		_, err := client.Admin.Organizations.Update(ctx, orgName, AdminOrganizationUpdateOptions{})
 		require.Error(t, err)
 		assert.EqualError(t, err, ErrResourceNotFound.Error())

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -18,7 +18,7 @@ func TestAdminOrganizations_Read(t *testing.T) {
 	t.Run("it fails to read an organization with an invalid id", func(t *testing.T) {
 		adminOrg, err := client.Admin.Organizations.Read(ctx, "")
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 		assert.Nil(t, adminOrg)
 	})
 
@@ -59,7 +59,7 @@ func TestAdminOrganizations_Delete(t *testing.T) {
 	t.Run("it fails to delete an organization with an invalid id", func(t *testing.T) {
 		err := client.Admin.Organizations.Delete(ctx, "")
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("it fails to delete an organization with an bad org name", func(t *testing.T) {
@@ -96,7 +96,7 @@ func TestAdminOrganizations_Update(t *testing.T) {
 	t.Run("it fails to update an organization with an invalid id", func(t *testing.T) {
 		_, err := client.Admin.Organizations.Update(ctx, "", AdminOrganizationUpdateOptions{})
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid value for organization")
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("it fails to update an organization with an bad org name", func(t *testing.T) {

--- a/admin_organization_test.go
+++ b/admin_organization_test.go
@@ -128,7 +128,6 @@ func TestAdminOrganizations_Update(t *testing.T) {
 			TerraformBuildWorkerPlanTimeout:  &terraformBuildWorkerPlanTimeout,
 		}
 
-		fmt.Println(org.Name)
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
 		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
 		assert.NoError(t, err)

--- a/agent_pool_test.go
+++ b/agent_pool_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAgentPoolsList(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -50,6 +52,8 @@ func TestAgentPoolsList(t *testing.T) {
 }
 
 func TestAgentPoolsCreate(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -92,6 +96,8 @@ func TestAgentPoolsCreate(t *testing.T) {
 }
 
 func TestAgentPoolsRead(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -120,6 +126,8 @@ func TestAgentPoolsRead(t *testing.T) {
 }
 
 func TestAgentPoolsUpdate(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -160,6 +168,8 @@ func TestAgentPoolsUpdate(t *testing.T) {
 }
 
 func TestAgentPoolsDelete(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/agent_token_test.go
+++ b/agent_token_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestAgentTokensList(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -46,6 +48,8 @@ func TestAgentTokensList(t *testing.T) {
 }
 
 func TestAgentTokensGenerate(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -75,6 +79,8 @@ func TestAgentTokensGenerate(t *testing.T) {
 	})
 }
 func TestAgentTokensRead(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -100,6 +106,8 @@ func TestAgentTokensRead(t *testing.T) {
 }
 
 func TestAgentTokensDelete(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/cost_estimate_test.go
+++ b/cost_estimate_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestCostEstimatesRead(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -972,3 +972,28 @@ func randomString(t *testing.T) string {
 	}
 	return v
 }
+
+// skips a test if ENABLE_TFE is not set to equal "1"
+// this is used to conditionally skip tests if not running against a Terraform
+// Enterprise instance. Effectively these tests will only run against a Terraform
+// Enterprise instance.
+func skipIfNotEnterprise(t *testing.T) {
+	if !enterpriseEnabled() {
+		t.Skip("Skipping Terraform Enterprise related test. Set ENABLE_TFE=1 to run.")
+	}
+}
+
+// skips a test if ENABLE_TFE is set to equal "1"
+// this is used to conditionally skip tests if running against a Terraform
+// Enterprise instance. Effectively these tests will only run against a Terraform
+// Cloud instance.
+func skipIfEnterprise(t *testing.T) {
+	if enterpriseEnabled() {
+		t.Skip("Skipping Terraform Cloud related test. Set ENABLE_TFE=0 to run.")
+	}
+}
+
+// Checks to see if ENABLE_TFE is set to 1, thereby enabling enterprise tests.
+func enterpriseEnabled() bool {
+	return os.Getenv("ENABLE_TFE") == "1"
+}

--- a/helper_test.go
+++ b/helper_test.go
@@ -973,23 +973,17 @@ func randomString(t *testing.T) string {
 	return v
 }
 
-// skips a test if ENABLE_TFE is not set to equal "1"
-// this is used to conditionally skip tests if not running against a Terraform
-// Enterprise instance. Effectively these tests will only run against a Terraform
-// Enterprise instance.
-func skipIfNotEnterprise(t *testing.T) {
+// skips a test if the environment is for Terraform Cloud.
+func skipIfCloud(t *testing.T) {
 	if !enterpriseEnabled() {
-		t.Skip("Skipping Terraform Enterprise related test. Set ENABLE_TFE=1 to run.")
+		t.Skip("Skipping test related to Terraform Cloud. Set ENABLE_TFE=1 to run.")
 	}
 }
 
-// skips a test if ENABLE_TFE is set to equal "1"
-// this is used to conditionally skip tests if running against a Terraform
-// Enterprise instance. Effectively these tests will only run against a Terraform
-// Cloud instance.
+// skips a test if the environment is for Terraform Enterprise
 func skipIfEnterprise(t *testing.T) {
 	if enterpriseEnabled() {
-		t.Skip("Skipping Terraform Cloud related test. Set ENABLE_TFE=0 to run.")
+		t.Skip("Skipping test related to Terraform Enterprise. Set ENABLE_TFE=0 to run.")
 	}
 }
 

--- a/ip_ranges_test.go
+++ b/ip_ranges_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestIPRangesRead(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/organization_test.go
+++ b/organization_test.go
@@ -250,6 +250,8 @@ func TestOrganizationsCapacity(t *testing.T) {
 }
 
 func TestOrganizationsEntitlements(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/policy_check_test.go
+++ b/policy_check_test.go
@@ -73,6 +73,8 @@ func TestPolicyChecksList(t *testing.T) {
 }
 
 func TestPolicyChecksRead(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/run_test.go
+++ b/run_test.go
@@ -121,6 +121,8 @@ func TestRunsCreate(t *testing.T) {
 }
 
 func TestRunsRead(t *testing.T) {
+	skipIfEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/tfe.go
+++ b/tfe.go
@@ -108,6 +108,7 @@ type Client struct {
 	retryServerErrors bool
 	remoteAPIVersion  string
 
+	Admin                      Admin
 	AgentPools                 AgentPools
 	AgentTokens                AgentTokens
 	Applies                    Applies
@@ -141,6 +142,13 @@ type Client struct {
 	Workspaces                 Workspaces
 
 	Meta Meta
+}
+
+// Admin is the the Terraform Enterprise Admin API. It provides access to site
+// wide admin settings. These are only available for Terraform Enterprise and
+// do not function against Terraform Cloud.
+type Admin struct {
+	Organizations AdminOrganizations
 }
 
 // Meta contains any Terraform Cloud APIs which provide data about the API itself.
@@ -219,6 +227,11 @@ func NewClient(cfg *Config) (*Client, error) {
 	// Save the API version so we can return it from the RemoteAPIVersion
 	// method later.
 	client.remoteAPIVersion = meta.APIVersion
+
+	// Create Admin
+	client.Admin = Admin{
+		Organizations: &adminOrganizations{client: client},
+	}
 
 	// Create the services.
 	client.AgentPools = &agentPools{client: client}


### PR DESCRIPTION
## Description

This PR adds the [Admin Organizations API](https://www.terraform.io/docs/cloud/api/admin/organizations.html).

The current implemented methods are `Read`, `Update`, `List`, and `Delete`

Updated other tests to skipIfEnterprise. 

## Testing plan

Run a local version of Terraform Enterprise, and then run the tests using the extra flag of `ENABLE_TFE`

```
TFE_TOKEN=<token> TFE_ADDRESS=<address> ENABLE_TFE=1 go test -v ./...  -timeout=30m
```

## Output tests

All tests pass.

```
PASS
ok  	github.com/hashicorp/go-tfe	486.873s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
```

## External links

- [Asana Ticket](https://app.asana.com/0/1199201948575144/1199964609043978)
- [API documentation](https://www.terraform.io/docs/cloud/api/admin/organizations.html)
- [Previous PR that had part of this work](https://github.com/hashicorp/go-tfe/pull/163) cc @joekarl 
