### PR TITLE
Add auto-apply to Runs and RunCreateOptions

### DIFF
--- a/run.go
+++ b/run.go
@@ -235,7 +235,7 @@ type RunCreateOptions struct {
 	ReplaceAddrs []string `jsonapi:"attr,replace-addrs,omitempty"`
 
 	// AutoApply determines if the run should be applied automatically without
-	// user confirmation.
+	// user confirmation. It defaults to the Workspace.AutoApply setting.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
 }
 

--- a/run.go
+++ b/run.go
@@ -91,6 +91,7 @@ type RunList struct {
 type Run struct {
 	ID                     string               `jsonapi:"primary,runs"`
 	Actions                *RunActions          `jsonapi:"attr,actions"`
+	AutoApply              bool                 `jsonapi:"attr,auto-apply,omitempty"`
 	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
 	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
@@ -232,6 +233,10 @@ type RunCreateOptions struct {
 	// (destroys and then re-creates) the objects specified by the given
 	// resource addresses.
 	ReplaceAddrs []string `jsonapi:"attr,replace-addrs,omitempty"`
+
+	// AutoApply determines if the run should be applied automatically without
+	// user confirmation.
+	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
 }
 
 func (o RunCreateOptions) valid() error {

--- a/run_test.go
+++ b/run_test.go
@@ -132,6 +132,20 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, true, r.RefreshOnly)
 	})
 
+	t.Run("with auto-apply requeted", func(t *testing.T) {
+		// ensure the worksapce auto-apply is false so it does not default to that.
+		assert.Equal(t, false, wTest.AutoApply)
+
+		options := RunCreateOptions{
+			Workspace: wTest,
+			AutoApply: Bool(true),
+		}
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, true, r.AutoApply)
+	})
+
 	t.Run("without a workspace", func(t *testing.T) {
 		r, err := client.Runs.Create(ctx, RunCreateOptions{})
 		assert.Nil(t, r)

--- a/run_test.go
+++ b/run_test.go
@@ -146,6 +146,16 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, true, r.AutoApply)
 	})
 
+	t.Run("without auto-apply, defaulting to workspace autoapply", func(t *testing.T) {
+		options := RunCreateOptions{
+			Workspace: wTest,
+		}
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, wTest.AutoApply, r.AutoApply)
+	})
+
 	t.Run("without a workspace", func(t *testing.T) {
 		r, err := client.Runs.Create(ctx, RunCreateOptions{})
 		assert.Nil(t, r)

--- a/run_test.go
+++ b/run_test.go
@@ -132,7 +132,7 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, true, r.RefreshOnly)
 	})
 
-	t.Run("with auto-apply requeted", func(t *testing.T) {
+	t.Run("with auto-apply requested", func(t *testing.T) {
 		// ensure the worksapce auto-apply is false so it does not default to that.
 		assert.Equal(t, false, wTest.AutoApply)
 


### PR DESCRIPTION
## Description

This PR allows for setting the `AutoApply` attribute for a particular run. 

The API documentation is being added [in this PR](https://github.com/hashicorp/terraform-website/pull/1869).

## External links

- [API documentation](https://github.com/hashicorp/terraform-website/pull/1869)

## Output from tests

```
$ go-tfe % TFE_TOKEN=<redacted> TFE_ADDRESS=https://app.terraform.io/  go test -v -run TestRunsCreate
=== RUN   TestRunsCreate
=== RUN   TestRunsCreate/without_a_configuration_version
=== RUN   TestRunsCreate/with_a_configuration_version
=== RUN   TestRunsCreate/refresh_defaults_to_true_if_not_set_as_a_create_option
=== RUN   TestRunsCreate/with_refresh-only_requested
    run_test.go:124: Skipping this test until -refresh-only is released in the Terraform CLI
=== RUN   TestRunsCreate/with_auto-apply_requeted
=== RUN   TestRunsCreate/with_auto-apply_defaulting_to_workspace_autoapply
=== RUN   TestRunsCreate/without_a_workspace
=== RUN   TestRunsCreate/with_additional_attributes
--- PASS: TestRunsCreate (38.77s)
    --- PASS: TestRunsCreate/without_a_configuration_version (0.46s)
    --- PASS: TestRunsCreate/with_a_configuration_version (0.41s)
    --- PASS: TestRunsCreate/refresh_defaults_to_true_if_not_set_as_a_create_option (1.13s)
    --- SKIP: TestRunsCreate/with_refresh-only_requested (0.00s)
    --- PASS: TestRunsCreate/with_auto-apply_requeted (15.36s)
    --- PASS: TestRunsCreate/with_auto-apply_defaulting_to_workspace_autoapply (15.40s)
    --- PASS: TestRunsCreate/without_a_workspace (0.00s)
    --- PASS: TestRunsCreate/with_additional_attributes (0.31s)
PASS
ok      github.com/hashicorp/go-tfe     39.419s
```
