### PR TITLE
Fix IPRanges client baseURL munging

### DIFF
--- a/ip_ranges.go
+++ b/ip_ranges.go
@@ -38,8 +38,7 @@ type IPRange struct {
 }
 
 func (i *ipRanges) Read(ctx context.Context, modifiedSince string) (*IPRange, error) {
-	i.client.baseURL.Path = "/api/"
-	req, err := i.client.newRequest("GET", "meta/ip-ranges", nil)
+	req, err := i.client.newRequest("GET", "/api/meta/ip-ranges", nil)
 	if err != nil {
 		return nil, err
 	}

--- a/tfe.go
+++ b/tfe.go
@@ -434,10 +434,12 @@ func (c *Client) configureLimiter(rawLimit string) {
 	c.limiter = rate.NewLimiter(limit, burst)
 }
 
-// newRequest creates an API request. A relative URL path can be provided in
-// path, in which case it is resolved relative to the apiVersionPath of the
-// Client. Relative URL paths should always be specified without a preceding
-// slash.
+// newRequest creates an API request with proper headers and serialization.
+//
+// A relative URL path can be provided, in which case it is resolved relative to the baseURL
+// of the Client. Relative URL paths should always be specified without a preceding slash. Adding a
+// preceding slash allows for ignoring the configured baseURL for non-standard endpoints.
+//
 // If v is supplied, the value will be JSONAPI encoded and included as the
 // request body. If the method is GET, the value will be parsed and added as
 // query parameters.


### PR DESCRIPTION
## Description

The IP Ranges API is not at /api/v2/. This function was changing the client singleton such that any time this function is called, all other calls will break as the baseURL is now incorrect. An absolute path can be provided here instead.

This bug was found downstream, here: https://github.com/hashicorp/terraform-provider-tfe/issues/315