### PR TITLE
Update state-version outputs for complex types

### DIFF
--- a/state_version_output.go
+++ b/state_version_output.go
@@ -2,6 +2,7 @@ package tfe
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/url"
 )
@@ -23,11 +24,11 @@ type stateVersionOutputs struct {
 }
 
 type StateVersionOutput struct {
-	ID        string `jsonapi:"primary,state-version-outputs"`
-	Name      string `jsonapi:"attr,name"`
-	Sensitive bool   `jsonapi:"attr,sensitive"`
-	Type      string `jsonapi:"attr,type"`
-	Value     string `jsonapi:"attr,value"`
+	ID        string          `jsonapi:"primary,state-version-outputs"`
+	Name      string          `jsonapi:"attr,name"`
+	Sensitive bool            `jsonapi:"attr,sensitive"`
+	Type      string          `jsonapi:"attr,type"`
+	Value     json.RawMessage `jsonapi:"attr,value"`
 }
 
 func (s *stateVersionOutputs) Read(ctx context.Context, outputID string) (*StateVersionOutput, error) {

--- a/test-fixtures/state-version/terraform.tfstate
+++ b/test-fixtures/state-version/terraform.tfstate
@@ -1,12 +1,16 @@
 {
   "version": 4,
-  "terraform_version": "0.12.29",
+  "terraform_version": "0.12.31",
   "serial": 2,
   "lineage": "b2b54b23-e7ea-5500-7b15-fcb68c1d92bb",
   "outputs": {
     "test_output": {
       "value": "9023256633839603543",
       "type": "string"
+    },
+    "test_output_arr": {
+      "value": ["1", "2"],
+      "type": "array"
     }
   },
   "resources": [


### PR DESCRIPTION
Replace string with json.RawMessage to account for non-string state outputs

## Description
TF state outputs can be complex types, but the current implementation always assumes strings.

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/state-version-outputs.html#show-a-state-version-output)

## Output from tests

I have to rely on the CI to execute tests as I don't have access to a live instance right now, sorry.