### PR TITLE
Url Encode the workspace ID when listing variables

### DIFF
--- a/variable.go
+++ b/variable.go
@@ -77,7 +77,7 @@ func (s *variables) List(ctx context.Context, workspaceID string, options Variab
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/vars", workspaceID)
+	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
 	req, err := s.client.newRequest("GET", u, &options)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix for #206
Use the same method for url encoded as the other functions

## Description

This is to fix the List function for variables, which fails to find workspaces unless they have been url encoded

## Testing plan

1.  _Describe how to replicate_
1.  _the conditions_
1.  _under which your code performs its purpose,_
1.  _including example code to run where necessary._

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

## Output from tests

_Please run the tests locally for any files you changes and include the output here._

```
$ go test

...
```
