### PR TITLE
Add structured run output support

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -96,38 +96,39 @@ type WorkspaceList struct {
 
 // Workspace represents a Terraform Enterprise workspace.
 type Workspace struct {
-	ID                   string                `jsonapi:"primary,workspaces"`
-	Actions              *WorkspaceActions     `jsonapi:"attr,actions"`
-	AgentPoolID          string                `jsonapi:"attr,agent-pool-id"`
-	AllowDestroyPlan     bool                  `jsonapi:"attr,allow-destroy-plan"`
-	AutoApply            bool                  `jsonapi:"attr,auto-apply"`
-	CanQueueDestroyPlan  bool                  `jsonapi:"attr,can-queue-destroy-plan"`
-	CreatedAt            time.Time             `jsonapi:"attr,created-at,iso8601"`
-	Description          string                `jsonapi:"attr,description"`
-	Environment          string                `jsonapi:"attr,environment"`
-	ExecutionMode        string                `jsonapi:"attr,execution-mode"`
-	FileTriggersEnabled  bool                  `jsonapi:"attr,file-triggers-enabled"`
-	GlobalRemoteState    bool                  `jsonapi:"attr,global-remote-state"`
-	Locked               bool                  `jsonapi:"attr,locked"`
-	MigrationEnvironment string                `jsonapi:"attr,migration-environment"`
-	Name                 string                `jsonapi:"attr,name"`
-	Operations           bool                  `jsonapi:"attr,operations"`
-	Permissions          *WorkspacePermissions `jsonapi:"attr,permissions"`
-	QueueAllRuns         bool                  `jsonapi:"attr,queue-all-runs"`
-	SpeculativeEnabled   bool                  `jsonapi:"attr,speculative-enabled"`
-	SourceName           string                `jsonapi:"attr,source-name"`
-	SourceURL            string                `jsonapi:"attr,source-url"`
-	TerraformVersion     string                `jsonapi:"attr,terraform-version"`
-	TriggerPrefixes      []string              `jsonapi:"attr,trigger-prefixes"`
-	VCSRepo              *VCSRepo              `jsonapi:"attr,vcs-repo"`
-	WorkingDirectory     string                `jsonapi:"attr,working-directory"`
-	UpdatedAt            time.Time             `jsonapi:"attr,updated-at,iso8601"`
-	ResourceCount        int                   `jsonapi:"attr,resource-count"`
-	ApplyDurationAverage time.Duration         `jsonapi:"attr,apply-duration-average"`
-	PlanDurationAverage  time.Duration         `jsonapi:"attr,plan-duration-average"`
-	PolicyCheckFailures  int                   `jsonapi:"attr,policy-check-failures"`
-	RunFailures          int                   `jsonapi:"attr,run-failures"`
-	RunsCount            int                   `jsonapi:"attr,workspace-kpis-runs-count"`
+	ID                         string                `jsonapi:"primary,workspaces"`
+	Actions                    *WorkspaceActions     `jsonapi:"attr,actions"`
+	AgentPoolID                string                `jsonapi:"attr,agent-pool-id"`
+	AllowDestroyPlan           bool                  `jsonapi:"attr,allow-destroy-plan"`
+	AutoApply                  bool                  `jsonapi:"attr,auto-apply"`
+	CanQueueDestroyPlan        bool                  `jsonapi:"attr,can-queue-destroy-plan"`
+	CreatedAt                  time.Time             `jsonapi:"attr,created-at,iso8601"`
+	Description                string                `jsonapi:"attr,description"`
+	Environment                string                `jsonapi:"attr,environment"`
+	ExecutionMode              string                `jsonapi:"attr,execution-mode"`
+	FileTriggersEnabled        bool                  `jsonapi:"attr,file-triggers-enabled"`
+	GlobalRemoteState          bool                  `jsonapi:"attr,global-remote-state"`
+	Locked                     bool                  `jsonapi:"attr,locked"`
+	MigrationEnvironment       string                `jsonapi:"attr,migration-environment"`
+	Name                       string                `jsonapi:"attr,name"`
+	Operations                 bool                  `jsonapi:"attr,operations"`
+	Permissions                *WorkspacePermissions `jsonapi:"attr,permissions"`
+	QueueAllRuns               bool                  `jsonapi:"attr,queue-all-runs"`
+	SpeculativeEnabled         bool                  `jsonapi:"attr,speculative-enabled"`
+	SourceName                 string                `jsonapi:"attr,source-name"`
+	SourceURL                  string                `jsonapi:"attr,source-url"`
+	StructuredRunOutputEnabled bool                  `jsonapi:"attr,structured-run-output-enabled"`
+	TerraformVersion           string                `jsonapi:"attr,terraform-version"`
+	TriggerPrefixes            []string              `jsonapi:"attr,trigger-prefixes"`
+	VCSRepo                    *VCSRepo              `jsonapi:"attr,vcs-repo"`
+	WorkingDirectory           string                `jsonapi:"attr,working-directory"`
+	UpdatedAt                  time.Time             `jsonapi:"attr,updated-at,iso8601"`
+	ResourceCount              int                   `jsonapi:"attr,resource-count"`
+	ApplyDurationAverage       time.Duration         `jsonapi:"attr,apply-duration-average"`
+	PlanDurationAverage        time.Duration         `jsonapi:"attr,plan-duration-average"`
+	PolicyCheckFailures        int                   `jsonapi:"attr,policy-check-failures"`
+	RunFailures                int                   `jsonapi:"attr,run-failures"`
+	RunsCount                  int                   `jsonapi:"attr,workspace-kpis-runs-count"`
 
 	// Relations
 	AgentPool    *AgentPool    `jsonapi:"relation,agent-pool"`
@@ -284,6 +285,12 @@ type WorkspaceCreateOptions struct {
 	// can be the URL of a related resource in another app, or a link to
 	// documentation or other info about the client.
 	SourceURL *string `jsonapi:"attr,source-url,omitempty"`
+
+	// BETA. Enable the experimental advanced run user interface.
+	// This only applies to runs using Terraform version 0.15.2 or newer,
+	// and runs executed using older versions will see the classic experience
+	// regardless of this setting.
+	StructuredRunOutputEnabled *bool `jsonapi:"attr,structured-run-output-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace. Upon creating a
 	// workspace, the latest version is selected unless otherwise specified.
@@ -498,6 +505,12 @@ type WorkspaceUpdateOptions struct {
 	// running plans on pull requests, which can improve security if the VCS
 	// repository is public or includes untrusted contributors.
 	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
+
+	// BETA. Enable the experimental advanced run user interface.
+	// This only applies to runs using Terraform version 0.15.2 or newer,
+	// and runs executed using older versions will see the classic experience
+	// regardless of this setting.
+	StructuredRunOutputEnabled *bool `jsonapi:"attr,structured-run-output-enabled,omitempty"`
 
 	// The version of Terraform to use for this workspace.
 	TerraformVersion *string `jsonapi:"attr,terraform-version,omitempty"`

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -105,19 +105,20 @@ func TestWorkspacesCreate(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceCreateOptions{
-			Name:                String("foo"),
-			AllowDestroyPlan:    Bool(false),
-			AutoApply:           Bool(true),
-			Description:         String("qux"),
-			FileTriggersEnabled: Bool(true),
-			Operations:          Bool(true),
-			QueueAllRuns:        Bool(true),
-			SpeculativeEnabled:  Bool(true),
-			SourceName:          String("my-app"),
-			SourceURL:           String("http://my-app-hostname.io"),
-			TerraformVersion:    String("0.11.0"),
-			TriggerPrefixes:     []string{"/modules", "/shared"},
-			WorkingDirectory:    String("bar/"),
+			Name:                       String("foo"),
+			AllowDestroyPlan:           Bool(false),
+			AutoApply:                  Bool(true),
+			Description:                String("qux"),
+			FileTriggersEnabled:        Bool(true),
+			Operations:                 Bool(true),
+			QueueAllRuns:               Bool(true),
+			SpeculativeEnabled:         Bool(true),
+			SourceName:                 String("my-app"),
+			SourceURL:                  String("http://my-app-hostname.io"),
+			StructuredRunOutputEnabled: Bool(true),
+			TerraformVersion:           String("0.11.0"),
+			TriggerPrefixes:            []string{"/modules", "/shared"},
+			WorkingDirectory:           String("bar/"),
 		}
 
 		w, err := client.Workspaces.Create(ctx, orgTest.Name, options)
@@ -142,6 +143,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
 			assert.Equal(t, *options.SourceName, item.SourceName)
 			assert.Equal(t, *options.SourceURL, item.SourceURL)
+			assert.Equal(t, *options.StructuredRunOutputEnabled, item.StructuredRunOutputEnabled)
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
@@ -497,16 +499,17 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
-			Name:                String(randomString(t)),
-			AllowDestroyPlan:    Bool(true),
-			AutoApply:           Bool(false),
-			FileTriggersEnabled: Bool(true),
-			Operations:          Bool(false),
-			QueueAllRuns:        Bool(false),
-			SpeculativeEnabled:  Bool(true),
-			TerraformVersion:    String("0.11.1"),
-			TriggerPrefixes:     []string{"/modules", "/shared"},
-			WorkingDirectory:    String("baz/"),
+			Name:                       String(randomString(t)),
+			AllowDestroyPlan:           Bool(true),
+			AutoApply:                  Bool(false),
+			FileTriggersEnabled:        Bool(true),
+			Operations:                 Bool(false),
+			QueueAllRuns:               Bool(false),
+			SpeculativeEnabled:         Bool(true),
+			StructuredRunOutputEnabled: Bool(true),
+			TerraformVersion:           String("0.11.1"),
+			TriggerPrefixes:            []string{"/modules", "/shared"},
+			WorkingDirectory:           String("baz/"),
 		}
 
 		w, err := client.Workspaces.UpdateByID(ctx, wTest.ID, options)
@@ -527,6 +530,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
 			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
+			assert.Equal(t, *options.StructuredRunOutputEnabled, item.StructuredRunOutputEnabled)
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
@@ -1051,7 +1055,7 @@ func TestWorkspace_Unmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	iso8601TimeFormat := "2006-01-02T15:04:05Z"
-	parsedTime, err := time.Parse(iso8601TimeFormat, "2020-07-15T23:38:43.821Z")
+	parsedTime, _ := time.Parse(iso8601TimeFormat, "2020-07-15T23:38:43.821Z")
 
 	assert.Equal(t, ws.ID, "ws-1234")
 	assert.Equal(t, ws.Name, "my-workspace")

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -387,17 +387,18 @@ func TestWorkspacesUpdate(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
-			Name:                String(randomString(t)),
-			AllowDestroyPlan:    Bool(true),
-			AutoApply:           Bool(false),
-			FileTriggersEnabled: Bool(true),
-			Operations:          Bool(false),
-			QueueAllRuns:        Bool(false),
-			SpeculativeEnabled:  Bool(true),
-			Description:         String("updated description"),
-			TerraformVersion:    String("0.11.1"),
-			TriggerPrefixes:     []string{"/modules", "/shared"},
-			WorkingDirectory:    String("baz/"),
+			Name:                       String(randomString(t)),
+			AllowDestroyPlan:           Bool(true),
+			AutoApply:                  Bool(false),
+			FileTriggersEnabled:        Bool(true),
+			Operations:                 Bool(false),
+			QueueAllRuns:               Bool(false),
+			SpeculativeEnabled:         Bool(true),
+			Description:                String("updated description"),
+			StructuredRunOutputEnabled: Bool(true),
+			TerraformVersion:           String("0.11.1"),
+			TriggerPrefixes:            []string{"/modules", "/shared"},
+			WorkingDirectory:           String("baz/"),
 		}
 
 		w, err := client.Workspaces.Update(ctx, orgTest.Name, wTest.Name, options)
@@ -419,6 +420,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
 			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
+			assert.Equal(t, *options.StructuredRunOutputEnabled, item.StructuredRunOutputEnabled)
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)


### PR DESCRIPTION
## Description

This PR adds support for the new UI beta feature to enable structured run output for a workspace and is a prerequisite for https://github.com/hashicorp/terraform-provider-tfe/issues/327.

## Testing plan

1. export TFE_TOKEN=...
1. go test ./... -timeout=30m

## External links

- [Related Issue](https://github.com/hashicorp/terraform-provider-tfe/issues/327)

## Output from tests

TestWorkspacesCreate
```
❯ go test -run TestWorkspacesCreate -v ./...                                                          
=== RUN   TestWorkspacesCreate
=== RUN   TestWorkspacesCreate/with_valid_options
=== RUN   TestWorkspacesCreate/when_options_is_missing_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_organization
=== RUN   TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode
=== RUN   TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesCreate/when_an_error_is_returned_from_the_API
--- PASS: TestWorkspacesCreate (2.63s)
    --- PASS: TestWorkspacesCreate/with_valid_options (0.79s)
    --- PASS: TestWorkspacesCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_organization (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode (0.00s)
    --- PASS: TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_error_is_returned_from_the_API (0.14s)
PASS
ok      github.com/hashicorp/go-tfe     2.788s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
```

TestWorkspacesUpdate,
TestWorkspacesUpdateByID
```
❯ go test -run TestWorkspacesUpdate -v ./...
=== RUN   TestWorkspacesUpdate
=== RUN   TestWorkspacesUpdate/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdate/with_valid_options
=== RUN   TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesUpdate/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_organization
--- PASS: TestWorkspacesUpdate (2.88s)
    --- PASS: TestWorkspacesUpdate/when_updating_a_subset_of_values (0.39s)
    --- PASS: TestWorkspacesUpdate/with_valid_options (0.35s)
    --- PASS: TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesUpdate/when_an_error_is_returned_from_the_api (0.14s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestWorkspacesUpdateByID
=== RUN   TestWorkspacesUpdateByID/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdateByID/with_valid_options
=== RUN   TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdateByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUpdateByID (4.18s)
    --- PASS: TestWorkspacesUpdateByID/when_updating_a_subset_of_values (0.76s)
    --- PASS: TestWorkspacesUpdateByID/with_valid_options (0.42s)
    --- PASS: TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api (0.18s)
    --- PASS: TestWorkspacesUpdateByID/without_a_valid_workspace_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     7.351s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
```


