### PR TITLE
add refresh and replace attributes for runs

### DIFF
--- a/run.go
+++ b/run.go
@@ -95,7 +95,7 @@ type Run struct {
 	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
 	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
-	IsRefresh              bool                 `jsonapi:"attr,is-refresh"`
+	Refresh                bool                 `jsonapi:"attr,refresh"`
 	Message                string               `jsonapi:"attr,message"`
 	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
 	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
@@ -187,9 +187,9 @@ type RunCreateOptions struct {
 	// provisioned resources.
 	IsDestroy *bool `jsonapi:"attr,is-destroy,omitempty"`
 
-	// IsRefresh determines if the run should
+	// Refresh determines if the run should
 	// update the state prior to checking for differences
-	IsRefresh *bool `jsonapi:"attr,is-refresh,omitempty"`
+	Refresh *bool `jsonapi:"attr,refresh,omitempty"`
 
 	// Specifies the message to be associated with this run.
 	Message *string `jsonapi:"attr,message,omitempty"`

--- a/run.go
+++ b/run.go
@@ -96,6 +96,7 @@ type Run struct {
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
 	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
 	Refresh                bool                 `jsonapi:"attr,refresh"`
+	RefreshOnly            bool                 `jsonapi:"attr,refresh-only"`
 	Message                string               `jsonapi:"attr,message"`
 	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
 	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
@@ -190,6 +191,10 @@ type RunCreateOptions struct {
 	// Refresh determines if the run should
 	// update the state prior to checking for differences
 	Refresh *bool `jsonapi:"attr,refresh,omitempty"`
+
+	// RefreshOnly determines if the run should ignore config changes
+	// and refresh the state only
+	RefreshOnly *bool `jsonapi:"attr,refresh-only,omitempty"`
 
 	// Specifies the message to be associated with this run.
 	Message *string `jsonapi:"attr,message,omitempty"`

--- a/run.go
+++ b/run.go
@@ -193,7 +193,7 @@ type RunCreateOptions struct {
 	// update the state prior to checking for differences
 	Refresh *bool `jsonapi:"attr,refresh,omitempty"`
 
-	// RefreshOnly determines if the run should ignore config changes
+	// RefreshOnly determines whether the run should ignore config changes
 	// and refresh the state only
 	RefreshOnly *bool `jsonapi:"attr,refresh-only,omitempty"`
 
@@ -221,7 +221,7 @@ type RunCreateOptions struct {
 	// this whenever this property is set.
 	TargetAddrs []string `jsonapi:"attr,target-addrs,omitempty"`
 
-	// If non-empty, requests Terraform to create a plan that replaces
+	// If non-empty, requests that Terraform create a plan that replaces
 	// (destroys and then re-creates) the objects specified by the given
 	// resource addresses.
 	ReplaceAddrs []string `jsonapi:"attr,replace-addrs,omitempty"`

--- a/run.go
+++ b/run.go
@@ -95,11 +95,12 @@ type Run struct {
 	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
 	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
-	Refresh                bool                 `jsonapi:"attr,refresh"`
-	RefreshOnly            bool                 `jsonapi:"attr,refresh-only"`
 	Message                string               `jsonapi:"attr,message"`
 	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
 	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
+	Refresh                bool                 `jsonapi:"attr,refresh"`
+	RefreshOnly            bool                 `jsonapi:"attr,refresh-only"`
+	ReplaceAddrs           []string             `jsonapi:"attr,replace-addrs,omitempty"`
 	Source                 RunSource            `jsonapi:"attr,source"`
 	Status                 RunStatus            `jsonapi:"attr,status"`
 	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
@@ -219,6 +220,11 @@ type RunCreateOptions struct {
 	// of routine workflow and Terraform will emit warnings reminding about
 	// this whenever this property is set.
 	TargetAddrs []string `jsonapi:"attr,target-addrs,omitempty"`
+
+	// If non-empty, requests Terraform to create a plan that replaces
+	// (destroys and then re-creates) the objects specified by the given
+	// resource addresses.
+	ReplaceAddrs []string `jsonapi:"attr,replace-addrs,omitempty"`
 }
 
 func (o RunCreateOptions) valid() error {

--- a/run.go
+++ b/run.go
@@ -95,6 +95,7 @@ type Run struct {
 	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
 	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
+	IsRefresh              bool                 `jsonapi:"attr,is-refresh"`
 	Message                string               `jsonapi:"attr,message"`
 	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
 	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
@@ -185,6 +186,10 @@ type RunCreateOptions struct {
 	// Specifies if this plan is a destroy plan, which will destroy all
 	// provisioned resources.
 	IsDestroy *bool `jsonapi:"attr,is-destroy,omitempty"`
+
+	// IsRefresh determines if the run should
+	// update the state prior to checking for differences
+	IsRefresh *bool `jsonapi:"attr,is-refresh,omitempty"`
 
 	// Specifies the message to be associated with this run.
 	Message *string `jsonapi:"attr,message,omitempty"`

--- a/run_test.go
+++ b/run_test.go
@@ -112,17 +112,6 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, cvTest.ID, r.ConfigurationVersion.ID)
 	})
 
-	t.Run("with refresh disabled", func(t *testing.T) {
-		options := RunCreateOptions{
-			Workspace: wTest,
-			Refresh:   Bool(false),
-		}
-
-		r, err := client.Runs.Create(ctx, options)
-		require.NoError(t, err)
-		assert.Equal(t, false, r.Refresh)
-	})
-
 	t.Run("with refresh not set", func(t *testing.T) {
 		options := RunCreateOptions{
 			Workspace: wTest,
@@ -133,7 +122,7 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, true, r.Refresh)
 	})
 
-	t.Run("with refresh-only set", func(t *testing.T) {
+	t.Run("with refresh-only requested", func(t *testing.T) {
 		options := RunCreateOptions{
 			Workspace:   wTest,
 			RefreshOnly: Bool(true),
@@ -152,14 +141,18 @@ func TestRunsCreate(t *testing.T) {
 
 	t.Run("with additional attributes", func(t *testing.T) {
 		options := RunCreateOptions{
-			Message:     String("yo"),
-			Workspace:   wTest,
-			TargetAddrs: []string{"null_resource.example"},
+			Message:      String("yo"),
+			Workspace:    wTest,
+			Refresh:      Bool(false),
+			ReplaceAddrs: []string{"null_resource.example"},
+			TargetAddrs:  []string{"null_resource.example"},
 		}
 
 		r, err := client.Runs.Create(ctx, options)
 		require.NoError(t, err)
 		assert.Equal(t, *options.Message, r.Message)
+		assert.Equal(t, *options.Refresh, r.Refresh)
+		assert.Equal(t, options.ReplaceAddrs, r.ReplaceAddrs)
 		assert.Equal(t, options.TargetAddrs, r.TargetAddrs)
 	})
 }

--- a/run_test.go
+++ b/run_test.go
@@ -112,6 +112,17 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, cvTest.ID, r.ConfigurationVersion.ID)
 	})
 
+	t.Run("with refresh enabled", func(t *testing.T) {
+		options := RunCreateOptions{
+			Workspace: wTest,
+			IsRefresh: Bool(true),
+		}
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, true, r.IsRefresh)
+	})
+
 	t.Run("without a workspace", func(t *testing.T) {
 		r, err := client.Runs.Create(ctx, RunCreateOptions{})
 		assert.Nil(t, r)

--- a/run_test.go
+++ b/run_test.go
@@ -123,6 +123,9 @@ func TestRunsCreate(t *testing.T) {
 	})
 
 	t.Run("with refresh-only requested", func(t *testing.T) {
+		// TODO: remove this skip after the release of Terraform 0.15.4
+		t.Skip("Skipping this test until -refresh-only is released in the Terraform CLI")
+
 		options := RunCreateOptions{
 			Workspace:   wTest,
 			RefreshOnly: Bool(true),

--- a/run_test.go
+++ b/run_test.go
@@ -115,12 +115,12 @@ func TestRunsCreate(t *testing.T) {
 	t.Run("with refresh enabled", func(t *testing.T) {
 		options := RunCreateOptions{
 			Workspace: wTest,
-			IsRefresh: Bool(true),
+			Refresh:   Bool(true),
 		}
 
 		r, err := client.Runs.Create(ctx, options)
 		require.NoError(t, err)
-		assert.Equal(t, true, r.IsRefresh)
+		assert.Equal(t, true, r.Refresh)
 	})
 
 	t.Run("without a workspace", func(t *testing.T) {

--- a/run_test.go
+++ b/run_test.go
@@ -112,15 +112,36 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, cvTest.ID, r.ConfigurationVersion.ID)
 	})
 
-	t.Run("with refresh enabled", func(t *testing.T) {
+	t.Run("with refresh disabled", func(t *testing.T) {
 		options := RunCreateOptions{
 			Workspace: wTest,
-			Refresh:   Bool(true),
+			Refresh:   Bool(false),
+		}
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, false, r.Refresh)
+	})
+
+	t.Run("with refresh not set", func(t *testing.T) {
+		options := RunCreateOptions{
+			Workspace: wTest,
 		}
 
 		r, err := client.Runs.Create(ctx, options)
 		require.NoError(t, err)
 		assert.Equal(t, true, r.Refresh)
+	})
+
+	t.Run("with refresh-only set", func(t *testing.T) {
+		options := RunCreateOptions{
+			Workspace:   wTest,
+			RefreshOnly: Bool(true),
+		}
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, true, r.RefreshOnly)
 	})
 
 	t.Run("without a workspace", func(t *testing.T) {

--- a/run_test.go
+++ b/run_test.go
@@ -112,7 +112,7 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, cvTest.ID, r.ConfigurationVersion.ID)
 	})
 
-	t.Run("with refresh not set", func(t *testing.T) {
+	t.Run("refresh defaults to true if not set as a create option", func(t *testing.T) {
 		options := RunCreateOptions{
 			Workspace: wTest,
 		}


### PR DESCRIPTION
## Description

Add support for the following run options:

- [`Run.Refresh`](https://www.terraform.io/docs/cli/commands/plan.html#refresh-false): allow specifying whether or not state should be refreshed prior to a plan
- [`Run.ReplaceAddrs`](https://www.terraform.io/docs/cli/commands/plan.html#replace-address): allow specifying resource addresses to be forcibly replaced during the apply
- `Run.RefreshOnly`: allow specifying whether the run should ignore configuration changes and only refresh the state
