### PR TITLE
Add admin/organization/relationships/module-consumers endpoint

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -179,6 +179,9 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 
 	var organizations []*AdminOrganizationID
 	for _, id := range consumerOrganizationIDs {
+		if !validStringID(&id) {
+			return ErrInvalidOrg
+		}
 		organizations = append(organizations, &AdminOrganizationID{ID: id})
 	}
 

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -25,6 +25,12 @@ type AdminOrganizations interface {
 
 	// Delete an organization by its name via admin API
 	Delete(ctx context.Context, organization string) error
+
+	// ListModuleConsumers lists specific organizations in the Terraform Enterprise installation that have permission to use an organization's modules.
+	ListModuleConsumers(ctx context.Context, organization string, options AdminOrganizationListModuleConsumersOptions) (*AdminOrganizationList, error)
+
+	// UpdateModuleConsumers specifies a list of organizations that can use modules from the sharing organization's private registry. Setting a list of module consumers will turn off global module sharing for an organization.
+	UpdateModuleConsumers(ctx context.Context, organization string, consumerOrganizations []string) error
 }
 
 // adminOrganizations implements AdminOrganizations.
@@ -77,10 +83,40 @@ type AdminOrganizationListOptions struct {
 	Include *string `url:"include"`
 }
 
+// AdminOrganizationListModuleConsumersOptions represents the options for listing organization module consumers through the Admin API
+type AdminOrganizationListModuleConsumersOptions struct {
+	ListOptions
+}
+
+type AdminOrganizationID struct {
+	ID string `jsonapi:"primary,organizations"`
+}
+
 // List all the organizations visible to the current user.
 func (s *adminOrganizations) List(ctx context.Context, options AdminOrganizationListOptions) (*AdminOrganizationList, error) {
 	url := "admin/organizations"
 	req, err := s.client.newRequest("GET", url, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	orgl := &AdminOrganizationList{}
+	err = s.client.do(ctx, req, orgl)
+	if err != nil {
+		return nil, err
+	}
+
+	return orgl, nil
+}
+
+func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options AdminOrganizationListModuleConsumersOptions) (*AdminOrganizationList, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+
+	url := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
+
+	req, err := s.client.newRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -132,6 +168,31 @@ func (s *adminOrganizations) Update(ctx context.Context, organization string, op
 	}
 
 	return org, nil
+}
+
+func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, consumerOrganizationIDs []string) error {
+	if !validStringID(&organization) {
+		return ErrInvalidOrg
+	}
+
+	url := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
+
+	var organizations []*AdminOrganizationID
+	for _, id := range consumerOrganizationIDs {
+		organizations = append(organizations, &AdminOrganizationID{ID: id})
+	}
+
+	req, err := s.client.newRequest("PATCH", url, organizations)
+	if err != nil {
+		return err
+	}
+
+	err = s.client.do(ctx, req, nil)
+	if err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // Delete an organization by its name.

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -152,6 +152,14 @@ func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
+	t.Run("returns error if invalid org string is used", func(t *testing.T) {
+		org1, org1TestCleanup := createOrganization(t, client)
+		defer org1TestCleanup()
+
+		err := client.Admin.Organizations.UpdateModuleConsumers(ctx, org1.Name, []string{"1Hello!"})
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
+	})
+
 	t.Run("can list and update module consumers", func(t *testing.T) {
 		org1, org1TestCleanup := createOrganization(t, client)
 		defer org1TestCleanup()

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -146,6 +146,42 @@ func TestAdminOrganizations_Delete(t *testing.T) {
 	})
 }
 
+func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
+	skipIfCloud(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("can list and update module consumers", func(t *testing.T) {
+		org1, org1TestCleanup := createOrganization(t, client)
+		defer org1TestCleanup()
+
+		org2, org2TestCleanup := createOrganization(t, client)
+		defer org2TestCleanup()
+
+		err := client.Admin.Organizations.UpdateModuleConsumers(ctx, org1.Name, []string{org2.Name})
+		assert.NoError(t, err)
+
+		adminModuleConsumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, AdminOrganizationListModuleConsumersOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, len(adminModuleConsumerList.Items), 1)
+		assert.Equal(t, adminModuleConsumerList.Items[0].Name, org2.Name)
+
+		org3, org3TestCleanup := createOrganization(t, client)
+		defer org3TestCleanup()
+
+		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org1.Name, []string{org3.Name})
+		assert.NoError(t, err)
+
+		adminModuleConsumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, AdminOrganizationListModuleConsumersOptions{})
+		require.NoError(t, err)
+
+		assert.Equal(t, len(adminModuleConsumerList.Items), 1)
+		assert.Equal(t, adminModuleConsumerList.Items[0].Name, org3.Name)
+	})
+}
+
 func TestAdminOrganizations_Update(t *testing.T) {
 	skipIfCloud(t)
 

--- a/mocks/admin_organization_mocks.go
+++ b/mocks/admin_organization_mocks.go
@@ -64,6 +64,21 @@ func (mr *MockAdminOrganizationsMockRecorder) List(ctx, options interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockAdminOrganizations)(nil).List), ctx, options)
 }
 
+// ListModuleConsumers mocks base method.
+func (m *MockAdminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options tfe.AdminOrganizationListModuleConsumersOptions) (*tfe.AdminOrganizationList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListModuleConsumers", ctx, organization, options)
+	ret0, _ := ret[0].(*tfe.AdminOrganizationList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListModuleConsumers indicates an expected call of ListModuleConsumers.
+func (mr *MockAdminOrganizationsMockRecorder) ListModuleConsumers(ctx, organization, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListModuleConsumers", reflect.TypeOf((*MockAdminOrganizations)(nil).ListModuleConsumers), ctx, organization, options)
+}
+
 // Read mocks base method.
 func (m *MockAdminOrganizations) Read(ctx context.Context, organization string) (*tfe.AdminOrganization, error) {
 	m.ctrl.T.Helper()
@@ -92,4 +107,18 @@ func (m *MockAdminOrganizations) Update(ctx context.Context, organization string
 func (mr *MockAdminOrganizationsMockRecorder) Update(ctx, organization, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockAdminOrganizations)(nil).Update), ctx, organization, options)
+}
+
+// UpdateModuleConsumers mocks base method.
+func (m *MockAdminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, consumerOrganizations []string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateModuleConsumers", ctx, organization, consumerOrganizations)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateModuleConsumers indicates an expected call of UpdateModuleConsumers.
+func (mr *MockAdminOrganizationsMockRecorder) UpdateModuleConsumers(ctx, organization, consumerOrganizations interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateModuleConsumers", reflect.TypeOf((*MockAdminOrganizations)(nil).UpdateModuleConsumers), ctx, organization, consumerOrganizations)
 }


### PR DESCRIPTION
## Description

Adds `admin/organizations/:name/relationships/module-consumers` and `admin/organizations/:name/relationships/update-module-consumers`

Fixes #287 

## External links

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/admin/organizations#update-an-organization-s-module-consumers)

## Output from tests

```
$ ENABLE_TFE=1 TFE_ADDRESS=https://$(tfc_local_hostname) TFE_TOKEN=$(tfc_local_token) go test ./... -v -tags=integration -run TestAdminOrganizations_ModuleConsumers
=== RUN   TestAdminOrganizations_ModuleConsumers
=== RUN   TestAdminOrganizations_ModuleConsumers/returns_error_if_invalid_org_string_is_used
=== RUN   TestAdminOrganizations_ModuleConsumers/can_list_and_update_module_consumers
--- PASS: TestAdminOrganizations_ModuleConsumers (301.99s)
    --- PASS: TestAdminOrganizations_ModuleConsumers/returns_error_if_invalid_org_string_is_used (0.70s)
    --- PASS: TestAdminOrganizations_ModuleConsumers/can_list_and_update_module_consumers (300.69s)
PASS
ok  	github.com/hashicorp/go-tfe	(cached)
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```
