### PR TITLE
Correct RunStatusTimestamps

### DIFF
--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -269,7 +269,7 @@ func TestAdminRun_Unmarshal(t *testing.T) {
 				"has-changes": true,
 				"status":      RunApplied,
 				"status-timestamps": map[string]string{
-					"queued-at": "2020-03-16T23:15:59+00:00",
+					"plan-queued-at": "2020-03-16T23:15:59+00:00",
 				},
 			},
 		},
@@ -279,7 +279,7 @@ func TestAdminRun_Unmarshal(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	queuedParsedTime, err := time.Parse(time.RFC3339, "2020-03-16T23:15:59+00:00")
+	planQueuedParsedTime, err := time.Parse(time.RFC3339, "2020-03-16T23:15:59+00:00")
 	require.NoError(t, err)
 
 	adminRun := &AdminRun{}
@@ -289,7 +289,7 @@ func TestAdminRun_Unmarshal(t *testing.T) {
 	assert.Equal(t, adminRun.ID, "run-VCsNJXa59eUza53R")
 	assert.Equal(t, adminRun.HasChanges, true)
 	assert.Equal(t, adminRun.Status, RunApplied)
-	assert.Equal(t, adminRun.StatusTimestamps.QueuedAt, queuedParsedTime)
+	assert.Equal(t, adminRun.StatusTimestamps.PlanQueuedAt, planQueuedParsedTime)
 }
 
 func adminRunItemsContainsID(items []*AdminRun, id string) bool {

--- a/run.go
+++ b/run.go
@@ -135,16 +135,23 @@ type RunPermissions struct {
 
 // RunStatusTimestamps holds the timestamps for individual run statuses.
 type RunStatusTimestamps struct {
-	ErroredAt            time.Time `jsonapi:"attr,errored-at,rfc3339"`
-	FinishedAt           time.Time `jsonapi:"attr,finished-at,rfc3339"`
-	QueuedAt             time.Time `jsonapi:"attr,queued-at,rfc3339"`
-	StartedAt            time.Time `jsonapi:"attr,started-at,rfc3339"`
-	ApplyingAt           time.Time `jsonapi:"attr,applying-at,rfc3339"`
 	AppliedAt            time.Time `jsonapi:"attr,applied-at,rfc3339"`
-	PlanningAt           time.Time `jsonapi:"attr,planning-at,rfc3339"`
-	PlannedAt            time.Time `jsonapi:"attr,planned-at,rfc3339"`
+	ApplyQueuedAt        time.Time `jsonapi:"attr,apply-queued-at,rfc3339"`
+	ApplyingAt           time.Time `jsonapi:"attr,applying-at,rfc3339"`
+	CanceledAt           time.Time `jsonapi:"attr,canceled-at,rfc3339"`
+	ConfirmedAt          time.Time `jsonapi:"attr,confirmed-at,rfc3339"`
+	CostEstimatedAt      time.Time `jsonapi:"attr,cost-estimated-at,rfc3339"`
+	CostEstimatingAt     time.Time `jsonapi:"attr,cost-estimating-at,rfc3339"`
+	DiscardedAt          time.Time `jsonapi:"attr,discarded-at,rfc3339"`
+	ErroredAt            time.Time `jsonapi:"attr,errored-at,rfc3339"`
+	ForceCanceledAt      time.Time `jsonapi:"attr,force-canceled-at,rfc3339"`
+	PlanQueueableAt      time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
+	PlanQueuedAt         time.Time `jsonapi:"attr,plan-queued-at,rfc3339"`
 	PlannedAndFinishedAt time.Time `jsonapi:"attr,planned-and-finished-at,rfc3339"`
-	PlanQueuabledAt      time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
+	PlannedAt            time.Time `jsonapi:"attr,planned-at,rfc3339"`
+	PlanningAt           time.Time `jsonapi:"attr,planning-at,rfc3339"`
+	PolicyCheckedAt      time.Time `jsonapi:"attr,policy-checked-at,rfc3339"`
+	PolicySoftFailedAt   time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
 }
 
 // RunListOptions represents the options for listing runs.

--- a/run_test.go
+++ b/run_test.go
@@ -98,7 +98,7 @@ func TestRunsCreate(t *testing.T) {
 		assert.NotNil(t, r.CreatedAt)
 		assert.NotNil(t, r.Source)
 		assert.NotEmpty(t, r.StatusTimestamps)
-		assert.NotNil(t, r.StatusTimestamps.StartedAt)
+		assert.NotZero(t, r.StatusTimestamps.PlanQueueableAt)
 	})
 
 	t.Run("with a configuration version", func(t *testing.T) {
@@ -389,8 +389,8 @@ func TestRun_Unmarshal(t *testing.T) {
 					"can-force-execute": true,
 				},
 				"status-timestamps": map[string]string{
-					"queued-at":  "2020-03-16T23:15:59+00:00",
-					"errored-at": "2019-03-16T23:23:59+00:00",
+					"plan-queued-at": "2020-03-16T23:15:59+00:00",
+					"errored-at":     "2019-03-16T23:23:59+00:00",
 				},
 			},
 		},
@@ -403,7 +403,7 @@ func TestRun_Unmarshal(t *testing.T) {
 	err = unmarshalResponse(responseBody, run)
 	require.NoError(t, err)
 
-	queuedParsedTime, err := time.Parse(time.RFC3339, "2020-03-16T23:15:59+00:00")
+	planQueuedParsedTime, err := time.Parse(time.RFC3339, "2020-03-16T23:15:59+00:00")
 	require.NoError(t, err)
 	erroredParsedTime, err := time.Parse(time.RFC3339, "2019-03-16T23:23:59+00:00")
 	require.NoError(t, err)
@@ -425,6 +425,6 @@ func TestRun_Unmarshal(t *testing.T) {
 	assert.Equal(t, run.Permissions.CanDiscard, true)
 	assert.Equal(t, run.Permissions.CanForceExecute, true)
 	assert.Equal(t, run.Permissions.CanForceCancel, true)
-	assert.Equal(t, run.StatusTimestamps.QueuedAt, queuedParsedTime)
+	assert.Equal(t, run.StatusTimestamps.PlanQueuedAt, planQueuedParsedTime)
 	assert.Equal(t, run.StatusTimestamps.ErroredAt, erroredParsedTime)
 }


### PR DESCRIPTION
## Description

These timestamp fields are wrong, and were wrong when originally introduced pre-Terraform Cloud. As they've never been populated correctly before, no client could be relying on them and the ones that don't work are removed as a 'not-so-breaking' change, with all the modern timestamps on runs added.

Closes #226 