### PR TITLE
updates links to docs to match the current url

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -14,7 +14,7 @@ var _ Applies = (*applies)(nil)
 // Applies describes all the apply related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/apply.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/applies.html
 type Applies interface {
 	// Read an apply by its ID.
 	Read(ctx context.Context, applyID string) (*Apply, error)

--- a/cost_estimate.go
+++ b/cost_estimate.go
@@ -15,7 +15,7 @@ var _ CostEstimates = (*costEstimates)(nil)
 // CostEstimates describes all the costEstimate related methods that
 // the Terraform Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/ (TBD)
+// TFE API docs: https://www.terraform.io/docs/cloud/api/cost-estimates.html
 type CostEstimates interface {
 	// Read a costEstimate by its ID.
 	Read(ctx context.Context, costEstimateID string) (*CostEstimate, error)

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -15,7 +15,7 @@ var _ NotificationConfigurations = (*notificationConfigurations)(nil)
 // related methods that the Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/notification-configurations.html
+// https://www.terraform.io/docs/cloud/api/notification-configurations.html
 type NotificationConfigurations interface {
 	// List all the notification configurations within a workspace.
 	List(ctx context.Context, workspaceID string, options NotificationConfigurationListOptions) (*NotificationConfigurationList, error)

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -15,7 +15,7 @@ var _ OAuthTokens = (*oAuthTokens)(nil)
 // Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/oauth-tokens.html
+// https://www.terraform.io/docs/cloud/api/oauth-tokens.html
 type OAuthTokens interface {
 	// List all the OAuth tokens for a given organization.
 	List(ctx context.Context, organization string, options OAuthTokenListOptions) (*OAuthTokenList, error)

--- a/organization.go
+++ b/organization.go
@@ -15,7 +15,7 @@ var _ Organizations = (*organizations)(nil)
 // Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/organizations.html
+// https://www.terraform.io/docs/cloud/api/organizations.html
 type Organizations interface {
 	// List all the organizations visible to the current user.
 	List(ctx context.Context, options OrganizationListOptions) (*OrganizationList, error)

--- a/organization_token.go
+++ b/organization_token.go
@@ -14,7 +14,7 @@ var _ OrganizationTokens = (*organizationTokens)(nil)
 // that the Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/organization-tokens.html
+// https://www.terraform.io/docs/cloud/api/organization-tokens.html
 type OrganizationTokens interface {
 	// Generate a new organization token, replacing any existing token.
 	Generate(ctx context.Context, organization string) (*OrganizationToken, error)

--- a/plan.go
+++ b/plan.go
@@ -16,7 +16,7 @@ var _ Plans = (*plans)(nil)
 // Plans describes all the plan related methods that the Terraform Enterprise
 // API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/plan.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/plan.html
 type Plans interface {
 	// Read a plan by its ID.
 	Read(ctx context.Context, planID string) (*Plan, error)

--- a/plan_export.go
+++ b/plan_export.go
@@ -15,7 +15,7 @@ var _ PlanExports = (*planExports)(nil)
 // PlanExports describes all the plan export related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/plan-exports.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/plan-exports.html
 type PlanExports interface {
 	// Export a plan by its ID with the given options.
 	Create(ctx context.Context, options PlanExportCreateOptions) (*PlanExport, error)

--- a/policy.go
+++ b/policy.go
@@ -15,7 +15,7 @@ var _ Policies = (*policies)(nil)
 // Policies describes all the policy related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/policies.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/policies.html
 type Policies interface {
 	// List all the policies for a given organization
 	List(ctx context.Context, organization string, options PolicyListOptions) (*PolicyList, error)

--- a/policy_check.go
+++ b/policy_check.go
@@ -17,7 +17,7 @@ var _ PolicyChecks = (*policyChecks)(nil)
 // Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/policy-checks.html
+// https://www.terraform.io/docs/cloud/api/policy-checks.html
 type PolicyChecks interface {
 	// List all policy checks of the given run.
 	List(ctx context.Context, runID string, options PolicyCheckListOptions) (*PolicyCheckList, error)

--- a/policy_set.go
+++ b/policy_set.go
@@ -14,7 +14,7 @@ var _ PolicySets = (*policySets)(nil)
 // PolicySets describes all the policy set related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/policies.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/policies.html
 type PolicySets interface {
 	// List all the policy sets for a given organization.
 	List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error)

--- a/policy_set_parameter.go
+++ b/policy_set_parameter.go
@@ -13,7 +13,7 @@ var _ PolicySetParameters = (*policySetParameters)(nil)
 // PolicySetParameters describes all the parameter related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/policy-set-params.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/policy-set-params.html
 type PolicySetParameters interface {
 	// List all the parameters associated with the given policy-set.
 	List(ctx context.Context, policySetID string, options PolicySetParameterListOptions) (*PolicySetParameterList, error)

--- a/run.go
+++ b/run.go
@@ -14,7 +14,7 @@ var _ Runs = (*runs)(nil)
 // Runs describes all the run related methods that the Terraform Enterprise
 // API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/run.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/run.html
 type Runs interface {
 	// List all the runs of the given workspace.
 	List(ctx context.Context, workspaceID string, options RunListOptions) (*RunList, error)

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -342,7 +342,7 @@ func TestRunsForceCancel(t *testing.T) {
 		// Force-cancel only becomes available if a normal cancel is performed
 		// first, and the desired canceled state is not reached within a pre-
 		// determined amount of time (see
-		// https://www.terraform.io/docs/enterprise/api/run.html#forcefully-cancel-a-run).
+		// https://www.terraform.io/docs/cloud/api/run.html#forcefully-cancel-a-run).
 	})
 
 	t.Run("when the run does not exist", func(t *testing.T) {

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -14,7 +14,7 @@ var _ SSHKeys = (*sshKeys)(nil)
 // Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/ssh-keys.html
+// https://www.terraform.io/docs/cloud/api/ssh-keys.html
 type SSHKeys interface {
 	// List all the SSH keys for a given organization
 	List(ctx context.Context, organization string, options SSHKeyListOptions) (*SSHKeyList, error)

--- a/state_version.go
+++ b/state_version.go
@@ -16,7 +16,7 @@ var _ StateVersions = (*stateVersions)(nil)
 // the Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/state-versions.html
+// https://www.terraform.io/docs/cloud/api/state-versions.html
 type StateVersions interface {
 	// List all the state versions for a given workspace.
 	List(ctx context.Context, options StateVersionListOptions) (*StateVersionList, error)

--- a/team.go
+++ b/team.go
@@ -13,7 +13,7 @@ var _ Teams = (*teams)(nil)
 // Teams describes all the team related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/teams.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/teams.html
 type Teams interface {
 	// List all the teams of the given organization.
 	List(ctx context.Context, organization string, options TeamListOptions) (*TeamList, error)

--- a/team_access.go
+++ b/team_access.go
@@ -14,7 +14,7 @@ var _ TeamAccesses = (*teamAccesses)(nil)
 // Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/team-access.html
+// https://www.terraform.io/docs/cloud/api/team-access.html
 type TeamAccesses interface {
 	// List all the team accesses for a given workspace.
 	List(ctx context.Context, options TeamAccessListOptions) (*TeamAccessList, error)

--- a/team_member.go
+++ b/team_member.go
@@ -16,7 +16,7 @@ var _ TeamMembers = (*teamMembers)(nil)
 // Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/team-members.html
+// https://www.terraform.io/docs/cloud/api/team-members.html
 type TeamMembers interface {
 	// List returns all Users of a team calling ListUsers
 	// See ListOrganizationMemberships for fetching memberships

--- a/team_token.go
+++ b/team_token.go
@@ -15,7 +15,7 @@ var _ TeamTokens = (*teamTokens)(nil)
 // Terraform Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/team-tokens.html
+// https://www.terraform.io/docs/cloud/api/team-tokens.html
 type TeamTokens interface {
 	// Generate a new team token, replacing any existing token.
 	Generate(ctx context.Context, teamID string) (*TeamToken, error)

--- a/user.go
+++ b/user.go
@@ -10,7 +10,7 @@ var _ Users = (*users)(nil)
 // Users describes all the user related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/user.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/account.html
 type Users interface {
 	// ReadCurrent reads the details of the currently authenticated user.
 	ReadCurrent(ctx context.Context) (*User, error)

--- a/user_token.go
+++ b/user_token.go
@@ -15,7 +15,7 @@ var _ UserTokens = (*userTokens)(nil)
 // Terraform Cloud/Enterprise API supports.
 //
 // TFE API docs:
-// https://www.terraform.io/docs/enterprise/api/user-tokens.html
+// https://www.terraform.io/docs/cloud/api/user-tokens.html
 type UserTokens interface {
 	// List all the tokens of the given user ID.
 	List(ctx context.Context, userID string) (*UserTokenList, error)

--- a/workspace.go
+++ b/workspace.go
@@ -16,7 +16,7 @@ var _ Workspaces = (*workspaces)(nil)
 // Workspaces describes all the workspace related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://www.terraform.io/docs/enterprise/api/workspaces.html
+// TFE API docs: https://www.terraform.io/docs/cloud/api/workspaces.html
 type Workspaces interface {
 	// List all the workspaces within an organization.
 	List(ctx context.Context, organization string, options WorkspaceListOptions) (*WorkspaceList, error)


### PR DESCRIPTION
## Description

Update comments that point to old API docs url

1. Most of them changes is just replacing `/entreprise` part of the url to `/cloud`
2. `users.go` points to `https://www.terraform.io/docs/enterprise/api/user.html` which takes you to a "page not found", replacing `/enterprise` with `/cloud` it does not help either. It looks like users.go represents the account API `https://www.terraform.io/docs/cloud/api/account.html`, so I changed `https://www.terraform.io/docs/enterprise/api/user.html` to be `https://www.terraform.io/docs/cloud/api/account.html`

