### PR TITLE
Add Admin General Settings attr default-remote-state-access

### DIFF
--- a/admin_setting_general.go
+++ b/admin_setting_general.go
@@ -36,6 +36,7 @@ type AdminGeneralSetting struct {
 	DefaultWorkspacesPerOrgCeiling   int    `jsonapi:"attr,default-workspaces-per-organization-ceiling"`
 	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
 	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
+	DefaultRemoteStateAccess         bool   `jsonapi:"attr,default-remote-state-access"`
 }
 
 // Read returns the general settings.
@@ -63,6 +64,7 @@ type AdminGeneralSettingsUpdateOptions struct {
 	APIRateLimit                      *int  `jsonapi:"attr,api-rate-limit,omitempty"`
 	SendPassingStatusUntriggeredPlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 	AllowSpeculativePlansOnPR         *bool `jsonapi:"attr,allow-speculative-plans-on-pull-requests-from-forks,omitempty"`
+	DefaultRemoteStateAccess          *bool `jsonapi:"attr,default-remote-state-access,omitempty"`
 }
 
 // Update updates the general settings.

--- a/admin_setting_general_test.go
+++ b/admin_setting_general_test.go
@@ -31,6 +31,7 @@ func TestAdminSettings_General_Read(t *testing.T) {
 	assert.NotNil(t, generalSettings.DefaultWorkspacesPerOrgCeiling)
 	assert.NotNil(t, generalSettings.TerraformBuildWorkerApplyTimeout)
 	assert.NotNil(t, generalSettings.TerraformBuildWorkerPlanTimeout)
+	assert.NotNil(t, generalSettings.DefaultRemoteStateAccess)
 }
 
 func TestAdminSettings_General_Update(t *testing.T) {
@@ -45,29 +46,35 @@ func TestAdminSettings_General_Update(t *testing.T) {
 	origLimitOrgCreation := generalSettings.LimitUserOrganizationCreation
 	origAPIRateLimitEnabled := generalSettings.APIRateLimitingEnabled
 	origAPIRateLimit := generalSettings.APIRateLimit
+	origDefaultRemoteState := generalSettings.DefaultRemoteStateAccess
 
 	limitOrgCreation := true
 	apiRateLimitEnabled := true
 	apiRateLimit := 50
+	defaultRemoteStateAccess := false
 
 	generalSettings, err = client.Admin.Settings.General.Update(ctx, AdminGeneralSettingsUpdateOptions{
-		LimitUserOrgCreation:   Bool(limitOrgCreation),
-		APIRateLimitingEnabled: Bool(apiRateLimitEnabled),
-		APIRateLimit:           Int(apiRateLimit),
+		LimitUserOrgCreation:     Bool(limitOrgCreation),
+		APIRateLimitingEnabled:   Bool(apiRateLimitEnabled),
+		APIRateLimit:             Int(apiRateLimit),
+		DefaultRemoteStateAccess: Bool(defaultRemoteStateAccess),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, limitOrgCreation, generalSettings.LimitUserOrganizationCreation)
 	assert.Equal(t, apiRateLimitEnabled, generalSettings.APIRateLimitingEnabled)
 	assert.Equal(t, apiRateLimit, generalSettings.APIRateLimit)
+	assert.Equal(t, defaultRemoteStateAccess, generalSettings.DefaultRemoteStateAccess)
 
 	// Undo Updates, revert back to original
 	generalSettings, err = client.Admin.Settings.General.Update(ctx, AdminGeneralSettingsUpdateOptions{
-		LimitUserOrgCreation:   Bool(origLimitOrgCreation),
-		APIRateLimitingEnabled: Bool(origAPIRateLimitEnabled),
-		APIRateLimit:           Int(origAPIRateLimit),
+		LimitUserOrgCreation:     Bool(origLimitOrgCreation),
+		APIRateLimitingEnabled:   Bool(origAPIRateLimitEnabled),
+		APIRateLimit:             Int(origAPIRateLimit),
+		DefaultRemoteStateAccess: Bool(origDefaultRemoteState),
 	})
 	require.NoError(t, err)
 	assert.Equal(t, origLimitOrgCreation, generalSettings.LimitUserOrganizationCreation)
 	assert.Equal(t, origAPIRateLimitEnabled, generalSettings.APIRateLimitingEnabled)
 	assert.Equal(t, origAPIRateLimit, generalSettings.APIRateLimit)
+	assert.Equal(t, origDefaultRemoteState, generalSettings.DefaultRemoteStateAccess)
 }


### PR DESCRIPTION
## Description

This PR adds the attribute to the Admin General Settings for `default-remote-state-access`. 

[See API Docs](https://github.com/hashicorp/terraform-website/pull/1672)


_Note: this was previously [opened/merged](https://github.com/hashicorp/go-tfe/pull/200) then [reverted](https://github.com/hashicorp/go-tfe/pull/203). Will merge at a later day._