### PR TITLE
OAuth API enhancements

### DIFF
--- a/mocks/oauth_client_mocks.go
+++ b/mocks/oauth_client_mocks.go
@@ -93,3 +93,18 @@ func (mr *MockOAuthClientsMockRecorder) Read(ctx, oAuthClientID interface{}) *go
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOAuthClients)(nil).Read), ctx, oAuthClientID)
 }
+
+// Update mocks base method.
+func (m *MockOAuthClients) Update(ctx context.Context, oAuthClientID string, options tfe.OAuthClientUpdateOptions) (*tfe.OAuthClient, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Update", ctx, oAuthClientID, options)
+	ret0, _ := ret[0].(*tfe.OAuthClient)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Update indicates an expected call of Update.
+func (mr *MockOAuthClientsMockRecorder) Update(ctx, oAuthClientID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockOAuthClients)(nil).Update), ctx, oAuthClientID, options)
+}

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -26,6 +26,9 @@ type OAuthClients interface {
 	// Read an OAuth client by its ID.
 	Read(ctx context.Context, oAuthClientID string) (*OAuthClient, error)
 
+	// Update an existing OAuth client by its ID.
+	Update(ctx context.Context, oAuthClientID string, options OAuthClientUpdateOptions) (*OAuthClient, error)
+
 	// Delete an OAuth client by its ID.
 	Delete(ctx context.Context, oAuthClientID string) error
 }
@@ -71,6 +74,7 @@ type OAuthClient struct {
 	HTTPURL             string              `jsonapi:"attr,http-url"`
 	Key                 string              `jsonapi:"attr,key"`
 	RSAPublicKey        string              `jsonapi:"attr,rsa-public-key"`
+	Secret              string              `jsonapi:"attr,secret"`
 	ServiceProvider     ServiceProviderType `jsonapi:"attr,service-provider"`
 	ServiceProviderName string              `jsonapi:"attr,service-provider-display-name"`
 
@@ -114,17 +118,30 @@ type OAuthClientCreateOptions struct {
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,oauth-clients"`
 
+	// A display name for the OAuth Client.
+	Name *string `jsonapi:"attr,name"`
+
 	// The base URL of your VCS provider's API.
 	APIURL *string `jsonapi:"attr,api-url"`
 
 	// The homepage of your VCS provider.
 	HTTPURL *string `jsonapi:"attr,http-url"`
 
+	// The OAuth Client key.
+	Key *string `jsonapi:"attr,key,omitempty"`
+
 	// The token string you were given by your VCS provider.
-	OAuthToken *string `jsonapi:"attr,oauth-token-string"`
+	OAuthToken *string `jsonapi:"attr,oauth-token-string,omitempty"`
 
 	// Private key associated with this vcs provider - only available for ado_server
-	PrivateKey *string `jsonapi:"attr,private-key"`
+	PrivateKey *string `jsonapi:"attr,private-key,omitempty"`
+
+	// Secret key associated with this vcs provider - only available for ado_server
+	Secret *string `jsonapi:"attr,secret,omitempty"`
+
+	// RSAPublicKey the text of the SSH public key associated with your BitBucket
+	// Server Application Link.
+	RSAPublicKey *string `jsonapi:"attr,rsa-public-key,omitempty"`
 
 	// The VCS provider being connected with.
 	ServiceProvider *ServiceProviderType `jsonapi:"attr,service-provider"`
@@ -137,11 +154,11 @@ func (o OAuthClientCreateOptions) valid() error {
 	if !validString(o.HTTPURL) {
 		return errors.New("HTTP URL is required")
 	}
-	if !validString(o.OAuthToken) {
-		return errors.New("OAuth token is required")
-	}
 	if o.ServiceProvider == nil {
 		return errors.New("service provider is required")
+	}
+	if !validString(o.OAuthToken) && *o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketServer) {
+		return errors.New("OAuth token is required")
 	}
 	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
 		return errors.New("private Key can only be present with Azure DevOps Server service provider")
@@ -181,6 +198,52 @@ func (s *oAuthClients) Read(ctx context.Context, oAuthClientID string) (*OAuthCl
 
 	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
 	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	oc := &OAuthClient{}
+	err = s.client.do(ctx, req, oc)
+	if err != nil {
+		return nil, err
+	}
+
+	return oc, err
+}
+
+// OAuthClientUpdateOptions represents the options for updating an OAuth client.
+type OAuthClientUpdateOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,oauth-clients"`
+
+	// A display name for the OAuth Client.
+	Name *string `jsonapi:"attr,name,omitempty"`
+
+	// The OAuth Client key.
+	Key *string `jsonapi:"attr,key,omitempty"`
+
+	// Secret key associated with this vcs provider - only available for ado_server
+	Secret *string `jsonapi:"attr,secret,omitempty"`
+
+	// RSAPublicKey the text of the SSH public key associated with your BitBucket
+	// Server Application Link.
+	RSAPublicKey *string `jsonapi:"attr,rsa-public-key,omitempty"`
+
+	// The token string you were given by your VCS provider.
+	OAuthToken *string `jsonapi:"attr,oauth-token-string,omitempty"`
+}
+
+// Update an OAuth client by its ID.
+func (s *oAuthClients) Update(ctx context.Context, oAuthClientID string, options OAuthClientUpdateOptions) (*OAuthClient, error) {
+	if !validStringID(&oAuthClientID) {
+		return nil, errors.New("invalid value for OAuth client ID")
+	}
+
+	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
+	req, err := s.client.newRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Description

This PR updates the OAuth Client wrapper to match with [changes in the OAuth Client API](https://www.terraform.io/docs/cloud/api/changelog.html#2021-12-03).

**Changes**
- Add the `key` field that is present in the response object.
- Update CreateOptions and UpdateOptions to match the API

## Output from tests

```
go-tfe % go test -tags=integration -v -run TestOAuthClient
=== RUN   TestOAuthClientsList
=== RUN   TestOAuthClientsList/without_list_options
=== RUN   TestOAuthClientsList/without_list_options/the_OAuth_tokens_relationship_is_decoded_correcly
=== CONT  TestOAuthClientsList/without_list_options
    oauth_client_integration_test.go:48: paging not supported yet in API
=== RUN   TestOAuthClientsList/with_list_options
    oauth_client_integration_test.go:54: paging not supported yet in API
=== RUN   TestOAuthClientsList/without_a_valid_organization
--- PASS: TestOAuthClientsList (3.01s)
    --- SKIP: TestOAuthClientsList/without_list_options (0.24s)
        --- PASS: TestOAuthClientsList/without_list_options/the_OAuth_tokens_relationship_is_decoded_correcly (0.00s)
    --- SKIP: TestOAuthClientsList/with_list_options (0.00s)
    --- PASS: TestOAuthClientsList/without_a_valid_organization (0.00s)
=== RUN   TestOAuthClientsCreate
=== RUN   TestOAuthClientsCreate/with_valid_options
=== RUN   TestOAuthClientsCreate/with_valid_options/the_organization_relationship_is_decoded_correcly
=== RUN   TestOAuthClientsCreate/without_an_valid_organization
=== RUN   TestOAuthClientsCreate/without_an_API_URL
=== RUN   TestOAuthClientsCreate/without_a_HTTP_URL
=== RUN   TestOAuthClientsCreate/without_an_OAuth_token
=== RUN   TestOAuthClientsCreate/without_a_service_provider
--- PASS: TestOAuthClientsCreate (1.39s)
    --- PASS: TestOAuthClientsCreate/with_valid_options (0.43s)
        --- PASS: TestOAuthClientsCreate/with_valid_options/the_organization_relationship_is_decoded_correcly (0.00s)
    --- PASS: TestOAuthClientsCreate/without_an_valid_organization (0.00s)
    --- PASS: TestOAuthClientsCreate/without_an_API_URL (0.00s)
    --- PASS: TestOAuthClientsCreate/without_a_HTTP_URL (0.00s)
    --- PASS: TestOAuthClientsCreate/without_an_OAuth_token (0.00s)
    --- PASS: TestOAuthClientsCreate/without_a_service_provider (0.00s)
=== RUN   TestOAuthClientsCreate_rsaKeyPair
=== RUN   TestOAuthClientsCreate_rsaKeyPair/with_key,_rsa_public/private_key_options
--- PASS: TestOAuthClientsCreate_rsaKeyPair (1.20s)
    --- PASS: TestOAuthClientsCreate_rsaKeyPair/with_key,_rsa_public/private_key_options (0.25s)
=== RUN   TestOAuthClientsRead
=== RUN   TestOAuthClientsRead/when_the_OAuth_client_exists
=== RUN   TestOAuthClientsRead/when_the_OAuth_client_does_not_exist
=== RUN   TestOAuthClientsRead/without_a_valid_OAuth_client_ID
--- PASS: TestOAuthClientsRead (2.08s)
    --- PASS: TestOAuthClientsRead/when_the_OAuth_client_exists (0.20s)
    --- PASS: TestOAuthClientsRead/when_the_OAuth_client_does_not_exist (0.19s)
    --- PASS: TestOAuthClientsRead/without_a_valid_OAuth_client_ID (0.00s)
=== RUN   TestOAuthClientsDelete
=== RUN   TestOAuthClientsDelete/with_valid_options
=== RUN   TestOAuthClientsDelete/when_the_OAuth_client_does_not_exist
=== RUN   TestOAuthClientsDelete/when_the_OAuth_client_ID_is_invalid
--- PASS: TestOAuthClientsDelete (2.17s)
    --- PASS: TestOAuthClientsDelete/with_valid_options (0.45s)
    --- PASS: TestOAuthClientsDelete/when_the_OAuth_client_does_not_exist (0.20s)
    --- PASS: TestOAuthClientsDelete/when_the_OAuth_client_ID_is_invalid (0.00s)
=== RUN   TestOAuthClientsCreateOptionsValid
=== RUN   TestOAuthClientsCreateOptionsValid/with_valid_options
=== RUN   TestOAuthClientsCreateOptionsValid/without_an_API_URL
=== RUN   TestOAuthClientsCreateOptionsValid/without_a_HTTP_URL
=== RUN   TestOAuthClientsCreateOptionsValid/without_an_OAuth_token
=== RUN   TestOAuthClientsCreateOptionsValid/without_a_service_provider
=== RUN   TestOAuthClientsCreateOptionsValid/without_private_key_and_not_ado_server_options
=== RUN   TestOAuthClientsCreateOptionsValid/with_empty_private_key_and_not_ado_server_options
=== RUN   TestOAuthClientsCreateOptionsValid/with_private_key_and_not_ado_server_options
=== RUN   TestOAuthClientsCreateOptionsValid/with_valid_options_including_private_key
--- PASS: TestOAuthClientsCreateOptionsValid (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_valid_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_an_API_URL (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_a_HTTP_URL (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_an_OAuth_token (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_a_service_provider (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_private_key_and_not_ado_server_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_empty_private_key_and_not_ado_server_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_private_key_and_not_ado_server_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_valid_options_including_private_key (0.00s)
=== RUN   TestOAuthClientsUpdate_rsaKeyPair
=== RUN   TestOAuthClientsUpdate_rsaKeyPair/updates_a_new_key
=== RUN   TestOAuthClientsUpdate_rsaKeyPair/errors_when_missing_key
--- PASS: TestOAuthClientsUpdate_rsaKeyPair (2.05s)
    --- PASS: TestOAuthClientsUpdate_rsaKeyPair/updates_a_new_key (0.50s)
    --- PASS: TestOAuthClientsUpdate_rsaKeyPair/errors_when_missing_key (0.48s)
PASS
ok  	github.com/hashicorp/go-tfe	12.546s

```