### PR TITLE
Add Manage Policy Overrides permission

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -778,8 +778,11 @@ func createTeam(t *testing.T, client *Client, org *Organization) (*Team, func())
 
 	ctx := context.Background()
 	tm, err := client.Teams.Create(ctx, org.Name, TeamCreateOptions{
-		Name:               String(randomString(t)),
-		OrganizationAccess: &OrganizationAccessOptions{ManagePolicies: Bool(true)},
+		Name: String(randomString(t)),
+		OrganizationAccess: &OrganizationAccessOptions{
+			ManagePolicies:        Bool(true),
+			ManagePolicyOverrides: Bool(true),
+		},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/team.go
+++ b/team.go
@@ -58,9 +58,10 @@ type Team struct {
 
 // OrganizationAccess represents the team's permissions on its organization
 type OrganizationAccess struct {
-	ManagePolicies    bool `jsonapi:"attr,manage-policies"`
-	ManageWorkspaces  bool `jsonapi:"attr,manage-workspaces"`
-	ManageVCSSettings bool `jsonapi:"attr,manage-vcs-settings"`
+	ManagePolicies        bool `jsonapi:"attr,manage-policies"`
+	ManagePolicyOverrides bool `jsonapi:"attr,manage-policy-overrides"`
+	ManageWorkspaces      bool `jsonapi:"attr,manage-workspaces"`
+	ManageVCSSettings     bool `jsonapi:"attr,manage-vcs-settings"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -117,9 +118,10 @@ type TeamCreateOptions struct {
 
 // OrganizationAccessOptions represents the organization access options of a team.
 type OrganizationAccessOptions struct {
-	ManagePolicies    *bool `json:"manage-policies,omitempty"`
-	ManageWorkspaces  *bool `json:"manage-workspaces,omitempty"`
-	ManageVCSSettings *bool `json:"manage-vcs-settings,omitempty"`
+	ManagePolicies        *bool `json:"manage-policies,omitempty"`
+	ManagePolicyOverrides *bool `json:"manage-policy-overrides,omitempty"`
+	ManageWorkspaces      *bool `json:"manage-workspaces,omitempty"`
+	ManageVCSSettings     *bool `json:"manage-vcs-settings,omitempty"`
 }
 
 func (o TeamCreateOptions) valid() error {

--- a/team_test.go
+++ b/team_test.go
@@ -169,8 +169,9 @@ func TestTeamsUpdate(t *testing.T) {
 		options := TeamUpdateOptions{
 			Name: String("foo bar"),
 			OrganizationAccess: &OrganizationAccessOptions{
-				ManagePolicies:    Bool(false),
-				ManageVCSSettings: Bool(true),
+				ManagePolicies:        Bool(false),
+				ManageVCSSettings:     Bool(true),
+				ManagePolicyOverrides: Bool(true),
 			},
 			Visibility: String("organization"),
 		}
@@ -197,6 +198,10 @@ func TestTeamsUpdate(t *testing.T) {
 			assert.Equal(t,
 				*options.OrganizationAccess.ManageVCSSettings,
 				item.OrganizationAccess.ManageVCSSettings,
+			)
+			assert.Equal(t,
+				*options.OrganizationAccess.ManagePolicyOverrides,
+				item.OrganizationAccess.ManagePolicyOverrides,
 			)
 		}
 	})


### PR DESCRIPTION
## Description

A new permission, `Manage Policy Overrides` is being added to the `Organization Access` for teams. This PR adds the field as required.

## External links

- [API documentation PR](https://github.com/hashicorp/terraform-website/pull/1667)
- [API documentation](https://www.terraform.io/docs/cloud/users-teams-organizations/permissions.html#organization-permissions)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/285)

## Output from tests

```
$ go test -run TestTeams -v ./...
=== RUN   TestTeamsList
=== RUN   TestTeamsList/without_list_options
    team_test.go:29: paging not supported yet in API
=== RUN   TestTeamsList/with_list_options
    team_test.go:35: paging not supported yet in API
=== RUN   TestTeamsList/without_a_valid_organization
--- PASS: TestTeamsList (6.57s)
    --- SKIP: TestTeamsList/without_list_options (0.68s)
    --- SKIP: TestTeamsList/with_list_options (0.00s)
    --- PASS: TestTeamsList/without_a_valid_organization (0.00s)
=== RUN   TestTeamsCreate
=== RUN   TestTeamsCreate/with_valid_options
=== RUN   TestTeamsCreate/when_options_is_missing_name
=== RUN   TestTeamsCreate/when_options_has_an_invalid_organization
--- PASS: TestTeamsCreate (3.45s)
    --- PASS: TestTeamsCreate/with_valid_options (1.08s)
    --- PASS: TestTeamsCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestTeamsCreate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestTeamsRead
=== RUN   TestTeamsRead/when_the_team_exists
=== RUN   TestTeamsRead/when_the_team_exists/visibility_is_returned
=== RUN   TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded
=== RUN   TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded
=== RUN   TestTeamsRead/when_the_team_does_not_exist
=== RUN   TestTeamsRead/without_a_valid_team_ID
--- PASS: TestTeamsRead (5.01s)
    --- PASS: TestTeamsRead/when_the_team_exists (0.53s)
        --- PASS: TestTeamsRead/when_the_team_exists/visibility_is_returned (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded (0.00s)
    --- PASS: TestTeamsRead/when_the_team_does_not_exist (0.57s)
    --- PASS: TestTeamsRead/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsUpdate
=== RUN   TestTeamsUpdate/with_valid_options
=== RUN   TestTeamsUpdate/when_the_team_does_not_exist
=== RUN   TestTeamsUpdate/without_a_valid_team_ID
--- PASS: TestTeamsUpdate (5.66s)
    --- PASS: TestTeamsUpdate/with_valid_options (1.21s)
    --- PASS: TestTeamsUpdate/when_the_team_does_not_exist (0.51s)
    --- PASS: TestTeamsUpdate/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsDelete
=== RUN   TestTeamsDelete/with_valid_options
=== RUN   TestTeamsDelete/without_valid_team_ID
--- PASS: TestTeamsDelete (4.68s)
    --- PASS: TestTeamsDelete/with_valid_options (1.06s)
    --- PASS: TestTeamsDelete/without_valid_team_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	25.851s
```
