### PR TITLE
Add new workspace fields

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -24,6 +26,9 @@ type Workspaces interface {
 
 	// Read a workspace by its name.
 	Read(ctx context.Context, organization string, workspace string) (*Workspace, error)
+
+	// Readme gets the readme of a workspace by its ID.
+	Readme(ctx context.Context, workspaceID string) (io.Reader, error)
 
 	// ReadByID reads a workspace by its ID.
 	ReadByID(ctx context.Context, workspaceID string) (*Workspace, error)
@@ -97,12 +102,31 @@ type Workspace struct {
 	TriggerPrefixes      []string              `jsonapi:"attr,trigger-prefixes"`
 	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`
 	WorkingDirectory     string                `jsonapi:"attr,working-directory"`
+	UpdatedAt            time.Time             `jsonapi:"attr,updated-at,iso8601"`
+	ResourceCount        int                   `jsonapi:"attr,resource-count"`
+	ApplyDurationAverage time.Duration         `jsonapi:"attr,apply-duration-average"`
+	PlanDurationAverage  time.Duration         `jsonapi:"attr,plan-duration-average"`
+	PolicyCheckFailures  int                   `jsonapi:"attr,policy-check-failures"`
+	RunFailures          int                   `jsonapi:"attr,run-failures"`
+	RunsCount            int                   `jsonapi:"attr,workspace-kpis-runs-count"`
 
 	// Relations
 	AgentPool    *AgentPool    `jsonapi:"relation,agent-pool"`
 	CurrentRun   *Run          `jsonapi:"relation,current-run"`
 	Organization *Organization `jsonapi:"relation,organization"`
 	SSHKey       *SSHKey       `jsonapi:"relation,ssh-key"`
+}
+
+// workspaceWithReadme is the same as a workspace but it has a readme.
+type workspaceWithReadme struct {
+	ID     string           `jsonapi:"primary,workspaces"`
+	Readme *workspaceReadme `jsonapi:"relation,readme"`
+}
+
+// workspaceReadme contains the readme of the workspace.
+type workspaceReadme struct {
+	ID          string `jsonapi:"primary,workspace-readme"`
+	RawMarkdown string `jsonapi:"attr,raw-markdown"`
 }
 
 // VCSRepo contains the configuration of a VCS integration.
@@ -322,6 +346,10 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 		return nil, err
 	}
 
+	// durations come over in ms
+	w.ApplyDurationAverage *= time.Millisecond
+	w.PlanDurationAverage *= time.Millisecond
+
 	return w, nil
 }
 
@@ -343,7 +371,32 @@ func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspa
 		return nil, err
 	}
 
+	// durations come over in ms
+	w.ApplyDurationAverage *= time.Millisecond
+	w.PlanDurationAverage *= time.Millisecond
+
 	return w, nil
+}
+
+// Readme gets the readme of a workspace by its ID.
+func (s *workspaces) Readme(ctx context.Context, workspaceID string) (io.Reader, error) {
+	if !validStringID(&workspaceID) {
+		return nil, ErrInvalidWorkspaceID
+	}
+
+	u := fmt.Sprintf("workspaces/%s?include=readme", url.QueryEscape(workspaceID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	r := &workspaceWithReadme{}
+	err = s.client.do(ctx, req, r)
+	if err != nil {
+		return nil, err
+	}
+
+	return strings.NewReader(r.Readme.RawMarkdown), nil
 }
 
 // WorkspaceUpdateOptions represents the options for updating a workspace.

--- a/workspace.go
+++ b/workspace.go
@@ -395,6 +395,9 @@ func (s *workspaces) Readme(ctx context.Context, workspaceID string) (io.Reader,
 	if err != nil {
 		return nil, err
 	}
+	if r.Readme == nil {
+		return nil, nil
+	}
 
 	return strings.NewReader(r.Readme.RawMarkdown), nil
 }

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -307,7 +307,7 @@ func TestWorkspacesReadReadme(t *testing.T) {
 	t.Run("when the readme does not exist", func(t *testing.T) {
 		w, err := client.Workspaces.Readme(ctx, "nonexisting")
 		assert.Nil(t, w)
-		assert.NoError(t, err)
+		assert.Error(t, err)
 	})
 
 	t.Run("without a valid workspace ID", func(t *testing.T) {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -291,6 +291,7 @@ func TestWorkspacesReadReadme(t *testing.T) {
 
 	w, err := client.Workspaces.Readme(context.Background(), wTest.ID)
 	require.NoError(t, err)
+	require.NotNil(t, w)
 
 	readme, err := ioutil.ReadAll(w)
 	require.NoError(t, err)


### PR DESCRIPTION
## Description

Adds support for new fields in the workspace object

## Example Output

```
(*tfe.Workspace)(0xc00016a000)({
...,
 UpdatedAt: (time.Time) 2020-12-16 18:05:40.569 +0000 UTC,
 ResourceCount: (int) 2,
 ApplyDurationAverage: (time.Duration) 41s,
 PlanDurationAverage: (time.Duration) 25s,
 PolicyCheckFailures: (int) 0,
 RunFailures: (int) 1,
 RunsCount: (int) 6,
})

// spew.Dump of workspaces.Readme:

([]uint8) (len=11 cap=1536) {
 00000000  23 20 74 66 74 65 73 74  0a 0a 31                 |# tftest..1|
}
```

## Testing plan

Added a unit test, but it won't work because this feature is not generally available yet. It should pass once it is.

The fields have been tested manually against an existing workspace with real data.