### PR TITLE
Oauth: Add missing uuid and secret fields

### DIFF
--- a/oauth_client.go
+++ b/oauth_client.go
@@ -129,7 +129,7 @@ type OAuthClientCreateOptions struct {
 	Secret *string `jsonapi:"attr,secret"`
 
 	// UUID of the vcs connection. If empty - automatically generated.
-	Uuid *string `jsonapi:"uuid,secret"`
+	Uuid *string `jsonapi:"attr,uuid"`
 
 	// The VCS provider being connected with.
 	ServiceProvider *ServiceProviderType `jsonapi:"attr,service-provider"`

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -70,6 +70,8 @@ type OAuthClient struct {
 	CreatedAt           time.Time           `jsonapi:"attr,created-at,iso8601"`
 	HTTPURL             string              `jsonapi:"attr,http-url"`
 	Key                 string              `jsonapi:"attr,key"`
+	Secret              string              `jsonapi:"attr,secret"`
+	Uuid                string              `jsonapi:"attr,uuid"`
 	RSAPublicKey        string              `jsonapi:"attr,rsa-public-key"`
 	ServiceProvider     ServiceProviderType `jsonapi:"attr,service-provider"`
 	ServiceProviderName string              `jsonapi:"attr,service-provider-display-name"`
@@ -122,6 +124,12 @@ type OAuthClientCreateOptions struct {
 
 	// Private key associated with this vcs provider - only available for ado_server
 	PrivateKey *string `jsonapi:"attr,private-key"`
+
+	// Oauth secret, available with some providers, e.g. github
+	Secret *string `jsonapi:"attr,secret"`
+
+	// UUID of the vcs connection. If empty - automatically generated.
+	Uuid *string `jsonapi:"uuid,secret"`
 
 	// The VCS provider being connected with.
 	ServiceProvider *ServiceProviderType `jsonapi:"attr,service-provider"`


### PR DESCRIPTION
## Description

My intention is to extend TFE provider to add missing secret and uuid fields. This would allow me to automate vcs connection creation for the TFE orgs. Should also be relevant to TFC users. 

## Testing plan

1. Create VCS connection to the github.com provider using TFE GUI.
2. Terraform UI will generate UUID in advance and show it to user as part of oauth callback
3. There will be input-field to enter GH secret

Sample API request provided below:

```
{
  "data": {
    "attributes": {
      "name": "Example GH",
      "created-at": null,
      "callback-url": null,
      "oauth-token-string": null,
      "connect-path": null,
      "key": "XXXXX",
      "secret": "XXXXXXXX",
      "rsa-public-key": null,
      "uuid": "82213e23-3d48-4061-8960-3c01ef3e2d6e",
      "service-provider": "github",
      "service-provider-display-name": null,
      "api-url": "https://api.github.com",
      "http-url": "https://github.com"
    },
    "relationships": {
      "organization": {
        "data": {
          "type": "organizations",
          "id": "sampl-org-gh"
        }
      }
    },
    "type": "oauth-clients"
  }
}
```

At the moment it is not possible to do this programmatically via go-tfe, as `uuid` and `secrets` fields are missing.

Also i found that API documentation includes secret only on PATCH method and not the POST one, however for POST it is working as well (tested with `curl` and also visible from TFE UI requests)
## External links

- [TFE API documentation](https://www.terraform.io/docs/cloud/api/oauth-clients.html)
- PR to update documentation: https://github.com/hashicorp/terraform-website/pull/1635
## Output from tests

