### PR TITLE
Update go-slug to v0.7.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ require (
 	github.com/google/go-querystring v1.0.0
 	github.com/hashicorp/go-cleanhttp v0.5.0
 	github.com/hashicorp/go-retryablehttp v0.5.2
-	github.com/hashicorp/go-slug v0.4.1
+	github.com/hashicorp/go-slug v0.7.0
 	github.com/hashicorp/go-uuid v1.0.1
 	github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -9,6 +9,8 @@ github.com/hashicorp/go-retryablehttp v0.5.2 h1:AoISa4P4IsW0/m4T6St8Yw38gTl5GtBA
 github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
 github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
 github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
+github.com/hashicorp/go-slug v0.7.0 h1:8HIi6oreWPtnhpYd8lIGQBgp4rXzDWQTOhfILZm+nok=
+github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
 github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
 github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3 h1:mzwkutymYIXR5oQT9YnfbLuuw7LZmksiHKRPUTN5ijo=


### PR DESCRIPTION
## Description

As explained in issue #239, our version of go-slug v0.4.x had a [security vulnerability](https://nvd.nist.gov/vuln/detail/CVE-2020-29529) that was [fixed](https://github.com/hashicorp/go-slug/pull/12). This PR updates go-slug to the [latest version v0.7.0](https://github.com/hashicorp/go-slug/releases/tag/v0.7.0).

## Testing plan

Full test suite

## External links

- [Security issue](https://nvd.nist.gov/vuln/detail/CVE-2020-29529)
- [Related PR](https://github.com/hashicorp/go-slug/pull/12)
