### PR TITLE
Unmarshal link members; Add Upload() for registry module version slugs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/hashicorp/go-retryablehttp v0.5.2
 	github.com/hashicorp/go-slug v0.4.1
 	github.com/hashicorp/go-uuid v1.0.1
-	github.com/hashicorp/jsonapi v0.0.0-20210420151930-edf82c9774bf
+	github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3
 	github.com/stretchr/testify v1.3.0
 	golang.org/x/time v0.0.0-20190308202827-9d24e82272b4
 )

--- a/go.sum
+++ b/go.sum
@@ -11,8 +11,8 @@ github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZ
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/jsonapi v0.0.0-20210420151930-edf82c9774bf h1:EsVVE/vPelkJ83dk/Y3CeMbH/yPR2S8bLzMtxUoMFGI=
-github.com/hashicorp/jsonapi v0.0.0-20210420151930-edf82c9774bf/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
+github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3 h1:mzwkutymYIXR5oQT9YnfbLuuw7LZmksiHKRPUTN5ijo=
+github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=


### PR DESCRIPTION
## Description

With https://github.com/hashicorp/jsonapi/pull/10, we're now able to do something often-requested for this client: Fetch upload URLs for policy sets and registry modules (which differ from configuration versions in that they provide upload links in [the `links` member of a response](https://jsonapi.org/format/#document-links), not a standard attribute).

Here I've included registry module uploads; policy set versions can be handled separately.

Closes #159 

## Output from tests

```
» go test -v ./... -timeout=30m -run TestRegistryModulesUpload
=== RUN   TestRegistryModulesUpload
=== RUN   TestRegistryModulesUpload/with_valid_upload_URL
=== RUN   TestRegistryModulesUpload/with_missing_upload_URL
--- PASS: TestRegistryModulesUpload (1.84s)
    --- PASS: TestRegistryModulesUpload/with_valid_upload_URL (0.11s)
    --- PASS: TestRegistryModulesUpload/with_missing_upload_URL (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     2.634s
...
```
