### PR TITLE
Add Additional VCS Attributes from Workspace

### DIFF
--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -2,6 +2,7 @@ package tfe
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"testing"
 
@@ -158,6 +159,8 @@ func TestPolicySetsCreate(t *testing.T) {
 			Identifier:        githubIdentifier,
 			OAuthTokenID:      oc.ID,
 			IngressSubmodules: true,
+			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
+			ServiceProvider:   "github",
 		})
 	})
 
@@ -193,6 +196,8 @@ func TestPolicySetsCreate(t *testing.T) {
 			Identifier:        githubIdentifier,
 			OAuthTokenID:      oc.ID,
 			IngressSubmodules: false,
+			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
+			ServiceProvider:   "github",
 		})
 	})
 

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -160,7 +160,7 @@ func TestPolicySetsCreate(t *testing.T) {
 			OAuthTokenID:      oc.ID,
 			IngressSubmodules: true,
 			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
-			ServiceProvider:   "github",
+			ServiceProvider:   string(ServiceProviderGithub),
 		})
 	})
 
@@ -197,7 +197,7 @@ func TestPolicySetsCreate(t *testing.T) {
 			OAuthTokenID:      oc.ID,
 			IngressSubmodules: false,
 			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
-			ServiceProvider:   "github",
+			ServiceProvider:   string(ServiceProviderGithub),
 		})
 	})
 

--- a/registry_module_test.go
+++ b/registry_module_test.go
@@ -228,7 +228,7 @@ func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 			DisplayIdentifier: githubIdentifier,
 			IngressSubmodules: true,
 			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
-			ServiceProvider:   "github",
+			ServiceProvider:   string(ServiceProviderGithub),
 		}, rm.VCSRepo)
 
 		t.Run("permissions are properly decoded", func(t *testing.T) {

--- a/registry_module_test.go
+++ b/registry_module_test.go
@@ -2,6 +2,7 @@ package tfe
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"strings"
 	"testing"
@@ -226,6 +227,8 @@ func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 			OAuthTokenID:      oauthTokenTest.ID,
 			DisplayIdentifier: githubIdentifier,
 			IngressSubmodules: true,
+			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
+			ServiceProvider:   "github",
 		}, rm.VCSRepo)
 
 		t.Run("permissions are properly decoded", func(t *testing.T) {

--- a/workspace.go
+++ b/workspace.go
@@ -112,6 +112,8 @@ type VCSRepo struct {
 	Identifier        string `json:"identifier"`
 	IngressSubmodules bool   `json:"ingress-submodules"`
 	OAuthTokenID      string `json:"oauth-token-id"`
+	RepositoryHTTPURL string `json:"repository-http-url"`
+	ServiceProvider   string `json:"service-provider"`
 }
 
 // WorkspaceActions represents the workspace actions.


### PR DESCRIPTION
## Description

The response from an individual workspace now includes the
repository HTTP URL and the Service Provider type as part of the
VCSRepo information. This adds the two new attributes to go-tfe.

## Output from tests

```
$ go test

=== RUN   TestPolicyChecksList
=== RUN   TestPolicyChecksList/without_list_options
=== RUN   TestPolicyChecksList/without_list_options/pagination_is_properly_decoded
    TestPolicyChecksList/without_list_options/pagination_is_properly_decoded: policy_check_test.go:32: paging not supported yet in API
=== RUN   TestPolicyChecksList/without_list_options/permissions_are_properly_decoded
=== RUN   TestPolicyChecksList/without_list_options/result_is_properly_decoded
=== RUN   TestPolicyChecksList/without_list_options/timestamps_are_properly_decoded
=== RUN   TestPolicyChecksList/with_list_options
    TestPolicyChecksList/with_list_options: policy_check_test.go:52: paging not supported yet in API
=== RUN   TestPolicyChecksList/without_a_valid_run_ID
--- PASS: TestPolicyChecksList (26.16s)
    --- PASS: TestPolicyChecksList/without_list_options (0.13s)
        --- SKIP: TestPolicyChecksList/without_list_options/pagination_is_properly_decoded (0.00s)
        --- PASS: TestPolicyChecksList/without_list_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestPolicyChecksList/without_list_options/result_is_properly_decoded (0.00s)
        --- PASS: TestPolicyChecksList/without_list_options/timestamps_are_properly_decoded (0.00s)
    --- SKIP: TestPolicyChecksList/with_list_options (0.00s)
    --- PASS: TestPolicyChecksList/without_a_valid_run_ID (0.00s)
=== RUN   TestPolicyChecksRead
=== RUN   TestPolicyChecksRead/when_the_policy_check_exists
=== RUN   TestPolicyChecksRead/when_the_policy_check_exists/result_is_properly_decoded
=== RUN   TestPolicyChecksRead/when_the_policy_check_does_not_exist
=== RUN   TestPolicyChecksRead/without_a_valid_policy_check_ID
--- PASS: TestPolicyChecksRead (23.45s)
    --- PASS: TestPolicyChecksRead/when_the_policy_check_exists (0.12s)
        --- PASS: TestPolicyChecksRead/when_the_policy_check_exists/result_is_properly_decoded (0.00s)
    --- PASS: TestPolicyChecksRead/when_the_policy_check_does_not_exist (0.09s)
    --- PASS: TestPolicyChecksRead/without_a_valid_policy_check_ID (0.00s)
=== RUN   TestPolicyChecksOverride
=== RUN   TestPolicyChecksOverride/when_the_policy_failed
=== RUN   TestPolicyChecksOverride/when_the_policy_passed
=== RUN   TestPolicyChecksOverride/without_a_valid_policy_check_ID
--- PASS: TestPolicyChecksOverride (47.36s)
    --- PASS: TestPolicyChecksOverride/when_the_policy_failed (22.21s)
    --- PASS: TestPolicyChecksOverride/when_the_policy_passed (23.50s)
    --- PASS: TestPolicyChecksOverride/without_a_valid_policy_check_ID (0.00s)
=== RUN   TestPolicyChecksLogs
=== RUN   TestPolicyChecksLogs/when_the_log_exists
=== RUN   TestPolicyChecksLogs/when_the_log_does_not_exist
--- PASS: TestPolicyChecksLogs (26.60s)
    --- PASS: TestPolicyChecksLogs/when_the_log_exists (0.51s)
    --- PASS: TestPolicyChecksLogs/when_the_log_does_not_exist (0.10s)
=== RUN   TestPolicySetParametersList
=== RUN   TestPolicySetParametersList/without_list_options
    TestPolicySetParametersList/without_list_options: policy_set_parameter_test.go:29: paging not supported yet in API
=== RUN   TestPolicySetParametersList/with_list_options
    TestPolicySetParametersList/with_list_options: policy_set_parameter_test.go:35: paging not supported yet in API
=== RUN   TestPolicySetParametersList/when_policy_set_ID_is_invalid_ID
--- PASS: TestPolicySetParametersList (1.05s)
    --- SKIP: TestPolicySetParametersList/without_list_options (0.15s)
    --- SKIP: TestPolicySetParametersList/with_list_options (0.00s)
    --- PASS: TestPolicySetParametersList/when_policy_set_ID_is_invalid_ID (0.00s)
=== RUN   TestPolicySetParametersCreate
=== RUN   TestPolicySetParametersCreate/with_valid_options
=== RUN   TestPolicySetParametersCreate/when_options_has_an_empty_string_value
=== RUN   TestPolicySetParametersCreate/when_options_is_missing_value
=== RUN   TestPolicySetParametersCreate/when_options_is_missing_key
=== RUN   TestPolicySetParametersCreate/when_options_has_an_empty_key
=== RUN   TestPolicySetParametersCreate/when_options_is_missing_category
=== RUN   TestPolicySetParametersCreate/when_policy_set_ID_is_invalid
--- PASS: TestPolicySetParametersCreate (1.19s)
    --- PASS: TestPolicySetParametersCreate/with_valid_options (0.14s)
    --- PASS: TestPolicySetParametersCreate/when_options_has_an_empty_string_value (0.12s)
    --- PASS: TestPolicySetParametersCreate/when_options_is_missing_value (0.12s)
    --- PASS: TestPolicySetParametersCreate/when_options_is_missing_key (0.00s)
    --- PASS: TestPolicySetParametersCreate/when_options_has_an_empty_key (0.00s)
    --- PASS: TestPolicySetParametersCreate/when_options_is_missing_category (0.00s)
    --- PASS: TestPolicySetParametersCreate/when_policy_set_ID_is_invalid (0.00s)
=== RUN   TestPolicySetParametersRead
=== RUN   TestPolicySetParametersRead/when_the_parameter_exists
=== RUN   TestPolicySetParametersRead/when_the_parameter_does_not_exist
=== RUN   TestPolicySetParametersRead/without_a_valid_policy_set_ID
=== RUN   TestPolicySetParametersRead/without_a_valid_parameter_ID
--- PASS: TestPolicySetParametersRead (1.43s)
    --- PASS: TestPolicySetParametersRead/when_the_parameter_exists (0.18s)
    --- PASS: TestPolicySetParametersRead/when_the_parameter_does_not_exist (0.10s)
    --- PASS: TestPolicySetParametersRead/without_a_valid_policy_set_ID (0.00s)
    --- PASS: TestPolicySetParametersRead/without_a_valid_parameter_ID (0.00s)
=== RUN   TestPolicySetParametersUpdate
=== RUN   TestPolicySetParametersUpdate/with_valid_options
=== RUN   TestPolicySetParametersUpdate/when_updating_a_subset_of_values
=== RUN   TestPolicySetParametersUpdate/with_sensitive_set
=== RUN   TestPolicySetParametersUpdate/without_any_changes
=== RUN   TestPolicySetParametersUpdate/with_invalid_parameter_ID
=== RUN   TestPolicySetParametersUpdate/with_invalid_parameter_ID#01
--- PASS: TestPolicySetParametersUpdate (2.42s)
    --- PASS: TestPolicySetParametersUpdate/with_valid_options (0.12s)
    --- PASS: TestPolicySetParametersUpdate/when_updating_a_subset_of_values (0.16s)
    --- PASS: TestPolicySetParametersUpdate/with_sensitive_set (0.12s)
    --- PASS: TestPolicySetParametersUpdate/without_any_changes (0.98s)
    --- PASS: TestPolicySetParametersUpdate/with_invalid_parameter_ID (0.00s)
    --- PASS: TestPolicySetParametersUpdate/with_invalid_parameter_ID#01 (0.00s)
=== RUN   TestParametersDelete
=== RUN   TestParametersDelete/with_valid_options
=== RUN   TestParametersDelete/with_non_existing_parameter_ID
=== RUN   TestParametersDelete/with_invalid_policy_set_ID
=== RUN   TestParametersDelete/with_invalid_parameter_ID
--- PASS: TestParametersDelete (1.14s)
    --- PASS: TestParametersDelete/with_valid_options (0.11s)
    --- PASS: TestParametersDelete/with_non_existing_parameter_ID (0.10s)
    --- PASS: TestParametersDelete/with_invalid_policy_set_ID (0.00s)
    --- PASS: TestParametersDelete/with_invalid_parameter_ID (0.00s)
=== RUN   TestPolicySetsList
=== RUN   TestPolicySetsList/without_list_options
=== RUN   TestPolicySetsList/with_pagination
=== RUN   TestPolicySetsList/with_search
=== RUN   TestPolicySetsList/without_a_valid_organization
--- PASS: TestPolicySetsList (1.22s)
    --- PASS: TestPolicySetsList/without_list_options (0.14s)
    --- PASS: TestPolicySetsList/with_pagination (0.15s)
    --- PASS: TestPolicySetsList/with_search (0.13s)
    --- PASS: TestPolicySetsList/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsCreate
=== RUN   TestPolicySetsCreate/with_valid_attributes
=== RUN   TestPolicySetsCreate/with_all_attributes_provided
=== RUN   TestPolicySetsCreate/with_policies_and_workspaces_provided
=== RUN   TestPolicySetsCreate/with_vcs_policy_set
=== RUN   TestPolicySetsCreate/with_vcs_policy_updated
=== RUN   TestPolicySetsCreate/without_a_name_provided
=== RUN   TestPolicySetsCreate/with_an_invalid_name_provided
=== RUN   TestPolicySetsCreate/without_a_valid_organization
--- PASS: TestPolicySetsCreate (5.66s)
    --- PASS: TestPolicySetsCreate/with_valid_attributes (0.17s)
    --- PASS: TestPolicySetsCreate/with_all_attributes_provided (0.14s)
    --- PASS: TestPolicySetsCreate/with_policies_and_workspaces_provided (0.49s)
    --- PASS: TestPolicySetsCreate/with_vcs_policy_set (1.46s)
    --- PASS: TestPolicySetsCreate/with_vcs_policy_updated (2.05s)
    --- PASS: TestPolicySetsCreate/without_a_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/with_an_invalid_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsRead
=== RUN   TestPolicySetsRead/with_a_valid_ID
=== RUN   TestPolicySetsRead/without_a_valid_ID
--- PASS: TestPolicySetsRead (0.78s)
    --- PASS: TestPolicySetsRead/with_a_valid_ID (0.11s)
    --- PASS: TestPolicySetsRead/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsUpdate
=== RUN   TestPolicySetsUpdate/with_valid_attributes
=== RUN   TestPolicySetsUpdate/with_invalid_attributes
=== RUN   TestPolicySetsUpdate/without_a_valid_ID
--- PASS: TestPolicySetsUpdate (0.78s)
    --- PASS: TestPolicySetsUpdate/with_valid_attributes (0.13s)
    --- PASS: TestPolicySetsUpdate/with_invalid_attributes (0.00s)
    --- PASS: TestPolicySetsUpdate/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsAddPolicies
=== RUN   TestPolicySetsAddPolicies/with_policies_provided
=== RUN   TestPolicySetsAddPolicies/without_policies_provided
=== RUN   TestPolicySetsAddPolicies/with_empty_policies_slice
=== RUN   TestPolicySetsAddPolicies/without_a_valid_ID
--- PASS: TestPolicySetsAddPolicies (1.24s)
    --- PASS: TestPolicySetsAddPolicies/with_policies_provided (0.28s)
    --- PASS: TestPolicySetsAddPolicies/without_policies_provided (0.00s)
    --- PASS: TestPolicySetsAddPolicies/with_empty_policies_slice (0.00s)
    --- PASS: TestPolicySetsAddPolicies/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsRemovePolicies
=== RUN   TestPolicySetsRemovePolicies/with_policies_provided
=== RUN   TestPolicySetsRemovePolicies/without_policies_provided
=== RUN   TestPolicySetsRemovePolicies/with_empty_policies_slice
=== RUN   TestPolicySetsRemovePolicies/without_a_valid_ID
--- PASS: TestPolicySetsRemovePolicies (1.40s)
    --- PASS: TestPolicySetsRemovePolicies/with_policies_provided (0.24s)
    --- PASS: TestPolicySetsRemovePolicies/without_policies_provided (0.00s)
    --- PASS: TestPolicySetsRemovePolicies/with_empty_policies_slice (0.00s)
    --- PASS: TestPolicySetsRemovePolicies/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsAddWorkspaces
=== RUN   TestPolicySetsAddWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsAddWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsAddWorkspaces (1.38s)
    --- PASS: TestPolicySetsAddWorkspaces/with_workspaces_provided (0.27s)
    --- PASS: TestPolicySetsAddWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsRemoveWorkspaces
=== RUN   TestPolicySetsRemoveWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsRemoveWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsRemoveWorkspaces (1.26s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_workspaces_provided (0.25s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsDelete
=== RUN   TestPolicySetsDelete/with_valid_options
=== RUN   TestPolicySetsDelete/when_the_policy_does_not_exist
=== RUN   TestPolicySetsDelete/when_the_policy_ID_is_invalid
--- PASS: TestPolicySetsDelete (1.03s)
    --- PASS: TestPolicySetsDelete/with_valid_options (0.21s)
    --- PASS: TestPolicySetsDelete/when_the_policy_does_not_exist (0.13s)
    --- PASS: TestPolicySetsDelete/when_the_policy_ID_is_invalid (0.00s)
=== RUN   TestPoliciesList
=== RUN   TestPoliciesList/without_list_options
=== RUN   TestPoliciesList/with_pagination
=== RUN   TestPoliciesList/with_search
=== RUN   TestPoliciesList/without_a_valid_organization
--- PASS: TestPoliciesList (1.23s)
    --- PASS: TestPoliciesList/without_list_options (0.17s)
    --- PASS: TestPoliciesList/with_pagination (0.12s)
    --- PASS: TestPoliciesList/with_search (0.14s)
    --- PASS: TestPoliciesList/without_a_valid_organization (0.00s)
=== RUN   TestPoliciesCreate
=== RUN   TestPoliciesCreate/with_valid_options
=== RUN   TestPoliciesCreate/when_options_has_an_invalid_name
=== RUN   TestPoliciesCreate/when_options_is_missing_name
=== RUN   TestPoliciesCreate/when_options_is_missing_an_enforcement
=== RUN   TestPoliciesCreate/when_options_is_missing_enforcement_path
=== RUN   TestPoliciesCreate/when_options_is_missing_enforcement_path#01
=== RUN   TestPoliciesCreate/when_options_has_an_invalid_organization
--- PASS: TestPoliciesCreate (0.76s)
    --- PASS: TestPoliciesCreate/with_valid_options (0.24s)
    --- PASS: TestPoliciesCreate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestPoliciesCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestPoliciesCreate/when_options_is_missing_an_enforcement (0.00s)
    --- PASS: TestPoliciesCreate/when_options_is_missing_enforcement_path (0.00s)
    --- PASS: TestPoliciesCreate/when_options_is_missing_enforcement_path#01 (0.00s)
    --- PASS: TestPoliciesCreate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestPoliciesRead
=== RUN   TestPoliciesRead/when_the_policy_exists_without_content
=== RUN   TestPoliciesRead/when_the_policy_exists_with_content
=== RUN   TestPoliciesRead/when_the_policy_does_not_exist
=== RUN   TestPoliciesRead/without_a_valid_policy_ID
--- PASS: TestPoliciesRead (1.60s)
    --- PASS: TestPoliciesRead/when_the_policy_exists_without_content (0.11s)
    --- PASS: TestPoliciesRead/when_the_policy_exists_with_content (0.15s)
    --- PASS: TestPoliciesRead/when_the_policy_does_not_exist (0.09s)
    --- PASS: TestPoliciesRead/without_a_valid_policy_ID (0.00s)
=== RUN   TestPoliciesUpdate
=== RUN   TestPoliciesUpdate/when_updating_with_an_existing_path
=== RUN   TestPoliciesUpdate/when_updating_with_a_nonexisting_path
    TestPoliciesUpdate/when_updating_with_a_nonexisting_path: policy_test.go:281: see comment...
=== RUN   TestPoliciesUpdate/with_a_new_description
=== RUN   TestPoliciesUpdate/without_a_valid_policy_ID
--- PASS: TestPoliciesUpdate (3.41s)
    --- PASS: TestPoliciesUpdate/when_updating_with_an_existing_path (0.97s)
    --- SKIP: TestPoliciesUpdate/when_updating_with_a_nonexisting_path (0.96s)
    --- PASS: TestPoliciesUpdate/with_a_new_description (0.98s)
    --- PASS: TestPoliciesUpdate/without_a_valid_policy_ID (0.00s)
=== RUN   TestPoliciesDelete
=== RUN   TestPoliciesDelete/with_valid_options
=== RUN   TestPoliciesDelete/when_the_policy_does_not_exist
=== RUN   TestPoliciesDelete/when_the_policy_ID_is_invalid
--- PASS: TestPoliciesDelete (1.02s)
    --- PASS: TestPoliciesDelete/with_valid_options (0.24s)
    --- PASS: TestPoliciesDelete/when_the_policy_does_not_exist (0.13s)
    --- PASS: TestPoliciesDelete/when_the_policy_ID_is_invalid (0.00s)
=== RUN   TestPoliciesUpload
=== RUN   TestPoliciesUpload/with_valid_options
=== RUN   TestPoliciesUpload/with_empty_content
=== RUN   TestPoliciesUpload/without_any_content
=== RUN   TestPoliciesUpload/without_a_valid_policy_ID
--- PASS: TestPoliciesUpload (2.15s)
    --- PASS: TestPoliciesUpload/with_valid_options (0.37s)
    --- PASS: TestPoliciesUpload/with_empty_content (0.46s)
    --- PASS: TestPoliciesUpload/without_any_content (0.44s)
    --- PASS: TestPoliciesUpload/without_a_valid_policy_ID (0.00s)
=== RUN   TestPoliciesDownload
=== RUN   TestPoliciesDownload/without_existing_content
=== RUN   TestPoliciesDownload/with_valid_options
=== RUN   TestPoliciesDownload/without_a_valid_policy_ID
--- PASS: TestPoliciesDownload (1.59s)
    --- PASS: TestPoliciesDownload/without_existing_content (0.10s)
    --- PASS: TestPoliciesDownload/with_valid_options (0.71s)
    --- PASS: TestPoliciesDownload/without_a_valid_policy_ID (0.00s)
=== RUN   TestRegistryModulesCreate
=== RUN   TestRegistryModulesCreate/with_valid_options
=== RUN   TestRegistryModulesCreate/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_invalid_options
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider
=== RUN   TestRegistryModulesCreate/without_a_valid_organization
--- PASS: TestRegistryModulesCreate (0.64s)
    --- PASS: TestRegistryModulesCreate/with_valid_options (0.13s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreate/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesCreate/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesCreateVersion
=== RUN   TestRegistryModulesCreateVersion/with_valid_options
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/without_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version
=== RUN   TestRegistryModulesCreateVersion/without_a_name
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_name
=== RUN   TestRegistryModulesCreateVersion/without_a_provider
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesCreateVersion/without_a_valid_organization
--- PASS: TestRegistryModulesCreateVersion (1.12s)
    --- PASS: TestRegistryModulesCreateVersion/with_valid_options (0.25s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/without_version (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesCreateWithVCSConnection
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/without_options
--- PASS: TestRegistryModulesCreateWithVCSConnection (1.95s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options (0.51s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/without_options (0.00s)
=== RUN   TestRegistryModulesRead
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/without_a_name
=== RUN   TestRegistryModulesRead/with_an_invalid_name
=== RUN   TestRegistryModulesRead/without_a_provider
=== RUN   TestRegistryModulesRead/with_an_invalid_provider
=== RUN   TestRegistryModulesRead/without_a_valid_organization
=== RUN   TestRegistryModulesRead/when_the_registry_module_does_not_exist
--- PASS: TestRegistryModulesRead (0.98s)
    --- PASS: TestRegistryModulesRead/with_valid_name_and_provider (0.11s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_name (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesRead/when_the_registry_module_does_not_exist (0.09s)
=== RUN   TestRegistryModulesDelete
=== RUN   TestRegistryModulesDelete/with_valid_name
=== RUN   TestRegistryModulesDelete/without_a_name
=== RUN   TestRegistryModulesDelete/with_an_invalid_name
=== RUN   TestRegistryModulesDelete/without_a_valid_organization
=== RUN   TestRegistryModulesDelete/when_the_registry_module_does_not_exist
--- PASS: TestRegistryModulesDelete (0.99s)
    --- PASS: TestRegistryModulesDelete/with_valid_name (0.26s)
    --- PASS: TestRegistryModulesDelete/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDelete/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDelete/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDelete/when_the_registry_module_does_not_exist (0.10s)
=== RUN   TestRegistryModulesDeleteProvider
=== RUN   TestRegistryModulesDeleteProvider/with_valid_name_and_provider
=== RUN   TestRegistryModulesDeleteProvider/without_a_name
=== RUN   TestRegistryModulesDeleteProvider/with_an_invalid_name
=== RUN   TestRegistryModulesDeleteProvider/without_a_provider
=== RUN   TestRegistryModulesDeleteProvider/with_an_invalid_provider
=== RUN   TestRegistryModulesDeleteProvider/without_a_valid_organization
=== RUN   TestRegistryModulesDeleteProvider/when_the_registry_module_name_and_provider_do_not_exist
--- PASS: TestRegistryModulesDeleteProvider (1.02s)
    --- PASS: TestRegistryModulesDeleteProvider/with_valid_name_and_provider (0.25s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/when_the_registry_module_name_and_provider_do_not_exist (0.10s)
=== RUN   TestRegistryModulesDeleteVersion
=== RUN   TestRegistryModulesDeleteVersion/with_valid_name_and_provider
=== RUN   TestRegistryModulesDeleteVersion/without_a_name
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_name
=== RUN   TestRegistryModulesDeleteVersion/without_a_provider
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesDeleteVersion/without_a_version
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_version
=== RUN   TestRegistryModulesDeleteVersion/without_a_valid_organization
=== RUN   TestRegistryModulesDeleteVersion/when_the_registry_module_name,_provider,_and_version_do_not_exist
--- PASS: TestRegistryModulesDeleteVersion (1.98s)
    --- PASS: TestRegistryModulesDeleteVersion/with_valid_name_and_provider (0.64s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_version (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_version (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/when_the_registry_module_name,_provider,_and_version_do_not_exist (0.10s)
=== RUN   TestWorkspacesList
=== RUN   TestWorkspacesList/without_list_options
=== RUN   TestWorkspacesList/with_list_options
=== RUN   TestWorkspacesList/when_searching_a_known_workspace
=== RUN   TestWorkspacesList/when_searching_an_unknown_workspace
=== RUN   TestWorkspacesList/without_a_valid_organization
=== RUN   TestWorkspacesList/with_organization_included
--- PASS: TestWorkspacesList (2.09s)
    --- PASS: TestWorkspacesList/without_list_options (0.16s)
    --- PASS: TestWorkspacesList/with_list_options (0.13s)
    --- PASS: TestWorkspacesList/when_searching_a_known_workspace (0.16s)
    --- PASS: TestWorkspacesList/when_searching_an_unknown_workspace (0.16s)
    --- PASS: TestWorkspacesList/without_a_valid_organization (0.00s)
    --- PASS: TestWorkspacesList/with_organization_included (0.20s)
=== RUN   TestWorkspacesCreate
=== RUN   TestWorkspacesCreate/with_valid_options
=== RUN   TestWorkspacesCreate/when_options_is_missing_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_organization
=== RUN   TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode
=== RUN   TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesCreate/when_an_error_is_returned_from_the_API
--- PASS: TestWorkspacesCreate (1.01s)
    --- PASS: TestWorkspacesCreate/with_valid_options (0.34s)
    --- PASS: TestWorkspacesCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_organization (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode (0.00s)
    --- PASS: TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_error_is_returned_from_the_API (0.09s)
=== RUN   TestWorkspacesRead
=== RUN   TestWorkspacesRead/when_the_workspace_exists
=== RUN   TestWorkspacesRead/when_the_workspace_exists/permissions_are_properly_decoded
=== RUN   TestWorkspacesRead/when_the_workspace_exists/relationships_are_properly_decoded
=== RUN   TestWorkspacesRead/when_the_workspace_exists/timestamps_are_properly_decoded
=== RUN   TestWorkspacesRead/when_the_workspace_does_not_exist
=== RUN   TestWorkspacesRead/when_the_organization_does_not_exist
=== RUN   TestWorkspacesRead/without_a_valid_organization
=== RUN   TestWorkspacesRead/without_a_valid_workspace
--- PASS: TestWorkspacesRead (1.27s)
    --- PASS: TestWorkspacesRead/when_the_workspace_exists (0.12s)
        --- PASS: TestWorkspacesRead/when_the_workspace_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesRead/when_the_workspace_exists/relationships_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesRead/when_the_workspace_exists/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestWorkspacesRead/when_the_workspace_does_not_exist (0.13s)
    --- PASS: TestWorkspacesRead/when_the_organization_does_not_exist (0.13s)
    --- PASS: TestWorkspacesRead/without_a_valid_organization (0.00s)
    --- PASS: TestWorkspacesRead/without_a_valid_workspace (0.00s)
=== RUN   TestWorkspacesReadByID
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists/permissions_are_properly_decoded
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists/relationships_are_properly_decoded
=== RUN   TestWorkspacesReadByID/when_the_workspace_exists/timestamps_are_properly_decoded
=== RUN   TestWorkspacesReadByID/when_the_workspace_does_not_exist
=== RUN   TestWorkspacesReadByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesReadByID (1.12s)
    --- PASS: TestWorkspacesReadByID/when_the_workspace_exists (0.12s)
        --- PASS: TestWorkspacesReadByID/when_the_workspace_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesReadByID/when_the_workspace_exists/relationships_are_properly_decoded (0.00s)
        --- PASS: TestWorkspacesReadByID/when_the_workspace_exists/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestWorkspacesReadByID/when_the_workspace_does_not_exist (0.12s)
    --- PASS: TestWorkspacesReadByID/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesUpdate
=== RUN   TestWorkspacesUpdate/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdate/with_valid_options
=== RUN   TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesUpdate/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_organization
--- PASS: TestWorkspacesUpdate (1.33s)
    --- PASS: TestWorkspacesUpdate/when_updating_a_subset_of_values (0.18s)
    --- PASS: TestWorkspacesUpdate/with_valid_options (0.33s)
    --- PASS: TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesUpdate/when_an_error_is_returned_from_the_api (0.10s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestWorkspacesUpdateByID
=== RUN   TestWorkspacesUpdateByID/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdateByID/with_valid_options
=== RUN   TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdateByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUpdateByID (1.38s)
    --- PASS: TestWorkspacesUpdateByID/when_updating_a_subset_of_values (0.17s)
    --- PASS: TestWorkspacesUpdateByID/with_valid_options (0.35s)
    --- PASS: TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api (0.13s)
    --- PASS: TestWorkspacesUpdateByID/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesDelete
=== RUN   TestWorkspacesDelete/with_valid_options
=== RUN   TestWorkspacesDelete/when_organization_is_invalid
=== RUN   TestWorkspacesDelete/when_workspace_is_invalid
--- PASS: TestWorkspacesDelete (1.00s)
    --- PASS: TestWorkspacesDelete/with_valid_options (0.28s)
    --- PASS: TestWorkspacesDelete/when_organization_is_invalid (0.00s)
    --- PASS: TestWorkspacesDelete/when_workspace_is_invalid (0.00s)
=== RUN   TestWorkspacesDeleteByID
=== RUN   TestWorkspacesDeleteByID/with_valid_options
=== RUN   TestWorkspacesDeleteByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesDeleteByID (1.06s)
    --- PASS: TestWorkspacesDeleteByID/with_valid_options (0.28s)
    --- PASS: TestWorkspacesDeleteByID/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesRemoveVCSConnection
=== RUN   TestWorkspacesRemoveVCSConnection/remove_vcs_integration
--- PASS: TestWorkspacesRemoveVCSConnection (2.98s)
    --- PASS: TestWorkspacesRemoveVCSConnection/remove_vcs_integration (0.65s)
=== RUN   TestWorkspacesRemoveVCSConnectionByID
=== RUN   TestWorkspacesRemoveVCSConnectionByID/remove_vcs_integration
--- PASS: TestWorkspacesRemoveVCSConnectionByID (3.01s)
    --- PASS: TestWorkspacesRemoveVCSConnectionByID/remove_vcs_integration (0.63s)
=== RUN   TestWorkspacesLock
=== RUN   TestWorkspacesLock/with_valid_options
=== RUN   TestWorkspacesLock/when_workspace_is_already_locked
=== RUN   TestWorkspacesLock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesLock (1.04s)
    --- PASS: TestWorkspacesLock/with_valid_options (0.20s)
    --- PASS: TestWorkspacesLock/when_workspace_is_already_locked (0.11s)
    --- PASS: TestWorkspacesLock/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesUnlock
=== RUN   TestWorkspacesUnlock/with_valid_options
=== RUN   TestWorkspacesUnlock/when_workspace_is_already_unlocked
=== RUN   TestWorkspacesUnlock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUnlock (1.19s)
    --- PASS: TestWorkspacesUnlock/with_valid_options (0.18s)
    --- PASS: TestWorkspacesUnlock/when_workspace_is_already_unlocked (0.10s)
    --- PASS: TestWorkspacesUnlock/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesForceUnlock
=== RUN   TestWorkspacesForceUnlock/with_valid_options
=== RUN   TestWorkspacesForceUnlock/when_workspace_is_already_unlocked
=== RUN   TestWorkspacesForceUnlock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesForceUnlock (1.24s)
    --- PASS: TestWorkspacesForceUnlock/with_valid_options (0.17s)
    --- PASS: TestWorkspacesForceUnlock/when_workspace_is_already_unlocked (0.11s)
    --- PASS: TestWorkspacesForceUnlock/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesAssignSSHKey
=== RUN   TestWorkspacesAssignSSHKey/with_valid_options
=== RUN   TestWorkspacesAssignSSHKey/without_an_SSH_key_ID
=== RUN   TestWorkspacesAssignSSHKey/without_a_valid_SSH_key_ID
=== RUN   TestWorkspacesAssignSSHKey/without_a_valid_workspace_ID
--- PASS: TestWorkspacesAssignSSHKey (1.26s)
    --- PASS: TestWorkspacesAssignSSHKey/with_valid_options (0.16s)
    --- PASS: TestWorkspacesAssignSSHKey/without_an_SSH_key_ID (0.00s)
    --- PASS: TestWorkspacesAssignSSHKey/without_a_valid_SSH_key_ID (0.00s)
    --- PASS: TestWorkspacesAssignSSHKey/without_a_valid_workspace_ID (0.00s)
=== RUN   TestWorkspacesUnassignSSHKey
=== RUN   TestWorkspacesUnassignSSHKey/with_valid_options
=== RUN   TestWorkspacesUnassignSSHKey/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUnassignSSHKey (1.42s)
    --- PASS: TestWorkspacesUnassignSSHKey/with_valid_options (0.16s)
    --- PASS: TestWorkspacesUnassignSSHKey/without_a_valid_workspace_ID (0.00s)
```
