### PR TITLE
verify go.mod and go.sum are up to date

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,5 +37,7 @@ jobs:
         run: go mod download
       - name: Generate mocks
         run:  ./generate_mocks.sh
+      - name: verify go.mod and go.sum are consistent
+        run : go mod tidy
       - name: Ensure nothing changed
         run: git diff --exit-code


### PR DESCRIPTION
## Description

As part of our repo hygiene, we want to verify that any individual contributor has already ran `go mod tidy` locally if they have made any changes to go.mod.
This additional step that I am adding to the pre-existing `codegen` github action job will catch any inconsistencies between go.mod and go.sum by running `go mod tidy` first and then `git diff --exit-code`.  If there are inconsistencies, the latter command will output something like this in the `Actions` terminal:

```
diff --git a/go.mod b/go.mod
index 0ab3f21..a8217e0 100644
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/hashicorp/go-tfe
 go 1.17
 
 require (
-	github.com/golang/mock v1.6.0
+	github.com/golang/mock v1.5.0
 	github.com/google/go-querystring v1.1.0
 	github.com/hashicorp/go-cleanhttp v0.5.2
 	github.com/hashicorp/go-retryablehttp v0.7.0
diff --git a/go.sum b/go.sum
index 7cd0767..bb41898 100644
--- a/go.sum
+++ b/go.sum
@@ -1,8 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
-github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
+github.com/golang/mock v1.5.0 h1:jlYHihg//f7RRwuPfptm04yp4s7O6Kw8EZiVYIGcH0g=
+github.com/golang/mock v1.5.0/go.mod h1:CWnOUgYIOo4TcNZ0wHX3YZCqsaM1I1Jvs6v3mP3KVu8
```

and then throw an exit code 1 which makes the github action workflow fail.
However, if there are no inconsistencies between go.mod and go.sum, the workflow should succeed.

