### PR TITLE
Add Workspace Remote State Consumers

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -38,6 +38,12 @@ var (
 	// ErrInvalidWorkspaceValue is returned when workspace value is invalid.
 	ErrInvalidWorkspaceValue = errors.New("invalid value for workspace")
 
+	// ErrWorkspacesRequired is returned when the Workspaces are not present.
+	ErrWorkspacesRequired = errors.New("workspaces is required")
+
+	// ErrWorkspaceMinLimit is returned when the length of Workspaces is 0.
+	ErrWorkspaceMinLimit = errors.New("must provide at least one workspace")
+
 	// Run/Apply errors
 
 	// ErrInvalidRunID is returned when the run ID is invalid.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.5.2
 	github.com/hashicorp/go-slug v0.4.1
 	github.com/hashicorp/go-uuid v1.0.1
-	github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2
+	github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.5.2
 	github.com/hashicorp/go-slug v0.4.1
 	github.com/hashicorp/go-uuid v1.0.1
-	github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171
+	github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.5.2
 	github.com/hashicorp/go-slug v0.4.1
 	github.com/hashicorp/go-uuid v1.0.1
-	github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1
+	github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,5 @@
 module github.com/hashicorp/go-tfe
 
-replace github.com/hashicorp/jsonapi => /Users/omarismail/work/hashi-jsonapi
-
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.0.0
@@ -9,7 +7,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.5.2
 	github.com/hashicorp/go-slug v0.4.1
 	github.com/hashicorp/go-uuid v1.0.1
-	github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1
+	github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,7 @@
 module github.com/hashicorp/go-tfe
 
+replace github.com/hashicorp/jsonapi => /Users/omarismail/work/hashi-jsonapi
+
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/google/go-querystring v1.0.0

--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,8 @@ github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1 h1:V95qyPxj4IE39U+fyXdQXUWFCwqXUfTbIl/Gb+lb3zc=
 github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
+github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171 h1:FI3cl6s//o2gq3YMuSNTR4LoXcVi88SEWkD2R5iOrcU=
+github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZ
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171 h1:FI3cl6s//o2gq3YMuSNTR4LoXcVi88SEWkD2R5iOrcU=
-github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
+github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1 h1:V95qyPxj4IE39U+fyXdQXUWFCwqXUfTbIl/Gb+lb3zc=
+github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZ
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2 h1:OjFUNGOswzMaescbEEB0v7LrNcnsk8OyrmmMU/0fk5w=
-github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171 h1:FI3cl6s//o2gq3YMuSNTR4LoXcVi88SEWkD2R5iOrcU=
 github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,6 @@ github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZ
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1 h1:V95qyPxj4IE39U+fyXdQXUWFCwqXUfTbIl/Gb+lb3zc=
-github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171 h1:FI3cl6s//o2gq3YMuSNTR4LoXcVi88SEWkD2R5iOrcU=
 github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1 h1:V95qyPxj4IE39U+fyXdQXUWFCwqXUfTbIl/Gb+lb3zc=
 github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
+github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2 h1:OjFUNGOswzMaescbEEB0v7LrNcnsk8OyrmmMU/0fk5w=
+github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,3 @@
-github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
@@ -12,10 +11,10 @@ github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZ
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1 h1:V95qyPxj4IE39U+fyXdQXUWFCwqXUfTbIl/Gb+lb3zc=
-github.com/hashicorp/jsonapi v0.0.0-20210326175023-166ae20eb0d1/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2 h1:OjFUNGOswzMaescbEEB0v7LrNcnsk8OyrmmMU/0fk5w=
 github.com/hashicorp/jsonapi v0.0.0-20210401204629-95d572587ba2/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
+github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171 h1:FI3cl6s//o2gq3YMuSNTR4LoXcVi88SEWkD2R5iOrcU=
+github.com/hashicorp/jsonapi v0.0.0-20210413154710-353a8ffc8171/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/helper_test.go
+++ b/helper_test.go
@@ -909,7 +909,7 @@ func createWorkspace(t *testing.T, client *Client, org *Organization) (*Workspac
 	}
 
 	ctx := context.Background()
-	w, err := client.Workspaces.Create(ctx, org.Name, WorkspaceCreateOptions{
+	w, err := client.Workspaces.Create(ctx, "omar-test", WorkspaceCreateOptions{
 		Name: String(randomString(t)),
 	})
 	if err != nil {
@@ -917,7 +917,7 @@ func createWorkspace(t *testing.T, client *Client, org *Organization) (*Workspac
 	}
 
 	return w, func() {
-		if err := client.Workspaces.Delete(ctx, org.Name, w.Name); err != nil {
+		if err := client.Workspaces.Delete(ctx, "omar-test", w.Name); err != nil {
 			t.Errorf("Error destroying workspace! WARNING: Dangling resources\n"+
 				"may exist! The full error is shown below.\n\n"+
 				"Workspace: %s\nError: %s", w.Name, err)

--- a/helper_test.go
+++ b/helper_test.go
@@ -909,7 +909,7 @@ func createWorkspace(t *testing.T, client *Client, org *Organization) (*Workspac
 	}
 
 	ctx := context.Background()
-	w, err := client.Workspaces.Create(ctx, "omar-test", WorkspaceCreateOptions{
+	w, err := client.Workspaces.Create(ctx, org.Name, WorkspaceCreateOptions{
 		Name: String(randomString(t)),
 	})
 	if err != nil {
@@ -917,7 +917,7 @@ func createWorkspace(t *testing.T, client *Client, org *Organization) (*Workspac
 	}
 
 	return w, func() {
-		if err := client.Workspaces.Delete(ctx, "omar-test", w.Name); err != nil {
+		if err := client.Workspaces.Delete(ctx, org.Name, w.Name); err != nil {
 			t.Errorf("Error destroying workspace! WARNING: Dangling resources\n"+
 				"may exist! The full error is shown below.\n\n"+
 				"Workspace: %s\nError: %s", w.Name, err)

--- a/workspace.go
+++ b/workspace.go
@@ -127,15 +127,10 @@ type Workspace struct {
 	RunsCount            int                   `jsonapi:"attr,workspace-kpis-runs-count"`
 
 	// Relations
-	AgentPool                  *AgentPool                `jsonapi:"relation,agent-pool"`
-	CurrentRun                 *Run                      `jsonapi:"relation,current-run"`
-	Organization               *Organization             `jsonapi:"relation,organization"`
-	RemoteStateConsumerDetails *RemoteStateConsumerLinks `jsonapi:"relation,remote-state-consumers"`
-	SSHKey                     *SSHKey                   `jsonapi:"relation,ssh-key"`
-}
-
-type RemoteStateConsumerLinks struct {
-	Links *jsonapi.Links `jsonapi:"links,omitempty"`
+	AgentPool    *AgentPool    `jsonapi:"relation,agent-pool"`
+	CurrentRun   *Run          `jsonapi:"relation,current-run"`
+	Organization *Organization `jsonapi:"relation,organization"`
+	SSHKey       *SSHKey       `jsonapi:"relation,ssh-key"`
 }
 
 // workspaceWithReadme is the same as a workspace but it has a readme.

--- a/workspace.go
+++ b/workspace.go
@@ -8,8 +8,6 @@ import (
 	"net/url"
 	"strings"
 	"time"
-
-	"github.com/hashicorp/jsonapi"
 )
 
 // Compile-time proof of interface implementation.

--- a/workspace.go
+++ b/workspace.go
@@ -74,7 +74,7 @@ type Workspaces interface {
 	// Remove remote state consumers from a workspace.
 	RemoveRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceRemoveRemoteStateConsumersOptions) error
 
-	// ReadRemoteStateConsumers todo
+	// ReadRemoteStateConsumers reads the remote state consumers for a workspace.
 	ReadRemoteStateConsumers(ctx context.Context, workspaceID string) (*WorkspaceList, error)
 }
 
@@ -825,7 +825,7 @@ func (o WorkspaceAddRemoteStateConsumersOptions) valid() error {
 	return nil
 }
 
-// Add workspaces to a policy set.
+// AddRemoteStateConsumere adds the remote state consumers to a given workspace.
 func (s *workspaces) AddRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceAddRemoteStateConsumersOptions) error {
 	if !validStringID(&workspaceID) {
 		return ErrInvalidWorkspaceID
@@ -860,7 +860,7 @@ func (o WorkspaceRemoveRemoteStateConsumersOptions) valid() error {
 	return nil
 }
 
-// Remove workspaces from a policy set.
+// RemoveRemoteStateConsumers removes the remote state consumers for a given workspace.
 func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceRemoveRemoteStateConsumersOptions) error {
 	if !validStringID(&workspaceID) {
 		return ErrInvalidWorkspaceID
@@ -878,6 +878,7 @@ func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID
 	return s.client.do(ctx, req, nil)
 }
 
+// ReadRemoteStateConsumers returns the remote state consumers for a given workspace.
 func (s *workspaces) ReadRemoteStateConsumers(ctx context.Context, workspaceID string) (*WorkspaceList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID

--- a/workspace.go
+++ b/workspace.go
@@ -750,10 +750,10 @@ type WorkspaceAddRemoteStateConsumersOptions struct {
 
 func (o WorkspaceAddRemoteStateConsumersOptions) valid() error {
 	if o.Workspaces == nil {
-		return errors.New("workspaces is required")
+		return ErrWorkspacesRequired
 	}
 	if len(o.Workspaces) == 0 {
-		return errors.New("must provide at least one workspace")
+		return ErrWorkspaceMinLimit
 	}
 	return nil
 }
@@ -761,7 +761,7 @@ func (o WorkspaceAddRemoteStateConsumersOptions) valid() error {
 // Add workspaces to a policy set.
 func (s *workspaces) AddRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceAddRemoteStateConsumersOptions) error {
 	if !validStringID(&workspaceID) {
-		return errors.New("invalid value for workspace ID")
+		return ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
 		return err
@@ -785,10 +785,10 @@ type WorkspaceRemoveRemoteStateConsumersOptions struct {
 
 func (o WorkspaceRemoveRemoteStateConsumersOptions) valid() error {
 	if o.Workspaces == nil {
-		return errors.New("workspaces is required")
+		return ErrWorkspacesRequired
 	}
 	if len(o.Workspaces) == 0 {
-		return errors.New("must provide at least one workspace")
+		return ErrWorkspaceMinLimit
 	}
 	return nil
 }
@@ -796,7 +796,7 @@ func (o WorkspaceRemoveRemoteStateConsumersOptions) valid() error {
 // Remove workspaces from a policy set.
 func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceRemoveRemoteStateConsumersOptions) error {
 	if !validStringID(&workspaceID) {
-		return errors.New("invalid value for workspace ID")
+		return ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
 		return err

--- a/workspace.go
+++ b/workspace.go
@@ -123,11 +123,11 @@ type Workspace struct {
 	RunsCount            int                   `jsonapi:"attr,workspace-kpis-runs-count"`
 
 	// Relations
-	AgentPool            *AgentPool                `jsonapi:"relation,agent-pool"`
-	CurrentRun           *Run                      `jsonapi:"relation,current-run"`
-	Organization         *Organization             `jsonapi:"relation,organization"`
-	RemoteStateConsumers *RemoteStateConsumerLinks `jsonapi:"relation,remote-state-consumers"`
-	SSHKey               *SSHKey                   `jsonapi:"relation,ssh-key"`
+	AgentPool                  *AgentPool                `jsonapi:"relation,agent-pool"`
+	CurrentRun                 *Run                      `jsonapi:"relation,current-run"`
+	Organization               *Organization             `jsonapi:"relation,organization"`
+	RemoteStateConsumerDetails *RemoteStateConsumerLinks `jsonapi:"relation,remote-state-consumers"`
+	SSHKey                     *SSHKey                   `jsonapi:"relation,ssh-key"`
 }
 
 type RemoteStateConsumerLinks struct {
@@ -883,7 +883,7 @@ func (s *workspaces) ReadRemoteStateConsumers(ctx context.Context, workspaceID s
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", workspaceID)
+	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
 
 	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -820,6 +820,13 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 	defer wTestCleanup()
 
+	// Update workspace to not allow global remote state
+	options := WorkspaceUpdateOptions{
+		GlobalRemoteState: Bool(false),
+	}
+	wTest, err := client.Workspaces.Update(ctx, orgTest.Name, wTest.Name, options)
+	require.NoError(t, err)
+
 	t.Run("successfully adds a remote state consumer", func(t *testing.T) {
 		wTestConsumer1, wTestCleanupConsumer1 := createWorkspace(t, client, orgTest)
 		defer wTestCleanupConsumer1()
@@ -872,6 +879,13 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 	defer wTestCleanup()
+
+	// Update workspace to not allow global remote state
+	options := WorkspaceUpdateOptions{
+		GlobalRemoteState: Bool(false),
+	}
+	wTest, err := client.Workspaces.Update(ctx, orgTest.Name, wTest.Name, options)
+	require.NoError(t, err)
 
 	t.Run("successfully removes a remote state consumer", func(t *testing.T) {
 		wTestConsumer1, wTestCleanupConsumer1 := createWorkspace(t, client, orgTest)

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -837,7 +837,7 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
+		_, err = client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 
 		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
@@ -905,7 +905,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
+		_, err = client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 
 		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -829,7 +829,7 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 
 		w, err := client.Workspaces.Read(ctx, "omar-test", wTest.Name)
 		require.NoError(t, err)
-		links := *w.RemoteStateConsumers.Links
+		links := *w.RemoteStateConsumerDetails.Links
 		related := links["related"]
 		assert.Equal(t, fmt.Sprintf("/api/v2/workspaces/%s/relationships/remote-state-consumers", wTest.ID), related)
 
@@ -893,7 +893,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 
 		w, err := client.Workspaces.Read(ctx, "omar-test", wTest.Name)
 		require.NoError(t, err)
-		links := *w.RemoteStateConsumers.Links
+		links := *w.RemoteStateConsumerDetails.Links
 		related := links["related"]
 		assert.Equal(t, fmt.Sprintf("/api/v2/workspaces/%s/relationships/remote-state-consumers", wTest.ID), related)
 

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -840,9 +840,6 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 
 		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
-		links := *w.RemoteStateConsumerDetails.Links
-		related := links["related"]
-		assert.Equal(t, fmt.Sprintf("/api/v2/workspaces/%s/relationships/remote-state-consumers", wTest.ID), related)
 
 		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
 		require.NoError(t, err)
@@ -911,9 +908,6 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 
 		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
-		links := *w.RemoteStateConsumerDetails.Links
-		related := links["related"]
-		assert.Equal(t, fmt.Sprintf("/api/v2/workspaces/%s/relationships/remote-state-consumers", wTest.ID), related)
 
 		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
 		require.NoError(t, err)

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -844,7 +844,7 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 		related := links["related"]
 		assert.Equal(t, fmt.Sprintf("/api/v2/workspaces/%s/relationships/remote-state-consumers", wTest.ID), related)
 
-		rsc, err := client.Workspaces.ReadRemoteStateConsumers(ctx, wTest.ID)
+		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -898,7 +898,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err := client.Workspaces.ReadRemoteStateConsumers(ctx, wTest.ID)
+		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -915,7 +915,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		related := links["related"]
 		assert.Equal(t, fmt.Sprintf("/api/v2/workspaces/%s/relationships/remote-state-consumers", wTest.ID), related)
 
-		rsc, err = client.Workspaces.ReadRemoteStateConsumers(ctx, wTest.ID)
+		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
 		require.NoError(t, err)
 		assert.Contains(t, rsc.Items, wTestConsumer2)
 		assert.Equal(t, 1, len(rsc.Items))
@@ -925,7 +925,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err = client.Workspaces.ReadRemoteStateConsumers(ctx, wTest.ID)
+		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
 		require.NoError(t, err)
 		assert.Empty(t, len(rsc.Items))
 	})

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"fmt"
 	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
 	"strings"

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -819,25 +819,42 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 	defer wTestCleanup()
 	fmt.Println(wTest.ID)
 
-	//	t.Run("successfully adds a remote state consumer", func(t *testing.T) {
-	//		wTestConsumer1, wTestCleanupConsumer1 := createWorkspace(t, client, orgTest)
-	//		defer wTestCleanupConsumer1()
-	//		wTestConsumer2, wTestCleanupConsumer2 := createWorkspace(t, client, orgTest)
-	//		defer wTestCleanupConsumer2()
-	//
-	//		err := client.Workspaces.AddRemoteStateConsumers(ctx, wTest.ID, WorkspaceAddRemoteStateConsumersOptions{
-	//			Workspaces: []*Workspace{wTestConsumer1, wTestConsumer2},
-	//		})
-	//		require.NoError(t, err)
-	//
-	//		w, err := client.Workspaces.Read(ctx, "omar-test", wTest.Name)
-	//		fmt.Println(w.ID)
-	//		time.Sleep(30 * time.Second)
-	//		require.NoError(t, err)
-	//		fmt.Println(len(w.RemoteStateConsumers))
-	//		//assert.Equal(t, wTest, w)
-	//		assert.Equal(t, 2, len(w.RemoteStateConsumers))
-	//	})
+	t.Run("successfully adds a remote state consumer", func(t *testing.T) {
+		wTestConsumer1, wTestCleanupConsumer1 := createWorkspace(t, client, orgTest)
+		defer wTestCleanupConsumer1()
+		wTestConsumer2, wTestCleanupConsumer2 := createWorkspace(t, client, orgTest)
+		defer wTestCleanupConsumer2()
+
+		w, err := client.Workspaces.Read(ctx, "omar-test", wTest.Name)
+		fmt.Println(w.ID)
+		time.Sleep(1 * time.Second)
+		fmt.Println("OMAR 1")
+		err = client.Workspaces.AddRemoteStateConsumers(ctx, wTest.ID, WorkspaceAddRemoteStateConsumersOptions{
+			Workspaces: []*Workspace{wTestConsumer1, wTestConsumer2},
+		})
+		require.NoError(t, err)
+		time.Sleep(1 * time.Second)
+
+		fmt.Println("OMAR 2")
+		w, err = client.Workspaces.Read(ctx, "omar-test", wTest.Name)
+		fmt.Println(w.ID)
+		require.NoError(t, err)
+		fmt.Println("")
+		fmt.Printf("%+v", w.RemoteStateConsumers)
+
+		fmt.Println("OMAR 3")
+		w, err = client.Workspaces.Read(ctx, "omar-test", wTestConsumer1.Name)
+		fmt.Println(w.ID)
+		require.NoError(t, err)
+		fmt.Println("")
+		fmt.Printf("%+v", w.RemoteStateConsumers)
+
+		fmt.Println("")
+		//fmt.Printf("%+v", w.RemoteStateConsumerLinks)
+
+		//assert.Equal(t, wTest, w)
+		//assert.Equal(t, 2, len(w.RemoteStateConsumers))
+	})
 
 	t.Run("with invalid options", func(t *testing.T) {
 		err := client.Workspaces.AddRemoteStateConsumers(ctx, wTest.ID, WorkspaceAddRemoteStateConsumersOptions{})

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -838,7 +838,7 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		w, err := client.Workspaces.Read(ctx, "omar-test", wTest.Name)
+		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 		links := *w.RemoteStateConsumerDetails.Links
 		related := links["related"]
@@ -909,7 +909,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		w, err := client.Workspaces.Read(ctx, "omar-test", wTest.Name)
+		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 		links := *w.RemoteStateConsumerDetails.Links
 		related := links["related"]


### PR DESCRIPTION
## Description

This PR adds the ability to add/remove remote state consumers of a Workspace.

Added a new boolean field on Workspace `GlobalRemoteState`. Added three methods on Workspace
1. `AddRemoteStateConsumers`
2. `RemoveRemoteStateConsumers`
3. `ReadRemoteStateConsumers`

