### PR TITLE
Workspace ReadWithOptions

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -145,7 +145,7 @@ type WorkspaceOutputs struct {
 	ID        string      `jsonapi:"primary,workspace-outputs"`
 	Name      string      `jsonapi:"attr,name"`
 	Sensitive bool        `jsonapi:"attr,sensitive"`
-	Type      string      `jsonapi:"attr,type"`
+	Type      string      `jsonapi:"attr,output-type"`
 	Value     interface{} `jsonapi:"attr,value"`
 }
 

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -294,13 +294,19 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 		assert.Len(t, w.Outputs, len(svOutputs))
 
 		wsOutputs := map[string]interface{}{}
+		wsOutputsTypes := map[string]string{}
 		for _, op := range w.Outputs {
 			wsOutputs[op.Name] = op.Value
+			wsOutputsTypes[op.Name] = op.Type
 		}
 		for _, svop := range svOutputs {
 			val, ok := wsOutputs[svop.Name]
 			assert.True(t, ok)
 			assert.Equal(t, svop.Value, val)
+
+			val, ok = wsOutputsTypes[svop.Name]
+			assert.True(t, ok)
+			assert.Equal(t, svop.Type, val)
 		}
 	})
 }

--- a/workspace_test.go
+++ b/workspace_test.go
@@ -284,14 +284,24 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 		}
 		w, err := client.Workspaces.ReadWithOptions(ctx, orgTest.Name, wTest.Name, opts)
 		require.NoError(t, err)
-		assert.Equal(t, wTest.ID, w.ID)
 
+		assert.Equal(t, wTest.ID, w.ID)
 		assert.NotEmpty(t, w.Outputs)
 
 		svOutputs, err := client.StateVersions.Outputs(ctx, svTest.ID, StateVersionOutputsListOptions{})
 		require.NoError(t, err)
 
 		assert.Len(t, w.Outputs, len(svOutputs))
+
+		wsOutputs := map[string]interface{}{}
+		for _, op := range w.Outputs {
+			wsOutputs[op.Name] = op.Value
+		}
+		for _, svop := range svOutputs {
+			val, ok := wsOutputs[svop.Name]
+			assert.True(t, ok)
+			assert.Equal(t, svop.Value, val)
+		}
 	})
 }
 


### PR DESCRIPTION
## Description

According to the [Workspace API](https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources), there are multiple resources to be included with reading a workspace. But in this client, we do not have the option to do so.

This adds a new method to `ReadWithOptions` that reads a workspace with additional options. 

_Note: there exists another method to `ReadByIDWithOptions`, but that assumes you have the workspace ID. This method takes an organization name and workspace name with the options._

## Testing plan

1. Create a workspace
2. Create state version with outputs
3. Query the workspace and ensure the outputs are present.

This setup is done in the added test.

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources)

## Output from tests

```
$ TFE_TOKEN=<token> TFE_ADDRESS=https://tfe-zone-4c292d5b.ngrok.io/ go test -v -run TestWorkspacesReadWithOptions
=== RUN   TestWorkspacesReadWithOptions
=== RUN   TestWorkspacesReadWithOptions/when_options_to_include_resource
--- PASS: TestWorkspacesReadWithOptions (3.33s)
    --- PASS: TestWorkspacesReadWithOptions/when_options_to_include_resource (0.46s)
PASS
ok      github.com/hashicorp/go-tfe     3.459s
```
