### PR TITLE
Policy Set field name change

### DIFF
--- a/policy_set.go
+++ b/policy_set.go
@@ -83,9 +83,9 @@ type PolicySet struct {
 	// The most recently created policy set version, regardless of status.
 	// Note that this relationship may include an errored and unusable version,
 	// and is intended to allow checking for errors.
-	PolicySetNewestVersion *PolicySetVersion `jsonapi:"relation,newest-version"`
+	NewestVersion *PolicySetVersion `jsonapi:"relation,newest-version"`
 	// The most recent successful policy set version.
-	PolicySetCurrentVersion *PolicySetVersion `jsonapi:"relation,current-version"`
+	CurrentVersion *PolicySetVersion `jsonapi:"relation,current-version"`
 }
 
 // PolicySetListOptions represents the options for listing policy sets.

--- a/policy_set_test.go
+++ b/policy_set_test.go
@@ -267,9 +267,9 @@ func TestPolicySetsRead(t *testing.T) {
 		require.NoError(t, err)
 
 		// The newest one is the policy set version created in this test.
-		assert.Equal(t, ps.PolicySetNewestVersion.ID, psv.ID)
+		assert.Equal(t, ps.NewestVersion.ID, psv.ID)
 		// The current policy set version is nil because nothing has been uploaded
-		assert.Nil(t, ps.PolicySetCurrentVersion)
+		assert.Nil(t, ps.CurrentVersion)
 
 		psvNew, psvCleanupNew := createPolicySetVersion(t, client, psTest)
 		defer psvCleanupNew()
@@ -288,13 +288,13 @@ func TestPolicySetsRead(t *testing.T) {
 
 		// The newest policy set version is changed to the most recent one
 		// that was created.
-		assert.Equal(t, ps.PolicySetNewestVersion.ID, psvNew.ID)
-		assert.Equal(t, ps.PolicySetNewestVersion.Status, PolicySetVersionPending)
+		assert.Equal(t, ps.NewestVersion.ID, psvNew.ID)
+		assert.Equal(t, ps.NewestVersion.Status, PolicySetVersionPending)
 		// The current one is now set because policies were uploaded to the
 		// policy set version. Notice how it is set to the one that was uplaoded,
 		// not the newest policy set version.
-		assert.Equal(t, ps.PolicySetCurrentVersion.ID, psv.ID)
-		assert.Equal(t, ps.PolicySetCurrentVersion.Status, PolicySetVersionReady)
+		assert.Equal(t, ps.CurrentVersion.ID, psv.ID)
+		assert.Equal(t, ps.CurrentVersion.Status, PolicySetVersionReady)
 	})
 }
 


### PR DESCRIPTION
## Description

Two new fields were added to PolicySet in a #234. One [suggestion regarding](https://github.com/hashicorp/go-tfe/pull/234#discussion_r652160904) naming was overlooked.

This PR changes the naming to remain consistent with how naming is done in this client.
