### PR TITLE
Add IngressAttributes of ConfigurationVersion

### DIFF
--- a/configuration_version.go
+++ b/configuration_version.go
@@ -30,6 +30,9 @@ type ConfigurationVersions interface {
 	// Read a configuration version by its ID.
 	Read(ctx context.Context, cvID string) (*ConfigurationVersion, error)
 
+	// ReadWithOptions reads a configuration version by its ID using the options supplied
+	ReadWithOptions(ctx context.Context, cvID string, options *ConfigurationVersionReadOptions) (*ConfigurationVersion, error)
+
 	// Upload packages and uploads Terraform configuration files. It requires
 	// the upload URL from a configuration version and the full path to the
 	// configuration files on disk.
@@ -82,6 +85,9 @@ type ConfigurationVersion struct {
 	Status           ConfigurationStatus `jsonapi:"attr,status"`
 	StatusTimestamps *CVStatusTimestamps `jsonapi:"attr,status-timestamps"`
 	UploadURL        string              `jsonapi:"attr,upload-url"`
+
+	// Relations
+	IngressAttributes *IngressAttributes `jsonapi:"relation,ingress-attributes"`
 }
 
 // CVStatusTimestamps holds the timestamps for individual configuration version
@@ -92,10 +98,43 @@ type CVStatusTimestamps struct {
 	StartedAt  time.Time `jsonapi:"attr,started-at,rfc3339"`
 }
 
+// ConfigurationVersionReadOptions represents the options for reading a configuration version.
+type ConfigurationVersionReadOptions struct {
+	Include string `url:"include"`
+}
+
 // ConfigurationVersionListOptions represents the options for listing
 // configuration versions.
 type ConfigurationVersionListOptions struct {
 	ListOptions
+
+	// A list of relations to include. See available resources:
+	// https://www.terraform.io/docs/cloud/api/configuration-versions.html#available-related-resources
+	Include *string `url:"include"`
+}
+
+// IngressAttributes include commit information associated with configuration versions sourced from VCS.
+type IngressAttributes struct {
+	ID                string `jsonapi:"primary,ingress-attributes"`
+	Branch            string `jsonapi:"attr,branch"`
+	CloneURL          string `jsonapi:"attr,clone-url"`
+	CommitMessage     string `jsonapi:"attr,commit-message"`
+	CommitURL         string `jsonapi:"attr,commit-url"`
+	CompareURL        string `jsonapi:"attr,compare-url"`
+	Identifier        string `jsonapi:"attr,identifier"`
+	IsPullRequest     bool   `jsonapi:"attr,is-pull-request"`
+	OnDefaultBranch   bool   `jsonapi:"attr,on-default-branch"`
+	PullRequestNumber int    `jsonapi:"attr,pull-request-number"`
+	PullRequestURL    string `jsonapi:"attr,pull-request-url"`
+	PullRequestTitle  string `jsonapi:"attr,pull-request-title"`
+	PullRequestBody   string `jsonapi:"attr,pull-request-body"`
+	Tag               string `jsonapi:"attr,tag"`
+	SenderUsername    string `jsonapi:"attr,sender-username"`
+	SenderAvatarURL   string `jsonapi:"attr,sender-avatar-url"`
+	SenderHTMLURL     string `jsonapi:"attr,sender-html-url"`
+
+	// Links
+	Links map[string]interface{} `jsonapi:"links,omitempty"`
 }
 
 // List returns all configuration versions of a workspace.
@@ -160,12 +199,17 @@ func (s *configurationVersions) Create(ctx context.Context, workspaceID string, 
 
 // Read a configuration version by its ID.
 func (s *configurationVersions) Read(ctx context.Context, cvID string) (*ConfigurationVersion, error) {
+	return s.ReadWithOptions(ctx, cvID, nil)
+}
+
+// Read a configuration version by its ID with the given options.
+func (s *configurationVersions) ReadWithOptions(ctx context.Context, cvID string, options *ConfigurationVersionReadOptions) (*ConfigurationVersion, error) {
 	if !validStringID(&cvID) {
 		return nil, ErrInvalidConfigVersionID
 	}
 
 	u := fmt.Sprintf("configuration-versions/%s", url.QueryEscape(cvID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/configuration_version_test.go
+++ b/configuration_version_test.go
@@ -151,7 +151,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, true)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{QueueAllRuns: Bool(true)})
 	defer wTestCleanup()
 
 	// Hack: Wait for TFC to ingress the configuration and queue a run

--- a/configuration_version_test.go
+++ b/configuration_version_test.go
@@ -144,6 +144,46 @@ func TestConfigurationVersionsRead(t *testing.T) {
 	})
 }
 
+func TestConfigurationVersionsReadWithOptions(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, true)
+	defer wTestCleanup()
+
+	// Hack: Wait for TFC to ingress the configuration and queue a run
+	time.Sleep(3 * time.Second)
+
+	w, err := client.Workspaces.ReadByIDWithOptions(ctx, wTest.ID, &WorkspaceReadOptions{
+		Include: "current-run.configuration-version",
+	})
+
+	if err != nil {
+		require.NoError(t, err)
+	}
+
+	if w.CurrentRun == nil {
+		t.Fatal("A run was expected to be found on this workspace as a test pre-condition")
+	}
+
+	cv := w.CurrentRun.ConfigurationVersion
+
+	t.Run("when the configuration version exists", func(t *testing.T) {
+		options := &ConfigurationVersionReadOptions{
+			Include: "ingress-attributes",
+		}
+
+		cv, err := client.ConfigurationVersions.ReadWithOptions(ctx, cv.ID, options)
+		require.NoError(t, err)
+
+		assert.NotZero(t, cv.IngressAttributes)
+		assert.NotZero(t, cv.IngressAttributes.CommitURL)
+	})
+}
+
 func TestConfigurationVersionsUpload(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()

--- a/helper_test.go
+++ b/helper_test.go
@@ -920,7 +920,7 @@ func createWorkspace(t *testing.T, client *Client, org *Organization) (*Workspac
 // false, runs triggered by a VCS change will not be queued until at least one run is manually
 // queued. If set to true, a run will be automatically started after the configuration is ingressed
 // from VCS.
-func createWorkspaceWithVCS(t *testing.T, client *Client, org *Organization, queueAllRuns bool) (*Workspace, func()) {
+func createWorkspaceWithVCS(t *testing.T, client *Client, org *Organization, options WorkspaceCreateOptions) (*Workspace, func()) {
 	var orgCleanup func()
 
 	if org == nil {
@@ -934,13 +934,15 @@ func createWorkspaceWithVCS(t *testing.T, client *Client, org *Organization, que
 		t.Fatal("Export a valid GITHUB_POLICY_SET_IDENTIFIER before running this test!")
 	}
 
-	options := WorkspaceCreateOptions{
-		Name:         String(randomString(t)),
-		QueueAllRuns: Bool(queueAllRuns),
-		VCSRepo: &VCSRepoOptions{
+	if options.Name == nil {
+		options.Name = String(randomString(t))
+	}
+
+	if options.VCSRepo == nil {
+		options.VCSRepo = &VCSRepoOptions{
 			Identifier:   String(githubIdentifier),
 			OAuthTokenID: String(oc.ID),
-		},
+		}
 	}
 
 	ctx := context.Background()

--- a/helper_test.go
+++ b/helper_test.go
@@ -916,7 +916,11 @@ func createWorkspace(t *testing.T, client *Client, org *Organization) (*Workspac
 	}
 }
 
-func createWorkspaceWithVCS(t *testing.T, client *Client, org *Organization) (*Workspace, func()) {
+// queueAllRuns: Whether runs should be queued immediately after workspace creation. When set to
+// false, runs triggered by a VCS change will not be queued until at least one run is manually
+// queued. If set to true, a run will be automatically started after the configuration is ingressed
+// from VCS.
+func createWorkspaceWithVCS(t *testing.T, client *Client, org *Organization, queueAllRuns bool) (*Workspace, func()) {
 	var orgCleanup func()
 
 	if org == nil {
@@ -931,7 +935,8 @@ func createWorkspaceWithVCS(t *testing.T, client *Client, org *Organization) (*W
 	}
 
 	options := WorkspaceCreateOptions{
-		Name: String(randomString(t)),
+		Name:         String(randomString(t)),
+		QueueAllRuns: Bool(queueAllRuns),
 		VCSRepo: &VCSRepoOptions{
 			Identifier:   String(githubIdentifier),
 			OAuthTokenID: String(oc.ID),

--- a/workspace.go
+++ b/workspace.go
@@ -33,6 +33,9 @@ type Workspaces interface {
 	// ReadByID reads a workspace by its ID.
 	ReadByID(ctx context.Context, workspaceID string) (*Workspace, error)
 
+	// ReadByIDWithOptions reads a workspace by its ID with the given options.
+	ReadByIDWithOptions(ctx context.Context, workspaceID string, options *WorkspaceReadOptions) (*Workspace, error)
+
 	// Update settings of an existing workspace.
 	Update(ctx context.Context, organization string, workspace string, options WorkspaceUpdateOptions) (*Workspace, error)
 
@@ -173,6 +176,11 @@ type WorkspacePermissions struct {
 	CanUnlock         bool `jsonapi:"attr,can-unlock"`
 	CanUpdate         bool `jsonapi:"attr,can-update"`
 	CanUpdateVariable bool `jsonapi:"attr,can-update-variable"`
+}
+
+// WorkspaceReadOptions represents the options for reading a workspace.
+type WorkspaceReadOptions struct {
+	Include string `url:"include"`
 }
 
 // WorkspaceListOptions represents the options for listing workspaces.
@@ -383,12 +391,17 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 
 // ReadByID reads a workspace by its ID.
 func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspace, error) {
+	return s.ReadByIDWithOptions(ctx, workspaceID, nil)
+}
+
+// ReadByIDWithOptions reads a workspace by its ID with the given options.
+func (s *workspaces) ReadByIDWithOptions(ctx context.Context, workspaceID string, options *WorkspaceReadOptions) (*Workspace, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -4,11 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"github.com/hashicorp/go-retryablehttp"
 	"io/ioutil"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -285,7 +286,7 @@ func TestWorkspacesReadReadme(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, false)
 	defer wTestCleanup()
 
 	_, rCleanup := createAppliedRun(t, client, wTest)
@@ -607,7 +608,7 @@ func TestWorkspacesRemoveVCSConnection(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, false)
 	defer wTestCleanup()
 
 	t.Run("remove vcs integration", func(t *testing.T) {
@@ -624,7 +625,7 @@ func TestWorkspacesRemoveVCSConnectionByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, false)
 	defer wTestCleanup()
 
 	t.Run("remove vcs integration", func(t *testing.T) {

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -286,7 +286,7 @@ func TestWorkspacesReadReadme(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, false)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{})
 	defer wTestCleanup()
 
 	_, rCleanup := createAppliedRun(t, client, wTest)
@@ -608,7 +608,7 @@ func TestWorkspacesRemoveVCSConnection(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, false)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{})
 	defer wTestCleanup()
 
 	t.Run("remove vcs integration", func(t *testing.T) {
@@ -625,7 +625,7 @@ func TestWorkspacesRemoveVCSConnectionByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, false)
+	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{})
 	defer wTestCleanup()
 
 	t.Run("remove vcs integration", func(t *testing.T) {


### PR DESCRIPTION
## Description

Ingress attributes are resources which include commit information associated with configuration versions sourced from VCS.

They're odd ducks in that they're separate resources but really specific to configuration versions; a long-time vestiage of the Terraform Enterprise API. They also have several ways to retrieve them, both with a standalone ID, a nested URL off of configuration version, and a JSON:API includeable resource.

Here, I've intentionally added the includeable resource bit and no more. Practically speaking, it isn't useful to fetch IA by ID only, and any time you're fetching them via a configuration version you usually want the data within the CV itself as well. So, accessing them as just an extra bit of information on a CV - only - seems most appropriate.

To test this functionality, I ironically needed to add a similar WithOptions function to workspaces, in order to fetch the configuration version of the current run with ingress attributes associated with it.

Closes #79 
Closes #137 