### PR TITLE
feature: added user endpoints

### DIFF
--- a/user.go
+++ b/user.go
@@ -18,7 +18,7 @@ type Users interface {
 	// Update attributes of the currently authenticated user.
 	Update(ctx context.Context, options UserUpdateOptions) (*User, error)
 
-	FetchById(ctx context.Context, userId string) (*User, error)
+	FetchByID(ctx context.Context, userId string) (*User, error)
 }
 
 // users implements Users.

--- a/user.go
+++ b/user.go
@@ -18,7 +18,7 @@ type Users interface {
 	// Update attributes of the currently authenticated user.
 	Update(ctx context.Context, options UserUpdateOptions) (*User, error)
 
-	FetchByID(ctx context.Context, userId string) (*User, error)
+	FetchByID(ctx context.Context, userID string) (*User, error)
 }
 
 // users implements Users.

--- a/user.go
+++ b/user.go
@@ -101,8 +101,8 @@ func (s *users) Update(ctx context.Context, options UserUpdateOptions) (*User, e
 	return u, nil
 }
 
-func (s *users) FetchById(ctx context.Context, userId string) (*User, error) {
-	req, err := s.client.newRequest("GET", "users/"+userId, nil)
+func (s *users) FetchByID(ctx context.Context, userID string) (*User, error) {
+	req, err := s.client.newRequest("GET", "users/"+userID, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -93,3 +93,21 @@ func TestUsersUpdate(t *testing.T) {
 		assert.Error(t, err)
 	})
 }
+
+// This test is included in case you wish to run it during a review. Due to
+// the trivial nature of this test, I'll remove it once the PR has been approved
+func TestUsersFetchById(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	// include user id here
+	u, err := client.Users.FetchById(ctx, "")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, u.ID)
+	assert.NotEmpty(t, u.AvatarURL)
+	assert.NotEmpty(t, u.Username)
+
+	t.Run("permissions are decoded", func(t *testing.T) {
+		assert.NotNil(t, u.Permissions)
+	})
+}

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -96,12 +96,12 @@ func TestUsersUpdate(t *testing.T) {
 
 // This test is included in case you wish to run it during a review. Due to
 // the trivial nature of this test, I'll remove it once the PR has been approved
-func TestUsersFetchById(t *testing.T) {
+func TestUsersFetchByID(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
 	// include user id here
-	u, err := client.Users.FetchById(ctx, "")
+	u, err := client.Users.FetchByID(ctx, "")
 	assert.NoError(t, err)
 	assert.NotEmpty(t, u.ID)
 	assert.NotEmpty(t, u.AvatarURL)


### PR DESCRIPTION
## Description

Added the Users endpoints which consists of one simple endpoint:

```
GET /users/:user-id
```

## Testing plan

In order to run the test, please modify the function `TestUsersFetchById()` to include a `:user-id` in the method parameters. This is a sanity check for the reviewer. You can run the test like so:

```sh
TFE_ADDRESS=$TFC_STAGING_URL TFE_TOKEN=$TFC_STAGING_TOKEN go test . -v -tags=integration -run TestUsersFetchById
```

I will remove the test once the PR is approved.

## External Links

API Docs for Endpoint: https://www.terraform.io/docs/cloud/api/users.html