### PR TITLE
Let official, enabled, and beta be optional when creating new Terrafo…

### DIFF
--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -106,9 +106,9 @@ type AdminTerraformVersionCreateOptions struct {
 	Version  *string `jsonapi:"attr,version"`
 	URL      *string `jsonapi:"attr,url"`
 	Sha      *string `jsonapi:"attr,sha"`
-	Official *bool   `jsonapi:"attr,official"`
-	Enabled  *bool   `jsonapi:"attr,enabled"`
-	Beta     *bool   `jsonapi:"attr,beta"`
+	Official *bool   `jsonapi:"attr,official,omitempty"`
+	Enabled  *bool   `jsonapi:"attr,enabled,omitempty"`
+	Beta     *bool   `jsonapi:"attr,beta,omitempty"`
 }
 
 // Create a new terraform version.

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -89,6 +89,28 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		assert.Equal(t, *opts.Beta, tfv.Beta)
 	})
 
+    t.Run("with only required options", func(t *testing.T) {
+	  opts := AdminTerraformVersionCreateOptions{
+		Version:  String("1.1.1"),
+		URL:      String("https://www.hashicorp.com"),
+		Sha:      String(genSha(t, "secret", "data")),
+	  }
+	  tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
+	  require.NoError(t, err)
+
+	  defer func() {
+		deleteErr := client.Admin.TerraformVersions.Delete(ctx, tfv.ID)
+		require.NoError(t, deleteErr)
+	  }()
+
+	  assert.Equal(t, *opts.Version, tfv.Version)
+	  assert.Equal(t, *opts.URL, tfv.URL)
+	  assert.Equal(t, *opts.Sha, tfv.Sha)
+	  assert.Equal(t, false, tfv.Official)
+	  assert.Equal(t, true, tfv.Enabled)
+	  assert.Equal(t, false, tfv.Beta)
+    })
+
 	t.Run("with empty options", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{}
 
@@ -149,7 +171,7 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, *opts.Beta, tfv.Beta)
 	})
 
-	t.Run("with non existant terraform version", func(t *testing.T) {
+	t.Run("with non-existent terraform version", func(t *testing.T) {
 		randomID := "random-id"
 		_, err := client.Admin.TerraformVersions.Read(ctx, randomID)
 		require.Error(t, err)


### PR DESCRIPTION
## Description

This PR changes official, enabled, and beta to be optional when creating new Terraform versions. This matches the [API docs](https://www.terraform.io/docs/cloud/api/admin/terraform-versions.html#create-a-terraform-version), where these values are optional.

## Testing plan

1.  Test that you can create a new Terraform version without specifying official, enabled, and beta. Make sure the values for these fields ends up match the defaults like expected.
2. Test that you can specify these values as expected. 

## External links

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)

## Output from tests

```
$ envchain go-tfe go test -run TestAdminTerraformVersions_CreateDelete -v ./... -tags=integration
=== RUN   TestAdminTerraformVersions_CreateDelete
=== RUN   TestAdminTerraformVersions_CreateDelete/with_valid_options
=== RUN   TestAdminTerraformVersions_CreateDelete/with_only_required_options
=== RUN   TestAdminTerraformVersions_CreateDelete/with_empty_options
--- PASS: TestAdminTerraformVersions_CreateDelete (1.87s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_valid_options (0.45s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_only_required_options (0.46s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_empty_options (0.40s)
PASS
ok      github.com/hashicorp/go-tfe     2.091s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
```
