### PR TITLE
fix marshalling nested structs in requests

### DIFF
--- a/registry_module.go
+++ b/registry_module.go
@@ -241,9 +241,9 @@ func (o RegistryModuleCreateWithVCSConnectionOptions) valid() error {
 }
 
 type RegistryModuleVCSRepoOptions struct {
-	Identifier        *string `jsonapi:"attr,identifier"`
-	OAuthTokenID      *string `jsonapi:"attr,oauth-token-id"`
-	DisplayIdentifier *string `jsonapi:"attr,display-identifier"`
+	Identifier        *string `json:"identifier"`
+	OAuthTokenID      *string `json:"oauth-token-id"`
+	DisplayIdentifier *string `json:"display-identifier"`
 }
 
 func (o RegistryModuleVCSRepoOptions) valid() error {

--- a/registry_module_test.go
+++ b/registry_module_test.go
@@ -607,7 +607,7 @@ func TestRegistryCreateOptions_Marshal(t *testing.T) {
 	bodyBytes, err := req.BodyBytes()
 	require.NoError(t, err)
 
-	expectedBody := `{"data":{"type":"registry-modules","attributes":{"vcs-repo":{"Identifier":"id","OAuthTokenID":"token","DisplayIdentifier":"display-id"}}}}
+	expectedBody := `{"data":{"type":"registry-modules","attributes":{"vcs-repo":{"identifier":"id","oauth-token-id":"token","display-identifier":"display-id"}}}}
 `
 	assert.Equal(t, expectedBody, string(bodyBytes))
 }

--- a/workspace.go
+++ b/workspace.go
@@ -271,10 +271,10 @@ type WorkspaceCreateOptions struct {
 // TODO: move this struct out. VCSRepoOptions is used by workspaces, policy sets, and registry modules
 // VCSRepoOptions represents the configuration options of a VCS integration.
 type VCSRepoOptions struct {
-	Branch            *string `jsonapi:"attr,branch,omitempty"`
-	Identifier        *string `jsonapi:"attr,identifier,omitempty"`
-	IngressSubmodules *bool   `jsonapi:"attr,ingress-submodules,omitempty"`
-	OAuthTokenID      *string `jsonapi:"attr,oauth-token-id,omitempty"`
+	Branch            *string `json:"branch,omitempty"`
+	Identifier        *string `json:"identifier,omitempty"`
+	IngressSubmodules *bool   `json:"ingress-submodules,omitempty"`
+	OAuthTokenID      *string `json:"oauth-token-id,omitempty"`
 }
 
 func (o WorkspaceCreateOptions) valid() error {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -1,10 +1,14 @@
 package tfe
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -803,4 +807,87 @@ func TestWorkspacesUnassignSSHKey(t *testing.T) {
 		assert.Nil(t, w)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})
+}
+
+func TestWorkspace_Unmarshal(t *testing.T) {
+	data := map[string]interface{}{
+		"data": map[string]interface{}{
+			"type": "workspaces",
+			"id":   "ws-1234",
+			"attributes": map[string]interface{}{
+				"name":           "my-workspace",
+				"auto-apply":     true,
+				"created-at":     "2020-07-15T23:38:43.821Z",
+				"resource-count": 2,
+				"permissions": map[string]interface{}{
+					"can-update": true,
+					"can-lock":   true,
+				},
+				"vcs-repo": map[string]interface{}{
+					"branch":              "main",
+					"display-identifier":  "repo-name",
+					"identifier":          "hashicorp/repo-name",
+					"ingress-submodules":  true,
+					"oauth-token-id":      "token",
+					"repository-http-url": "github.com",
+					"service-provider":    "github",
+				},
+				"actions": map[string]interface{}{
+					"is-destroyable": true,
+				},
+				"trigger-prefixes": []string{"prefix-"},
+			},
+		},
+	}
+
+	byteData, err := json.Marshal(data)
+	require.NoError(t, err)
+
+	responseBody := bytes.NewReader(byteData)
+	ws := &Workspace{}
+	err = unmarshalResponse(responseBody, ws)
+	require.NoError(t, err)
+
+	iso8601TimeFormat := "2006-01-02T15:04:05Z"
+	parsedTime, err := time.Parse(iso8601TimeFormat, "2020-07-15T23:38:43.821Z")
+
+	assert.Equal(t, ws.ID, "ws-1234")
+	assert.Equal(t, ws.Name, "my-workspace")
+	assert.Equal(t, ws.AutoApply, true)
+	assert.Equal(t, ws.CreatedAt, parsedTime)
+	assert.Equal(t, ws.ResourceCount, 2)
+	assert.Equal(t, ws.Permissions.CanUpdate, true)
+	assert.Equal(t, ws.Permissions.CanLock, true)
+	assert.Equal(t, ws.VCSRepo.Branch, "main")
+	assert.Equal(t, ws.VCSRepo.DisplayIdentifier, "repo-name")
+	assert.Equal(t, ws.VCSRepo.Identifier, "hashicorp/repo-name")
+	assert.Equal(t, ws.VCSRepo.IngressSubmodules, true)
+	assert.Equal(t, ws.VCSRepo.OAuthTokenID, "token")
+	assert.Equal(t, ws.VCSRepo.RepositoryHTTPURL, "github.com")
+	assert.Equal(t, ws.VCSRepo.ServiceProvider, "github")
+	assert.Equal(t, ws.Actions.IsDestroyable, true)
+	assert.Equal(t, ws.TriggerPrefixes, []string{"prefix-"})
+}
+
+func TestWorkspaceCreateOptions_Marshal(t *testing.T) {
+	opts := WorkspaceCreateOptions{
+		AllowDestroyPlan: Bool(true),
+		Name:             String("my-workspace"),
+		TriggerPrefixes:  []string{"prefix-"},
+		VCSRepo: &VCSRepoOptions{
+			Identifier:   String("id"),
+			OAuthTokenID: String("token"),
+		},
+	}
+
+	reqBody, err := serializeRequestBody(&opts)
+	require.NoError(t, err)
+	req, err := retryablehttp.NewRequest("POST", "url", reqBody)
+	require.NoError(t, err)
+	bodyBytes, err := req.BodyBytes()
+	require.NoError(t, err)
+
+	expectedBody := `{"data":{"type":"workspaces","attributes":{"allow-destroy-plan":true,"name":"my-workspace","trigger-prefixes":["prefix-"],"vcs-repo":{"identifier":"id","oauth-token-id":"token"}}}}
+`
+	assert.Equal(t, expectedBody, string(bodyBytes))
 }


### PR DESCRIPTION
## Description

The jsonapi library doesn't marshal model attributes that are structs properly if they use the jsonapi attr struct tag, but only when marshalling requests; when unmarshalling the response, `attr` tags work just fine. In other words, [`WorkspacePermissions`](https://github.com/hashicorp/go-tfe/blob/4f141e7aaf7fa5d9ad8353125e2eab5f6ddd1876/workspace.go#L149-L160) are working fine since they're included in the response, but aren't something that's set in the request; [`VCSRepoOptions`](https://github.com/hashicorp/go-tfe/blob/4f141e7aaf7fa5d9ad8353125e2eab5f6ddd1876/workspace.go#L273-L278) are options for the request itself, so they're not working.

## Testing plan

1. Using a nested struct in create or update options marshalls to real JSON.

## External links

#202 
