### PR TITLE
Add RemoteStateConsumersListOptions to Workspaces.RemoteStateconsumers()

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -73,7 +73,7 @@ type Workspaces interface {
 	UnassignSSHKey(ctx context.Context, workspaceID string) (*Workspace, error)
 
 	// RemoteStateConsumers reads the remote state consumers for a workspace.
-	RemoteStateConsumers(ctx context.Context, workspaceID string) (*WorkspaceList, error)
+	RemoteStateConsumers(ctx context.Context, workspaceID string, options *RemoteStateConsumersListOptions) (*WorkspaceList, error)
 
 	// AddRemoteStateConsumers adds remote state consumers to a workspace.
 	AddRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceAddRemoteStateConsumersOptions) error
@@ -878,15 +878,19 @@ func (s *workspaces) UnassignSSHKey(ctx context.Context, workspaceID string) (*W
 	return w, nil
 }
 
+type RemoteStateConsumersListOptions struct {
+	ListOptions
+}
+
 // RemoteStateConsumers returns the remote state consumers for a given workspace.
-func (s *workspaces) RemoteStateConsumers(ctx context.Context, workspaceID string) (*WorkspaceList, error) {
+func (s *workspaces) RemoteStateConsumers(ctx context.Context, workspaceID string, options *RemoteStateConsumersListOptions) (*WorkspaceList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
 
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.newRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -938,7 +938,7 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 		_, err = client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 
-		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
+		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -992,7 +992,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
+		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -1006,7 +1006,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		_, err = client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 
-		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
+		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Contains(t, rsc.Items, wTestConsumer2)
 		assert.Equal(t, 1, len(rsc.Items))
@@ -1016,7 +1016,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
+		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Empty(t, len(rsc.Items))
 	})
@@ -1068,7 +1068,7 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
+		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -1078,7 +1078,7 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID)
+		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer2)


### PR DESCRIPTION
## Description

**This is a breaking change**

Sadly, when the remote state consumers API was added in #201, the ability to pass options to this relationships index query was forgotten. The end result is that you cannot effectively fetch more than a single page (defaulted to 20 results) of remote state consumers for a workspace. This adds those options, to pass pagination concerns to the request.

Given that functionality is fairly broken past 20 state consumers in the original method signature, it's a relatively new API, and that the path to updating users of this package is to simply add `nil` to the end of the argument list at any caller, this is an intentional breaking change instead of leaving the broken method and adding a 'RemoteStateConsumersWithOptions' alternative.