### PR TITLE
Admin Workspaces API

### DIFF
--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -17,11 +17,11 @@ type AdminWorkspaces interface {
 	// List all the workspaces within an organization.
 	List(ctx context.Context, options AdminWorkspaceListOptions) (*AdminWorkspaceList, error)
 
-	// Read a workspace by its name.
-	Read(ctx context.Context, workspace string) (*AdminWorkspace, error)
+	// Read a workspace by its ID.
+	Read(ctx context.Context, workspaceID string) (*AdminWorkspace, error)
 
-	// Delete a workspace by its name.
-	Delete(ctx context.Context, workspace string) error
+	// Delete a workspace by its ID.
+	Delete(ctx context.Context, workspaceID string) error
 }
 
 // adminWorkspaces implements AdminWorkspaces.
@@ -46,6 +46,7 @@ type AdminWorkspaceListOptions struct {
 	ListOptions
 
 	// A query string (partial workspace name) used to filter the results.
+	// https://www.terraform.io/docs/cloud/api/admin/workspaces.html#query-parameters
 	Query *string `url:"q,omitempty"`
 
 	// A list of relations to include. See available resources
@@ -76,7 +77,7 @@ func (s *adminWorkspaces) List(ctx context.Context, options AdminWorkspaceListOp
 	return awl, nil
 }
 
-// Read a workspace by its name.
+// Read a workspace by its ID.
 func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminWorkspace, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceValue
@@ -97,7 +98,7 @@ func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminW
 	return aw, nil
 }
 
-// Delete a workspace by its name.
+// Delete a workspace by its ID.
 func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error {
 	if !validStringID(&workspaceID) {
 		return ErrInvalidWorkspaceValue

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -29,12 +29,16 @@ type adminWorkspaces struct {
 	client *Client
 }
 
+type AdminVCSRepo struct {
+	Identifier string `json:"identifier"`
+}
+
 // AdminWorkspaces represents a Terraform Enterprise admin workspace.
 type AdminWorkspace struct {
-	ID      string   `jsonapi:"primary,workspaces"`
-	Name    string   `jsonapi:"attr,name"`
-	Locked  bool     `jsonapi:"attr,locked"`
-	VCSRepo *VCSRepo `jsonapi:"attr,vcs-repo"`
+	ID      string        `jsonapi:"primary,workspaces"`
+	Name    string        `jsonapi:"attr,name"`
+	Locked  bool          `jsonapi:"attr,locked"`
+	VCSRepo *AdminVCSRepo `jsonapi:"attr,vcs-repo"`
 
 	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -80,7 +80,7 @@ func (s *adminWorkspaces) List(ctx context.Context, options AdminWorkspaceListOp
 // Read a workspace by its name.
 func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminWorkspace, error) {
 	if !validStringID(&workspaceID) {
-		return nil, errors.New("invalid value for workspace")
+		return nil, ErrInvalidWorkspaceValue
 	}
 
 	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))
@@ -101,7 +101,7 @@ func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminW
 // Delete a workspace by its name.
 func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error {
 	if !validStringID(&workspaceID) {
-		return errors.New("invalid value for workspace")
+		return ErrInvalidWorkspaceValue
 	}
 
 	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -1,0 +1,112 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminWorkspaces = (*adminWorkspaces)(nil)
+
+// AdminWorkspaces describes all the admin workspace related methods that the Terraform
+// Enterprise API supports.
+// Note that admin settings are only available in Terraform Enterprise.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/admin/workspaces.html
+type AdminWorkspaces interface {
+	// List all the workspaces within an organization.
+	List(ctx context.Context, options AdminWorkspaceListOptions) (*AdminWorkspaceList, error)
+
+	// Read a workspace by its name.
+	Read(ctx context.Context, workspace string) (*AdminWorkspace, error)
+
+	// Delete a workspace by its name.
+	Delete(ctx context.Context, workspace string) error
+}
+
+// adminWorkspaces implements AdminWorkspaces.
+type adminWorkspaces struct {
+	client *Client
+}
+
+// AdminWorkspaces represents a Terraform Enterprise admin workspace.
+type AdminWorkspace struct {
+	ID      string   `jsonapi:"primary,workspaces"`
+	Name    string   `jsonapi:"attr,name"`
+	Locked  bool     `jsonapi:"attr,locked"`
+	VCSRepo *VCSRepo `jsonapi:"attr,vcs-repo"`
+
+	Organization *Organization `jsonapi:"relation,organization"`
+}
+
+// AdminWorkspaceListOptions represents the options for listing workspaces.
+type AdminWorkspaceListOptions struct {
+	ListOptions
+
+	// A search string (partial workspace name) used to filter the results.
+	Search *string `url:"search[name],omitempty"`
+
+	// A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
+	Include *string `url:"include"`
+}
+
+// AdminWorkspaceList represents a list of workspaces.
+type AdminWorkspaceList struct {
+	*Pagination
+	Items []*AdminWorkspace
+}
+
+// List all the workspaces within an organization.
+func (s *adminWorkspaces) List(ctx context.Context, options AdminWorkspaceListOptions) (*AdminWorkspaceList, error) {
+	u := fmt.Sprintf("admin/workspaces")
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	awl := &AdminWorkspaceList{}
+	err = s.client.do(ctx, req, awl)
+	if err != nil {
+		return nil, err
+	}
+
+	return awl, nil
+}
+
+// Read a workspace by its name.
+func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminWorkspace, error) {
+	if !validStringID(&workspaceID) {
+		return nil, errors.New("invalid value for workspace")
+	}
+
+	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	aw := &AdminWorkspace{}
+	err = s.client.do(ctx, req, aw)
+	if err != nil {
+		return nil, err
+	}
+
+	return aw, nil
+}
+
+// Delete a workspace by its name.
+func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error {
+	if !validStringID(&workspaceID) {
+		return errors.New("invalid value for workspace")
+	}
+
+	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -10,8 +10,7 @@ import (
 // Compile-time proof of interface implementation.
 var _ AdminWorkspaces = (*adminWorkspaces)(nil)
 
-// AdminWorkspaces describes all the admin workspace related methods that the Terraform
-// Enterprise API supports.
+// AdminWorkspaces describes all the admin workspace related methods that the Terraform Enterprise API supports.
 // Note that admin settings are only available in Terraform Enterprise.
 //
 // TFE API docs: https://www.terraform.io/docs/cloud/api/admin/workspaces.html
@@ -38,17 +37,20 @@ type AdminWorkspace struct {
 	Locked  bool     `jsonapi:"attr,locked"`
 	VCSRepo *VCSRepo `jsonapi:"attr,vcs-repo"`
 
+	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`
+	CurrentRun   *Run          `jsonapi:"relation,current-run"`
 }
 
 // AdminWorkspaceListOptions represents the options for listing workspaces.
 type AdminWorkspaceListOptions struct {
 	ListOptions
 
-	// A search string (partial workspace name) used to filter the results.
-	Search *string `url:"search[name],omitempty"`
+	// A query string (partial workspace name) used to filter the results.
+	Query *string `url:"q,omitempty"`
 
-	// A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
+	// A list of relations to include. See available resources
+	// https://www.terraform.io/docs/cloud/api/admin/workspaces.html#available-related-resources
 	Include *string `url:"include"`
 }
 

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -14,7 +14,7 @@ var _ AdminWorkspaces = (*adminWorkspaces)(nil)
 //
 // TFE API docs: https://www.terraform.io/docs/cloud/api/admin/workspaces.html
 type AdminWorkspaces interface {
-	// List all the workspaces within an organization.
+	// List all the workspaces within a workspace.
 	List(ctx context.Context, options AdminWorkspaceListOptions) (*AdminWorkspaceList, error)
 
 	// Read a workspace by its ID.
@@ -60,7 +60,7 @@ type AdminWorkspaceList struct {
 	Items []*AdminWorkspace
 }
 
-// List all the workspaces within an organization.
+// List all the workspaces within a worksapce.
 func (s *adminWorkspaces) List(ctx context.Context, options AdminWorkspaceListOptions) (*AdminWorkspaceList, error) {
 	u := fmt.Sprintf("admin/workspaces")
 	req, err := s.client.newRequest("GET", u, &options)

--- a/admin_workspace_test.go
+++ b/admin_workspace_test.go
@@ -120,7 +120,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		})
 		assert.Nil(t, wl)
 		assert.Error(t, err)
-		assert.EqualError(t, err, ErrInvalidIncludeParam.Error())
+		assert.EqualError(t, err, "bad request\n\nInvalid include parameter")
 	})
 }
 

--- a/admin_workspace_test.go
+++ b/admin_workspace_test.go
@@ -28,8 +28,8 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{})
 		require.NoError(t, err)
 
-		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest1.ID), true)
-		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest2.ID), true)
+		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest1.ID), true)
+		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest2.ID), true)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
@@ -52,8 +52,8 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 1, wl.CurrentPage)
-		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest1.ID), true)
-		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest2.ID), true)
+		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest1.ID), true)
+		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest2.ID), true)
 	})
 
 	t.Run("when searching a known workspace", func(t *testing.T) {
@@ -63,8 +63,8 @@ func TestAdminWorkspaces_List(t *testing.T) {
 			Query: String(wTest1.Name),
 		})
 		require.NoError(t, err)
-		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest1.ID), true)
-		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest2.ID), false)
+		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest1.ID), true)
+		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest2.ID), false)
 		assert.Equal(t, 1, wl.CurrentPage)
 		assert.Equal(t, true, wl.TotalCount == 1)
 	})
@@ -87,7 +87,6 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		})
 
 		assert.NoError(t, err)
-
 		assert.NotEmpty(t, wl.Items)
 		assert.NotNil(t, wl.Items[0].Organization)
 		assert.NotEmpty(t, wl.Items[0].Organization.Name)
@@ -157,10 +156,8 @@ func TestAdminWorkspaces_Read(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotNilf(t, adminWorkspace, "Admin Workspace is not nil")
 		assert.Equal(t, adminWorkspace.ID, workspace.ID)
-
-		// attributes part of an AdminWorkspace response that are not null
-		assert.NotNilf(t, adminWorkspace.Name, "Name is not nil")
-		assert.NotNilf(t, adminWorkspace.Locked, "Locked is not nil")
+		assert.Equal(t, adminWorkspace.Name, workspace.Name)
+		assert.Equal(t, adminWorkspace.Locked, workspace.Locked)
 	})
 }
 
@@ -204,7 +201,7 @@ func TestAdminWorkspaces_Delete(t *testing.T) {
 	})
 }
 
-func workspaceItemsContainsID(items []*AdminWorkspace, id string) bool {
+func adminWorkspaceItemsContainsID(items []*AdminWorkspace, id string) bool {
 	hasID := false
 	for _, item := range items {
 		if item.ID == id {

--- a/admin_workspace_test.go
+++ b/admin_workspace_test.go
@@ -134,7 +134,7 @@ func TestAdminWorkspaces_Read(t *testing.T) {
 	t.Run("it fails to read a workspace with an invalid name", func(t *testing.T) {
 		workspace, err := client.Admin.Workspaces.Read(ctx, "")
 		require.Error(t, err)
-		assert.EqualError(t, err, ErrInvalidOrg.Error())
+		assert.EqualError(t, err, ErrInvalidWorkspaceValue.Error())
 		assert.Nil(t, workspace)
 	})
 

--- a/admin_workspace_test.go
+++ b/admin_workspace_test.go
@@ -173,7 +173,7 @@ func TestAdminWorkspaces_Delete(t *testing.T) {
 	t.Run("it fails to delete an organization with an invalid id", func(t *testing.T) {
 		err := client.Admin.Workspaces.Delete(ctx, "")
 		require.Error(t, err)
-		assert.EqualError(t, err, "invalid value for workspace")
+		assert.EqualError(t, err, ErrInvalidWorkspaceValue.Error())
 	})
 
 	t.Run("it fails to delete an organization with an bad org name", func(t *testing.T) {

--- a/admin_workspace_test.go
+++ b/admin_workspace_test.go
@@ -1,0 +1,199 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminWorkspaces_Read(t *testing.T) {
+	skipIfNotEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("it fails to read a workspace with an invalid name", func(t *testing.T) {
+		workspace, err := client.Admin.Workspaces.Read(ctx, "")
+		require.Error(t, err)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
+		assert.Nil(t, workspace)
+	})
+
+	t.Run("it fails to read a workspace that is non existant", func(t *testing.T) {
+		workspaceID := fmt.Sprintf("id-%s", randomString(t))
+		adminWorkspace, err := client.Admin.Workspaces.Read(ctx, workspaceID)
+		require.Error(t, err)
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
+		assert.Nil(t, adminWorkspace)
+	})
+
+	t.Run("it reads a worksapce successfully", func(t *testing.T) {
+		org, orgCleanup := createOrganization(t, client)
+		defer orgCleanup()
+
+		workspace, workspaceCleanup := createWorkspace(t, client, org)
+		defer workspaceCleanup()
+
+		adminWorkspace, err := client.Admin.Workspaces.Read(ctx, workspace.ID)
+		assert.NoError(t, err)
+		assert.NotNilf(t, adminWorkspace, "Admin Workspace is not nil")
+		assert.Equal(t, adminWorkspace.ID, workspace.ID)
+
+		// attributes part of an AdminWorkspace response that are not null
+		assert.NotNilf(t, adminWorkspace.Name, "Name is not nil")
+		assert.NotNilf(t, adminWorkspace.Locked, "Locked is not nil")
+	})
+}
+
+func TestAdminWorkspaces_Delete(t *testing.T) {
+	skipIfNotEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("it fails to delete an organization with an invalid id", func(t *testing.T) {
+		err := client.Admin.Workspaces.Delete(ctx, "")
+		require.Error(t, err)
+		assert.EqualError(t, err, "invalid value for workspace")
+	})
+
+	t.Run("it fails to delete an organization with an bad org name", func(t *testing.T) {
+		workspaceID := fmt.Sprintf("id-%s", randomString(t))
+		err := client.Admin.Workspaces.Delete(ctx, workspaceID)
+		require.Error(t, err)
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
+	})
+
+	t.Run("it deletes a workspace successfully", func(t *testing.T) {
+		org, orgCleanup := createOrganization(t, client)
+		defer orgCleanup()
+
+		workspace, _ := createWorkspace(t, client, org)
+
+		adminWorkspace, err := client.Admin.Workspaces.Read(ctx, workspace.ID)
+		assert.NoError(t, err)
+		assert.NotNilf(t, adminWorkspace, "Admin Workspace is not nil")
+		assert.Equal(t, adminWorkspace.ID, workspace.ID)
+
+		err = client.Admin.Workspaces.Delete(ctx, adminWorkspace.ID)
+		assert.NoError(t, err)
+
+		// Cannot find deleted workspace
+		_, err = client.Admin.Workspaces.Read(ctx, workspace.ID)
+		assert.Error(t, err)
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
+	})
+}
+
+func TestAdminWorkspaces_List(t *testing.T) {
+	skipIfNotEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	org, orgCleanup := createOrganization(t, client)
+	defer orgCleanup()
+
+	wTest1, wTest1Cleanup := createWorkspace(t, client, org)
+	defer wTest1Cleanup()
+	wTest2, wTest2Cleanup := createWorkspace(t, client, org)
+	defer wTest2Cleanup()
+
+	t.Run("without list options", func(t *testing.T) {
+		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{})
+		require.NoError(t, err)
+		fmt.Println(wl)
+
+		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest1.ID), true)
+		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest2.ID), true)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+
+		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		// Out of range page number, so the items should be empty
+		assert.Empty(t, wl.Items)
+		assert.Equal(t, 999, wl.CurrentPage)
+		assert.Equal(t, true, wl.TotalCount >= 2)
+
+		wl, err = client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 1,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, wl.CurrentPage)
+		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest1.ID), true)
+		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest2.ID), true)
+	})
+
+	t.Run("when searching a known workspace", func(t *testing.T) {
+		// Use a known workspace prefix as search attribute. The result
+		// should be successful and only contain the matching workspace.
+		name := wTest1.Name[:len(wTest1.Name)-3]
+		fmt.Println(name)
+		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+			Search: String(wTest1.Name),
+		})
+		require.NoError(t, err)
+		fmt.Println(wl.TotalCount)
+		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest1.ID), true)
+		assert.Equal(t, workspaceItemsContainsID(wl.Items, wTest2.ID), false)
+		assert.Equal(t, 1, wl.CurrentPage)
+		assert.Equal(t, true, wl.TotalCount >= 1)
+	})
+
+	t.Run("when searching an unknown workspace", func(t *testing.T) {
+		// Use a nonexisting workspace name as search attribute. The result
+		// should be successful, but return no results.
+		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+			Search: String("nonexisting"),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, wl.Items)
+		assert.Equal(t, 1, wl.CurrentPage)
+		assert.Equal(t, 0, wl.TotalCount)
+	})
+
+	//k	t.Run("list with include without a valid organization", func(t *testing.T) {
+	//k		wl, err := client.Workspaces.List(ctx, AdminWorkspaceListOptions{
+	//k			Include: String("some-invalid-resources"),
+	//k		})
+	//k		assert.Nil(t, wl)
+	//k		assert.EqualError(t, err, ErrInvalidOrg.Error())
+	//k	})
+	//k
+	//k	t.Run("with organization included", func(t *testing.T) {
+	//k		wl, err := client.Workspaces.List(ctx, AdminWorkspaceListOptions{
+	//k			Include: String("organization"),
+	//k		})
+	//k
+	//k		assert.NoError(t, err)
+	//k
+	//k		assert.NotEmpty(t, wl.Items)
+	//k		assert.NotNil(t, wl.Items[0].Organization)
+	//k		assert.NotEmpty(t, wl.Items[0].Organization.Email)
+	//k	})
+}
+
+func workspaceItemsContainsID(items []*AdminWorkspace, id string) bool {
+	hasID := false
+	for _, item := range items {
+		if item.ID == id {
+			hasID = true
+			break
+		}
+	}
+
+	return hasID
+}

--- a/errors.go
+++ b/errors.go
@@ -12,9 +12,6 @@ var (
 	// ErrResourceNotFound is returned when a receiving a 404.
 	ErrResourceNotFound = errors.New("resource not found")
 
-	// ErrInvalidIncludeParam is returned when an 'include' parameter is invalid.
-	ErrInvalidIncludeParam = errors.New("bad request\n\nInvalid include parameter")
-
 	// ErrRequiredName is returned when a name option is not present.
 	ErrRequiredName = errors.New("name is required")
 

--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,9 @@ var (
 	// ErrInvalidWorkspaceID is returned when the workspace ID is invalid.
 	ErrInvalidWorkspaceID = errors.New("invalid value for workspace ID")
 
+	// ErrInvalidWorkspaceValue is returned when workspace value is invalid.
+	ErrInvalidWorkspaceValue = errors.New("invalid value for workspace")
+
 	// Run/Apply errors
 
 	// ErrInvalidRunID is returned when the run ID is invalid.

--- a/errors.go
+++ b/errors.go
@@ -20,6 +20,9 @@ var (
 	// ErrResourceNotFound is returned when a receiving a 404.
 	ErrResourceNotFound = errors.New("resource not found")
 
+	// ErrInvalidIncludeParam is returned when an 'include' parameter is invalid.
+	ErrInvalidIncludeParam = errors.New("bad request\n\nInvalid include parameter")
+
 	// ErrRequiredName is returned when a name option is not present.
 	ErrRequiredName = errors.New("name is required")
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -972,3 +972,19 @@ func randomString(t *testing.T) string {
 	}
 	return v
 }
+func skipIfNotEnterprise(t *testing.T) {
+	if !enterpriseEnabled() {
+		t.Skip("Skipping Terraform Enterprise related test. Set ENABLE_TFE=1 to run.")
+	}
+}
+
+func skipIfEnterprise(t *testing.T) {
+	if enterpriseEnabled() {
+		t.Skip("Skipping Terraform Cloud related test. Set ENABLE_TFE=0 to run.")
+	}
+}
+
+// Checks to see if ENABLE_TFE is set to 1, thereby enabling enterprise tests.
+func enterpriseEnabled() bool {
+	return os.Getenv("ENABLE_TFE") == "1"
+}

--- a/tfe.go
+++ b/tfe.go
@@ -94,6 +94,7 @@ type Client struct {
 	retryServerErrors bool
 	remoteAPIVersion  string
 
+	Admin                      Admin
 	AgentPools                 AgentPools
 	AgentTokens                AgentTokens
 	Applies                    Applies
@@ -127,6 +128,13 @@ type Client struct {
 	Workspaces                 Workspaces
 
 	Meta Meta
+}
+
+// Admin is the the Terraform Enterprise Admin API. It provides access to site
+// wide admin settings. These are only available for Terraform Enterprise and
+// do not function against Terraform Cloud.
+type Admin struct {
+	Workspaces AdminWorkspaces
 }
 
 // Meta contains any Terraform Cloud APIs which provide data about the API itself.
@@ -205,6 +213,11 @@ func NewClient(cfg *Config) (*Client, error) {
 	// Save the API version so we can return it from the RemoteAPIVersion
 	// method later.
 	client.remoteAPIVersion = meta.APIVersion
+
+	// Create Admin
+	client.Admin = Admin{
+		Workspaces: &adminWorkspaces{client: client},
+	}
 
 	// Create the services.
 	client.AgentPools = &agentPools{client: client}

--- a/workspace.go
+++ b/workspace.go
@@ -301,7 +301,7 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
-		return nil, errors.New("invalid value for workspace")
+		return nil, ErrInvalidWorkspaceValue
 	}
 
 	u := fmt.Sprintf(
@@ -436,7 +436,7 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
-		return nil, errors.New("invalid value for workspace")
+		return nil, ErrInvalidWorkspaceValue
 	}
 	if err := options.valid(); err != nil {
 		return nil, err
@@ -494,7 +494,7 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 		return ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
-		return errors.New("invalid value for workspace")
+		return ErrInvalidWorkspaceValue
 	}
 
 	u := fmt.Sprintf(
@@ -537,7 +537,7 @@ func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, work
 		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
-		return nil, errors.New("invalid value for workspace")
+		return nil, ErrInvalidWorkspaceValue
 	}
 
 	u := fmt.Sprintf(

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -252,7 +252,7 @@ func TestWorkspacesRead(t *testing.T) {
 	t.Run("without a valid workspace", func(t *testing.T) {
 		w, err := client.Workspaces.Read(ctx, orgTest.Name, badIdentifier)
 		assert.Nil(t, w)
-		assert.EqualError(t, err, "invalid value for workspace")
+		assert.EqualError(t, err, ErrInvalidWorkspaceValue.Error())
 	})
 }
 
@@ -399,7 +399,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 	t.Run("when options has an invalid name", func(t *testing.T) {
 		w, err := client.Workspaces.Update(ctx, orgTest.Name, badIdentifier, WorkspaceUpdateOptions{})
 		assert.Nil(t, w)
-		assert.EqualError(t, err, "invalid value for workspace")
+		assert.EqualError(t, err, ErrInvalidWorkspaceValue.Error())
 	})
 
 	t.Run("when options has an invalid organization", func(t *testing.T) {
@@ -517,7 +517,7 @@ func TestWorkspacesDelete(t *testing.T) {
 
 	t.Run("when workspace is invalid", func(t *testing.T) {
 		err := client.Workspaces.Delete(ctx, orgTest.Name, badIdentifier)
-		assert.EqualError(t, err, "invalid value for workspace")
+		assert.EqualError(t, err, ErrInvalidWorkspaceValue.Error())
 	})
 }
 


### PR DESCRIPTION
## Description

This PR adds the [Admin Workspaces API](https://www.terraform.io/docs/cloud/api/admin/workspaces.html).

The current implemented methods are List, Read, and Delete

## Testing plan

Run tests against an Terraform Enterprise Instance.

## Output from tests

```
$ TFE_TOKEN=<token> TFE_ADDRESS=<adrress-of-tfe-instance>  ENABLE_TFE=1 go test -v ./...  -timeout=30m
...
PASS
ok  	github.com/hashicorp/go-tfe	485.784s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]

```

## External links

- [Asana](https://app.asana.com/0/1199201948575144/1199972599424003)
- [Admin Workspace API Docs](https://www.terraform.io/docs/cloud/api/admin/workspaces.html)
