### PR TITLE
Add Policy Set Versions

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -250,6 +250,27 @@ func createPolicySet(t *testing.T, client *Client, org *Organization, policies [
 	}
 }
 
+func createPolicySetVersion(t *testing.T, client *Client, ps *PolicySet) (*PolicySetVersion, func()) {
+	var psCleanup func()
+
+	if ps == nil {
+		ps, psCleanup = createPolicySet(t, client, nil, nil, nil)
+	}
+
+	ctx := context.Background()
+	psv, err := client.PolicySetVersions.Create(ctx, ps.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return psv, func() {
+		// Deleting a Policy Set Version is done through deleting a Policy Set.
+		if psCleanup != nil {
+			psCleanup()
+		}
+	}
+}
+
 func createPolicy(t *testing.T, client *Client, org *Organization) (*Policy, func()) {
 	var orgCleanup func()
 

--- a/policy.go
+++ b/policy.go
@@ -35,7 +35,7 @@ type Policies interface {
 	// Upload the policy content of the policy.
 	Upload(ctx context.Context, policyID string, content []byte) error
 
-	// Upload the policy content of the policy.
+	// Download the policy content of the policy.
 	Download(ctx context.Context, policyID string) ([]byte, error)
 }
 

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -33,16 +33,16 @@ type policySetVersions struct {
 	client *Client
 }
 
-// PolciySetVersionSource represents a source type of a policy set version.
-type PolciySetVersionSource string
+// PolicySetVersionSource represents a source type of a policy set version.
+type PolicySetVersionSource string
 
 // List all available sources for a Policy Set Version.
 const (
-	PolciySetVersionSourceAPI       PolciySetVersionSource = "tfe-api"
-	PolciySetVersionSourceADO       PolciySetVersionSource = "ado"
-	PolciySetVersionSourceBitBucket PolciySetVersionSource = "bitbucket"
-	PolciySetVersionSourceGitHub    PolciySetVersionSource = "github"
-	PolciySetVersionSourceGitLab    PolciySetVersionSource = "gitlab"
+	PolicySetVersionSourceAPI       PolicySetVersionSource = "tfe-api"
+	PolicySetVersionSourceADO       PolicySetVersionSource = "ado"
+	PolicySetVersionSourceBitBucket PolicySetVersionSource = "bitbucket"
+	PolicySetVersionSourceGitHub    PolicySetVersionSource = "github"
+	PolicySetVersionSourceGitLab    PolicySetVersionSource = "gitlab"
 )
 
 // PolicySetVersionStatus represents a policy set version status.
@@ -50,14 +50,15 @@ type PolicySetVersionStatus string
 
 //List all available policy set version statuses.
 const (
-	PolicySetVersionErrored PolicySetVersionStatus = "errored"
-	PolicySetVersionPending PolicySetVersionStatus = "pending"
-	PolicySetVersionReady   PolicySetVersionStatus = "ready"
+	PolicySetVersionErrored    PolicySetVersionStatus = "errored"
+	PolicySetVersionIngressing PolicySetVersionStatus = "ingressing"
+	PolicySetVersionPending    PolicySetVersionStatus = "pending"
+	PolicySetVersionReady      PolicySetVersionStatus = "ready"
 )
 
-// PolciySetVersionStatusTimestamps holds the timestamps for individual policy
+// PolicySetVersionStatusTimestamps holds the timestamps for individual policy
 // set version statuses.
-type PolciySetVersionStatusTimestamps struct {
+type PolicySetVersionStatusTimestamps struct {
 	PendingAt    time.Time `jsonapi:"attr,pending-at,rfc3339"`
 	IngressingAt time.Time `jsonapi:"attr,ingressing-at,rfc3339"`
 	ReadyAt      time.Time `jsonapi:"attr,ready-at,rfc3339"`
@@ -66,10 +67,11 @@ type PolciySetVersionStatusTimestamps struct {
 
 type PolicySetVersion struct {
 	ID               string                           `jsonapi:"primary,policy-set-versions"`
-	Source           PolciySetVersionSource           `jsonapi:"attr,source"`
+	Source           PolicySetVersionSource           `jsonapi:"attr,source"`
 	Status           PolicySetVersionStatus           `jsonapi:"attr,status"`
-	StatusTimestamps PolciySetVersionStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	StatusTimestamps PolicySetVersionStatusTimestamps `jsonapi:"attr,status-timestamps"`
 	Error            string                           `jsonapi:"attr,error"`
+	ErrorMessage     string                           `jsonapi:"attr,error-message"`
 	CreatedAt        time.Time                        `jsonapi:"attr,created-at,iso8601"`
 	UpdatedAt        time.Time                        `jsonapi:"attr,updated-at,iso8601"`
 
@@ -144,7 +146,7 @@ func (p *policySetVersions) Upload(ctx context.Context, psv PolicySetVersion, pa
 		return err
 	}
 
-	body, err := readFile(path)
+	body, err := packContents(path)
 	if err != nil {
 		return err
 	}

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -24,6 +24,15 @@ type policySetParameters struct {
 	client *Client
 }
 
+// PolciySetVersionSource represents a source type of a policy set version.
+type PolciySetVersionSource string
+
+// List all available run sources.
+const (
+	PolciySetVersionSourceAPI PolciySetVersionSource = "tfe-api"
+	PolciySetVersionSourceUI  PolciySetVersionSource = "tfe-ui"
+)
+
 type PolicySetVersion struct {
 	ID     string `jsonapi:"primary,policy-set-versions"`
 	Source string `jsonapi:"attr,source"`

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -1,0 +1,103 @@
+package tfe
+
+// Compile-time proof of interface implementation.
+var _ PolicySetVersions = (*policySetVersions)(nil)
+
+// PolicySetVersions describes all the Policy Set Version related methods that the Terraform
+// Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/policy-sets.html#create-a-policy-set-version
+
+type PolicySetVersions interface {
+	// Create is used to create a new Policy Set Version.
+	Create(ctx context.Context, policySetID string) (*PolicySetVersion, error)
+
+	// Read is used to read a Policy Set Version by the policy set ID.
+	Read(ctx context.Context, policySetID string) (*PolicySetVersion, error)
+
+	// Upload a tarball to the Policy Set Version.
+	Upload(ctx context.Context, policySetID string, context []byte) (*PolicySetVersion, error)
+}
+
+// policySetVersions implements Policy Set Versions.
+type policySetParameters struct {
+	client *Client
+}
+
+type PolicySetVersion struct {
+	ID     string `jsonapi:"primary,policy-set-versions"`
+	Source string `jsonapi:"attr,source"`
+	Status string `jsonapi:"attr,status"`
+	// TODO: StatusTimestamps  string `jsonapi:"attr,status-timestamps"`
+	Error     string    `jsonapi:"attr,error"`
+	CreatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt time.Time `jsonapi:"attr,updated-at,iso8601"`
+
+	// Relations
+	PolicySet *PolicySet `jsonapi:"relation,policy-set"`
+
+	// Links
+	Links map[string]interface{} `jsonapi:"links,omitempty"`
+}
+
+func (p *policySetVersions) Create(ctx context.Context, policySetID string) (*PolicySetVersion, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("invalid value for policy set ID")
+	}
+
+	u := fmt.Sprintf("policy-sets/%s/versions", url.QueryEscape(policySetID))
+	req, err := p.client.newRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	psv := &PolicySetVersion{}
+	err = p.client.do(ctx, req, psv)
+	if err != nil {
+		return nil, err
+	}
+
+	return psv, nil
+}
+
+func (p *policySetVersions) Read(ctx context.Context, policySetID string) (*PolicySetVersion, error) {
+	if !validStringID(&policySetID) {
+		return nil, errors.New("invalid value for policy set ID")
+	}
+
+	u := fmt.Sprintf("policy-set-versions/%s", url.QueryEscape(policySetID))
+	req, err := p.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	psv := &PolicySetVersion{}
+	err = p.client.do(ctx, req, psv)
+	if err != nil {
+		return nil, err
+	}
+
+	return psv, nil
+}
+
+func (p *policySetVersions) Upload(ctx context.Context, policySetID string, content []byte) (*PolicySetVersion, error) {
+	if !validStringID(&policyID) {
+		return errors.New("invalid value for policy ID")
+	}
+
+	psv, err := p.Read(ctx, policySetID)
+	if err != nil {
+		return err
+	}
+	uploadURL, ok := psv.Links["upload"].(string)
+	if !ok {
+		return fmt.Errorf("The Policy Set Version does not contain an upload link.")
+	}
+
+	req, err := p.client.newRequest("PUT", uploadURL, content)
+	if err != nil {
+		return err
+	}
+
+	return p.client.do(ctx, req, nil)
+}

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -53,10 +53,20 @@ type PolciySetVersionStatusTimestamps struct {
 	ErroredAt    time.Time `jsonapi:"attr,errored-at,rfc3339"`
 }
 
+// PolicySetVersionStatus represents a policy set version status.
+type PolicySetVersionStatus string
+
+//List all available policy set version statuses.
+const (
+	PolicySetVersionErrored PolicySetVersionStatus = "errored"
+	PolicySetVersionPending PolicySetVersionStatus = "pending"
+	PolicySetVersionReady   PolicySetVersionStatus = "ready"
+)
+
 type PolicySetVersion struct {
 	ID               string                           `jsonapi:"primary,policy-set-versions"`
-	Source           string                           `jsonapi:"attr,source"`
-	Status           PolciySetVersionSource           `jsonapi:"attr,status"`
+	Source           PolciySetVersionSource           `jsonapi:"attr,source"`
+	Status           PolicySetVersionStatus           `jsonapi:"attr,status"`
 	StatusTimestamps PolciySetVersionStatusTimestamps `jsonapi:"attr,status-timestamps"`
 	Error            string                           `jsonapi:"attr,error"`
 	CreatedAt        time.Time                        `jsonapi:"attr,created-at,iso8601"`

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -80,7 +80,7 @@ type PolicySetVersion struct {
 	Links map[string]interface{} `jsonapi:"links,omitempty"`
 }
 
-func (p PolicySetVersion) UploadURL() (string, error) {
+func (p PolicySetVersion) uploadURL() (string, error) {
 	uploadURL, ok := p.Links["upload"].(string)
 	if !ok {
 		return uploadURL, fmt.Errorf("The Policy Set Version does not contain an upload link.")
@@ -139,7 +139,7 @@ func (p *policySetVersions) Read(ctx context.Context, policySetVersionID string)
 // to the set of sentinel files, which will be packaged by hashicorp/go-slug
 // before being uploaded.
 func (p *policySetVersions) Upload(ctx context.Context, psv PolicySetVersion, path string) error {
-	uploadURL, err := psv.UploadURL()
+	uploadURL, err := psv.uploadURL()
 	if err != nil {
 		return err
 	}

--- a/policy_set_version_test.go
+++ b/policy_set_version_test.go
@@ -95,3 +95,43 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 		assert.EqualError(t, err, "The Policy Set Version does not contain an upload link.")
 	})
 }
+
+func TestPolicySetVersionsUploadURL(t *testing.T) {
+	t.Run("successfully returns upload link", func(t *testing.T) {
+		links := map[string]interface{}{
+			"upload": "example.com",
+		}
+		psv := PolicySetVersion{
+			Links: links,
+		}
+
+		uploadURL, err := psv.uploadURL()
+		require.NoError(t, err)
+
+		assert.Equal(t, uploadURL, "example.com")
+	})
+
+	t.Run("errors when there is no upload key in the Links", func(t *testing.T) {
+		links := map[string]interface{}{
+			"bad-field": "example.com",
+		}
+		psv := PolicySetVersion{
+			Links: links,
+		}
+
+		_, err := psv.uploadURL()
+		assert.EqualError(t, err, "The Policy Set Version does not contain an upload link.")
+	})
+
+	t.Run("errors when the upload link is empty", func(t *testing.T) {
+		links := map[string]interface{}{
+			"upload": "",
+		}
+		psv := PolicySetVersion{
+			Links: links,
+		}
+
+		_, err := psv.uploadURL()
+		assert.EqualError(t, err, "The Policy Set Version upload URL is empty.")
+	})
+}

--- a/policy_set_version_test.go
+++ b/policy_set_version_test.go
@@ -1,5 +1,13 @@
 package tfe
 
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
 func TestPolicySetVersionsCreate(t *testing.T) {
 	skipIfFreeOnly(t)
 
@@ -14,46 +22,13 @@ func TestPolicySetVersionsCreate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, psv.ID)
-		assert.Equal(t, psv.Source, PolciySetVersionSourceAPI)
+		assert.Equal(t, psv.Source, string(PolciySetVersionSourceAPI))
 		assert.Equal(t, psv.PolicySet.ID, psTest.ID)
 	})
 
 	t.Run("with invalid identifier", func(t *testing.T) {
 		_, err := client.PolicySetVersions.Create(ctx, badIdentifier)
 		assert.EqualError(t, err, "invalid value for policy set ID")
-	})
-}
-
-func TestPolicySetVersionsUpload(t *testing.T) {
-	skipIfFreeOnly(t)
-
-	client := testClient(t)
-	ctx := context.Background()
-
-	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil)
-	defer psTestCleanup()
-
-	psv, err := client.PolicySetVersions.Create(ctx, psTest.ID)
-	require.NoError(t, err)
-
-	t.Run("with valid upload URL", func(t *testing.T) {
-		err = client.TestPolicySetVersions.Upload(
-			ctx,
-			psv.psTest.ID,
-			"test-fixtures/config-version",
-		)
-		require.NoError(t, err)
-	})
-
-	t.Run("with missing upload URL", func(t *testing.T) {
-		delete(psv.Links, "upload")
-
-		err = client.TestPolicySetVersions.Upload(
-			ctx,
-			psv.psTest.ID,
-			"test-fixtures/config-version",
-		)
-		assert.EqualError(t, err, "The Policy Set Version does not contain an upload link.")
 	})
 }
 
@@ -80,5 +55,38 @@ func TestPolicySetVersionsRead(t *testing.T) {
 	t.Run("with invalid id", func(t *testing.T) {
 		_, err := client.PolicySetVersions.Read(ctx, randomString(t))
 		require.Error(t, err)
+	})
+}
+
+func TestPolicySetVersionsUpload(t *testing.T) {
+	skipIfFreeOnly(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil)
+	defer psTestCleanup()
+
+	psv, err := client.PolicySetVersions.Create(ctx, psTest.ID)
+	require.NoError(t, err)
+
+	t.Run("with valid upload URL", func(t *testing.T) {
+		err = client.PolicySetVersions.Upload(
+			ctx,
+			*psv,
+			"test-fixtures/config-version",
+		)
+		require.NoError(t, err)
+	})
+
+	t.Run("with missing upload URL", func(t *testing.T) {
+		delete(psv.Links, "upload")
+
+		err = client.PolicySetVersions.Upload(
+			ctx,
+			*psv,
+			"test-fixtures/config-version",
+		)
+		assert.EqualError(t, err, "The Policy Set Version does not contain an upload link.")
 	})
 }

--- a/policy_set_version_test.go
+++ b/policy_set_version_test.go
@@ -22,7 +22,7 @@ func TestPolicySetVersionsCreate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, psv.ID)
-		assert.Equal(t, psv.Source, PolciySetVersionSourceAPI)
+		assert.Equal(t, psv.Source, PolicySetVersionSourceAPI)
 		assert.Equal(t, psv.PolicySet.ID, psTest.ID)
 	})
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -1,14 +1,10 @@
 package tfe
 
 import (
-	"bytes"
 	"context"
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
-
-	slug "github.com/hashicorp/go-slug"
 )
 
 // Compile-time proof of interface implementation.
@@ -117,17 +113,7 @@ func (r *registryModules) Upload(ctx context.Context, rmv RegistryModuleVersion,
 		return fmt.Errorf("Provided RegistryModuleVersion does not contain an upload link")
 	}
 
-	file, err := os.Stat(path)
-	if err != nil {
-		return err
-	}
-	if !file.Mode().IsDir() {
-		return ErrMissingDirectory
-	}
-
-	body := bytes.NewBuffer(nil)
-
-	_, err = slug.Pack(path, body, true)
+	body, err := readFile(path)
 	if err != nil {
 		return err
 	}

--- a/registry_module.go
+++ b/registry_module.go
@@ -113,7 +113,7 @@ func (r *registryModules) Upload(ctx context.Context, rmv RegistryModuleVersion,
 		return fmt.Errorf("Provided RegistryModuleVersion does not contain an upload link")
 	}
 
-	body, err := readFile(path)
+	body, err := packContents(path)
 	if err != nil {
 		return err
 	}

--- a/test-fixtures/policy-set-version/enforce-mandatory-tags.sentinel
+++ b/test-fixtures/policy-set-version/enforce-mandatory-tags.sentinel
@@ -1,0 +1,13 @@
+# This policy is a sample policy that has a list of tags and 
+# has a rule to confirm the length of the tags.
+
+# List of environment tags
+tags = [
+  "Production",
+  "Staging",
+]
+
+# Main rule
+main = rule {
+  length(tags) is 2
+}

--- a/test-fixtures/policy-set-version/sentinel.hcl
+++ b/test-fixtures/policy-set-version/sentinel.hcl
@@ -1,0 +1,4 @@
+policy "enforce-mandatory-tags" {
+  source = "./enforce-mandatory-tags.sentinel"
+  enforcement_level = "hard-mandatory"
+}

--- a/tfe.go
+++ b/tfe.go
@@ -111,6 +111,7 @@ type Client struct {
 	Policies                   Policies
 	PolicyChecks               PolicyChecks
 	PolicySetParameters        PolicySetParameters
+	PolicySetVersions          PolicySetVersions
 	PolicySets                 PolicySets
 	RegistryModules            RegistryModules
 	Runs                       Runs
@@ -246,6 +247,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Policies = &policies{client: client}
 	client.PolicyChecks = &policyChecks{client: client}
 	client.PolicySetParameters = &policySetParameters{client: client}
+	client.PolicySetVersions = &policySetVersions{client: client}
 	client.PolicySets = &policySets{client: client}
 	client.RegistryModules = &registryModules{client: client}
 	client.Runs = &runs{client: client}

--- a/tfe.go
+++ b/tfe.go
@@ -21,6 +21,8 @@ import (
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/jsonapi"
 	"golang.org/x/time/rate"
+
+	slug "github.com/hashicorp/go-slug"
 )
 
 const (
@@ -744,4 +746,23 @@ func checkResponseCode(r *http.Response) error {
 	}
 
 	return fmt.Errorf(strings.Join(errs, "\n"))
+}
+
+func readFile(path string) (*bytes.Buffer, error) {
+	body := bytes.NewBuffer(nil)
+
+	file, err := os.Stat(path)
+	if err != nil {
+		return body, err
+	}
+	if !file.Mode().IsDir() {
+		return body, ErrMissingDirectory
+	}
+
+	_, err = slug.Pack(path, body, true)
+	if err != nil {
+		return body, err
+	}
+
+	return body, nil
 }

--- a/tfe.go
+++ b/tfe.go
@@ -748,7 +748,7 @@ func checkResponseCode(r *http.Response) error {
 	return fmt.Errorf(strings.Join(errs, "\n"))
 }
 
-func readFile(path string) (*bytes.Buffer, error) {
+func packContents(path string) (*bytes.Buffer, error) {
 	body := bytes.NewBuffer(nil)
 
 	file, err := os.Stat(path)


### PR DESCRIPTION
## Description

This PR introduces support for [Policy Set Versions](https://www.terraform.io/docs/cloud/api/policy-sets.html#create-a-policy-set-version). The functionality allows for
* Creating Policy Set Versions
* Reading Policy Set Versions
* Uploading policies

## Output from tests

```
$ go-tfe % TFE_TOKEN=<token> TFE_ADDRESS=https://tfe-zone-4c292d5b.ngrok.io go test -v -run TestPolicySetVersion -timeout=30m
=== RUN   TestPolicySetVersionsCreate
=== RUN   TestPolicySetVersionsCreate/with_valid_identifier
=== RUN   TestPolicySetVersionsCreate/with_invalid_identifier
--- PASS: TestPolicySetVersionsCreate (1.49s)
    --- PASS: TestPolicySetVersionsCreate/with_valid_identifier (0.22s)
    --- PASS: TestPolicySetVersionsCreate/with_invalid_identifier (0.00s)
=== RUN   TestPolicySetVersionsRead
=== RUN   TestPolicySetVersionsRead/with_valid_id
=== RUN   TestPolicySetVersionsRead/with_invalid_id
--- PASS: TestPolicySetVersionsRead (1.86s)
    --- PASS: TestPolicySetVersionsRead/with_valid_id (0.17s)
    --- PASS: TestPolicySetVersionsRead/with_invalid_id (0.14s)
=== RUN   TestPolicySetVersionsUpload
=== RUN   TestPolicySetVersionsUpload/with_valid_upload_URL
=== RUN   TestPolicySetVersionsUpload/with_missing_upload_URL
--- PASS: TestPolicySetVersionsUpload (1.81s)
    --- PASS: TestPolicySetVersionsUpload/with_valid_upload_URL (0.42s)
    --- PASS: TestPolicySetVersionsUpload/with_missing_upload_URL (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     5.773s
```


## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/policy-sets.html#create-a-policy-set-version)
- [GitHub Issue](https://github.com/hashicorp/go-tfe/issues/151)
