### PR TITLE
Fix enforce marshalling

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -260,7 +260,7 @@ func createPolicy(t *testing.T, client *Client, org *Organization) (*Policy, fun
 	name := randomString(t)
 	options := PolicyCreateOptions{
 		Name: String(name),
-		Enforce: []*EnforcementOptions{
+		Enforce: []EnforcementOptions{
 			{
 				Path: String(name + ".sentinel"),
 				Mode: EnforcementMode(EnforcementSoft),

--- a/policy.go
+++ b/policy.go
@@ -123,13 +123,13 @@ type PolicyCreateOptions struct {
 	Description *string `jsonapi:"attr,description,omitempty"`
 
 	// The enforcements of the policy.
-	Enforce []*EnforcementOptions `jsonapi:"attr,enforce"`
+	Enforce []EnforcementOptions `jsonapi:"attr,enforce"`
 }
 
 // EnforcementOptions represents the enforcement options of a policy.
 type EnforcementOptions struct {
-	Path *string           `jsonapi:"attr,path,omitempty"`
-	Mode *EnforcementLevel `jsonapi:"attr,mode"`
+	Path *string           `json:"path,omitempty"`
+	Mode *EnforcementLevel `json:"mode"`
 }
 
 func (o PolicyCreateOptions) valid() error {
@@ -210,7 +210,7 @@ type PolicyUpdateOptions struct {
 	Description *string `jsonapi:"attr,description,omitempty"`
 
 	// The enforcements of the policy.
-	Enforce []*EnforcementOptions `jsonapi:"attr,enforce,omitempty"`
+	Enforce []EnforcementOptions `jsonapi:"attr,enforce,omitempty"`
 }
 
 // Update an existing policy.

--- a/policy_check_test.go
+++ b/policy_check_test.go
@@ -19,12 +19,16 @@ func TestPolicyChecksList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	pTest1, _ := createUploadedPolicy(t, client, true, orgTest)
-	pTest2, _ := createUploadedPolicy(t, client, true, orgTest)
-	wTest, _ := createWorkspace(t, client, orgTest)
+	pTest1, policyCleanup1 := createUploadedPolicy(t, client, true, orgTest)
+	defer policyCleanup1()
+	pTest2, policyCleanup2 := createUploadedPolicy(t, client, true, orgTest)
+	defer policyCleanup2()
+	wTest, wsCleanup := createWorkspace(t, client, orgTest)
+	defer wsCleanup()
 	createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, []*Workspace{wTest})
 
-	rTest, _ := createPlannedRun(t, client, wTest)
+	rTest, runCleanup := createPlannedRun(t, client, wTest)
+	defer runCleanup()
 
 	t.Run("without list options", func(t *testing.T) {
 		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})


### PR DESCRIPTION
## Description

A previous PR #197 sought to use `jsonapi` for all marshalling and unmarshalling of Resources. This went mostly well, but had a few breaking changes. It was discovered that some structs were not properly being marshaled. Those were fixed in #204 . 

This PR changes a few the tag for `EnforcementOptions` that was altered in #197 back to using `json` tag. This is an interim step until the [hashicorp/jsonapi](https://github.com/hashicorp/jsonapi/) package has the capability to handle nested structs. 

It also alters the `Enforce` attribute to not use a slice of pointers because that is incompatabile with [hashicorp/jsonapi](https://github.com/hashicorp/jsonapi/), and just uses a slice of structs (which works with the jsonapi package). 


## Output from tests

```
$ go test -v -run TestPolicyCreateOptions_Marshal
=== RUN   TestPolicyCreateOptions_Marshal
--- PASS: TestPolicyCreateOptions_Marshal (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     0.139s
$ go test -v -run TestPolicyUpdateOptions_Marshal
=== RUN   TestPolicyUpdateOptions_Marshal
--- PASS: TestPolicyUpdateOptions_Marshal (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     0.137s
```

todo: print output from full test suite