### PR TITLE
Add Organization Tags Endpoints to client

### DIFF
--- a/organization_tags.go
+++ b/organization_tags.go
@@ -1,0 +1,158 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+var _ OrganizationTags = (*organizationTags)(nil)
+
+type OrganizationTags interface {
+	List(ctx context.Context, organization string, options OrganizationTagsListOptions) (*OrganizationTagsList, error)
+
+	Delete(ctx context.Context, organization string, options OrganizationTagsDeleteOptions) error
+
+	AddWorkspaces(ctx context.Context, tag string, options AddWorkspacesToTagOptions) error
+}
+
+type organizationTags struct {
+	client *Client
+}
+
+type OrganizationTagsList struct {
+	*Pagination
+	Items []*OrganizationTag
+}
+
+type OrganizationTag struct {
+	ID            string `jsonapi:"primary,tags"`
+	Name          string `jsonapi:"attr,name,omitempty"`
+	InstanceCount string `jsonapi:"attr,instance_count,omitempty"`
+
+	// Relations
+	Organization *Organization `jsonapi:"relation,organization"`
+}
+
+type OrganizationTagsListOptions struct {
+	ListOptions
+
+	FilterExclude  *string `url:"filter[exclude],omitempty"`
+	FilterTaggable *string `url:"filter[taggable],omitempty"`
+	FilterId       *string `url:"filter[id],omitempty"`
+}
+
+func (s *organizationTags) List(ctx context.Context, organization string, options OrganizationTagsListOptions) (*OrganizationTagsList, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+
+	u := fmt.Sprintf("organizations/%s/tags", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	tags := &OrganizationTagsList{}
+	err = s.client.do(ctx, req, tags)
+	if err != nil {
+		return nil, err
+	}
+
+	fmt.Println(tags.Items[0])
+
+	return tags, nil
+}
+
+type OrganizationTagsDeleteOptions struct {
+	IDs []string
+}
+
+type tagID struct {
+	ID string `jsonapi:primary,tag`
+}
+
+func (opts *OrganizationTagsDeleteOptions) valid() error {
+	if opts.IDs == nil || len(opts.IDs) == 0 {
+		return errors.New("you must specify at least one tag id to remove")
+	}
+
+	for _, id := range opts.IDs {
+		if !validStringID(&id) {
+			errorMsg := fmt.Sprintf("%s is not a valid id value", id)
+			return errors.New(errorMsg)
+		}
+	}
+
+	return nil
+}
+
+func (s *organizationTags) Delete(ctx context.Context, organization string, options OrganizationTagsDeleteOptions) error {
+	if !validStringID(&organization) {
+		return ErrInvalidOrg
+	}
+
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("organizations/%s/tags", url.QueryEscape(organization))
+	var tagsToRemove []*tagID
+	for _, id := range options.IDs {
+		tagsToRemove = append(tagsToRemove, &tagID{ID: id})
+	}
+
+	req, err := s.client.newRequest("DELETE", u, tagsToRemove)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+type AddWorkspacesToTagOptions struct {
+	WorkspaceIDs []string
+}
+
+func (w *AddWorkspacesToTagOptions) valid() error {
+	if w.WorkspaceIDs == nil || len(w.WorkspaceIDs) == 0 {
+		return errors.New("you must specify at least one workspace to add tag to")
+	}
+
+	for _, id := range w.WorkspaceIDs {
+		if !validStringID(&id) {
+			errorMsg := fmt.Sprintf("%s is not a valid id value", id)
+			return errors.New(errorMsg)
+		}
+	}
+
+	return nil
+}
+
+type workspaceID struct {
+	Id string `jsonapi:primary,workspaces`
+}
+
+func (s *organizationTags) AddWorkspaces(ctx context.Context, tag string, options AddWorkspacesToTagOptions) error {
+	if !validStringID(&tag) {
+		return errors.New("invalid tag id")
+	}
+
+	if err := options.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf("tags/%s/relationships/workspaces", url.QueryEscape(tag))
+	var workspaces []*workspaceID
+	for _, id := range options.WorkspaceIDs {
+		workspaces = append(workspaces, &workspaceID{Id: id})
+	}
+
+	req, err := s.client.newRequest("POST", u, workspaces)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/organization_tags_integration_test.go
+++ b/organization_tags_integration_test.go
@@ -1,0 +1,54 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizationTagsList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	assert.NotNil(t, orgTest)
+
+	workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
+	defer workspaceTestCleanup()
+
+	assert.NotNil(t, workspaceTest)
+
+	var tags []*Tag
+	for i := 0; i < 10; i++ {
+		tags = append(tags, &Tag{
+			Name: fmt.Sprintf("tag%d", i),
+		})
+	}
+
+	err := client.Workspaces.AddTags(ctx, workspaceTest.ID, WorkspaceAddTagsOptions{
+		Tags: tags,
+	})
+	require.NoError(t, err)
+
+	t.Run("with no query params", func(t *testing.T) {
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, 10, len(tags.Items))
+
+		for _, tag := range tags.Items {
+			assert.NotNil(t, tag.ID)
+			assert.NotNil(t, tag.Name)
+			assert.NotNil(t, tag.InstanceCount)
+
+			t.Run("ensure org relation is properly decoded", func(t *testing.T) {
+				assert.NotNil(t, tag.Organization)
+			})
+		}
+	})
+}

--- a/organization_tags_integration_test.go
+++ b/organization_tags_integration_test.go
@@ -35,20 +35,153 @@ func TestOrganizationTagsList(t *testing.T) {
 	})
 	require.NoError(t, err)
 
+	// this is a tag id we'll use in the filter param of the second test
+	var testTagID string
+
 	t.Run("with no query params", func(t *testing.T) {
 		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
 		require.NoError(t, err)
 
 		assert.Equal(t, 10, len(tags.Items))
 
+		testTagID = tags.Items[0].ID
+
 		for _, tag := range tags.Items {
 			assert.NotNil(t, tag.ID)
 			assert.NotNil(t, tag.Name)
-			assert.NotNil(t, tag.InstanceCount)
+			assert.GreaterOrEqual(t, tag.InstanceCount, 1)
 
 			t.Run("ensure org relation is properly decoded", func(t *testing.T) {
 				assert.NotNil(t, tag.Organization)
 			})
 		}
+	})
+
+	t.Run("with query params", func(t *testing.T) {
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 1,
+				PageSize:   5,
+			},
+			Filter: &testTagID,
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, 5, len(tags.Items))
+
+		for _, tag := range tags.Items {
+			// ensure tag specified in filter param was omitted from results
+			assert.NotNil(t, tag.ID, testTagID)
+
+			t.Run("ensure org relation is properly decoded", func(t *testing.T) {
+				assert.NotNil(t, tag.Organization)
+			})
+		}
+	})
+}
+
+func TestOrganizationTagsDelete(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	assert.NotNil(t, orgTest)
+
+	workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
+	defer workspaceTestCleanup()
+
+	assert.NotNil(t, workspaceTest)
+
+	var tags []*Tag
+	for i := 0; i < 10; i++ {
+		tags = append(tags, &Tag{
+			Name: fmt.Sprintf("tag%d", i),
+		})
+	}
+
+	err := client.Workspaces.AddTags(ctx, workspaceTest.ID, WorkspaceAddTagsOptions{
+		Tags: tags,
+	})
+	require.NoError(t, err)
+
+	t.Run("delete tags by id", func(t *testing.T) {
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		require.NoError(t, err)
+
+		var tagIds []string
+		// since we added 10 tags to the org, grab a subset
+		for i := 0; i < 5; i++ {
+			assert.NotNil(t, tags.Items[i].ID)
+			tagIds = append(tagIds, tags.Items[i].ID)
+		}
+
+		err = client.OrganizationTags.Delete(ctx, orgTest.Name, OrganizationTagsDeleteOptions{
+			IDs: tagIds,
+		})
+		require.NoError(t, err)
+
+		//sanity check ensure tags were deleted from the organization
+		tags, err = client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, 5, len(tags.Items))
+	})
+}
+
+func TestOrganizationTagsAddWorkspace(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	assert.NotNil(t, orgTest)
+
+	workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
+	defer workspaceTestCleanup()
+
+	assert.NotNil(t, workspaceTest)
+
+	var tags []*Tag
+	for i := 0; i < 2; i++ {
+		tags = append(tags, &Tag{
+			Name: fmt.Sprintf("tag%d", i),
+		})
+	}
+
+	err := client.Workspaces.AddTags(ctx, workspaceTest.ID, WorkspaceAddTagsOptions{
+		Tags: tags,
+	})
+	require.NoError(t, err)
+
+	t.Run("add tags to new workspaces", func(t *testing.T) {
+		// fetch tag ids to associate to workspace
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		require.NoError(t, err)
+
+		tagID := tags.Items[0].ID
+
+		// create the workspaces we'll use to associate tags
+		workspaceToAdd1, workspaceToAdd1Cleanup := createWorkspace(t, client, orgTest)
+		defer workspaceToAdd1Cleanup()
+
+		workspaceToAdd2, workspaceToAdd2Cleanup := createWorkspace(t, client, orgTest)
+		defer workspaceToAdd2Cleanup()
+
+		err = client.OrganizationTags.AddWorkspaces(ctx, tagID, AddWorkspacesToTagOptions{
+			WorkspaceIDs: []string{workspaceToAdd1.ID, workspaceToAdd2.ID},
+		})
+		require.NoError(t, err)
+
+		//Ensure the tag was properly associated with the workspaces
+		fetched, err := client.Workspaces.Tags(ctx, workspaceToAdd1.ID, WorkspaceTagListOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, fetched.Items[0].ID, tagID)
+
+		fetched, err = client.Workspaces.Tags(ctx, workspaceToAdd2.ID, WorkspaceTagListOptions{})
+		require.NoError(t, err)
+		assert.Equal(t, fetched.Items[0].ID, tagID)
 	})
 }

--- a/tfe.go
+++ b/tfe.go
@@ -109,6 +109,7 @@ type Client struct {
 	OAuthTokens                OAuthTokens
 	Organizations              Organizations
 	OrganizationMemberships    OrganizationMemberships
+	OrganizationTags           OrganizationTags
 	OrganizationTokens         OrganizationTokens
 	Plans                      Plans
 	PlanExports                PlanExports
@@ -245,6 +246,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.OAuthTokens = &oAuthTokens{client: client}
 	client.Organizations = &organizations{client: client}
 	client.OrganizationMemberships = &organizationMemberships{client: client}
+	client.OrganizationTags = &organizationTags{client: client}
 	client.OrganizationTokens = &organizationTokens{client: client}
 	client.Plans = &plans{client: client}
 	client.PlanExports = &planExports{client: client}


### PR DESCRIPTION
## Description

Adding the Organization Tags endpoints to the client

## Testing plan

You can run the tests using this command:

```
TFE_ADDRESS=$TFC_LOCAL_URL TFE_TOKEN=$TFC_LOCAL_TOKEN go test . -v -tags=integration -run TestOrganizationTags
```

Sidenote: I did run these tests against the staging environment.

## External links

- [OrganizationTags API documentation](https://www.terraform.io/docs/cloud/api/organization-tags.html)

## Further Notes

There is a file called `tags.go` that defines a partial interface for Organization Tags and I only noticed it after substantial work on this feature. To keep things from breaking as `Workspaces` depends on that interface, I left it untouched. Let me know if you wish to include the refactor in this PR. 

I tried to maintain some consistency with the doc comments from other files, however let me know if those need any changes. 
