### PR TITLE
Change create/update options in resources to match JSON:API Type field

### DIFF
--- a/agent_pool.go
+++ b/agent_pool.go
@@ -78,8 +78,9 @@ func (s *agentPools) List(ctx context.Context, organization string, options Agen
 
 // AgentPoolCreateOptions represents the options for creating an agent pool.
 type AgentPoolCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,agent-pools"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,agent-pools"`
 
 	// A name to identify the agent pool.
 	Name *string `jsonapi:"attr,name"`
@@ -104,9 +105,6 @@ func (s *agentPools) Create(ctx context.Context, organization string, options Ag
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("organizations/%s/agent-pools", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)
@@ -146,8 +144,9 @@ func (s *agentPools) Read(ctx context.Context, agentpoolID string) (*AgentPool, 
 
 // AgentPoolUpdateOptions represents the options for updating an agent pool.
 type AgentPoolUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,agent-pools"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,agent-pools"`
 
 	// A new name to identify the agent pool.
 	Name *string `jsonapi:"attr,name"`
@@ -169,9 +168,6 @@ func (s *agentPools) Update(ctx context.Context, agentPoolID string, options Age
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentPoolID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -78,7 +78,9 @@ func (s *agentPools) List(ctx context.Context, organization string, options Agen
 
 // AgentPoolCreateOptions represents the options for creating an agent pool.
 type AgentPoolCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,agent-pools"`
 
@@ -144,7 +146,9 @@ func (s *agentPools) Read(ctx context.Context, agentpoolID string) (*AgentPool, 
 
 // AgentPoolUpdateOptions represents the options for updating an agent pool.
 type AgentPoolUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,agent-pools"`
 

--- a/agent_token.go
+++ b/agent_token.go
@@ -72,7 +72,9 @@ func (s *agentTokens) List(ctx context.Context, agentPoolID string) (*AgentToken
 
 // AgentTokenGenerateOptions represents the options for creating an agent token.
 type AgentTokenGenerateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,agent-tokens"`
 

--- a/agent_token.go
+++ b/agent_token.go
@@ -72,8 +72,9 @@ func (s *agentTokens) List(ctx context.Context, agentPoolID string) (*AgentToken
 
 // AgentTokenGenerateOptions represents the options for creating an agent token.
 type AgentTokenGenerateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,agent-tokens"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,agent-tokens"`
 
 	// Description of the token
 	Description *string `jsonapi:"attr,description"`
@@ -88,9 +89,6 @@ func (s *agentTokens) Generate(ctx context.Context, agentPoolID string, options 
 	if !validString(options.Description) {
 		return nil, ErrAgentTokenDescription
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("agent-pools/%s/authentication-tokens", url.QueryEscape(agentPoolID))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -122,7 +122,9 @@ func (s *configurationVersions) List(ctx context.Context, workspaceID string, op
 // ConfigurationVersionCreateOptions represents the options for creating a
 // configuration version.
 type ConfigurationVersionCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,configuration-versions"`
 

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -122,8 +122,9 @@ func (s *configurationVersions) List(ctx context.Context, workspaceID string, op
 // ConfigurationVersionCreateOptions represents the options for creating a
 // configuration version.
 type ConfigurationVersionCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,configuration-versions"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,configuration-versions"`
 
 	// When true, runs are queued automatically when the configuration version
 	// is uploaded.
@@ -139,9 +140,6 @@ func (s *configurationVersions) Create(ctx context.Context, workspaceID string, 
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -131,8 +131,9 @@ func (s *notificationConfigurations) List(ctx context.Context, workspaceID strin
 // NotificationConfigurationCreateOptions represents the options for
 // creating a new notification configuration.
 type NotificationConfigurationCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,notification-configurations"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,notification-configurations"`
 
 	// The destination type of the notification configuration
 	DestinationType *NotificationDestinationType `jsonapi:"attr,destination-type"`
@@ -188,9 +189,6 @@ func (s *notificationConfigurations) Create(ctx context.Context, workspaceID str
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	u := fmt.Sprintf("workspaces/%s/notification-configurations", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
@@ -230,8 +228,9 @@ func (s *notificationConfigurations) Read(ctx context.Context, notificationConfi
 // NotificationConfigurationUpdateOptions represents the options for
 // updating a existing notification configuration.
 type NotificationConfigurationUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,notification-configurations"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,notification-configurations"`
 
 	// Whether the notification configuration should be enabled or not
 	Enabled *bool `jsonapi:"attr,enabled,omitempty"`
@@ -261,9 +260,6 @@ func (s *notificationConfigurations) Update(ctx context.Context, notificationCon
 	if !validStringID(&notificationConfigurationID) {
 		return nil, errors.New("invalid value for notification configuration ID")
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("notification-configurations/%s", url.QueryEscape(notificationConfigurationID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -131,7 +131,9 @@ func (s *notificationConfigurations) List(ctx context.Context, workspaceID strin
 // NotificationConfigurationCreateOptions represents the options for
 // creating a new notification configuration.
 type NotificationConfigurationCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,notification-configurations"`
 
@@ -228,7 +230,9 @@ func (s *notificationConfigurations) Read(ctx context.Context, notificationConfi
 // NotificationConfigurationUpdateOptions represents the options for
 // updating a existing notification configuration.
 type NotificationConfigurationUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,notification-configurations"`
 

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -108,8 +108,9 @@ func (s *oAuthClients) List(ctx context.Context, organization string, options OA
 
 // OAuthClientCreateOptions represents the options for creating an OAuth client.
 type OAuthClientCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,oauth-clients"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,oauth-clients"`
 
 	// The base URL of your VCS provider's API.
 	APIURL *string `jsonapi:"attr,api-url"`
@@ -154,9 +155,6 @@ func (s *oAuthClients) Create(ctx context.Context, organization string, options 
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -108,7 +108,9 @@ func (s *oAuthClients) List(ctx context.Context, organization string, options OA
 
 // OAuthClientCreateOptions represents the options for creating an OAuth client.
 type OAuthClientCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,oauth-clients"`
 

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -103,7 +103,9 @@ func (s *oAuthTokens) Read(ctx context.Context, oAuthTokenID string) (*OAuthToke
 
 // OAuthTokenUpdateOptions represents the options for updating an OAuth token.
 type OAuthTokenUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,oauth-tokens"`
 

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -103,8 +103,9 @@ func (s *oAuthTokens) Read(ctx context.Context, oAuthTokenID string) (*OAuthToke
 
 // OAuthTokenUpdateOptions represents the options for updating an OAuth token.
 type OAuthTokenUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,oauth-tokens"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,oauth-tokens"`
 
 	// A private SSH key to be used for git clone operations.
 	PrivateSSHKey *string `jsonapi:"attr,ssh-key"`
@@ -115,9 +116,6 @@ func (s *oAuthTokens) Update(ctx context.Context, oAuthTokenID string, options O
 	if !validStringID(&oAuthTokenID) {
 		return nil, errors.New("invalid value for OAuth token ID")
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("oauth-tokens/%s", url.QueryEscape(oAuthTokenID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/organization.go
+++ b/organization.go
@@ -155,7 +155,9 @@ func (s *organizations) List(ctx context.Context, options OrganizationListOption
 
 // OrganizationCreateOptions represents the options for creating an organization.
 type OrganizationCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,organizations"`
 
@@ -237,7 +239,9 @@ func (s *organizations) Read(ctx context.Context, organization string) (*Organiz
 
 // OrganizationUpdateOptions represents the options for updating an organization.
 type OrganizationUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,organizations"`
 

--- a/organization.go
+++ b/organization.go
@@ -155,8 +155,9 @@ func (s *organizations) List(ctx context.Context, options OrganizationListOption
 
 // OrganizationCreateOptions represents the options for creating an organization.
 type OrganizationCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,organizations"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,organizations"`
 
 	// Name of the organization.
 	Name *string `jsonapi:"attr,name"`
@@ -199,9 +200,6 @@ func (s *organizations) Create(ctx context.Context, options OrganizationCreateOp
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	req, err := s.client.newRequest("POST", "organizations", &options)
 	if err != nil {
 		return nil, err
@@ -239,8 +237,9 @@ func (s *organizations) Read(ctx context.Context, organization string) (*Organiz
 
 // OrganizationUpdateOptions represents the options for updating an organization.
 type OrganizationUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,organizations"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,organizations"`
 
 	// New name for the organization.
 	Name *string `jsonapi:"attr,name,omitempty"`
@@ -269,9 +268,6 @@ func (s *organizations) Update(ctx context.Context, organization string, options
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -94,8 +94,9 @@ func (s *organizationMemberships) List(ctx context.Context, organization string,
 
 // OrganizationMembershipCreateOptions represents the options for creating an organization membership.
 type OrganizationMembershipCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,organization-memberships"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,organization-memberships"`
 
 	// User's email address.
 	Email *string `jsonapi:"attr,email"`
@@ -116,8 +117,6 @@ func (s *organizationMemberships) Create(ctx context.Context, organization strin
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	options.ID = ""
 
 	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -94,7 +94,9 @@ func (s *organizationMemberships) List(ctx context.Context, organization string,
 
 // OrganizationMembershipCreateOptions represents the options for creating an organization membership.
 type OrganizationMembershipCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,organization-memberships"`
 

--- a/plan_export.go
+++ b/plan_export.go
@@ -75,7 +75,9 @@ type PlanExport struct {
 
 // PlanExportCreateOptions represents the options for exporting data from a plan.
 type PlanExportCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,plan-exports"`
 

--- a/plan_export.go
+++ b/plan_export.go
@@ -75,8 +75,9 @@ type PlanExport struct {
 
 // PlanExportCreateOptions represents the options for exporting data from a plan.
 type PlanExportCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,plan-exports"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,plan-exports"`
 
 	// The plan to export.
 	Plan *Plan `jsonapi:"relation,plan"`
@@ -99,9 +100,6 @@ func (s *planExports) Create(ctx context.Context, options PlanExportCreateOption
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	req, err := s.client.newRequest("POST", "plan-exports", &options)
 	if err != nil {

--- a/policy.go
+++ b/policy.go
@@ -110,7 +110,9 @@ func (s *policies) List(ctx context.Context, organization string, options Policy
 
 // PolicyCreateOptions represents the options for creating a new policy.
 type PolicyCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,policies"`
 
@@ -198,7 +200,9 @@ func (s *policies) Read(ctx context.Context, policyID string) (*Policy, error) {
 
 // PolicyUpdateOptions represents the options for updating a policy.
 type PolicyUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,policies"`
 

--- a/policy.go
+++ b/policy.go
@@ -110,8 +110,9 @@ func (s *policies) List(ctx context.Context, organization string, options Policy
 
 // PolicyCreateOptions represents the options for creating a new policy.
 type PolicyCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,policies"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,policies"`
 
 	// The name of the policy.
 	Name *string `jsonapi:"attr,name"`
@@ -159,9 +160,6 @@ func (s *policies) Create(ctx context.Context, organization string, options Poli
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	u := fmt.Sprintf("organizations/%s/policies", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
@@ -200,8 +198,9 @@ func (s *policies) Read(ctx context.Context, policyID string) (*Policy, error) {
 
 // PolicyUpdateOptions represents the options for updating a policy.
 type PolicyUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,policies"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,policies"`
 
 	// A description of the policy's purpose.
 	Description *string `jsonapi:"attr,description,omitempty"`
@@ -215,9 +214,6 @@ func (s *policies) Update(ctx context.Context, policyID string, options PolicyUp
 	if !validStringID(&policyID) {
 		return nil, errors.New("invalid value for policy ID")
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("policies/%s", url.QueryEscape(policyID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/policy_set.go
+++ b/policy_set.go
@@ -107,7 +107,9 @@ func (s *policySets) List(ctx context.Context, organization string, options Poli
 
 // PolicySetCreateOptions represents the options for creating a new policy set.
 type PolicySetCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,policy-sets"`
 
@@ -196,7 +198,9 @@ func (s *policySets) Read(ctx context.Context, policySetID string) (*PolicySet, 
 
 // PolicySetUpdateOptions represents the options for updating a policy set.
 type PolicySetUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,policy-sets"`
 

--- a/policy_set.go
+++ b/policy_set.go
@@ -107,8 +107,9 @@ func (s *policySets) List(ctx context.Context, organization string, options Poli
 
 // PolicySetCreateOptions represents the options for creating a new policy set.
 type PolicySetCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,policy-sets"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,policy-sets"`
 
 	// The name of the policy set.
 	Name *string `jsonapi:"attr,name"`
@@ -157,9 +158,6 @@ func (s *policySets) Create(ctx context.Context, organization string, options Po
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
@@ -198,8 +196,9 @@ func (s *policySets) Read(ctx context.Context, policySetID string) (*PolicySet, 
 
 // PolicySetUpdateOptions represents the options for updating a policy set.
 type PolicySetUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,policy-sets"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,policy-sets"`
 
 	/// The name of the policy set.
 	Name *string `jsonapi:"attr,name,omitempty"`
@@ -239,9 +238,6 @@ func (s *policySets) Update(ctx context.Context, policySetID string, options Pol
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/policy_set_parameter.go
+++ b/policy_set_parameter.go
@@ -89,7 +89,9 @@ func (s *policySetParameters) List(ctx context.Context, policySetID string, opti
 
 // PolicySetParameterCreateOptions represents the options for creating a new parameter.
 type PolicySetParameterCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,vars"`
 
@@ -169,7 +171,9 @@ func (s *policySetParameters) Read(ctx context.Context, policySetID string, para
 
 // PolicySetParameterUpdateOptions represents the options for updating a parameter.
 type PolicySetParameterUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,vars"`
 

--- a/policy_set_parameter.go
+++ b/policy_set_parameter.go
@@ -89,8 +89,9 @@ func (s *policySetParameters) List(ctx context.Context, policySetID string, opti
 
 // PolicySetParameterCreateOptions represents the options for creating a new parameter.
 type PolicySetParameterCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,vars"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
 
 	// The name of the parameter.
 	Key *string `jsonapi:"attr,key"`
@@ -126,9 +127,6 @@ func (s *policySetParameters) Create(ctx context.Context, policySetID string, op
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("policy-sets/%s/parameters", url.QueryEscape(policySetID))
 	req, err := s.client.newRequest("POST", u, &options)
@@ -171,8 +169,9 @@ func (s *policySetParameters) Read(ctx context.Context, policySetID string, para
 
 // PolicySetParameterUpdateOptions represents the options for updating a parameter.
 type PolicySetParameterUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,vars"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
 
 	// The name of the parameter.
 	Key *string `jsonapi:"attr,key,omitempty"`
@@ -192,9 +191,6 @@ func (s *policySetParameters) Update(ctx context.Context, policySetID string, pa
 	if !validStringID(&parameterID) {
 		return nil, errors.New("invalid value for parameter ID")
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = parameterID
 
 	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/registry_module.go
+++ b/registry_module.go
@@ -110,7 +110,9 @@ type RegistryModuleVersionStatuses struct {
 
 // RegistryModuleCreateOptions is used when creating a registry module without a VCS repo
 type RegistryModuleCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,registry-modules"`
 
@@ -163,7 +165,9 @@ func (r *registryModules) Create(ctx context.Context, organization string, optio
 
 // RegistryModuleCreateVersionOptions is used when creating a registry module version
 type RegistryModuleCreateVersionOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,registry-module-versions"`
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -110,8 +110,9 @@ type RegistryModuleVersionStatuses struct {
 
 // RegistryModuleCreateOptions is used when creating a registry module without a VCS repo
 type RegistryModuleCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,registry-modules"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,registry-modules"`
 
 	Name     *string `jsonapi:"attr,name"`
 	Provider *string `jsonapi:"attr,provider"`
@@ -142,9 +143,6 @@ func (r *registryModules) Create(ctx context.Context, organization string, optio
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules",
 		url.QueryEscape(organization),
@@ -165,8 +163,9 @@ func (r *registryModules) Create(ctx context.Context, organization string, optio
 
 // RegistryModuleCreateVersionOptions is used when creating a registry module version
 type RegistryModuleCreateVersionOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,registry-module-versions"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,registry-module-versions"`
 
 	Version *string `jsonapi:"attr,version"`
 }
@@ -201,9 +200,6 @@ func (r *registryModules) CreateVersion(ctx context.Context, organization string
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf(
 		"registry-modules/%s/%s/%s/versions",

--- a/run.go
+++ b/run.go
@@ -176,8 +176,9 @@ func (s *runs) List(ctx context.Context, workspaceID string, options RunListOpti
 
 // RunCreateOptions represents the options for creating a new run.
 type RunCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,runs"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,runs"`
 
 	// Specifies if this plan is a destroy plan, which will destroy all
 	// provisioned resources.
@@ -220,9 +221,6 @@ func (s *runs) Create(ctx context.Context, options RunCreateOptions) (*Run, erro
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	req, err := s.client.newRequest("POST", "runs", &options)
 	if err != nil {

--- a/run.go
+++ b/run.go
@@ -176,7 +176,9 @@ func (s *runs) List(ctx context.Context, workspaceID string, options RunListOpti
 
 // RunCreateOptions represents the options for creating a new run.
 type RunCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,runs"`
 

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -99,8 +99,9 @@ func (s *runTriggers) List(ctx context.Context, workspaceID string, options RunT
 // RunTriggerCreateOptions represents the options for
 // creating a new run trigger.
 type RunTriggerCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,run-triggers"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,run-triggers"`
 
 	// The source workspace
 	Sourceable *Workspace `jsonapi:"relation,sourceable"`
@@ -121,9 +122,6 @@ func (s *runTriggers) Create(ctx context.Context, workspaceID string, options Ru
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -99,7 +99,9 @@ func (s *runTriggers) List(ctx context.Context, workspaceID string, options RunT
 // RunTriggerCreateOptions represents the options for
 // creating a new run trigger.
 type RunTriggerCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,run-triggers"`
 

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -77,7 +77,9 @@ func (s *sshKeys) List(ctx context.Context, organization string, options SSHKeyL
 
 // SSHKeyCreateOptions represents the options for creating an SSH key.
 type SSHKeyCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,ssh-keys"`
 

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -77,8 +77,9 @@ func (s *sshKeys) List(ctx context.Context, organization string, options SSHKeyL
 
 // SSHKeyCreateOptions represents the options for creating an SSH key.
 type SSHKeyCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,ssh-keys"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,ssh-keys"`
 
 	// A name to identify the SSH key.
 	Name *string `jsonapi:"attr,name"`
@@ -106,9 +107,6 @@ func (s *sshKeys) Create(ctx context.Context, organization string, options SSHKe
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("organizations/%s/ssh-keys", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/state_version.go
+++ b/state_version.go
@@ -104,7 +104,9 @@ func (s *stateVersions) List(ctx context.Context, options StateVersionListOption
 
 // StateVersionCreateOptions represents the options for creating a state version.
 type StateVersionCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,state-versions"`
 

--- a/state_version.go
+++ b/state_version.go
@@ -104,8 +104,9 @@ func (s *stateVersions) List(ctx context.Context, options StateVersionListOption
 
 // StateVersionCreateOptions represents the options for creating a state version.
 type StateVersionCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,state-versions"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,state-versions"`
 
 	// The lineage of the state.
 	Lineage *string `jsonapi:"attr,lineage,omitempty"`
@@ -148,9 +149,6 @@ func (s *stateVersions) Create(ctx context.Context, workspaceID string, options 
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("workspaces/%s/state-versions", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/team.go
+++ b/team.go
@@ -99,8 +99,9 @@ func (s *teams) List(ctx context.Context, organization string, options TeamListO
 
 // TeamCreateOptions represents the options for creating a team.
 type TeamCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,teams"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,teams"`
 
 	// Name of the team.
 	Name *string `jsonapi:"attr,name"`
@@ -134,9 +135,6 @@ func (s *teams) Create(ctx context.Context, organization string, options TeamCre
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)
@@ -176,8 +174,9 @@ func (s *teams) Read(ctx context.Context, teamID string) (*Team, error) {
 
 // TeamUpdateOptions represents the options for updating a team.
 type TeamUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,teams"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,teams"`
 
 	// New name for the team
 	Name *string `jsonapi:"attr,name,omitempty"`
@@ -194,9 +193,6 @@ func (s *teams) Update(ctx context.Context, teamID string, options TeamUpdateOpt
 	if !validStringID(&teamID) {
 		return nil, errors.New("invalid value for team ID")
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/team.go
+++ b/team.go
@@ -99,7 +99,9 @@ func (s *teams) List(ctx context.Context, organization string, options TeamListO
 
 // TeamCreateOptions represents the options for creating a team.
 type TeamCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,teams"`
 
@@ -174,7 +176,9 @@ func (s *teams) Read(ctx context.Context, teamID string) (*Team, error) {
 
 // TeamUpdateOptions represents the options for updating a team.
 type TeamUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,teams"`
 

--- a/team_access.go
+++ b/team_access.go
@@ -139,7 +139,9 @@ func (s *teamAccesses) List(ctx context.Context, options TeamAccessListOptions) 
 
 // TeamAccessAddOptions represents the options for adding team access.
 type TeamAccessAddOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,team-workspaces"`
 
@@ -217,7 +219,9 @@ func (s *teamAccesses) Read(ctx context.Context, teamAccessID string) (*TeamAcce
 
 // TeamAccessUpdateOptions represents the options for updating team access.
 type TeamAccessUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,team-workspaces"`
 

--- a/team_access.go
+++ b/team_access.go
@@ -139,8 +139,9 @@ func (s *teamAccesses) List(ctx context.Context, options TeamAccessListOptions) 
 
 // TeamAccessAddOptions represents the options for adding team access.
 type TeamAccessAddOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,team-workspaces"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,team-workspaces"`
 
 	// The type of access to grant.
 	Access *AccessType `jsonapi:"attr,access"`
@@ -179,9 +180,6 @@ func (s *teamAccesses) Add(ctx context.Context, options TeamAccessAddOptions) (*
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	req, err := s.client.newRequest("POST", "team-workspaces", &options)
 	if err != nil {
 		return nil, err
@@ -219,8 +217,9 @@ func (s *teamAccesses) Read(ctx context.Context, teamAccessID string) (*TeamAcce
 
 // TeamAccessUpdateOptions represents the options for updating team access.
 type TeamAccessUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,team-workspaces"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,team-workspaces"`
 
 	// The type of access to grant.
 	Access *AccessType `jsonapi:"attr,access,omitempty"`
@@ -239,9 +238,6 @@ func (s *teamAccesses) Update(ctx context.Context, teamAccessID string, options 
 	if !validStringID(&teamAccessID) {
 		return nil, errors.New("invalid value for team access ID")
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/user.go
+++ b/user.go
@@ -63,7 +63,9 @@ func (s *users) ReadCurrent(ctx context.Context) (*User, error) {
 
 // UserUpdateOptions represents the options for updating a user.
 type UserUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,users"`
 

--- a/user.go
+++ b/user.go
@@ -63,8 +63,9 @@ func (s *users) ReadCurrent(ctx context.Context) (*User, error) {
 
 // UserUpdateOptions represents the options for updating a user.
 type UserUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,users"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,users"`
 
 	// New username.
 	Username *string `jsonapi:"attr,username,omitempty"`
@@ -75,9 +76,6 @@ type UserUpdateOptions struct {
 
 // Update attributes of the currently authenticated user.
 func (s *users) Update(ctx context.Context, options UserUpdateOptions) (*User, error) {
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	req, err := s.client.newRequest("PATCH", "account/update", &options)
 	if err != nil {
 		return nil, err

--- a/variable.go
+++ b/variable.go
@@ -94,8 +94,9 @@ func (s *variables) List(ctx context.Context, workspaceID string, options Variab
 
 // VariableCreateOptions represents the options for creating a new variable.
 type VariableCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,vars"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
 
 	// The name of the variable.
 	Key *string `jsonapi:"attr,key"`
@@ -134,9 +135,6 @@ func (s *variables) Create(ctx context.Context, workspaceID string, options Vari
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("POST", u, &options)
@@ -179,8 +177,9 @@ func (s *variables) Read(ctx context.Context, workspaceID string, variableID str
 
 // VariableUpdateOptions represents the options for updating a variable.
 type VariableUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,vars"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
 
 	// The name of the variable.
 	Key *string `jsonapi:"attr,key,omitempty"`
@@ -206,9 +205,6 @@ func (s *variables) Update(ctx context.Context, workspaceID string, variableID s
 	if !validStringID(&variableID) {
 		return nil, errors.New("invalid value for variable ID")
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = variableID
 
 	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
 	req, err := s.client.newRequest("PATCH", u, &options)

--- a/variable.go
+++ b/variable.go
@@ -94,7 +94,9 @@ func (s *variables) List(ctx context.Context, workspaceID string, options Variab
 
 // VariableCreateOptions represents the options for creating a new variable.
 type VariableCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,vars"`
 
@@ -177,7 +179,9 @@ func (s *variables) Read(ctx context.Context, workspaceID string, variableID str
 
 // VariableUpdateOptions represents the options for updating a variable.
 type VariableUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,vars"`
 

--- a/workspace.go
+++ b/workspace.go
@@ -167,7 +167,9 @@ func (s *workspaces) List(ctx context.Context, organization string, options Work
 
 // WorkspaceCreateOptions represents the options for creating a new workspace.
 type WorkspaceCreateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,workspaces"`
 
@@ -344,7 +346,9 @@ func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspa
 
 // WorkspaceUpdateOptions represents the options for updating a workspace.
 type WorkspaceUpdateOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,workspaces"`
 
@@ -647,7 +651,9 @@ func (s *workspaces) ForceUnlock(ctx context.Context, workspaceID string) (*Work
 // WorkspaceAssignSSHKeyOptions represents the options to assign an SSH key to
 // a workspace.
 type WorkspaceAssignSSHKeyOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,workspaces"`
 
@@ -692,7 +698,9 @@ func (s *workspaces) AssignSSHKey(ctx context.Context, workspaceID string, optio
 // workspaceUnassignSSHKeyOptions represents the options to unassign an SSH key
 // to a workspace.
 type workspaceUnassignSSHKeyOptions struct {
-	// Type is the required field as part of JSON:API.
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,workspaces"`
 

--- a/workspace.go
+++ b/workspace.go
@@ -167,8 +167,9 @@ func (s *workspaces) List(ctx context.Context, organization string, options Work
 
 // WorkspaceCreateOptions represents the options for creating a new workspace.
 type WorkspaceCreateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,workspaces"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,workspaces"`
 
 	// Required when execution-mode is set to agent. The ID of the agent pool
 	// belonging to the workspace's organization. This value must not be specified
@@ -277,9 +278,6 @@ func (s *workspaces) Create(ctx context.Context, organization string, options Wo
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
@@ -346,8 +344,9 @@ func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspa
 
 // WorkspaceUpdateOptions represents the options for updating a workspace.
 type WorkspaceUpdateOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,workspaces"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,workspaces"`
 
 	// Required when execution-mode is set to agent. The ID of the agent pool
 	// belonging to the workspace's organization. This value must not be specified
@@ -442,9 +441,6 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	u := fmt.Sprintf(
 		"organizations/%s/workspaces/%s",
 		url.QueryEscape(organization),
@@ -469,9 +465,6 @@ func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
-
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
 
 	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("PATCH", u, &options)
@@ -654,8 +647,9 @@ func (s *workspaces) ForceUnlock(ctx context.Context, workspaceID string) (*Work
 // WorkspaceAssignSSHKeyOptions represents the options to assign an SSH key to
 // a workspace.
 type WorkspaceAssignSSHKeyOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,workspaces"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,workspaces"`
 
 	// The SSH key ID to assign.
 	SSHKeyID *string `jsonapi:"attr,id"`
@@ -680,9 +674,6 @@ func (s *workspaces) AssignSSHKey(ctx context.Context, workspaceID string, optio
 		return nil, err
 	}
 
-	// Make sure we don't send a user provided ID.
-	options.ID = ""
-
 	u := fmt.Sprintf("workspaces/%s/relationships/ssh-key", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("PATCH", u, &options)
 	if err != nil {
@@ -701,8 +692,9 @@ func (s *workspaces) AssignSSHKey(ctx context.Context, workspaceID string, optio
 // workspaceUnassignSSHKeyOptions represents the options to unassign an SSH key
 // to a workspace.
 type workspaceUnassignSSHKeyOptions struct {
-	// For internal use only!
-	ID string `jsonapi:"primary,workspaces"`
+	// Type is the required field as part of JSON:API.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,workspaces"`
 
 	// Must be nil to unset the currently assigned SSH key.
 	SSHKeyID *string `jsonapi:"attr,id"`


### PR DESCRIPTION
## Description

Currently a lot of the Create/UpdateOptions structs for various resources have an `ID` attribute that represents the primary field in JSON:API. This is misleading, as [JSON:API indicates](https://jsonapi.org/format/#crud-creating) that this field is a `Type` field. 

This PR is to make the fields more accurately represent the JSON:API spec. It also removes the frequent `options.ID = ""` as that is not necessary.

## Testing plan

No changes. Run all the tests locally.

## Output from tests

```
$ 
...
```

## External links

- [JSON:API](https://jsonapi.org/format/#crud-creating)

