### PR TITLE
Admin Runs API

### DIFF
--- a/admin_run.go
+++ b/admin_run.go
@@ -22,7 +22,7 @@ type AdminRuns interface {
 	List(ctx context.Context, options AdminRunsListOptions) (*AdminRunsList, error)
 
 	// Force-cancel a run by its ID.
-	ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error
+	ForceCancel(ctx context.Context, runID string, options AdminRunForceCancelOptions) error
 }
 
 // runs implements Users.
@@ -105,9 +105,16 @@ func (s *adminRuns) List(ctx context.Context, options AdminRunsListOptions) (*Ad
 	return rl, nil
 }
 
+// AdminRunForceCancelOptions represents the options for force-canceling a run.
+type AdminRunForceCancelOptions struct {
+	// An optional comment explaining the reason for the force-cancel.
+	// https://www.terraform.io/docs/cloud/api/admin/runs.html#request-body
+	Comment *string `json:"comment,omitempty"`
+}
+
 // ForceCancel is used to forcefully cancel a run by its ID.
 // https://www.terraform.io/docs/cloud/api/admin/runs.html#force-a-run-into-the-quot-cancelled-quot-state
-func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error {
+func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options AdminRunForceCancelOptions) error {
 	if !validStringID(&runID) {
 		return errors.New("invalid value for run ID")
 	}

--- a/admin_run.go
+++ b/admin_run.go
@@ -1,0 +1,122 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminRuns = (*adminRuns)(nil)
+
+// AdminRuns describes all the admin run realted methods that the Terraform
+// Enterprise  API supports.
+// It contains endpoints to help site administrators manage user accounts.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/admin/runs.html
+type AdminRuns interface {
+	// List all the runs of the given installation.
+	List(ctx context.Context, options AdminRunsListOptions) (*AdminRunsList, error)
+
+	// Force-cancel a run by its ID.
+	ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error
+}
+
+// runs implements Users.
+type adminRuns struct {
+	client *Client
+}
+
+type AdminRun struct {
+	ID               string               `jsonapi:"primary,runs"`
+	CreatedAt        time.Time            `jsonapi:"attr,created-at,iso8601"`
+	HasChanges       bool                 `jsonapi:"attr,has-changes"`
+	Status           RunStatus            `jsonapi:"attr,status"`
+	StatusTimestamps *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
+
+	// Relations
+	Workspace    *AdminWorkspace    `jsonapi:"relation,workspace"`
+	Organization *AdminOrganization `jsonapi:"relation,workspace.organization"`
+}
+
+// AdminRunsList represents a list of runs.
+type AdminRunsList struct {
+	*Pagination
+	Items []*AdminRun
+}
+
+// AdminRunsListOptions represents the options for listing runs.
+// https://www.terraform.io/docs/cloud/api/admin/runs.html#query-parameters
+type AdminRunsListOptions struct {
+	ListOptions
+	RunStatus *string `url:"filter[status],omitempty"`
+	Query     *string `url:"q,omitempty"`
+	Include   *string `url:"include,omitempty"`
+}
+
+func (o AdminRunsListOptions) valid() error {
+	if validString(o.RunStatus) {
+		validRunStatus := []string{"pending", "plan_queued", "planning", "planned", "confirmed", "apply_queued", "applying", "applied", "discarded", "errored", "canceled", "cost_estimating", "cost_estimated", "policy_checking", "policy_override", "policy_soft_failed", "policy_checked", "planned_and_finished"}
+		runStatus := strings.Split(*o.RunStatus, ",")
+
+		// iterate over our statuses
+		for _, status := range runStatus {
+
+			// start with invalid
+			valid := false
+			for _, s := range validRunStatus {
+				if status == s {
+					// found a match, set to true and continue to the next status
+					valid = true
+					break
+				}
+			}
+
+			if valid == false {
+				return fmt.Errorf("invalid value %s for run status", status)
+			}
+		}
+	}
+	return nil
+}
+
+// List all the runs of the terraform enterprise installation.
+// https://www.terraform.io/docs/cloud/api/admin/runs.html#list-all-runs
+func (s *adminRuns) List(ctx context.Context, options AdminRunsListOptions) (*AdminRunsList, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("admin/runs")
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	rl := &AdminRunsList{}
+	err = s.client.do(ctx, req, rl)
+	if err != nil {
+		return nil, err
+	}
+
+	return rl, nil
+}
+
+// ForceCancel is used to forcefully cancel a run by its ID.
+// https://www.terraform.io/docs/cloud/api/admin/runs.html#force-a-run-into-the-quot-cancelled-quot-state
+func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error {
+	if !validStringID(&runID) {
+		return errors.New("invalid value for run ID")
+	}
+
+	u := fmt.Sprintf("admin/runs/%s/actions/force-cancel", url.QueryEscape(runID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -206,6 +206,8 @@ func TestAdminRuns_ForceCancel(t *testing.T) {
 }
 
 func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
+	skipIfCloud(t)
+
 	t.Run("has valid status", func(t *testing.T) {
 		opts := AdminRunsListOptions{
 			RunStatus: String(string(RunPending)),

--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -2,6 +2,7 @@ package tfe
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -203,6 +204,37 @@ func TestAdminRuns_ForceCancel(t *testing.T) {
 		assert.Equal(t, RunCanceled, rTestPlanningResult.Status)
 	})
 }
+
+func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
+	t.Run("has valid status", func(t *testing.T) {
+		opts := AdminRunsListOptions{
+			RunStatus: String(string(RunPending)),
+		}
+
+		err := opts.valid()
+		assert.NoError(t, err)
+	})
+
+	t.Run("has invalid status", func(t *testing.T) {
+		opts := AdminRunsListOptions{
+			RunStatus: String("random_status"),
+		}
+
+		err := opts.valid()
+		assert.Error(t, err)
+	})
+
+	t.Run("has invalid status, even with a valid one", func(t *testing.T) {
+		statuses := fmt.Sprintf("%s,%s", string(RunPending), "random_status")
+		opts := AdminRunsListOptions{
+			RunStatus: String(statuses),
+		}
+
+		err := opts.valid()
+		assert.Error(t, err)
+	})
+}
+
 func adminRunItemsContainsID(items []*AdminRun, id string) bool {
 	hasID := false
 	for _, item := range items {

--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -1,0 +1,144 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminRuns_List(t *testing.T) {
+	skipIfCloud(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	org, orgCleanup := createOrganization(t, client)
+	defer orgCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, org)
+	defer wTestCleanup()
+
+	rTest1, _ := createRun(t, client, wTest)
+	rTest2, _ := createRun(t, client, wTest)
+
+	t.Run("without list options", func(t *testing.T) {
+		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, rl.Items)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), true)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), true)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		// Out of range page number, so the items should be empty
+		assert.Empty(t, rl.Items)
+		assert.Equal(t, 999, rl.CurrentPage)
+
+		rl, err = client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 1,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, rl.Items)
+		assert.Equal(t, 1, rl.CurrentPage)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), true)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), true)
+	})
+
+	t.Run("with workspace included", func(t *testing.T) {
+		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			Include: String("workspace"),
+		})
+
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, rl.Items)
+		assert.NotNil(t, rl.Items[0].Workspace)
+		assert.NotEmpty(t, rl.Items[0].Workspace.Name)
+	})
+
+	t.Run("with workspace.organization included", func(t *testing.T) {
+		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			Include: String("workspace.organization"),
+		})
+
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, rl.Items)
+		assert.NotNil(t, rl.Items[0].Workspace)
+		assert.NotNil(t, rl.Items[0].Workspace.Organization)
+		assert.NotEmpty(t, rl.Items[0].Workspace.Organization.Name)
+	})
+
+	t.Run("with RunStatus.pending filter", func(t *testing.T) {
+		r1, err := client.Runs.Read(ctx, rTest1.ID)
+		assert.NoError(t, err)
+		r2, err := client.Runs.Read(ctx, rTest2.ID)
+		assert.NoError(t, err)
+
+		// There should be pending Runs
+		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			RunStatus: String(string(RunPending)),
+		})
+		assert.NoError(t, err)
+		assert.NotEmpty(t, rl.Items)
+
+		assert.Equal(t, r1.Status, RunPlanning)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, r1.ID), false)
+		assert.Equal(t, r2.Status, RunPending)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, r2.ID), true)
+	})
+
+	t.Run("with RunStatus.applied filter", func(t *testing.T) {
+		// There should be no applied Runs
+		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			RunStatus: String(string(RunApplied)),
+		})
+		assert.NoError(t, err)
+		assert.Empty(t, rl.Items)
+	})
+
+	t.Run("with query", func(t *testing.T) {
+		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			Query: String(rTest1.ID),
+		})
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, rl.Items)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), true)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), false)
+
+		rl, err = client.Admin.Runs.List(ctx, AdminRunsListOptions{
+			Query: String(rTest2.ID),
+		})
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, rl.Items)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), false)
+		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), true)
+	})
+}
+
+func adminRunItemsContainsID(items []*AdminRun, id string) bool {
+	hasID := false
+	for _, item := range items {
+		if item.ID == id {
+			hasID = true
+			break
+		}
+	}
+
+	return hasID
+}

--- a/tfe.go
+++ b/tfe.go
@@ -136,6 +136,7 @@ type Client struct {
 type Admin struct {
 	Organizations AdminOrganizations
 	Workspaces    AdminWorkspaces
+	Runs          AdminRuns
 }
 
 // Meta contains any Terraform Cloud APIs which provide data about the API itself.
@@ -219,6 +220,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Admin = Admin{
 		Organizations: &adminOrganizations{client: client},
 		Workspaces:    &adminWorkspaces{client: client},
+		Runs:          &adminRuns{client: client},
 	}
 
 	// Create the services.


### PR DESCRIPTION
## Description

This PR adds [Admin Runs API](https://www.terraform.io/docs/cloud/api/admin/runs.html).

This implements two API endpoints: `List()` and `ForceCancel()`

## Testing plan

1. Pull down this branch and run the tests

## Output from tests

```
$ TFE_TOKEN=<token> TFE_ADDRESS=<address>  ENABLE_TFE=1 go test -v ./...  -timeout=30m
...
PASS
ok  	github.com/hashicorp/go-tfe	504.616s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]

```

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/admin/runs.html)
