### PR TITLE
Expose NewRequest() and Do()

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -434,13 +434,17 @@ func (c *Client) configureLimiter(rawLimit string) {
 	c.limiter = rate.NewLimiter(limit, burst)
 }
 
-// newRequest creates an API request. A relative URL path can be provided in
+// NewRequest creates an API request. A relative URL path can be provided in
 // path, in which case it is resolved relative to the apiVersionPath of the
 // Client. Relative URL paths should always be specified without a preceding
 // slash.
 // If v is supplied, the value will be JSONAPI encoded and included as the
 // request body. If the method is GET, the value will be parsed and added as
 // query parameters.
+func (c *Client) NewRequest(method, path string, v interface{}) (*retryablehttp.Request, error) {
+	return c.newRequest(method, path, v)
+}
+
 func (c *Client) newRequest(method, path string, v interface{}) (*retryablehttp.Request, error) {
 	u, err := c.baseURL.Parse(path)
 	if err != nil {

--- a/tfe.go
+++ b/tfe.go
@@ -559,7 +559,7 @@ func serializeRequestBody(v interface{}) (interface{}, error) {
 	}
 }
 
-// do sends an API request and returns the API response. The API response
+// Do sends an API request and returns the API response. The API response
 // is JSONAPI decoded and the document's primary data is stored in the value
 // pointed to by v, or returned as an error if an API error has occurred.
 
@@ -568,6 +568,11 @@ func serializeRequestBody(v interface{}) (interface{}, error) {
 //
 // The provided ctx must be non-nil. If it is canceled or times out, ctx.Err()
 // will be returned.
+
+func (c *Client) Do(ctx context.Context, req *retryablehttp.Request, v interface{}) error {
+	return c.do(ctx, req, v)
+}
+
 func (c *Client) do(ctx context.Context, req *retryablehttp.Request, v interface{}) error {
 	// Wait will block until the limiter can obtain a new token
 	// or returns an error if the given context is canceled.


### PR DESCRIPTION
## Description

This addition exposes `NewRequest()` and `Do()` so that users of this client may make a request using the underlying configuration of the client, which includes everything from parsing the path, adding headers, serializing the request, etc. This is helpful when working with newer endpoints and avoids the need to reimplement some of the functionality within `newRequest()`, `do()`