### PR TITLE
Add Workspace tag options validation to return error when no tags

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -1040,6 +1040,9 @@ type WorkspaceAddTagsOptions struct {
 }
 
 func (o WorkspaceAddTagsOptions) valid() error {
+	if len(o.Tags) == 0 {
+		return ErrMissingTagIdentifier
+	}
 	for _, s := range o.Tags {
 		if s.Name == "" && s.ID == "" {
 			return ErrMissingTagIdentifier
@@ -1072,6 +1075,9 @@ type WorkspaceRemoveTagsOptions struct {
 }
 
 func (o WorkspaceRemoveTagsOptions) valid() error {
+	if len(o.Tags) == 0 {
+		return ErrMissingTagIdentifier
+	}
 	for _, s := range o.Tags {
 		if s.Name == "" && s.ID == "" {
 			return ErrMissingTagIdentifier


### PR DESCRIPTION
## Description

The Workspace Add/Remove Tags tests are failing because the options validation should return an error when there are no tags present.

This fixes that. 


## Output from tests

```
go-tfe % TFE_TOKEN=<token> TFE_ADDRESS=https://app.terraform.io  go test -v -run TestWorkspaces_AddTags
=== RUN   TestWorkspaces_AddTags
=== RUN   TestWorkspaces_AddTags/successfully_adds_tags
=== RUN   TestWorkspaces_AddTags/successfully_adds_tags_by_id_and_name
=== RUN   TestWorkspaces_AddTags/with_invalid_options
=== RUN   TestWorkspaces_AddTags/without_a_valid_workspace_ID
--- PASS: TestWorkspaces_AddTags (2.77s)
    --- PASS: TestWorkspaces_AddTags/successfully_adds_tags (0.56s)
    --- PASS: TestWorkspaces_AddTags/successfully_adds_tags_by_id_and_name (1.16s)
    --- PASS: TestWorkspaces_AddTags/with_invalid_options (0.00s)
    --- PASS: TestWorkspaces_AddTags/without_a_valid_workspace_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     2.899s
go-tfe % TFE_TOKEN=<token> TFE_ADDRESS=https://app.terraform.io  go test -v -run TestWorkspaces_RemoveTags
=== RUN   TestWorkspaces_RemoveTags
=== RUN   TestWorkspaces_RemoveTags/successfully_removes_tags
=== RUN   TestWorkspaces_RemoveTags/attempts_to_remove_a_tag_that_doesn't_exist
=== RUN   TestWorkspaces_RemoveTags/with_invalid_options
=== RUN   TestWorkspaces_RemoveTags/without_a_valid_workspace_ID
--- PASS: TestWorkspaces_RemoveTags (4.26s)
    --- PASS: TestWorkspaces_RemoveTags/successfully_removes_tags (2.30s)
    --- PASS: TestWorkspaces_RemoveTags/attempts_to_remove_a_tag_that_doesn't_exist (0.08s)
    --- PASS: TestWorkspaces_RemoveTags/with_invalid_options (0.00s)
    --- PASS: TestWorkspaces_RemoveTags/without_a_valid_workspace_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     4.394s
```
