### PR TITLE
Add missing defer cleanups

### DIFF
--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -21,8 +21,10 @@ func TestAdminRuns_List(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, org)
 	defer wTestCleanup()
 
-	rTest1, _ := createRun(t, client, wTest)
-	rTest2, _ := createRun(t, client, wTest)
+	rTest1, rTestCleanup1 := createRun(t, client, wTest)
+	defer rTestCleanup1()
+	rTest2, rTestCleanup2 := createRun(t, client, wTest)
+	defer rTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{})

--- a/agent_pool_test.go
+++ b/agent_pool_test.go
@@ -17,7 +17,8 @@ func TestAgentPoolsList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	agentPool, _ := createAgentPool(t, client, orgTest)
+	agentPool, agentPoolCleanup := createAgentPool(t, client, orgTest)
+	defer agentPoolCleanup()
 
 	t.Run("without list options", func(t *testing.T) {
 		pools, err := client.AgentPools.List(ctx, orgTest.Name, AgentPoolListOptions{})
@@ -104,7 +105,8 @@ func TestAgentPoolsRead(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	pool, _ := createAgentPool(t, client, orgTest)
+	pool, poolCleanup := createAgentPool(t, client, orgTest)
+	defer poolCleanup()
 
 	t.Run("when the agent pool exists", func(t *testing.T) {
 		k, err := client.AgentPools.Read(ctx, pool.ID)

--- a/cost_estimate_test.go
+++ b/cost_estimate_test.go
@@ -27,8 +27,10 @@ func TestCostEstimatesRead(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	wTest, _ := createWorkspace(t, client, orgTest)
-	rTest, _ := createCostEstimatedRun(t, client, wTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+	rTest, rTestCleanup := createCostEstimatedRun(t, client, wTest)
+	defer rTestCleanup()
 
 	t.Run("when the costEstimate exists", func(t *testing.T) {
 		ce, err := client.CostEstimates.Read(ctx, rTest.CostEstimate.ID)

--- a/notification_configuration_test.go
+++ b/notification_configuration_test.go
@@ -15,8 +15,10 @@ func TestNotificationConfigurationList(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, nil)
 	defer wTestCleanup()
 
-	ncTest1, _ := createNotificationConfiguration(t, client, wTest, nil)
-	ncTest2, _ := createNotificationConfiguration(t, client, wTest, nil)
+	ncTest1, ncTestCleanup1 := createNotificationConfiguration(t, client, wTest, nil)
+	defer ncTestCleanup1()
+	ncTest2, ncTestCleanup2 := createNotificationConfiguration(t, client, wTest, nil)
+	defer ncTestCleanup2()
 
 	t.Run("with a valid workspace", func(t *testing.T) {
 		ncl, err := client.NotificationConfigurations.List(

--- a/oauth_client_test.go
+++ b/oauth_client_test.go
@@ -16,8 +16,10 @@ func TestOAuthClientsList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	ocTest1, _ := createOAuthClient(t, client, orgTest)
-	ocTest2, _ := createOAuthClient(t, client, orgTest)
+	ocTest1, ocTestCleanup1 := createOAuthClient(t, client, orgTest)
+	defer ocTestCleanup1()
+	ocTest2, ocTestCleanup2 := createOAuthClient(t, client, orgTest)
+	defer ocTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		options := OAuthClientListOptions{}

--- a/oauth_token_test.go
+++ b/oauth_token_test.go
@@ -16,8 +16,10 @@ func TestOAuthTokensList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	otTest1, _ := createOAuthToken(t, client, orgTest)
-	otTest2, _ := createOAuthToken(t, client, orgTest)
+	otTest1, otTest1Cleanup := createOAuthToken(t, client, orgTest)
+	defer otTest1Cleanup()
+	otTest2, otTest2Cleanup := createOAuthToken(t, client, orgTest)
+	defer otTest2Cleanup()
 
 	t.Run("without list options", func(t *testing.T) {
 		options := OAuthTokenListOptions{}
@@ -166,7 +168,8 @@ func TestOAuthTokensDelete(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	otTest, _ := createOAuthToken(t, client, orgTest)
+	otTest, otCleanup := createOAuthToken(t, client, orgTest)
+	defer otCleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.OAuthTokens.Delete(ctx, otTest.ID)

--- a/organization_test.go
+++ b/organization_test.go
@@ -211,10 +211,14 @@ func TestOrganizationsCapacity(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest1, _ := createWorkspace(t, client, orgTest)
-	wTest2, _ := createWorkspace(t, client, orgTest)
-	wTest3, _ := createWorkspace(t, client, orgTest)
-	wTest4, _ := createWorkspace(t, client, orgTest)
+	wTest1, wTestCleanup1 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup1()
+	wTest2, wTestCleanup2 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup2()
+	wTest3, wTestCleanup3 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup3()
+	wTest4, wTestCleanup4 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup4()
 
 	t.Run("without queued runs", func(t *testing.T) {
 		c, err := client.Organizations.Capacity(ctx, orgTest.Name)
@@ -226,10 +230,14 @@ func TestOrganizationsCapacity(t *testing.T) {
 	// For this test FRQ should be enabled and have a
 	// limit of 2 concurrent runs per organization.
 	t.Run("with queued runs", func(t *testing.T) {
-		_, _ = createRun(t, client, wTest1)
-		_, _ = createRun(t, client, wTest2)
-		_, _ = createRun(t, client, wTest3)
-		_, _ = createRun(t, client, wTest4)
+		_, runCleanup1 := createRun(t, client, wTest1)
+		defer runCleanup1()
+		_, runCleanup2 := createRun(t, client, wTest2)
+		defer runCleanup2()
+		_, runCleanup3 := createRun(t, client, wTest3)
+		defer runCleanup3()
+		_, runCleanup4 := createRun(t, client, wTest4)
+		defer runCleanup4()
 
 		c, err := client.Organizations.Capacity(ctx, orgTest.Name)
 		require.NoError(t, err)
@@ -295,10 +303,14 @@ func TestOrganizationsRunQueue(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest1, _ := createWorkspace(t, client, orgTest)
-	wTest2, _ := createWorkspace(t, client, orgTest)
-	wTest3, _ := createWorkspace(t, client, orgTest)
-	wTest4, _ := createWorkspace(t, client, orgTest)
+	wTest1, wTestCleanup1 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup1()
+	wTest2, wTestCleanup2 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup2()
+	wTest3, wTestCleanup3 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup3()
+	wTest4, wTestCleanup4 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup4()
 
 	t.Run("without queued runs", func(t *testing.T) {
 		rq, err := client.Organizations.RunQueue(ctx, orgTest.Name, RunQueueOptions{})
@@ -307,10 +319,14 @@ func TestOrganizationsRunQueue(t *testing.T) {
 	})
 
 	// Create a couple or runs to fill the queue.
-	rTest1, _ := createRun(t, client, wTest1)
-	rTest2, _ := createRun(t, client, wTest2)
-	rTest3, _ := createRun(t, client, wTest3)
-	rTest4, _ := createRun(t, client, wTest4)
+	rTest1, rTestCleanup1 := createRun(t, client, wTest1)
+	defer rTestCleanup1()
+	rTest2, rTestCleanup2 := createRun(t, client, wTest2)
+	defer rTestCleanup2()
+	rTest3, rTestCleanup3 := createRun(t, client, wTest3)
+	defer rTestCleanup3()
+	rTest4, rTestCleanup4 := createRun(t, client, wTest4)
+	defer rTestCleanup4()
 
 	// For this test FRQ should be enabled and have a
 	// limit of 2 concurrent runs per organization.

--- a/policy_check_test.go
+++ b/policy_check_test.go
@@ -110,9 +110,11 @@ func TestPolicyChecksOverride(t *testing.T) {
 		pTest, pTestCleanup := createUploadedPolicy(t, client, false, orgTest)
 		defer pTestCleanup()
 
-		wTest, _ := createWorkspace(t, client, orgTest)
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		defer wTestCleanup()
 		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
-		rTest, _ := createPlannedRun(t, client, wTest)
+		rTest, tTestCleanup := createPlannedRun(t, client, wTest)
+		defer tTestCleanup()
 
 		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
 		require.NoError(t, err)
@@ -133,9 +135,11 @@ func TestPolicyChecksOverride(t *testing.T) {
 		pTest, pTestCleanup := createUploadedPolicy(t, client, true, orgTest)
 		defer pTestCleanup()
 
-		wTest, _ := createWorkspace(t, client, orgTest)
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		defer wTestCleanup()
 		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
-		rTest, _ := createPlannedRun(t, client, wTest)
+		rTest, rTestCleanup := createPlannedRun(t, client, wTest)
+		defer rTestCleanup()
 
 		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
 		require.NoError(t, err)
@@ -160,11 +164,14 @@ func TestPolicyChecksLogs(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	pTest, _ := createUploadedPolicy(t, client, true, orgTest)
-	wTest, _ := createWorkspace(t, client, orgTest)
+	pTest, pTestCleanup := createUploadedPolicy(t, client, true, orgTest)
+	defer pTestCleanup()
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
 
-	rTest, _ := createPlannedRun(t, client, wTest)
+	rTest, rTestCleanup := createPlannedRun(t, client, wTest)
+	defer rTestCleanup()
 	require.Equal(t, 1, len(rTest.PolicyChecks))
 
 	t.Run("when the log exists", func(t *testing.T) {

--- a/policy_set_parameter_test.go
+++ b/policy_set_parameter_test.go
@@ -15,10 +15,13 @@ func TestPolicySetParametersList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	psTest, _ := createPolicySet(t, client, orgTest, nil, nil)
+	psTest, pTestCleanup := createPolicySet(t, client, orgTest, nil, nil)
+	defer pTestCleanup()
 
-	pTest1, _ := createPolicySetParameter(t, client, psTest)
-	pTest2, _ := createPolicySetParameter(t, client, psTest)
+	pTest1, pTestCleanup1 := createPolicySetParameter(t, client, psTest)
+	defer pTestCleanup1()
+	pTest2, pTestCleanup2 := createPolicySetParameter(t, client, psTest)
+	defer pTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		pl, err := client.PolicySetParameters.List(ctx, psTest.ID, PolicySetParameterListOptions{})

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -17,8 +17,10 @@ func TestPolicySetsList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	psTest1, _ := createPolicySet(t, client, orgTest, nil, nil)
-	psTest2, _ := createPolicySet(t, client, orgTest, nil, nil)
+	psTest1, psTestCleanup1 := createPolicySet(t, client, orgTest, nil, nil)
+	defer psTestCleanup1()
+	psTest2, psTestCleanup2 := createPolicySet(t, client, orgTest, nil, nil)
+	defer psTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		psl, err := client.PolicySets.List(ctx, orgTest.Name, PolicySetListOptions{})
@@ -105,8 +107,10 @@ func TestPolicySetsCreate(t *testing.T) {
 	})
 
 	t.Run("with policies and workspaces provided", func(t *testing.T) {
-		pTest, _ := createPolicy(t, client, orgTest)
-		wTest, _ := createWorkspace(t, client, orgTest)
+		pTest, pTestCleanup := createPolicy(t, client, orgTest)
+		defer pTestCleanup()
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		defer wTestCleanup()
 
 		options := PolicySetCreateOptions{
 			Name:       String("populated-policy-set"),
@@ -130,7 +134,8 @@ func TestPolicySetsCreate(t *testing.T) {
 			t.Skip("Export a valid GITHUB_POLICY_SET_IDENTIFIER before running this test")
 		}
 
-		oc, _ := createOAuthToken(t, client, orgTest)
+		oc, ocTestCleanup := createOAuthToken(t, client, orgTest)
+		defer ocTestCleanup()
 
 		options := PolicySetCreateOptions{
 			Name:         String("vcs-policy-set"),
@@ -170,7 +175,8 @@ func TestPolicySetsCreate(t *testing.T) {
 			t.Skip("Export a valid GITHUB_POLICY_SET_IDENTIFIER before running this test")
 		}
 
-		oc, _ := createOAuthToken(t, client, orgTest)
+		oc, ocTestCleanup := createOAuthToken(t, client, orgTest)
+		defer ocTestCleanup()
 
 		options := PolicySetUpdateOptions{
 			Name:         String("vcs-policy-set"),
@@ -231,7 +237,8 @@ func TestPolicySetsRead(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	psTest, _ := createPolicySet(t, client, orgTest, nil, nil)
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil)
+	defer psTestCleanup()
 
 	t.Run("with a valid ID", func(t *testing.T) {
 		ps, err := client.PolicySets.Read(ctx, psTest.ID)
@@ -254,7 +261,8 @@ func TestPolicySetsUpdate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	psTest, _ := createPolicySet(t, client, orgTest, nil, nil)
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil)
+	defer psTestCleanup()
 
 	t.Run("with valid attributes", func(t *testing.T) {
 		options := PolicySetUpdateOptions{
@@ -295,9 +303,12 @@ func TestPolicySetsAddPolicies(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	pTest1, _ := createPolicy(t, client, orgTest)
-	pTest2, _ := createPolicy(t, client, orgTest)
-	psTest, _ := createPolicySet(t, client, orgTest, nil, nil)
+	pTest1, pTestCleanup1 := createPolicy(t, client, orgTest)
+	defer pTestCleanup1()
+	pTest2, pTestCleanup2 := createPolicy(t, client, orgTest)
+	defer pTestCleanup2()
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil)
+	defer psTestCleanup()
 
 	t.Run("with policies provided", func(t *testing.T) {
 		err := client.PolicySets.AddPolicies(ctx, psTest.ID, PolicySetAddPoliciesOptions{
@@ -345,9 +356,12 @@ func TestPolicySetsRemovePolicies(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	pTest1, _ := createPolicy(t, client, orgTest)
-	pTest2, _ := createPolicy(t, client, orgTest)
-	psTest, _ := createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, nil)
+	pTest1, pTestCleanup1 := createPolicy(t, client, orgTest)
+	defer pTestCleanup1()
+	pTest2, pTestCleanup2 := createPolicy(t, client, orgTest)
+	defer pTestCleanup2()
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, nil)
+	defer psTestCleanup()
 
 	t.Run("with policies provided", func(t *testing.T) {
 		err := client.PolicySets.RemovePolicies(ctx, psTest.ID, PolicySetRemovePoliciesOptions{
@@ -389,9 +403,12 @@ func TestPolicySetsAddWorkspaces(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest1, _ := createWorkspace(t, client, orgTest)
-	wTest2, _ := createWorkspace(t, client, orgTest)
-	psTest, _ := createPolicySet(t, client, orgTest, nil, nil)
+	wTest1, wTestCleanup1 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup1()
+	wTest2, wTestCleanup2 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup2()
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil)
+	defer psTestCleanup()
 
 	t.Run("with workspaces provided", func(t *testing.T) {
 		err := client.PolicySets.AddWorkspaces(
@@ -453,9 +470,12 @@ func TestPolicySetsRemoveWorkspaces(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest1, _ := createWorkspace(t, client, orgTest)
-	wTest2, _ := createWorkspace(t, client, orgTest)
-	psTest, _ := createPolicySet(t, client, orgTest, nil, []*Workspace{wTest1, wTest2})
+	wTest1, wTestCleanup1 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup1()
+	wTest2, wTestCleanup2 := createWorkspace(t, client, orgTest)
+	defer wTestCleanup2()
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, []*Workspace{wTest1, wTest2})
+	defer psTestCleanup()
 
 	t.Run("with workspaces provided", func(t *testing.T) {
 		err := client.PolicySets.RemoveWorkspaces(

--- a/policy_test.go
+++ b/policy_test.go
@@ -15,8 +15,10 @@ func TestPoliciesList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	pTest1, _ := createPolicy(t, client, orgTest)
-	pTest2, _ := createPolicy(t, client, orgTest)
+	pTest1, pTestCleanup1 := createPolicy(t, client, orgTest)
+	defer pTestCleanup1()
+	pTest2, pTestCleanup2 := createPolicy(t, client, orgTest)
+	defer pTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		pl, err := client.Policies.List(ctx, orgTest.Name, PolicyListOptions{})

--- a/registry_module_test.go
+++ b/registry_module_test.go
@@ -409,7 +409,6 @@ func TestRegistryModulesDeleteProvider(t *testing.T) {
 	defer orgTestCleanup()
 
 	registryModuleTest, _ := createRegistryModule(t, client, orgTest)
-	//defer registryModuleTestCleanup()
 
 	t.Run("with valid name and provider", func(t *testing.T) {
 		err := client.RegistryModules.DeleteProvider(ctx, orgTest.Name, registryModuleTest.Name, registryModuleTest.Provider)

--- a/run_test.go
+++ b/run_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 	"time"
 
-	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/run_test.go
+++ b/run_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"fmt"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -16,8 +17,10 @@ func TestRunsList(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, nil)
 	defer wTestCleanup()
 
-	rTest1, _ := createRun(t, client, wTest)
-	rTest2, _ := createRun(t, client, wTest)
+	rTest1, rTestCleanup1 := createRun(t, client, wTest)
+	defer rTestCleanup1()
+	rTest2, rTestCleanup2 := createRun(t, client, wTest)
+	defer rTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		rl, err := client.Runs.List(ctx, wTest.ID, RunListOptions{})
@@ -78,7 +81,8 @@ func TestRunsCreate(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, nil)
 	defer wTestCleanup()
 
-	cvTest, _ := createUploadedConfigurationVersion(t, client, wTest)
+	cvTest, cvTestCleanup := createUploadedConfigurationVersion(t, client, wTest)
+	defer cvTestCleanup()
 
 	t.Run("without a configuration version", func(t *testing.T) {
 		options := RunCreateOptions{
@@ -202,8 +206,10 @@ func TestRunsCancel(t *testing.T) {
 	// be planned so that one cannot be cancelled. The second one will
 	// be pending until the first one is confirmed or discarded, so we
 	// can cancel that one.
-	_, _ = createRun(t, client, wTest)
-	rTest2, _ := createRun(t, client, wTest)
+	_, rTestCleanup1 := createRun(t, client, wTest)
+	defer rTestCleanup1()
+	rTest2, rTestCleanup2 := createRun(t, client, wTest)
+	defer rTestCleanup2()
 
 	t.Run("when the run exists", func(t *testing.T) {
 		err := client.Runs.Cancel(ctx, rTest2.ID, RunCancelOptions{})
@@ -232,8 +238,10 @@ func TestRunsForceCancel(t *testing.T) {
 	// be planned so that one cannot be cancelled. The second one will
 	// be pending until the first one is confirmed or discarded, so we
 	// can cancel that one.
-	_, _ = createRun(t, client, wTest)
-	rTest, _ := createRun(t, client, wTest)
+	_, rTestCleanup1 := createRun(t, client, wTest)
+	defer rTestCleanup1()
+	rTest, rTestCleanup2 := createRun(t, client, wTest)
+	defer rTestCleanup2()
 
 	t.Run("run is not force-cancelable", func(t *testing.T) {
 		assert.False(t, rTest.Actions.IsForceCancelable)

--- a/run_trigger_test.go
+++ b/run_trigger_test.go
@@ -24,8 +24,10 @@ func TestRunTriggerList(t *testing.T) {
 	sourceable2Test, sourceable2TestCleanup := createWorkspace(t, client, orgTest)
 	defer sourceable2TestCleanup()
 
-	rtTest1, _ := createRunTrigger(t, client, wTest, sourceable1Test)
-	rtTest2, _ := createRunTrigger(t, client, wTest, sourceable2Test)
+	rtTest1, rtTestCleanup1 := createRunTrigger(t, client, wTest, sourceable1Test)
+	defer rtTestCleanup1()
+	rtTest2, rtTestCleanup2 := createRunTrigger(t, client, wTest, sourceable2Test)
+	defer rtTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		rtl, err := client.RunTriggers.List(

--- a/ssh_key_test.go
+++ b/ssh_key_test.go
@@ -15,8 +15,10 @@ func TestSSHKeysList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	kTest1, _ := createSSHKey(t, client, orgTest)
-	kTest2, _ := createSSHKey(t, client, orgTest)
+	kTest1, kTestCleanup1 := createSSHKey(t, client, orgTest)
+	defer kTestCleanup1()
+	kTest2, kTestCleanup2 := createSSHKey(t, client, orgTest)
+	defer kTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		kl, err := client.SSHKeys.List(ctx, orgTest.Name, SSHKeyListOptions{})
@@ -114,7 +116,8 @@ func TestSSHKeysRead(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	kTest, _ := createSSHKey(t, client, orgTest)
+	kTest, kTestCleanup := createSSHKey(t, client, orgTest)
+	defer kTestCleanup()
 
 	t.Run("when the SSH key exists", func(t *testing.T) {
 		k, err := client.SSHKeys.Read(ctx, kTest.ID)

--- a/state_version_test.go
+++ b/state_version_test.go
@@ -23,8 +23,10 @@ func TestStateVersionsList(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 	defer wTestCleanup()
 
-	svTest1, _ := createStateVersion(t, client, 0, wTest)
-	svTest2, _ := createStateVersion(t, client, 1, wTest)
+	svTest1, svTestCleanup1 := createStateVersion(t, client, 0, wTest)
+	defer svTestCleanup1()
+	svTest2, svTestCleanup2 := createStateVersion(t, client, 1, wTest)
+	defer svTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		options := StateVersionListOptions{
@@ -193,7 +195,8 @@ func TestStateVersionsCreate(t *testing.T) {
 	t.Run("with a run to associate with", func(t *testing.T) {
 		t.Skip("This can only be tested with the run specific token")
 
-		rTest, _ := createRun(t, client, wTest)
+		rTest, rTestCleanup := createRun(t, client, wTest)
+		defer rTestCleanup()
 
 		ctx := context.Background()
 		sv, err := client.StateVersions.Create(ctx, wTest.ID, StateVersionCreateOptions{

--- a/team_access_test.go
+++ b/team_access_test.go
@@ -276,8 +276,7 @@ func TestTeamAccessesRemove(t *testing.T) {
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	defer tmTestCleanup()
 
-	taTest, taTestCleanup := createTeamAccess(t, client, tmTest, nil, orgTest)
-	defer taTestCleanup()
+	taTest, _ := createTeamAccess(t, client, tmTest, nil, orgTest)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.TeamAccess.Remove(ctx, taTest.ID)

--- a/team_access_test.go
+++ b/team_access_test.go
@@ -15,7 +15,8 @@ func TestTeamAccessesList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
 	tmTest1, tmTest1Cleanup := createTeam(t, client, orgTest)
 	defer tmTest1Cleanup()
@@ -79,7 +80,8 @@ func TestTeamAccessesAdd(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	defer tmTestCleanup()
@@ -274,7 +276,8 @@ func TestTeamAccessesRemove(t *testing.T) {
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	defer tmTestCleanup()
 
-	taTest, _ := createTeamAccess(t, client, tmTest, nil, orgTest)
+	taTest, taTestCleanup := createTeamAccess(t, client, tmTest, nil, orgTest)
+	defer taTestCleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.TeamAccess.Remove(ctx, taTest.ID)

--- a/variable_test.go
+++ b/variable_test.go
@@ -15,10 +15,13 @@ func TestVariablesList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
-	vTest1, _ := createVariable(t, client, wTest)
-	vTest2, _ := createVariable(t, client, wTest)
+	vTest1, vTestCleanup1 := createVariable(t, client, wTest)
+	defer vTestCleanup1()
+	vTest2, vTestCleanup2 := createVariable(t, client, wTest)
+	defer vTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
 		vl, err := client.Variables.List(ctx, wTest.ID, VariableListOptions{})

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -304,8 +304,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
@@ -417,8 +416,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -304,7 +304,8 @@ func TestWorkspacesUpdate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
@@ -416,7 +417,8 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
@@ -552,7 +554,8 @@ func TestWorkspacesRemoveVCSConnection(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspaceWithVCS(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest)
+	defer wTestCleanup()
 
 	t.Run("remove vcs integration", func(t *testing.T) {
 		w, err := client.Workspaces.RemoveVCSConnection(ctx, orgTest.Name, wTest.Name)
@@ -568,7 +571,8 @@ func TestWorkspacesRemoveVCSConnectionByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspaceWithVCS(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest)
+	defer wTestCleanup()
 
 	t.Run("remove vcs integration", func(t *testing.T) {
 		w, err := client.Workspaces.RemoveVCSConnectionByID(ctx, wTest.ID)
@@ -584,7 +588,8 @@ func TestWorkspacesLock(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
 		w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
@@ -611,7 +616,8 @@ func TestWorkspacesUnlock(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
 	w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
 	if err != nil {
@@ -645,7 +651,8 @@ func TestWorkspacesForceUnlock(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
 
 	w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
 	if err != nil {


### PR DESCRIPTION
## Description

There are a number of resources that are left without being cleaned up. This is because some create calls don't include the cleanup function. This isn't added to every test, as some tests explicitly test Deletion.

This PR goes through and adds the missing `defer cleanup()` for various resources.

## Testing plan

1. Run tests.

## Output from tests

```
$ go test -v  ./...  -timeout=30m 
PASS
ok  	github.com/hashicorp/go-tfe	562.416s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]

...
```
