### PR TITLE
eliminate some more test flakiness

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -538,7 +538,11 @@ func createRunWithStatus(t *testing.T, client *Client, w *Workspace, timeout int
 }
 
 func createPlannedRun(t *testing.T, client *Client, w *Workspace) (*Run, func()) {
-	return createRunWithStatus(t, client, w, 45, plannedRunStatus())
+	if paidFeaturesDisabled() {
+		return createRunWithStatus(t, client, w, 45, RunPlanned)
+	} else {
+		return createRunWithStatus(t, client, w, 45, RunCostEstimated)
+	}
 }
 
 func createCostEstimatedRun(t *testing.T, client *Client, w *Workspace) (*Run, func()) {
@@ -553,19 +557,13 @@ func createAppliedRun(t *testing.T, client *Client, w *Workspace) (*Run, func())
 	return createRunWithStatus(t, client, w, 90, RunApplied)
 }
 
-func plannedRunStatus() RunStatus {
-	if paidFeaturesDisabled() {
-		return RunPlanned
-	} else {
-		return RunCostEstimated
-	}
-}
-
 func hasApplyableStatus(r *Run) bool {
 	if len(r.PolicyChecks) > 0 {
 		return r.Status == RunPolicyChecked || r.Status == RunPolicyOverride
+	} else if r.CostEstimate != nil {
+		return r.Status == RunCostEstimated
 	} else {
-		return r.Status == plannedRunStatus()
+		return r.Status == RunPlanned
 	}
 }
 


### PR DESCRIPTION
## Description

https://github.com/hashicorp/go-tfe/pull/217 fixed a bunch of race conditions in our tests around planned runs where we were waiting for multiple run statuses and getting inconsistent results. However, it also introduced a new race condition around _applied_ runs where we sometimes get [`transition not allowed` errors](https://app.circleci.com/pipelines/github/hashicorp/go-tfe/515/workflows/46a1da32-1880-46bb-a2dd-44de4f0e8449/jobs/680/tests#failed-test-0) from trying to, say, apply a run that's finished planning, but hasn't finished its cost estimation check yet.

This change makes that applied run check even moar deterministic so we're only ever looking for one status to see if it's ok to apply a run.
