### PR TITLE
fix flaky run-status-related tests

### DIFF
--- a/policy_check_test.go
+++ b/policy_check_test.go
@@ -29,7 +29,7 @@ func TestPolicyChecksList(t *testing.T) {
 	defer wsCleanup()
 	createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, []*Workspace{wTest})
 
-	rTest, runCleanup := createPlannedRun(t, client, wTest)
+	rTest, runCleanup := createPolicyCheckedRun(t, client, wTest)
 	defer runCleanup()
 
 	t.Run("without list options", func(t *testing.T) {
@@ -81,7 +81,7 @@ func TestPolicyChecksRead(t *testing.T) {
 	wTest, _ := createWorkspace(t, client, orgTest)
 	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
 
-	rTest, _ := createPlannedRun(t, client, wTest)
+	rTest, _ := createPolicyCheckedRun(t, client, wTest)
 	require.Equal(t, 1, len(rTest.PolicyChecks))
 
 	t.Run("when the policy check exists", func(t *testing.T) {
@@ -126,7 +126,7 @@ func TestPolicyChecksOverride(t *testing.T) {
 		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 		defer wTestCleanup()
 		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
-		rTest, tTestCleanup := createPlannedRun(t, client, wTest)
+		rTest, tTestCleanup := createPolicyCheckedRun(t, client, wTest)
 		defer tTestCleanup()
 
 		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
@@ -151,7 +151,7 @@ func TestPolicyChecksOverride(t *testing.T) {
 		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 		defer wTestCleanup()
 		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
-		rTest, rTestCleanup := createPlannedRun(t, client, wTest)
+		rTest, rTestCleanup := createPolicyCheckedRun(t, client, wTest)
 		defer rTestCleanup()
 
 		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
@@ -185,7 +185,7 @@ func TestPolicyChecksLogs(t *testing.T) {
 	defer wTestCleanup()
 	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest})
 
-	rTest, rTestCleanup := createPlannedRun(t, client, wTest)
+	rTest, rTestCleanup := createPolicyCheckedRun(t, client, wTest)
 	defer rTestCleanup()
 	require.Equal(t, 1, len(rTest.PolicyChecks))
 


### PR DESCRIPTION
## Description

Currently, we're seeing pretty frequent test flakes with errors about [mismatched policy check output
](https://app.circleci.com/pipelines/github/hashicorp/go-tfe/498/workflows/7d6dc2c8-85d5-4cf1-9894-2b8f5c05d3a4/jobs/641/tests#failed-test-1) or [`transition not allowed`](https://app.circleci.com/pipelines/github/hashicorp/go-tfe/497/workflows/1fed2a81-978e-4912-bcca-1a1792f49c6f/jobs/634/tests#failed-test-0).

It seems likely that both of these errors have the same root cause: we've been overloading the `createPlannedRun` helper so that it looks for runs with planned, cost-estimated, **or** policy-checked statuses, instead of just the planned status.

This leaves us open to race conditions when, say, the `createPlannedRun` helper returns an actual planned run, but the test is really expecting a cost-estimated or policy-checked run, and so it fails. In the case of the `transition not allowed` errors, the error comes from attempting to discard a run that's isn't discardable (yet).

This change adds a `createRunWithStatus` helper to make it easy to be very specific about which statuses to accept when creating test runs.

## Testing plan

1. The tests pass, and do so consistently.
