### PR TITLE
Update Variables documentation link

### DIFF
--- a/variable.go
+++ b/variable.go
@@ -13,7 +13,7 @@ var _ Variables = (*variables)(nil)
 // Variables describes all the variable related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/variables.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/workspace-variables.html
 type Variables interface {
 	// List all the variables associated with the given workspace.
 	List(ctx context.Context, workspaceID string, options VariableListOptions) (*VariableList, error)


### PR DESCRIPTION
## Description

This link is old and incorrect. The `Variables` interface uses the (correct) Workspace Variables API.

Closes #228