### PR TITLE
add support for deprecated admin terraform versions

### DIFF
--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -39,15 +39,17 @@ type adminTerraformVersions struct {
 
 // AdminTerraformVersion represents a Terraform Version
 type AdminTerraformVersion struct {
-	ID        string    `jsonapi:"primary,terraform-versions"`
-	Version   string    `jsonapi:"attr,version"`
-	URL       string    `jsonapi:"attr,url"`
-	Sha       string    `jsonapi:"attr,sha"`
-	Official  bool      `jsonapi:"attr,official"`
-	Enabled   bool      `jsonapi:"attr,enabled"`
-	Beta      bool      `jsonapi:"attr,beta"`
-	Usage     int       `jsonapi:"attr,usage"`
-	CreatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
+	ID               string    `jsonapi:"primary,terraform-versions"`
+	Version          string    `jsonapi:"attr,version"`
+	URL              string    `jsonapi:"attr,url"`
+	Sha              string    `jsonapi:"attr,sha"`
+	Deprecated       bool      `jsonapi:"attr,deprecated"`
+	DeprecatedReason *string   `jsonapi:"attr,deprecated-reason,omitempty"`
+	Official         bool      `jsonapi:"attr,official"`
+	Enabled          bool      `jsonapi:"attr,enabled"`
+	Beta             bool      `jsonapi:"attr,beta"`
+	Usage            int       `jsonapi:"attr,usage"`
+	CreatedAt        time.Time `jsonapi:"attr,created-at,iso8601"`
 }
 
 // AdminTerraformVersionsListOptions represents the options for listing
@@ -102,13 +104,15 @@ func (a *adminTerraformVersions) Read(ctx context.Context, id string) (*AdminTer
 // AdminTerraformVersionCreateOptions for creating a terraform version.
 // https://www.terraform.io/docs/cloud/api/admin/terraform-versions.html#request-body
 type AdminTerraformVersionCreateOptions struct {
-	Type     string  `jsonapi:"primary,terraform-versions"`
-	Version  *string `jsonapi:"attr,version"`
-	URL      *string `jsonapi:"attr,url"`
-	Sha      *string `jsonapi:"attr,sha"`
-	Official *bool   `jsonapi:"attr,official,omitempty"`
-	Enabled  *bool   `jsonapi:"attr,enabled,omitempty"`
-	Beta     *bool   `jsonapi:"attr,beta,omitempty"`
+	Type             string  `jsonapi:"primary,terraform-versions"`
+	Version          *string `jsonapi:"attr,version"`
+	URL              *string `jsonapi:"attr,url"`
+	Sha              *string `jsonapi:"attr,sha"`
+	Official         *bool   `jsonapi:"attr,official,omitempty"`
+	Deprecated       *bool   `jsonapi:"attr,deprecated,omitempty"`
+	DeprecatedReason *string `jsonapi:"attr,deprecated-reason,omitempty"`
+	Enabled          *bool   `jsonapi:"attr,enabled,omitempty"`
+	Beta             *bool   `jsonapi:"attr,beta,omitempty"`
 }
 
 // Create a new terraform version.
@@ -130,13 +134,15 @@ func (a *adminTerraformVersions) Create(ctx context.Context, options AdminTerraf
 // AdminTerraformVersionUpdateOptions for updating terraform version.
 // https://www.terraform.io/docs/cloud/api/admin/terraform-versions.html#request-body
 type AdminTerraformVersionUpdateOptions struct {
-	Type     string  `jsonapi:"primary,terraform-versions"`
-	Version  *string `jsonapi:"attr,version,omitempty"`
-	URL      *string `jsonapi:"attr,url,omitempty"`
-	Sha      *string `jsonapi:"attr,sha,omitempty"`
-	Official *bool   `jsonapi:"attr,official,omitempty"`
-	Enabled  *bool   `jsonapi:"attr,enabled,omitempty"`
-	Beta     *bool   `jsonapi:"attr,beta,omitempty"`
+	Type             string  `jsonapi:"primary,terraform-versions"`
+	Version          *string `jsonapi:"attr,version,omitempty"`
+	URL              *string `jsonapi:"attr,url,omitempty"`
+	Sha              *string `jsonapi:"attr,sha,omitempty"`
+	Official         *bool   `jsonapi:"attr,official,omitempty"`
+	Deprecated       *bool   `jsonapi:"attr,deprecated,omitempty"`
+	DeprecatedReason *string `jsonapi:"attr,deprecated-reason,omitempty"`
+	Enabled          *bool   `jsonapi:"attr,enabled,omitempty"`
+	Beta             *bool   `jsonapi:"attr,beta,omitempty"`
 }
 
 // Update an existing terraform version.

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -50,6 +50,12 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 			assert.NotNil(t, item.URL)
 			assert.NotNil(t, item.Sha)
 			assert.NotNil(t, item.Official)
+			assert.NotNil(t, item.Deprecated)
+			if item.Deprecated {
+				assert.NotNil(t, item.DeprecatedReason)
+			} else {
+				assert.Nil(t, item.DeprecatedReason)
+			}
 			assert.NotNil(t, item.Enabled)
 			assert.NotNil(t, item.Beta)
 			assert.NotNil(t, item.Usage)
@@ -66,12 +72,14 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
-			Version:  String("1.1.1"),
-			URL:      String("https://www.hashicorp.com"),
-			Sha:      String(genSha(t, "secret", "data")),
-			Official: Bool(false),
-			Enabled:  Bool(false),
-			Beta:     Bool(false),
+			Version:          String("1.1.100"),
+			URL:              String("https://www.hashicorp.com"),
+			Sha:              String(genSha(t, "secret", "data")),
+			Deprecated:       Bool(true),
+			DeprecatedReason: String("Test Reason"),
+			Official:         Bool(false),
+			Enabled:          Bool(false),
+			Beta:             Bool(false),
 		}
 		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
 		require.NoError(t, err)
@@ -85,31 +93,35 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		assert.Equal(t, *opts.URL, tfv.URL)
 		assert.Equal(t, *opts.Sha, tfv.Sha)
 		assert.Equal(t, *opts.Official, tfv.Official)
+		assert.Equal(t, *opts.Deprecated, tfv.Deprecated)
+		assert.Equal(t, *opts.DeprecatedReason, *tfv.DeprecatedReason)
 		assert.Equal(t, *opts.Enabled, tfv.Enabled)
 		assert.Equal(t, *opts.Beta, tfv.Beta)
 	})
 
-    t.Run("with only required options", func(t *testing.T) {
-	  opts := AdminTerraformVersionCreateOptions{
-		Version:  String("1.1.1"),
-		URL:      String("https://www.hashicorp.com"),
-		Sha:      String(genSha(t, "secret", "data")),
-	  }
-	  tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
-	  require.NoError(t, err)
+	t.Run("with only required options", func(t *testing.T) {
+		opts := AdminTerraformVersionCreateOptions{
+			Version: String("1.1.100"),
+			URL:     String("https://www.hashicorp.com"),
+			Sha:     String(genSha(t, "secret", "data")),
+		}
+		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
+		require.NoError(t, err)
 
-	  defer func() {
-		deleteErr := client.Admin.TerraformVersions.Delete(ctx, tfv.ID)
-		require.NoError(t, deleteErr)
-	  }()
+		defer func() {
+			deleteErr := client.Admin.TerraformVersions.Delete(ctx, tfv.ID)
+			require.NoError(t, deleteErr)
+		}()
 
-	  assert.Equal(t, *opts.Version, tfv.Version)
-	  assert.Equal(t, *opts.URL, tfv.URL)
-	  assert.Equal(t, *opts.Sha, tfv.Sha)
-	  assert.Equal(t, false, tfv.Official)
-	  assert.Equal(t, true, tfv.Enabled)
-	  assert.Equal(t, false, tfv.Beta)
-    })
+		assert.Equal(t, *opts.Version, tfv.Version)
+		assert.Equal(t, *opts.URL, tfv.URL)
+		assert.Equal(t, *opts.Sha, tfv.Sha)
+		assert.Equal(t, false, tfv.Official)
+		assert.Equal(t, false, tfv.Deprecated)
+		assert.Nil(t, tfv.DeprecatedReason)
+		assert.Equal(t, true, tfv.Enabled)
+		assert.Equal(t, false, tfv.Beta)
+	})
 
 	t.Run("with empty options", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{}
@@ -127,12 +139,14 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 
 	t.Run("reads and updates", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
-			Version:  String("1.1.1"),
-			URL:      String("https://www.hashicorp.com"),
-			Sha:      String(genSha(t, "secret", "data")),
-			Official: Bool(false),
-			Enabled:  Bool(false),
-			Beta:     Bool(false),
+			Version:          String("1.1.100"),
+			URL:              String("https://www.hashicorp.com"),
+			Sha:              String(genSha(t, "secret", "data")),
+			Official:         Bool(false),
+			Deprecated:       Bool(true),
+			DeprecatedReason: String("Test Reason"),
+			Enabled:          Bool(false),
+			Beta:             Bool(false),
 		}
 		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
 		require.NoError(t, err)
@@ -150,14 +164,17 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, *opts.URL, tfv.URL)
 		assert.Equal(t, *opts.Sha, tfv.Sha)
 		assert.Equal(t, *opts.Official, tfv.Official)
+		assert.Equal(t, *opts.Deprecated, tfv.Deprecated)
+		assert.Equal(t, *opts.DeprecatedReason, *tfv.DeprecatedReason)
 		assert.Equal(t, *opts.Enabled, tfv.Enabled)
 		assert.Equal(t, *opts.Beta, tfv.Beta)
 
-		updateVersion := "1.1.2"
+		updateVersion := "1.1.200"
 		updateURL := "https://app.terraform.io/"
 		updateOpts := AdminTerraformVersionUpdateOptions{
-			Version: String(updateVersion),
-			URL:     String(updateURL),
+			Version:    String(updateVersion),
+			URL:        String(updateURL),
+			Deprecated: Bool(false),
 		}
 
 		tfv, err = client.Admin.TerraformVersions.Update(ctx, id, updateOpts)
@@ -167,6 +184,7 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, updateURL, tfv.URL)
 		assert.Equal(t, *opts.Sha, tfv.Sha)
 		assert.Equal(t, *opts.Official, tfv.Official)
+		assert.Equal(t, *updateOpts.Deprecated, tfv.Deprecated)
 		assert.Equal(t, *opts.Enabled, tfv.Enabled)
 		assert.Equal(t, *opts.Beta, tfv.Beta)
 	})


### PR DESCRIPTION
## Description

Adds deprecated and deprecated-reason fields to admin terraform versions, released recently

## Output from tests

_Please run the tests locally for any files you changes and include the output here._

```
$ TFE_ADDRESS=https://$(tfc_local_hostname) ENABLE_TFE=1 TF_ACC=1 go test ./... -v -tags=integration -run TestAdminTerraformVersions
=== RUN   TestAdminTerraformVersions_List
=== RUN   TestAdminTerraformVersions_List/without_list_options
=== RUN   TestAdminTerraformVersions_List/with_list_options
--- PASS: TestAdminTerraformVersions_List (1.62s)
    --- PASS: TestAdminTerraformVersions_List/without_list_options (0.27s)
    --- PASS: TestAdminTerraformVersions_List/with_list_options (0.76s)
=== RUN   TestAdminTerraformVersions_CreateDelete
=== RUN   TestAdminTerraformVersions_CreateDelete/with_valid_options
=== RUN   TestAdminTerraformVersions_CreateDelete/with_only_required_options
=== RUN   TestAdminTerraformVersions_CreateDelete/with_empty_options
--- PASS: TestAdminTerraformVersions_CreateDelete (1.49s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_valid_options (0.47s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_only_required_options (0.47s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_empty_options (0.23s)
=== RUN   TestAdminTerraformVersions_ReadUpdate
=== RUN   TestAdminTerraformVersions_ReadUpdate/reads_and_updates
=== RUN   TestAdminTerraformVersions_ReadUpdate/with_non-existent_terraform_version
--- PASS: TestAdminTerraformVersions_ReadUpdate (1.50s)
    --- PASS: TestAdminTerraformVersions_ReadUpdate/reads_and_updates (0.96s)
    --- PASS: TestAdminTerraformVersions_ReadUpdate/with_non-existent_terraform_version (0.21s)
PASS
ok  	github.com/hashicorp/go-tfe	(cached)
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```
