### PR TITLE
Add CurrentStateVersion to Workspace

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -144,12 +144,13 @@ type Workspace struct {
 	TagNames                   []string              `jsonapi:"attr,tag-names"`
 
 	// Relations
-	AgentPool    *AgentPool          `jsonapi:"relation,agent-pool"`
-	CurrentRun   *Run                `jsonapi:"relation,current-run"`
-	Organization *Organization       `jsonapi:"relation,organization"`
-	SSHKey       *SSHKey             `jsonapi:"relation,ssh-key"`
-	Outputs      []*WorkspaceOutputs `jsonapi:"relation,outputs"`
-	Tags         []*Tag              `jsonapi:"relation,tags"`
+	AgentPool           *AgentPool          `jsonapi:"relation,agent-pool"`
+	CurrentRun          *Run                `jsonapi:"relation,current-run"`
+	CurrentStateVersion *StateVersion       `jsonapi:"relation,current-state-version"`
+	Organization        *Organization       `jsonapi:"relation,organization"`
+	SSHKey              *SSHKey             `jsonapi:"relation,ssh-key"`
+	Outputs             []*WorkspaceOutputs `jsonapi:"relation,outputs"`
+	Tags                []*Tag              `jsonapi:"relation,tags"`
 }
 
 type WorkspaceOutputs struct {

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -122,6 +122,31 @@ func TestWorkspacesList(t *testing.T) {
 		assert.NotNil(t, wl.Items[0].Organization)
 		assert.NotEmpty(t, wl.Items[0].Organization.Email)
 	})
+
+	t.Run("with current-state-version,current-run included", func(t *testing.T) {
+		_, rCleanup := createAppliedRun(t, client, wTest1)
+		t.Cleanup(rCleanup)
+
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+			Include: String("current-state-version,current-run"),
+		})
+
+		assert.NoError(t, err)
+		assert.NotEmpty(t, wl.Items)
+
+		foundWTest1 := false
+		for _, ws := range wl.Items {
+			if ws.ID == wTest1.ID {
+				foundWTest1 = true
+				assert.NotNil(t, wl.Items[0].CurrentStateVersion)
+				assert.NotEmpty(t, wl.Items[0].CurrentStateVersion.DownloadURL)
+				assert.NotNil(t, wl.Items[0].CurrentRun)
+				assert.NotEmpty(t, wl.Items[0].CurrentRun.Message)
+			}
+		}
+
+		assert.True(t, foundWTest1)
+	})
 }
 
 func TestWorkspacesCreate(t *testing.T) {


### PR DESCRIPTION
## Description

The current workspace ID is included in the Workspace API response, but
was not made available here. This is similar to the current run ID that
is already included.

## Testing plan

1.  Grab the Current State Version ID in the terraform executable

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/workspaces#show-workspace)
- [Related PR](https://github.com/hashicorp/terraform/pull/30308) Will consume this ID

## Output from tests

_Please run the tests locally for any files you changes and include the output here._

```
$ TFE_TOKEN=$TFE_TOKEN TFE_ADDRESS=$TFE_ADDRESS ENABLE_TFE=1 go test -v -run TestWorkspacesList ./... -timeout=30m -tags=integration
=== RUN   TestWorkspacesList
=== RUN   TestWorkspacesList/without_list_options
=== RUN   TestWorkspacesList/with_list_options
=== RUN   TestWorkspacesList/when_searching_a_known_workspace
=== RUN   TestWorkspacesList/when_searching_using_a_tag
=== RUN   TestWorkspacesList/when_searching_an_unknown_workspace
=== RUN   TestWorkspacesList/without_a_valid_organization
=== RUN   TestWorkspacesList/with_organization_included
=== RUN   TestWorkspacesList/with_current-state-version_included
--- PASS: TestWorkspacesList (19.91s)
    --- PASS: TestWorkspacesList/without_list_options (0.16s)
    --- PASS: TestWorkspacesList/with_list_options (0.12s)
    --- PASS: TestWorkspacesList/when_searching_a_known_workspace (0.13s)
    --- PASS: TestWorkspacesList/when_searching_using_a_tag (0.27s)
    --- PASS: TestWorkspacesList/when_searching_an_unknown_workspace (0.14s)
    --- PASS: TestWorkspacesList/without_a_valid_organization (0.00s)
    --- PASS: TestWorkspacesList/with_organization_included (0.21s)
    --- PASS: TestWorkspacesList/with_current-state-version_included (17.32s)
PASS
```
