### PR TITLE
Add IngressAttribute.CommitSHA

### DIFF
--- a/configuration_version.go
+++ b/configuration_version.go
@@ -119,6 +119,7 @@ type IngressAttributes struct {
 	Branch            string `jsonapi:"attr,branch"`
 	CloneURL          string `jsonapi:"attr,clone-url"`
 	CommitMessage     string `jsonapi:"attr,commit-message"`
+	CommitSHA         string `jsonapi:"attr,commit-sha"`
 	CommitURL         string `jsonapi:"attr,commit-url"`
 	CompareURL        string `jsonapi:"attr,compare-url"`
 	Identifier        string `jsonapi:"attr,identifier"`

--- a/configuration_version_test.go
+++ b/configuration_version_test.go
@@ -182,6 +182,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 
 		assert.NotZero(t, cv.IngressAttributes)
 		assert.NotZero(t, cv.IngressAttributes.CommitURL)
+		assert.NotZero(t, cv.IngressAttributes.CommitSHA)
 	})
 }
 


### PR DESCRIPTION
## Description

Adding `CommitSHA` to the newly added `IngressAttributes` struct. The API already returns `commit-sha` in its response, this just allows the client access to that information.

## Testing plan

1.  Retrieve an ingress attribute record
2. Confirm it contains a commit SHA

## Output from tests

```
go test -run TestConfigurationVersions -v
=== RUN   TestConfigurationVersionsList
=== RUN   TestConfigurationVersionsList/without_list_options
=== RUN   TestConfigurationVersionsList/with_list_options
=== RUN   TestConfigurationVersionsList/without_a_valid_organization
--- PASS: TestConfigurationVersionsList (2.37s)
    --- PASS: TestConfigurationVersionsList/without_list_options (0.18s)
    --- PASS: TestConfigurationVersionsList/with_list_options (0.21s)
    --- PASS: TestConfigurationVersionsList/without_a_valid_organization (0.00s)
=== RUN   TestConfigurationVersionsCreate
=== RUN   TestConfigurationVersionsCreate/with_valid_options
=== RUN   TestConfigurationVersionsCreate/with_invalid_workspace_id
--- PASS: TestConfigurationVersionsCreate (1.40s)
    --- PASS: TestConfigurationVersionsCreate/with_valid_options (0.32s)
    --- PASS: TestConfigurationVersionsCreate/with_invalid_workspace_id (0.00s)
=== RUN   TestConfigurationVersionsRead
=== RUN   TestConfigurationVersionsRead/when_the_configuration_version_exists
=== RUN   TestConfigurationVersionsRead/when_the_configuration_version_does_not_exist
=== RUN   TestConfigurationVersionsRead/with_invalid_configuration_version_id
--- PASS: TestConfigurationVersionsRead (1.40s)
    --- PASS: TestConfigurationVersionsRead/when_the_configuration_version_exists (0.12s)
    --- PASS: TestConfigurationVersionsRead/when_the_configuration_version_does_not_exist (0.05s)
    --- PASS: TestConfigurationVersionsRead/with_invalid_configuration_version_id (0.00s)
=== RUN   TestConfigurationVersionsReadWithOptions
=== RUN   TestConfigurationVersionsReadWithOptions/when_the_configuration_version_exists
--- PASS: TestConfigurationVersionsReadWithOptions (8.61s)
    --- PASS: TestConfigurationVersionsReadWithOptions/when_the_configuration_version_exists (0.22s)
=== RUN   TestConfigurationVersionsUpload
=== RUN   TestConfigurationVersionsUpload/with_valid_options
=== RUN   TestConfigurationVersionsUpload/without_a_valid_upload_URL
=== RUN   TestConfigurationVersionsUpload/without_a_valid_path
--- PASS: TestConfigurationVersionsUpload (2.64s)
    --- PASS: TestConfigurationVersionsUpload/with_valid_options (1.43s)
    --- PASS: TestConfigurationVersionsUpload/without_a_valid_upload_URL (0.04s)
    --- PASS: TestConfigurationVersionsUpload/without_a_valid_path (0.00s)
=== RUN   TestConfigurationVersions_Unmarshal
--- PASS: TestConfigurationVersions_Unmarshal (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	16.580s
```

Closes #238