### PR TITLE
Refactored unmarshal into its own function

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -664,8 +664,6 @@ func unmarshalResponse(responseBody io.Reader, model interface{}) error {
 	pagination.Set(reflect.ValueOf(p))
 
 	return nil
-
-	return nil
 }
 
 // ListOptions is used to specify pagination options when making API requests.

--- a/tfe.go
+++ b/tfe.go
@@ -604,10 +604,14 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 		return err
 	}
 
-	// Get the value of v so we can test if it's a struct.
-	dst := reflect.Indirect(reflect.ValueOf(v))
+	return unmarshalResponse(resp.Body, v)
+}
 
-	// Return an error if v is not a struct or an io.Writer.
+func unmarshalResponse(responseBody io.Reader, model interface{}) error {
+	// Get the value of model so we can test if it's a struct.
+	dst := reflect.Indirect(reflect.ValueOf(model))
+
+	// Return an error if model is not a struct or an io.Writer.
 	if dst.Kind() != reflect.Struct {
 		return fmt.Errorf("v must be a struct or an io.Writer")
 	}
@@ -619,7 +623,7 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 	// Unmarshal a single value if v does not contain the
 	// Items and Pagination struct fields.
 	if !items.IsValid() || !pagination.IsValid() {
-		return jsonapi.UnmarshalPayload(resp.Body, v)
+		return jsonapi.UnmarshalPayload(responseBody, model)
 	}
 
 	// Return an error if v.Items is not a slice.
@@ -629,7 +633,7 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 
 	// Create a temporary buffer and copy all the read data into it.
 	body := bytes.NewBuffer(nil)
-	reader := io.TeeReader(resp.Body, body)
+	reader := io.TeeReader(responseBody, body)
 
 	// Unmarshal as a list of values as v.Items is a slice.
 	raw, err := jsonapi.UnmarshalManyPayload(reader, items.Type().Elem())
@@ -658,6 +662,8 @@ func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface
 
 	// Pointer-swap the decoded pagination details.
 	pagination.Set(reflect.ValueOf(p))
+
+	return nil
 
 	return nil
 }

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -12,6 +12,8 @@ import (
 	"time"
 
 	"github.com/hashicorp/go-retryablehttp"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"github.com/svanharmelen/jsonapi"
 	"golang.org/x/time/rate"
 )
@@ -374,6 +376,87 @@ func createRequest(v interface{}) (*retryablehttp.Request, []byte, error) {
 		return request, nil, err
 	}
 	return request, body, nil
+}
+
+type tfeAPI struct {
+	ID               string            `jsonapi:"primary,tfe"`
+	Name             string            `jsonapi:"attr,name"`
+	CreatedAt        time.Time         `jsonapi:"attr,created-at,iso8601"`
+	Enalbed          bool              `jsonapi:"attr,enalbed"`
+	Emails           []string          `jsonapi:"attr,emails"`
+	Status           tfeAPIStatus      `jsonapi:"attr,status"`
+	StatusTimestamps *tfeAPITimestamps `jsonapi:"attr,status-timestamps"`
+}
+
+type tfeAPIStatus string
+
+const (
+	tfeAPIStatusNormal tfeAPIStatus = "normal"
+)
+
+type tfeAPITimestamps struct {
+	QueuedAt time.Time `json:"queued-at"`
+}
+
+func Test_unmarshalResponse(t *testing.T) {
+	t.Run("unmarshal properly formatted json", func(t *testing.T) {
+		// This structure is intended to include every possible field and format
+		// that is valid for JSON:API
+		data := map[string]interface{}{
+			"data": map[string]interface{}{
+				"type": "tfe",
+				"id":   "1",
+				"attributes": map[string]interface{}{
+					"name":       "terraform",
+					"created-at": "2016-08-17T08:27:12Z",
+					"enabled":    "true",
+					"status":     tfeAPIStatusNormal,
+					"emails":     []string{"test@hashicorp.com"},
+					"status-timestamps": map[string]string{
+						"queued-at": "2021-03-16T23:09:59+00:00",
+					},
+				},
+			},
+		}
+		byteData, _ := json.Marshal(data)
+		responseBody := bytes.NewReader(byteData)
+
+		unmarshalledRequestBody := tfeAPI{}
+		err := unmarshalResponse(responseBody, &unmarshalledRequestBody)
+		require.NoError(t, err)
+
+		assert.Equal(t, unmarshalledRequestBody.ID, "1")
+		assert.Equal(t, unmarshalledRequestBody.Name, "terraform")
+		assert.Equal(t, unmarshalledRequestBody.Status, tfeAPIStatusNormal)
+		assert.Equal(t, len(unmarshalledRequestBody.Emails), 1)
+		assert.Equal(t, unmarshalledRequestBody.Emails[0], "test@hashicorp.com")
+		assert.NotEmpty(t, unmarshalledRequestBody.StatusTimestamps)
+		assert.NotNil(t, unmarshalledRequestBody.StatusTimestamps.QueuedAt)
+	})
+
+	t.Run("can only unmarshal Items that are slices", func(t *testing.T) {
+		responseBody := bytes.NewReader([]byte(""))
+		malformattedItemStruct := struct {
+			*Pagination
+			Items int
+		}{
+			Items: 1,
+		}
+		err := unmarshalResponse(responseBody, &malformattedItemStruct)
+		require.Error(t, err)
+		assert.EqualError(t, err, "v.Items must be a slice")
+	})
+
+	t.Run("can only unmarshal a struct", func(t *testing.T) {
+		payload := "random"
+		responseBody := bytes.NewReader([]byte(payload))
+
+		notStruct := "not a struct"
+		err := unmarshalResponse(responseBody, notStruct)
+		assert.Error(t, err)
+		assert.EqualError(t, err, "v must be a struct or an io.Writer")
+	})
+
 }
 
 func TestClient_configureLimiter(t *testing.T) {


### PR DESCRIPTION
## Description

This PR extracts some unmarshalling logic into its own function. The reason for this change is to make it easier to test unmarshalling response. It is done in preparation for a further change of using an up-to-date JSONAPI library. 

## Testing plan

Run tests.

## Output from tests


```
$ go test -v  ./...  -failfast -timeout=30m

```
