### PR TITLE
Workspace source metadata

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -112,6 +112,8 @@ type Workspace struct {
 	Permissions          *WorkspacePermissions `jsonapi:"attr,permissions"`
 	QueueAllRuns         bool                  `jsonapi:"attr,queue-all-runs"`
 	SpeculativeEnabled   bool                  `jsonapi:"attr,speculative-enabled"`
+	SourceName           string                `jsonapi:"attr,source-name"`
+	SourceURL            string                `jsonapi:"attr,source-url"`
 	TerraformVersion     string                `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes      []string              `jsonapi:"attr,trigger-prefixes"`
 	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`
@@ -264,6 +266,15 @@ type WorkspaceCreateOptions struct {
 	// running plans on pull requests, which can improve security if the VCS
 	// repository is public or includes untrusted contributors.
 	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
+
+	// A friendly name for the application or client creating this workspace.
+	// If set, this will be displayed on the workspace as "Created via <SOURCE NAME>".
+	SourceName *string `jsonapi:"attr,source-name,omitempty"`
+
+	// A URL for the application or client creating this workspace. This can be
+	// the URL of a related resource in another app, or a link to documentation
+	// or other info about the client.
+	SourceURL *string `jsonapi:"attr,source-url,omitempty"`
 
 	// The version of Terraform to use for this workspace. Upon creating a
 	// workspace, the latest version is selected unless otherwise specified.

--- a/workspace.go
+++ b/workspace.go
@@ -267,13 +267,14 @@ type WorkspaceCreateOptions struct {
 	// repository is public or includes untrusted contributors.
 	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
 
-	// A friendly name for the application or client creating this workspace.
-	// If set, this will be displayed on the workspace as "Created via <SOURCE NAME>".
+	// BETA. A friendly name for the application or client creating this
+	// workspace. If set, this will be displayed on the workspace as
+	// "Created via <SOURCE NAME>".
 	SourceName *string `jsonapi:"attr,source-name,omitempty"`
 
-	// A URL for the application or client creating this workspace. This can be
-	// the URL of a related resource in another app, or a link to documentation
-	// or other info about the client.
+	// BETA. A URL for the application or client creating this workspace. This
+	// can be the URL of a related resource in another app, or a link to
+	// documentation or other info about the client.
 	SourceURL *string `jsonapi:"attr,source-url,omitempty"`
 
 	// The version of Terraform to use for this workspace. Upon creating a

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -112,6 +112,8 @@ func TestWorkspacesCreate(t *testing.T) {
 			Operations:          Bool(true),
 			QueueAllRuns:        Bool(true),
 			SpeculativeEnabled:  Bool(true),
+			SourceName:          String("my-app"),
+			SourceURL:           String("my-app-hostname.io"),
 			TerraformVersion:    String("0.11.0"),
 			TriggerPrefixes:     []string{"/modules", "/shared"},
 			WorkingDirectory:    String("bar/"),
@@ -137,6 +139,8 @@ func TestWorkspacesCreate(t *testing.T) {
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
 			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
+			assert.Equal(t, *options.SourceName, item.SourceName)
+			assert.Equal(t, *options.SourceURL, item.SourceURL)
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -113,7 +113,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			QueueAllRuns:        Bool(true),
 			SpeculativeEnabled:  Bool(true),
 			SourceName:          String("my-app"),
-			SourceURL:           String("my-app-hostname.io"),
+			SourceURL:           String("http://my-app-hostname.io"),
 			TerraformVersion:    String("0.11.0"),
 			TriggerPrefixes:     []string{"/modules", "/shared"},
 			WorkingDirectory:    String("bar/"),


### PR DESCRIPTION
## Description

Adds attributes `source-name` and `source-url` to the `workspace` object and create option. These attributes were marked as beta for over year now and has multiple applications using it.

## Testing plan
1. Use these attributes via the API directly using curl
```sh
$ curl  -X POST https://app.terraform.io/api/v2/organizations/<org>/workspaces  \
  --header "Content-Type: application/vnd.api+json" \
  --header "Authorization: Bearer $TFC_TOKEN" \
  --data '{
    "data": {
      "attributes": {
        "name": "my-workspace",
        "source-name": "my-app",
        "source-url": "http://my-app-hostname.io"
      },
      "type": "workspaces"
    }
  }' | jq .
{
  "data": {
    "id": "ws-000",
    "type": "workspaces",
    "attributes": {
      ...
      "source": "tfe-api",
      "source-name": "my-app",
      "source-url": "http://my-app-hostname.io"
    }
  }
}
```

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/workspaces.html#create-a-workspace)

## Output from tests

```sh
$ go test ./... -v -run TestWorkspacesCreate
=== RUN   TestWorkspacesCreate
=== RUN   TestWorkspacesCreate/with_valid_options
=== RUN   TestWorkspacesCreate/when_options_is_missing_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_organization
=== RUN   TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode
=== RUN   TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesCreate/when_an_error_is_returned_from_the_API
--- PASS: TestWorkspacesCreate (2.15s)
    --- PASS: TestWorkspacesCreate/with_valid_options (0.52s)
    --- PASS: TestWorkspacesCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_organization (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode (0.00s)
    --- PASS: TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_error_is_returned_from_the_API (0.41s)
PASS
ok  	github.com/hashicorp/go-tfe	2.322s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
```
