### PR TITLE
Admin Users API

### DIFF
--- a/admin_user.go
+++ b/admin_user.go
@@ -30,7 +30,7 @@ type AdminUsers interface {
 	// GrantAdmin grants admin privilages to a user by its ID.
 	GrantAdmin(ctx context.Context, userID string) (*AdminUser, error)
 
-	// RevokeAdmin revokees admin privlages to a user by its ID.
+	// RevokeAdmin revokees admin privilages to a user by its ID.
 	RevokeAdmin(ctx context.Context, userID string) (*AdminUser, error)
 
 	// Disable2FA disables a user's two-factor authentication in the situation
@@ -178,7 +178,7 @@ func (a *adminUsers) GrantAdmin(ctx context.Context, userID string) (*AdminUser,
 	return au, nil
 }
 
-// RevokeAdmin revokes admin privlages to a user by its ID.
+// RevokeAdmin revokes admin privilages to a user by its ID.
 func (a *adminUsers) RevokeAdmin(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue

--- a/admin_user.go
+++ b/admin_user.go
@@ -21,29 +21,29 @@ type AdminUsers interface {
 	// Delete a user by its ID.
 	Delete(ctx context.Context, userID string) error
 
-	//	// Suspend a user account by its ID.
-	//	Suspend(ctx context.Context, userID string) (*AdminUser, error)
-	//
-	//	// Unsuspend a user account by its ID.
-	//	Unsuspend(ctx context.Context, userID string) (*AdminUser, error)
-	//
-	//	// GrantAdminPrivlages to a user account by its ID.
-	//	GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
-	//
-	//	// RevokeAdminPrivlages to a user account by its ID.
-	//	RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
-	//
-	//	// Disable2FA disables a user's two-factor authentication in the situation
-	//	// where they have lost access to their device and recovery codes.
-	//	Disable2FA(ctx context.Context, userID string) (*AdminUser, error)
-	//
-	//	// ImpersonateUser allows an admin to begin a new session as another user in
-	//	// the system
-	//	ImpersonateUser(ctx context.Context, userID string) (*AdminUser, error)
-	//
-	//	// UnimpersonateUser allows an admin to end an impersonationn session of
-	//	// another user in the system
-	//	UnimpersonateUser(ctx context.Context, userID string) (*AdminUser, error)
+	// Suspend a user account by its ID.
+	Suspend(ctx context.Context, userID string) (*AdminUser, error)
+
+	// Unsuspend a user account by its ID.
+	Unsuspend(ctx context.Context, userID string) (*AdminUser, error)
+
+	// GrantAdminPrivlages to a user account by its ID.
+	GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
+
+	// RevokeAdminPrivlages to a user account by its ID.
+	RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
+
+	// Disable2FA disables a user's two-factor authentication in the situation
+	// where they have lost access to their device and recovery codes.
+	Disable2FA(ctx context.Context, userID string) (*AdminUser, error)
+
+	// ImpersonateUser allows an admin to begin a new session as another user in
+	// the system
+	ImpersonateUser(ctx context.Context, userID string, options ImpersonateReasonOption) error
+
+	// UnimpersonateUser allows an admin to end an impersonationn session of
+	// another user in the system
+	UnimpersonateUser(ctx context.Context, userID string) error
 }
 
 // adminUsers implements the AdminUsers interface.
@@ -51,9 +51,16 @@ type adminUsers struct {
 	client *Client
 }
 
+// AdminUser represents a user as seen by an Admin.
 type AdminUser struct {
-	ID    string `jsonapi:"primary,users"`
-	Email string `jsonapi:"attr,email"`
+	ID               string     `jsonapi:"primary,users"`
+	Email            string     `jsonapi:"attr,email"`
+	Username         string     `jsonapi:"attr,username"`
+	AvatarURL        string     `jsonapi:"attr,avatar-url"`
+	TwoFactor        *TwoFactor `jsonapi:"attr,two-factor"`
+	IsAdmin          bool       `jsonapi:"attr,is-admin"`
+	IsSuspended      bool       `jsonapi:"attr,is-suspended"`
+	IsServiceAccount bool       `jsonapi:"attr,is-service-account"`
 
 	// Relations
 	Organizations []*Organization `jsonapi:"relation,organizations"`
@@ -85,33 +92,177 @@ type AdminUserListOptions struct {
 }
 
 // List all user accounts in the Terraform Enterprise installation
-func (s *adminUsers) List(ctx context.Context, options AdminUserListOptions) (*AdminUserList, error) {
+func (a *adminUsers) List(ctx context.Context, options AdminUserListOptions) (*AdminUserList, error) {
 	u := fmt.Sprintf("admin/users")
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := a.client.newRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
-	awl := &AdminUserList{}
-	err = s.client.do(ctx, req, awl)
+	aul := &AdminUserList{}
+	err = a.client.do(ctx, req, aul)
 	if err != nil {
 		return nil, err
 	}
 
-	return awl, nil
+	return aul, nil
 }
 
 // Delete a user by its ID.
-func (s *adminUsers) Delete(ctx context.Context, userID string) error {
+func (a *adminUsers) Delete(ctx context.Context, userID string) error {
 	if !validStringID(&userID) {
 		return ErrInvalidUserValue
 	}
 
 	u := fmt.Sprintf("admin/users/%s", url.QueryEscape(userID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := a.client.newRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return a.client.do(ctx, req, nil)
+}
+
+// Suspend a user account by its ID.
+func (a *adminUsers) Suspend(ctx context.Context, userID string) (*AdminUser, error) {
+	if !validStringID(&userID) {
+		return nil, ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s/actions/suspend", url.QueryEscape(userID))
+	req, err := a.client.newRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	au := &AdminUser{}
+	err = a.client.do(ctx, req, au)
+	if err != nil {
+		return nil, err
+	}
+
+	return au, nil
+}
+
+// Unsuspend a user account by its ID.
+func (a *adminUsers) Unsuspend(ctx context.Context, userID string) (*AdminUser, error) {
+	if !validStringID(&userID) {
+		return nil, ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s/actions/unsuspend", url.QueryEscape(userID))
+	req, err := a.client.newRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	au := &AdminUser{}
+	err = a.client.do(ctx, req, au)
+	if err != nil {
+		return nil, err
+	}
+
+	return au, nil
+}
+
+// GrantAdminPrivlages to a user account by its ID.
+func (a *adminUsers) GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error) {
+	if !validStringID(&userID) {
+		return nil, ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s/actions/grant_admin", url.QueryEscape(userID))
+	req, err := a.client.newRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	au := &AdminUser{}
+	err = a.client.do(ctx, req, au)
+	if err != nil {
+		return nil, err
+	}
+
+	return au, nil
+}
+
+// RevokeAdminPrivlages to a user account by its ID.
+func (a *adminUsers) RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error) {
+	if !validStringID(&userID) {
+		return nil, ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s/actions/revoke_admin", url.QueryEscape(userID))
+	req, err := a.client.newRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	au := &AdminUser{}
+	err = a.client.do(ctx, req, au)
+	if err != nil {
+		return nil, err
+	}
+
+	return au, nil
+}
+
+// Disable2FA disables a user's two-factor authentication in the situation
+// where they have lost access to their device and recovery codes.
+func (a *adminUsers) Disable2FA(ctx context.Context, userID string) (*AdminUser, error) {
+	if !validStringID(&userID) {
+		return nil, ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s/actions/disable_two_factor", url.QueryEscape(userID))
+	req, err := a.client.newRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	au := &AdminUser{}
+	err = a.client.do(ctx, req, au)
+	if err != nil {
+		return nil, err
+	}
+
+	return au, nil
+}
+
+// ImpersonateReasonOption represents the options for impersonating a user.
+type ImpersonateReasonOption struct {
+	// Specifies the reason for impersonating a user.
+	Reason *string `json:"reason"`
+}
+
+// ImpersonateUser allows an admin to begin a new session as another user in
+// the system
+func (a *adminUsers) ImpersonateUser(ctx context.Context, userID string, options ImpersonateReasonOption) error {
+	if !validStringID(&userID) {
+		return ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s/actions/impersonate", url.QueryEscape(userID))
+	req, err := a.client.newRequest("POST", u, &options)
+	if err != nil {
+		return err
+	}
+
+	return a.client.do(ctx, req, nil)
+}
+
+// UnimpersonateUser allows an admin to end an impersonationn session of
+// another user in the system
+func (a *adminUsers) UnimpersonateUser(ctx context.Context, userID string) error {
+	if !validStringID(&userID) {
+		return ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s/actions/unimpersonate", url.QueryEscape(userID))
+	req, err := a.client.newRequest("POST", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return a.client.do(ctx, req, nil)
 }

--- a/admin_user.go
+++ b/admin_user.go
@@ -27,23 +27,15 @@ type AdminUsers interface {
 	// Unsuspend a user by its ID.
 	Unsuspend(ctx context.Context, userID string) (*AdminUser, error)
 
-	// GrantAdminPrivlages grants admin pirvlages to a user by its ID.
-	GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
+	// GrantAdmin grants admin privilages to a user by its ID.
+	GrantAdmin(ctx context.Context, userID string) (*AdminUser, error)
 
-	// RevokeAdminPrivlages revokees admin privlages to a user by its ID.
-	RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
+	// RevokeAdmin revokees admin privlages to a user by its ID.
+	RevokeAdmin(ctx context.Context, userID string) (*AdminUser, error)
 
 	// Disable2FA disables a user's two-factor authentication in the situation
 	// where they have lost access to their device and recovery codes.
 	Disable2FA(ctx context.Context, userID string) (*AdminUser, error)
-
-	// ImpersonateUser allows an admin to begin a new session as another user in
-	// the system.
-	ImpersonateUser(ctx context.Context, userID string, options ImpersonateReasonOption) error
-
-	// UnimpersonateUser allows an admin to end an impersonationn session of
-	// another user in the system.
-	UnimpersonateUser(ctx context.Context, userID string) error
 }
 
 // adminUsers implements the AdminUsers interface.
@@ -165,8 +157,8 @@ func (a *adminUsers) Unsuspend(ctx context.Context, userID string) (*AdminUser, 
 	return au, nil
 }
 
-// GrantAdminPrivlages grants admin pirvlages to a user by its ID.
-func (a *adminUsers) GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error) {
+// GrantAdmin grants admin privilages to a user by its ID.
+func (a *adminUsers) GrantAdmin(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue
 	}
@@ -186,8 +178,8 @@ func (a *adminUsers) GrantAdminPrivlages(ctx context.Context, userID string) (*A
 	return au, nil
 }
 
-// RevokeAdminPrivlages revokees admin privlages to a user by its ID.
-func (a *adminUsers) RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error) {
+// RevokeAdmin revokes admin privlages to a user by its ID.
+func (a *adminUsers) RevokeAdmin(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue
 	}
@@ -227,42 +219,4 @@ func (a *adminUsers) Disable2FA(ctx context.Context, userID string) (*AdminUser,
 	}
 
 	return au, nil
-}
-
-// ImpersonateReasonOption represents the options for impersonating a user.
-type ImpersonateReasonOption struct {
-	// Specifies the reason for impersonating a user.
-	Reason *string `json:"reason"`
-}
-
-// ImpersonateUser allows an admin to begin a new session as another user in
-// the system.
-func (a *adminUsers) ImpersonateUser(ctx context.Context, userID string, options ImpersonateReasonOption) error {
-	if !validStringID(&userID) {
-		return ErrInvalidUserValue
-	}
-
-	u := fmt.Sprintf("admin/users/%s/actions/impersonate", url.QueryEscape(userID))
-	req, err := a.client.newRequest("POST", u, &options)
-	if err != nil {
-		return err
-	}
-
-	return a.client.do(ctx, req, nil)
-}
-
-// UnimpersonateUser allows an admin to end an impersonationn session of
-// another user in the system.
-func (a *adminUsers) UnimpersonateUser(ctx context.Context, userID string) error {
-	if !validStringID(&userID) {
-		return ErrInvalidUserValue
-	}
-
-	u := fmt.Sprintf("admin/users/%s/actions/unimpersonate", url.QueryEscape(userID))
-	req, err := a.client.newRequest("POST", u, nil)
-	if err != nil {
-		return err
-	}
-
-	return a.client.do(ctx, req, nil)
 }

--- a/admin_user.go
+++ b/admin_user.go
@@ -21,16 +21,16 @@ type AdminUsers interface {
 	// Delete a user by its ID.
 	Delete(ctx context.Context, userID string) error
 
-	// Suspend a user account by its ID.
+	// Suspend a user by its ID.
 	Suspend(ctx context.Context, userID string) (*AdminUser, error)
 
-	// Unsuspend a user account by its ID.
+	// Unsuspend a user by its ID.
 	Unsuspend(ctx context.Context, userID string) (*AdminUser, error)
 
-	// GrantAdminPrivlages to a user account by its ID.
+	// GrantAdminPrivlages grants admin pirvlages to a user by its ID.
 	GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
 
-	// RevokeAdminPrivlages to a user account by its ID.
+	// RevokeAdminPrivlages revokees admin privlages to a user by its ID.
 	RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
 
 	// Disable2FA disables a user's two-factor authentication in the situation
@@ -38,11 +38,11 @@ type AdminUsers interface {
 	Disable2FA(ctx context.Context, userID string) (*AdminUser, error)
 
 	// ImpersonateUser allows an admin to begin a new session as another user in
-	// the system
+	// the system.
 	ImpersonateUser(ctx context.Context, userID string, options ImpersonateReasonOption) error
 
 	// UnimpersonateUser allows an admin to end an impersonationn session of
-	// another user in the system
+	// another user in the system.
 	UnimpersonateUser(ctx context.Context, userID string) error
 }
 
@@ -123,7 +123,7 @@ func (a *adminUsers) Delete(ctx context.Context, userID string) error {
 	return a.client.do(ctx, req, nil)
 }
 
-// Suspend a user account by its ID.
+// Suspend a user by its ID.
 func (a *adminUsers) Suspend(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue
@@ -144,7 +144,7 @@ func (a *adminUsers) Suspend(ctx context.Context, userID string) (*AdminUser, er
 	return au, nil
 }
 
-// Unsuspend a user account by its ID.
+// Unsuspend a user by its ID.
 func (a *adminUsers) Unsuspend(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue
@@ -165,7 +165,7 @@ func (a *adminUsers) Unsuspend(ctx context.Context, userID string) (*AdminUser, 
 	return au, nil
 }
 
-// GrantAdminPrivlages to a user account by its ID.
+// GrantAdminPrivlages grants admin pirvlages to a user by its ID.
 func (a *adminUsers) GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue
@@ -186,7 +186,7 @@ func (a *adminUsers) GrantAdminPrivlages(ctx context.Context, userID string) (*A
 	return au, nil
 }
 
-// RevokeAdminPrivlages to a user account by its ID.
+// RevokeAdminPrivlages revokees admin privlages to a user by its ID.
 func (a *adminUsers) RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue
@@ -236,7 +236,7 @@ type ImpersonateReasonOption struct {
 }
 
 // ImpersonateUser allows an admin to begin a new session as another user in
-// the system
+// the system.
 func (a *adminUsers) ImpersonateUser(ctx context.Context, userID string, options ImpersonateReasonOption) error {
 	if !validStringID(&userID) {
 		return ErrInvalidUserValue
@@ -252,7 +252,7 @@ func (a *adminUsers) ImpersonateUser(ctx context.Context, userID string, options
 }
 
 // UnimpersonateUser allows an admin to end an impersonationn session of
-// another user in the system
+// another user in the system.
 func (a *adminUsers) UnimpersonateUser(ctx context.Context, userID string) error {
 	if !validStringID(&userID) {
 		return ErrInvalidUserValue

--- a/admin_user.go
+++ b/admin_user.go
@@ -1,0 +1,117 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ AdminUsers = (*adminUsers)(nil)
+
+// AdminUsers describes all the admin user related methods that the Terraform
+// Enterprise  API supports.
+// It contains endpoints to help site administrators manage their users.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/admin/users.html
+type AdminUsers interface {
+	// List all the users of the given installation.
+	List(ctx context.Context, options AdminUserListOptions) (*AdminUserList, error)
+
+	// Delete a user by its ID.
+	Delete(ctx context.Context, userID string) error
+
+	//	// Suspend a user account by its ID.
+	//	Suspend(ctx context.Context, userID string) (*AdminUser, error)
+	//
+	//	// Unsuspend a user account by its ID.
+	//	Unsuspend(ctx context.Context, userID string) (*AdminUser, error)
+	//
+	//	// GrantAdminPrivlages to a user account by its ID.
+	//	GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
+	//
+	//	// RevokeAdminPrivlages to a user account by its ID.
+	//	RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)
+	//
+	//	// Disable2FA disables a user's two-factor authentication in the situation
+	//	// where they have lost access to their device and recovery codes.
+	//	Disable2FA(ctx context.Context, userID string) (*AdminUser, error)
+	//
+	//	// ImpersonateUser allows an admin to begin a new session as another user in
+	//	// the system
+	//	ImpersonateUser(ctx context.Context, userID string) (*AdminUser, error)
+	//
+	//	// UnimpersonateUser allows an admin to end an impersonationn session of
+	//	// another user in the system
+	//	UnimpersonateUser(ctx context.Context, userID string) (*AdminUser, error)
+}
+
+// adminUsers implements the AdminUsers interface.
+type adminUsers struct {
+	client *Client
+}
+
+type AdminUser struct {
+	ID    string `jsonapi:"primary,users"`
+	Email string `jsonapi:"attr,email"`
+
+	// Relations
+	Organizations []*Organization `jsonapi:"relation,organizations"`
+}
+
+// AdminUserList represents a list of users.
+type AdminUserList struct {
+	*Pagination
+	Items []*AdminUser
+}
+
+// AdminUserListOptions represents the options for listing users.
+// https://www.terraform.io/docs/cloud/api/admin/users.html#query-parameters
+type AdminUserListOptions struct {
+	ListOptions
+
+	// A search query string. Users are searchable by username and email address.
+	Query *string `url:"q,omitempty"`
+
+	// Can be "true" or "false" to show only administrators or non-administrators.
+	Administrators *string `url:"filter[admin]"`
+
+	// Can be "true" or "false" to show only suspended users or users who are not suspended.
+	SuspendedUsers *string `url:"filter[suspended]"`
+
+	// A list of relations to include. See available resources
+	// https://www.terraform.io/docs/cloud/api/admin/users.html#available-related-resources
+	Include *string `url:"include"`
+}
+
+// List all user accounts in the Terraform Enterprise installation
+func (s *adminUsers) List(ctx context.Context, options AdminUserListOptions) (*AdminUserList, error) {
+	u := fmt.Sprintf("admin/users")
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	awl := &AdminUserList{}
+	err = s.client.do(ctx, req, awl)
+	if err != nil {
+		return nil, err
+	}
+
+	return awl, nil
+}
+
+// Delete a user by its ID.
+func (s *adminUsers) Delete(ctx context.Context, userID string) error {
+	if !validStringID(&userID) {
+		return ErrInvalidUserValue
+	}
+
+	u := fmt.Sprintf("admin/users/%s", url.QueryEscape(userID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/admin_user_test.go
+++ b/admin_user_test.go
@@ -1,0 +1,97 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestAdminUsers_List(t *testing.T) {
+	skipIfCloud(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	currentUser, err := client.Users.ReadCurrent(ctx)
+	fmt.Println(currentUser.ID)
+	fmt.Println(currentUser.Email)
+	assert.NoError(t, err)
+
+	org, orgCleanup := createOrganization(t, client)
+	defer orgCleanup()
+	fmt.Println(org.Name)
+
+	t.Run("without list options", func(t *testing.T) {
+		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{})
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, ul.Items)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		// Out of range page number, so the items should be empty
+		assert.Empty(t, ul.Items)
+		assert.Equal(t, 999, ul.CurrentPage)
+
+		ul, err = client.Admin.Users.List(ctx, AdminUserListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 1,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, ul.Items)
+		assert.Equal(t, 1, ul.CurrentPage)
+	})
+
+	t.Run("query by username or email", func(t *testing.T) {
+		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+			Query: String(currentUser.Username),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, currentUser.ID, ul.Items[0].ID)
+		assert.Equal(t, 1, ul.CurrentPage)
+		assert.Equal(t, true, ul.TotalCount == 1)
+
+		ul, err = client.Admin.Users.List(ctx, AdminUserListOptions{
+			Query: String(currentUser.Email),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, currentUser.Email, ul.Items[0].Email)
+		assert.Equal(t, 1, ul.CurrentPage)
+		assert.Equal(t, true, ul.TotalCount == 1)
+	})
+
+	t.Run("with organization included", func(t *testing.T) {
+		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+			Include: String("organizations"),
+		})
+
+		assert.NoError(t, err)
+
+		assert.NotEmpty(t, ul.Items)
+		assert.NotNil(t, ul.Items[0].Organizations)
+		assert.NotEmpty(t, ul.Items[0].Organizations[0].Name)
+	})
+
+	t.Run("filter by admin", func(t *testing.T) {
+		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+			Administrators: String("true"),
+		})
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, ul.Items)
+		assert.NotNil(t, ul.Items[0])
+		assert.Equal(t, currentUser.Email, ul.Items[0].Email)
+	})
+}

--- a/admin_user_test.go
+++ b/admin_user_test.go
@@ -160,11 +160,11 @@ func TestAdminUsers_AdminPrivlages_Suspensions(t *testing.T) {
 	}
 	user := ul.Items[0]
 
-	user, err = client.Admin.Users.GrantAdminPrivlages(ctx, user.ID)
+	user, err = client.Admin.Users.GrantAdmin(ctx, user.ID)
 	require.NoError(t, err)
 	require.True(t, user.IsAdmin)
 
-	user, err = client.Admin.Users.RevokeAdminPrivlages(ctx, user.ID)
+	user, err = client.Admin.Users.RevokeAdmin(ctx, user.ID)
 	require.NoError(t, err)
 	require.False(t, user.IsAdmin)
 

--- a/admin_user_test.go
+++ b/admin_user_test.go
@@ -139,44 +139,6 @@ func TestAdminUsers_Delete(t *testing.T) {
 	})
 }
 
-func TestAdminUsers_AdminPrivlages_Suspensions(t *testing.T) {
-	// This test relies on a user already existing on the instance
-	// this test is run against. This user has a 'tst' as part of their
-	// email. We look this user up, and execute both the AdminPrivlage and
-	// Suspension operations on this user. This is why both are done in
-	// the same test.
-
-	skipIfCloud(t)
-
-	client := testClient(t)
-	ctx := context.Background()
-
-	ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
-		Query: String("tst"),
-	})
-	require.NoError(t, err)
-	if len(ul.Items) == 0 {
-		t.Skip("No test users available")
-	}
-	user := ul.Items[0]
-
-	user, err = client.Admin.Users.GrantAdmin(ctx, user.ID)
-	require.NoError(t, err)
-	require.True(t, user.IsAdmin)
-
-	user, err = client.Admin.Users.RevokeAdmin(ctx, user.ID)
-	require.NoError(t, err)
-	require.False(t, user.IsAdmin)
-
-	user, err = client.Admin.Users.Suspend(ctx, user.ID)
-	require.NoError(t, err)
-	require.True(t, user.IsSuspended)
-
-	user, err = client.Admin.Users.Unsuspend(ctx, user.ID)
-	require.NoError(t, err)
-	require.False(t, user.IsSuspended)
-}
-
 func TestAdminUsers_Disable2FA(t *testing.T) {
 	skipIfCloud(t)
 

--- a/admin_user_test.go
+++ b/admin_user_test.go
@@ -2,7 +2,6 @@ package tfe
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -20,7 +19,6 @@ func TestAdminUsers_List(t *testing.T) {
 
 	org, orgCleanup := createOrganization(t, client)
 	defer orgCleanup()
-	fmt.Println(org.Name)
 
 	t.Run("without list options", func(t *testing.T) {
 		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{})
@@ -122,8 +120,6 @@ func TestAdminUsers_Delete(t *testing.T) {
 		assert.Equal(t, 1, ul.CurrentPage)
 		assert.Equal(t, true, ul.TotalCount == 1)
 
-		fmt.Println(member.User.ID)
-
 		err = client.Admin.Users.Delete(ctx, member.User.ID)
 		require.NoError(t, err)
 
@@ -144,9 +140,11 @@ func TestAdminUsers_Delete(t *testing.T) {
 }
 
 func TestAdminUsers_AdminPrivlages_Suspensions(t *testing.T) {
-	// Doing both AdminPrivlages API and Suspensions API tests in
-	// one test run so as to avoid operating on the same test user and
-	// messing up the admin/suspension states.
+	// This test relies on a user already existing on the instance
+	// this test is run against. This user has a 'tst' as part of their
+	// email. We look this user up, and execute both the AdminPrivlage and
+	// Suspension operations on this user. This is why both are done in
+	// the same test.
 
 	skipIfCloud(t)
 

--- a/errors.go
+++ b/errors.go
@@ -73,4 +73,9 @@ var (
 
 	// ErrInvalidCostEstimateID is returned when the cost estimate ID is invalid.
 	ErrInvalidCostEstimateID = errors.New("invalid value for cost estimate ID")
+
+	// User
+
+	// ErrInvalidUservalue is invalid.
+	ErrInvalidUserValue = errors.New("invalid value for user")
 )

--- a/helper_test.go
+++ b/helper_test.go
@@ -495,10 +495,10 @@ func createRun(t *testing.T, client *Client, w *Workspace) (*Run, func()) {
 	}
 
 	return r, func() {
+		cvCleanup()
+
 		if wCleanup != nil {
 			wCleanup()
-		} else {
-			cvCleanup()
 		}
 	}
 }
@@ -536,6 +536,7 @@ func createCostEstimatedRun(t *testing.T, client *Client, w *Workspace) (*Run, f
 	for i := 0; ; i++ {
 		r, err = client.Runs.Read(ctx, r.ID)
 		if err != nil {
+			rCleanup()
 			t.Fatal(err)
 		}
 
@@ -565,6 +566,7 @@ func createAppliedRun(t *testing.T, client *Client, w *Workspace) (*Run, func())
 	for i := 0; ; i++ {
 		r, err = client.Runs.Read(ctx, r.ID)
 		if err != nil {
+			rCleanup()
 			t.Fatal(err)
 		}
 
@@ -797,7 +799,7 @@ func createTeam(t *testing.T, client *Client, org *Organization) (*Team, func())
 }
 
 func createTeamAccess(t *testing.T, client *Client, tm *Team, w *Workspace, org *Organization) (*TeamAccess, func()) {
-	var orgCleanup, tmCleanup func()
+	var orgCleanup, tmCleanup, wCleanup func()
 
 	if org == nil {
 		org, orgCleanup = createOrganization(t, client)
@@ -808,7 +810,7 @@ func createTeamAccess(t *testing.T, client *Client, tm *Team, w *Workspace, org 
 	}
 
 	if w == nil {
-		w, _ = createWorkspace(t, client, org)
+		w, wCleanup = createWorkspace(t, client, org)
 	}
 
 	ctx := context.Background()
@@ -834,6 +836,10 @@ func createTeamAccess(t *testing.T, client *Client, tm *Team, w *Workspace, org 
 
 		if orgCleanup != nil {
 			orgCleanup()
+		}
+
+		if wCleanup != nil {
+			wCleanup()
 		}
 	}
 }

--- a/run_test.go
+++ b/run_test.go
@@ -13,7 +13,9 @@ func TestRunsList(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	wTest, wTestCleanup := createWorkspace(t, client, nil)
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 	defer wTestCleanup()
 
 	rTest1, rTestCleanup1 := createRun(t, client, wTest)

--- a/run_test.go
+++ b/run_test.go
@@ -177,7 +177,12 @@ func TestRunsApply(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	rTest, rTestCleanup := createPlannedRun(t, client, nil)
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	rTest, rTestCleanup := createPlannedRun(t, client, wTest)
 	defer rTestCleanup()
 
 	t.Run("when the run exists", func(t *testing.T) {

--- a/team_access_test.go
+++ b/team_access_test.go
@@ -197,7 +197,14 @@ func TestTeamAccessesRead(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	taTest, taTestCleanup := createTeamAccess(t, client, nil, nil, nil)
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
+	defer tmTestCleanup()
+
+	taTest, taTestCleanup := createTeamAccess(t, client, tmTest, wTest, orgTest)
 	defer taTestCleanup()
 
 	t.Run("when the team access exists", func(t *testing.T) {
@@ -249,7 +256,7 @@ func TestTeamAccessesUpdate(t *testing.T) {
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	defer tmTestCleanup()
 
-	taTest, taTestCleanup := createTeamAccess(t, client, tmTest, wTest, nil)
+	taTest, taTestCleanup := createTeamAccess(t, client, tmTest, wTest, orgTest)
 	defer taTestCleanup()
 
 	t.Run("with valid attributes", func(t *testing.T) {

--- a/tfe.go
+++ b/tfe.go
@@ -136,6 +136,7 @@ type Client struct {
 type Admin struct {
 	Organizations AdminOrganizations
 	Workspaces    AdminWorkspaces
+	Users         AdminUsers
 }
 
 // Meta contains any Terraform Cloud APIs which provide data about the API itself.
@@ -219,6 +220,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Admin = Admin{
 		Organizations: &adminOrganizations{client: client},
 		Workspaces:    &adminWorkspaces{client: client},
+		Users:         &adminUsers{client: client},
 	}
 
 	// Create the services.


### PR DESCRIPTION
## Description

This PR adds all the [Admin Users API](https://www.terraform.io/docs/cloud/api/admin/users.html).

It implements: 
```
type AdminUsers interface {
	// List all the users of the given installation.
	List(ctx context.Context, options AdminUserListOptions) (*AdminUserList, error)

	// Delete a user by its ID.
	Delete(ctx context.Context, userID string) error

	// Suspend a user account by its ID.
	Suspend(ctx context.Context, userID string) (*AdminUser, error)

	// Unsuspend a user account by its ID.
	Unsuspend(ctx context.Context, userID string) (*AdminUser, error)

	// GrantAdminPrivlages to a user account by its ID.
	GrantAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)

	// RevokeAdminPrivlages to a user account by its ID.
	RevokeAdminPrivlages(ctx context.Context, userID string) (*AdminUser, error)

	// Disable2FA disables a user's two-factor authentication in the situation
	// where they have lost access to their device and recovery codes.
	Disable2FA(ctx context.Context, userID string) (*AdminUser, error)

	// ImpersonateUser allows an admin to begin a new session as another user in
	// the system
	ImpersonateUser(ctx context.Context, userID string, options ImpersonateReasonOption) error

	// UnimpersonateUser allows an admin to end an impersonationn session of
	// another user in the system
	UnimpersonateUser(ctx context.Context, userID string) error
}
```

## Testing plan

1. Pull down and run the tests 

## Output from tests

```
$ TFE_TOKEN=<token> TFE_ADDRESS=<address>  ENABLE_TFE=1 go test -v ./...  -timeout=30m
...
PASS
ok  	github.com/hashicorp/go-tfe	514.436s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
```


## External links


- [API documentation](https://www.terraform.io/docs/cloud/api/admin/users.html)
