### PR TITLE
Add PolicySetVersions relation to PolicySet

### DIFF
--- a/policy_set.go
+++ b/policy_set.go
@@ -79,7 +79,7 @@ type PolicySet struct {
 	Policies []*Policy `jsonapi:"relation,policies"`
 	// The most recently created policy set version, regardless of status.
 	// Note that this relationship may include an errored and unusable version,
-	// and is intended to allow checking for VCS errors.
+	// and is intended to allow checking for errors.
 	PolicySetVersionNewest *PolicySetVersion `jsonapi:"relation,newest-version"`
 	// The most recent successful policy set version.
 	PolicySetVersionCurrent *PolicySetVersion `jsonapi:"relation,current-version"`

--- a/policy_set.go
+++ b/policy_set.go
@@ -72,8 +72,16 @@ type PolicySet struct {
 
 	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`
-	Policies     []*Policy     `jsonapi:"relation,policies"`
-	Workspaces   []*Workspace  `jsonapi:"relation,workspaces"`
+	// The workspaces to which the policy set applies
+	Workspaces []*Workspace `jsonapi:"relation,workspaces"`
+	// Individually managed policies which are associated with the policy set.
+	Policies []*Policy `jsonapi:"relation,policies"`
+	// The most recently created policy set version, regardless of status.
+	// Note that this relationship may include an errored and unusable version,
+	// and is intended to allow checking for VCS errors.
+	PolicySetVersionNewest *PolicySetVersion `jsonapi:"relation,newest-version"`
+	// The most recent successful policy set version.
+	PolicySetVersionCurrent *PolicySetVersion `jsonapi:"relation,current-version"`
 }
 
 // PolicySetListOptions represents the options for listing policy sets.

--- a/policy_set.go
+++ b/policy_set.go
@@ -187,6 +187,9 @@ func (s *policySets) Create(ctx context.Context, organization string, options Po
 	return ps, err
 }
 
+// PolicySetReadOptions are read options.
+// For a full list of relations, please see:
+// https://www.terraform.io/docs/cloud/api/policy-sets.html#relationships
 type PolicySetReadOptions struct {
 	Include string `url:"include"`
 }

--- a/policy_set.go
+++ b/policy_set.go
@@ -71,8 +71,9 @@ type PolicySet struct {
 	UpdatedAt      time.Time `jsonapi:"attr,updated-at,iso8601"`
 
 	// Relations
+	// The organization to which the policy set belongs to.
 	Organization *Organization `jsonapi:"relation,organization"`
-	// The workspaces to which the policy set applies
+	// The workspaces to which the policy set applies.
 	Workspaces []*Workspace `jsonapi:"relation,workspaces"`
 	// Individually managed policies which are associated with the policy set.
 	Policies []*Policy `jsonapi:"relation,policies"`

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -267,9 +267,9 @@ func TestPolicySetsRead(t *testing.T) {
 		require.NoError(t, err)
 
 		// The newest one is the policy set version created in this test.
-		assert.Equal(t, ps.PolicySetVersionNewest.ID, psv.ID)
+		assert.Equal(t, ps.PolicySetNewestVersion.ID, psv.ID)
 		// The current policy set version is nil because nothing has been uploaded
-		assert.Nil(t, ps.PolicySetVersionCurrent)
+		assert.Nil(t, ps.PolicySetCurrentVersion)
 
 		psvNew, psvCleanupNew := createPolicySetVersion(t, client, psTest)
 		defer psvCleanupNew()
@@ -280,16 +280,21 @@ func TestPolicySetsRead(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		ps, err = client.PolicySets.Read(ctx, psTest.ID)
+		opts := &PolicySetReadOptions{
+			Include: "current-version,newest-version",
+		}
+		ps, err = client.PolicySets.ReadWithOptions(ctx, psTest.ID, opts)
 		require.NoError(t, err)
 
 		// The newest policy set version is changed to the most recent one
 		// that was created.
-		assert.Equal(t, ps.PolicySetVersionNewest.ID, psvNew.ID)
+		assert.Equal(t, ps.PolicySetNewestVersion.ID, psvNew.ID)
+		assert.Equal(t, ps.PolicySetNewestVersion.Status, PolicySetVersionPending)
 		// The current one is now set because policies were uploaded to the
 		// policy set version. Notice how it is set to the one that was uplaoded,
 		// not the newest policy set version.
-		assert.Equal(t, ps.PolicySetVersionCurrent.ID, psv.ID)
+		assert.Equal(t, ps.PolicySetCurrentVersion.ID, psv.ID)
+		assert.Equal(t, ps.PolicySetCurrentVersion.Status, PolicySetVersionReady)
 	})
 }
 


### PR DESCRIPTION
## Description

The [API for PolicySets includes two relations](https://www.terraform.io/docs/cloud/api/policy-sets.html#relationships) that we currently do not implement:
```
- newest-version: The most recently created policy set version, regardless of status. Note that this relationship may include an errored and unusable version, and is intended to allow checking for VCS errors.
- current-version: The most recent successful policy set version.
```

This PR updates the PolicySet to include these two relations, and adds a test to assert how/when the relations are set. It also adds a method on PolicySet to `ReadWithOptions` so that one can `Include` other relationships.

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/policy-sets.html#relationships)

## Output from tests
```
go-tfe % TFE_TOKEN=<token> TFE_ADDRESS=https://tfe-zone-4c292d5b.ngrok.io/ go test -v -run TestPolicySetsRead
=== RUN   TestPolicySetsRead
=== RUN   TestPolicySetsRead/with_a_valid_ID
=== RUN   TestPolicySetsRead/without_a_valid_ID
=== RUN   TestPolicySetsRead/with_policy_set_version
--- PASS: TestPolicySetsRead (2.12s)
    --- PASS: TestPolicySetsRead/with_a_valid_ID (0.18s)
    --- PASS: TestPolicySetsRead/without_a_valid_ID (0.00s)
    --- PASS: TestPolicySetsRead/with_policy_set_version (0.80s)
PASS
ok      github.com/hashicorp/go-tfe     2.718s
```