### PR TITLE
Add support for plan JSON output

### DIFF
--- a/plan.go
+++ b/plan.go
@@ -1,6 +1,7 @@
 package tfe
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"fmt"
@@ -22,6 +23,9 @@ type Plans interface {
 
 	// Logs retrieves the logs of a plan.
 	Logs(ctx context.Context, planID string) (io.Reader, error)
+
+	// Retrieve the JSON execution plan
+	JSONOutput(ctx context.Context, planID string) ([]byte, error)
 }
 
 // plans implements Plans.
@@ -133,4 +137,25 @@ func (s *plans) Logs(ctx context.Context, planID string) (io.Reader, error) {
 		done:   done,
 		logURL: u,
 	}, nil
+}
+
+// Retrieve the JSON execution plan
+func (s *plans) JSONOutput(ctx context.Context, planID string) ([]byte, error) {
+	if !validStringID(&planID) {
+		return nil, errors.New("invalid value for plan ID")
+	}
+
+	u := fmt.Sprintf("plans/%s/json-output", url.QueryEscape(planID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var buf bytes.Buffer
+	err = s.client.do(ctx, req, &buf)
+	if err != nil {
+		return nil, err
+	}
+
+	return buf.Bytes(), nil
 }

--- a/plan_test.go
+++ b/plan_test.go
@@ -112,3 +112,26 @@ func TestPlan_Unmarshal(t *testing.T) {
 	assert.Equal(t, plan.StatusTimestamps.QueuedAt, queuedParsedTime)
 	assert.Equal(t, plan.StatusTimestamps.ErroredAt, erroredParsedTime)
 }
+
+func TestPlansJSONOutput(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+	rTest, rTestCleanup := createPlannedRun(t, client, nil)
+	defer rTestCleanup()
+
+	t.Run("when the JSON output exists", func(t *testing.T) {
+		d, err := client.Plans.JSONOutput(ctx, rTest.Plan.ID)
+		require.NoError(t, err)
+		var m map[string]interface{}
+		err = json.Unmarshal(d, &m)
+		require.NoError(t, err)
+		assert.Contains(t, m, "planned_values")
+		assert.Contains(t, m, "terraform_version")
+	})
+
+	t.Run("when the JSON output does not exist", func(t *testing.T) {
+		d, err := client.Plans.JSONOutput(ctx, "nonexisting")
+		assert.Nil(t, d)
+		assert.Error(t, err)
+	})
+}


### PR DESCRIPTION
## Description

Get the JSON plan output.  I've just updated #164 to include a test.

## Test Output

```
% go test -v -timeout 30s -run ^TestPlansJSONOutput$ github.com/hashicorp/go-tfe
=== RUN   TestPlansJSONOutput
=== RUN   TestPlansJSONOutput/when_the_JSON_output_exists
=== RUN   TestPlansJSONOutput/when_the_JSON_output_does_not_exist
--- PASS: TestPlansJSONOutput (13.14s)
    --- PASS: TestPlansJSONOutput/when_the_JSON_output_exists (0.26s)
    --- PASS: TestPlansJSONOutput/when_the_JSON_output_does_not_exist (0.10s)
PASS
ok      github.com/hashicorp/go-tfe     13.347s
```
