### PR TITLE
listOptions in list functions should be pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ if err != nil {
 	log.Fatal(err)
 }
 
-orgs, err := client.Organizations.List(context.Background(), tfe.OrganizationListOptions{})
+orgs, err := client.Organizations.List(context.Background(), nil)
 if err != nil {
 	log.Fatal(err)
 }

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -15,7 +15,7 @@ var _ AdminOrganizations = (*adminOrganizations)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/admin/organizations.html
 type AdminOrganizations interface {
 	// List all the organizations visible to the current user.
-	List(ctx context.Context, options AdminOrganizationListOptions) (*AdminOrganizationList, error)
+	List(ctx context.Context, options *AdminOrganizationListOptions) (*AdminOrganizationList, error)
 
 	// Read attributes of an existing organization via admin API.
 	Read(ctx context.Context, organization string) (*AdminOrganization, error)
@@ -101,9 +101,9 @@ type AdminOrganizationID struct {
 }
 
 // List all the organizations visible to the current user.
-func (s *adminOrganizations) List(ctx context.Context, options AdminOrganizationListOptions) (*AdminOrganizationList, error) {
+func (s *adminOrganizations) List(ctx context.Context, options *AdminOrganizationListOptions) (*AdminOrganizationList, error) {
 	url := "admin/organizations"
-	req, err := s.client.newRequest("GET", url, &options)
+	req, err := s.client.newRequest("GET", url, options)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -22,7 +22,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 	defer orgTestCleanup()
 
 	t.Run("with no list options", func(t *testing.T) {
-		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{})
+		adminOrgList, err := client.Admin.Organizations.List(ctx, nil)
 		require.NoError(t, err)
 
 		// Given that org creation occurs on every test, the ordering is not
@@ -36,7 +36,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 		_, orgTestCleanup := createOrganization(t, client)
 		defer orgTestCleanup()
 
-		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{
+		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
 			Query: &org.Name,
 		})
 		assert.NoError(t, err)
@@ -48,7 +48,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 	t.Run("with list options and org name that doesn't exist", func(t *testing.T) {
 		randomName := "random-org-name"
 
-		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{
+		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
 			Query: &randomName,
 		})
 		assert.NoError(t, err)
@@ -58,7 +58,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 	})
 
 	t.Run("with owners included", func(t *testing.T) {
-		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{
+		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
 			Include: &([]AdminOrgIncludeOps{AdminOrgOwners}),
 		})
 		assert.NoError(t, err)

--- a/admin_run.go
+++ b/admin_run.go
@@ -19,7 +19,7 @@ var _ AdminRuns = (*adminRuns)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/admin/runs.html
 type AdminRuns interface {
 	// List all the runs of the given installation.
-	List(ctx context.Context, options AdminRunsListOptions) (*AdminRunsList, error)
+	List(ctx context.Context, options *AdminRunsListOptions) (*AdminRunsList, error)
 
 	// Force-cancel a run by its ID.
 	ForceCancel(ctx context.Context, runID string, options AdminRunForceCancelOptions) error
@@ -69,13 +69,15 @@ type AdminRunsListOptions struct {
 
 // List all the runs of the terraform enterprise installation.
 // https://www.terraform.io/docs/cloud/api/admin/runs.html#list-all-runs
-func (s *adminRuns) List(ctx context.Context, options AdminRunsListOptions) (*AdminRunsList, error) {
-	if err := options.valid(); err != nil {
-		return nil, err
+func (s *adminRuns) List(ctx context.Context, options *AdminRunsListOptions) (*AdminRunsList, error) {
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
 	}
 
 	u := "admin/runs"
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -112,6 +114,7 @@ func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options Admin
 	return s.client.do(ctx, req, nil)
 }
 
+// Check that the field RunStatus has a valid string value
 func (o AdminRunsListOptions) valid() error {
 	if validString(o.RunStatus) {
 		validRunStatus := map[string]int{

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -34,7 +34,7 @@ func TestAdminRuns_List(t *testing.T) {
 	defer rTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{})
+		rl, err := client.Admin.Runs.List(ctx, nil)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, rl.Items)
@@ -43,7 +43,7 @@ func TestAdminRuns_List(t *testing.T) {
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -54,7 +54,7 @@ func TestAdminRuns_List(t *testing.T) {
 		assert.Empty(t, rl.Items)
 		assert.Equal(t, 999, rl.CurrentPage)
 
-		rl, err = client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err = client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 1,
 				PageSize:   100,
@@ -68,7 +68,7 @@ func TestAdminRuns_List(t *testing.T) {
 	})
 
 	t.Run("with workspace included", func(t *testing.T) {
-		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			Include: &([]AdminRunIncludeOps{AdminRunWorkspace}),
 		})
 
@@ -80,7 +80,7 @@ func TestAdminRuns_List(t *testing.T) {
 	})
 
 	t.Run("with workspace.organization included", func(t *testing.T) {
-		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			Include: &([]AdminRunIncludeOps{AdminRunWorkspaceOrg}),
 		})
 
@@ -99,7 +99,7 @@ func TestAdminRuns_List(t *testing.T) {
 		assert.NoError(t, err)
 
 		// There should be pending Runs
-		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			RunStatus: String(string(RunPending)),
 		})
 		assert.NoError(t, err)
@@ -113,7 +113,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with RunStatus.applied filter", func(t *testing.T) {
 		// There should be no applied Runs
-		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			RunStatus: String(string(RunApplied)),
 		})
 		assert.NoError(t, err)
@@ -121,7 +121,7 @@ func TestAdminRuns_List(t *testing.T) {
 	})
 
 	t.Run("with query", func(t *testing.T) {
-		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			Query: String(rTest1.ID),
 		})
 		assert.NoError(t, err)
@@ -130,7 +130,7 @@ func TestAdminRuns_List(t *testing.T) {
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), true)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), false)
 
-		rl, err = client.Admin.Runs.List(ctx, AdminRunsListOptions{
+		rl, err = client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			Query: String(rTest2.ID),
 		})
 		assert.NoError(t, err)

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -17,7 +17,7 @@ var _ AdminTerraformVersions = (*adminTerraformVersions)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/admin/terraform-versions.html
 type AdminTerraformVersions interface {
 	// List all the terraform versions.
-	List(ctx context.Context, options AdminTerraformVersionsListOptions) (*AdminTerraformVersionsList, error)
+	List(ctx context.Context, options *AdminTerraformVersionsListOptions) (*AdminTerraformVersionsList, error)
 
 	// Read a terraform version by its ID.
 	Read(ctx context.Context, id string) (*AdminTerraformVersion, error)
@@ -71,8 +71,8 @@ type AdminTerraformVersionsList struct {
 }
 
 // List all the terraform versions.
-func (a *adminTerraformVersions) List(ctx context.Context, options AdminTerraformVersionsListOptions) (*AdminTerraformVersionsList, error) {
-	req, err := a.client.newRequest("GET", "admin/terraform-versions", &options)
+func (a *adminTerraformVersions) List(ctx context.Context, options *AdminTerraformVersionsListOptions) (*AdminTerraformVersionsList, error) {
+	req, err := a.client.newRequest("GET", "admin/terraform-versions", options)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -19,14 +19,14 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("without list options", func(t *testing.T) {
-		tfList, err := client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{})
+		tfList, err := client.Admin.TerraformVersions.List(ctx, nil)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, tfList.Items)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		tfList, err := client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+		tfList, err := client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -37,7 +37,7 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 		assert.Empty(t, tfList.Items)
 		assert.Equal(t, 999, tfList.CurrentPage)
 
-		tfList, err = client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+		tfList, err = client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 1,
 				PageSize:   100,
@@ -65,14 +65,14 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 	})
 
 	t.Run("with filter query string", func(t *testing.T) {
-		tfList, err := client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+		tfList, err := client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
 			Filter: String("1.0.4"),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(tfList.Items))
 
 		// Query for a Terraform version that does not exist
-		tfList, err = client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+		tfList, err = client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
 			Filter: String("1000.1000.42"),
 		})
 		require.NoError(t, err)
@@ -81,7 +81,7 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 
 	t.Run("with search version query string", func(t *testing.T) {
 		searchVersion := "1.0"
-		tfList, err := client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+		tfList, err := client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
 			Search: String(searchVersion),
 		})
 		require.NoError(t, err)

--- a/admin_user.go
+++ b/admin_user.go
@@ -16,7 +16,7 @@ var _ AdminUsers = (*adminUsers)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/admin/users.html
 type AdminUsers interface {
 	// List all the users of the given installation.
-	List(ctx context.Context, options AdminUserListOptions) (*AdminUserList, error)
+	List(ctx context.Context, options *AdminUserListOptions) (*AdminUserList, error)
 
 	// Delete a user by its ID.
 	Delete(ctx context.Context, userID string) error
@@ -90,9 +90,9 @@ type AdminUserListOptions struct {
 }
 
 // List all user accounts in the Terraform Enterprise installation
-func (a *adminUsers) List(ctx context.Context, options AdminUserListOptions) (*AdminUserList, error) {
+func (a *adminUsers) List(ctx context.Context, options *AdminUserListOptions) (*AdminUserList, error) {
 	u := "admin/users"
-	req, err := a.client.newRequest("GET", u, &options)
+	req, err := a.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -24,14 +24,14 @@ func TestAdminUsers_List(t *testing.T) {
 	defer orgCleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{})
+		ul, err := client.Admin.Users.List(ctx, nil)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, ul.Items)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -42,7 +42,7 @@ func TestAdminUsers_List(t *testing.T) {
 		assert.Empty(t, ul.Items)
 		assert.Equal(t, 999, ul.CurrentPage)
 
-		ul, err = client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err = client.Admin.Users.List(ctx, &AdminUserListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 1,
 				PageSize:   100,
@@ -54,7 +54,7 @@ func TestAdminUsers_List(t *testing.T) {
 	})
 
 	t.Run("query by username or email", func(t *testing.T) {
-		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
 			Query: String(currentUser.Username),
 		})
 		require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestAdminUsers_List(t *testing.T) {
 		member, memberCleanup := createOrganizationMembership(t, client, org)
 		defer memberCleanup()
 
-		ul, err = client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err = client.Admin.Users.List(ctx, &AdminUserListOptions{
 			Query: String(member.User.Email),
 		})
 		require.NoError(t, err)
@@ -75,7 +75,7 @@ func TestAdminUsers_List(t *testing.T) {
 	})
 
 	t.Run("with organization included", func(t *testing.T) {
-		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
 			Include: &([]AdminUserIncludeOps{AdminUserOrgs}),
 		})
 
@@ -87,7 +87,7 @@ func TestAdminUsers_List(t *testing.T) {
 	})
 
 	t.Run("filter by admin", func(t *testing.T) {
-		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
 			Administrators: String("true"),
 		})
 
@@ -115,7 +115,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 		// gets deleted below.
 		member, _ := createOrganizationMembership(t, client, org)
 
-		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
 			Query: String(member.User.Email),
 		})
 		require.NoError(t, err)
@@ -126,7 +126,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 		err = client.Admin.Users.Delete(ctx, member.User.ID)
 		require.NoError(t, err)
 
-		ul, err = client.Admin.Users.List(ctx, AdminUserListOptions{
+		ul, err = client.Admin.Users.List(ctx, &AdminUserListOptions{
 			Query: String(member.User.Email),
 		})
 		require.NoError(t, err)

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -15,7 +15,7 @@ var _ AdminWorkspaces = (*adminWorkspaces)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/admin/workspaces.html
 type AdminWorkspaces interface {
 	// List all the workspaces within a workspace.
-	List(ctx context.Context, options AdminWorkspaceListOptions) (*AdminWorkspaceList, error)
+	List(ctx context.Context, options *AdminWorkspaceListOptions) (*AdminWorkspaceList, error)
 
 	// Read a workspace by its ID.
 	Read(ctx context.Context, workspaceID string) (*AdminWorkspace, error)
@@ -73,9 +73,9 @@ type AdminWorkspaceList struct {
 }
 
 // List all the workspaces within a worksapce.
-func (s *adminWorkspaces) List(ctx context.Context, options AdminWorkspaceListOptions) (*AdminWorkspaceList, error) {
+func (s *adminWorkspaces) List(ctx context.Context, options *AdminWorkspaceListOptions) (*AdminWorkspaceList, error) {
 	u := "admin/workspaces"
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -30,7 +30,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 	defer wTest2Cleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{})
+		wl, err := client.Admin.Workspaces.List(ctx, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest1.ID), true)
@@ -38,7 +38,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -49,7 +49,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		assert.Empty(t, wl.Items)
 		assert.Equal(t, 999, wl.CurrentPage)
 
-		wl, err = client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+		wl, err = client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 1,
 				PageSize:   100,
@@ -64,7 +64,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 	t.Run("when searching a known workspace", func(t *testing.T) {
 		// Use a known workspace prefix as search attribute. The result
 		// should be successful and only contain the matching workspace.
-		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
 			Query: String(wTest1.Name),
 		})
 		require.NoError(t, err)
@@ -77,7 +77,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 	t.Run("when searching an unknown workspace", func(t *testing.T) {
 		// Use a nonexisting workspace name as search attribute. The result
 		// should be successful, but return no results.
-		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
 			Query: String("nonexisting"),
 		})
 		require.NoError(t, err)
@@ -87,7 +87,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 	})
 
 	t.Run("with organization included", func(t *testing.T) {
-		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
 			Include: &([]AdminWorkspaceIncludeOps{AdminWorkspaceOrg}),
 		})
 
@@ -108,7 +108,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		run, err := client.Runs.Create(ctx, runOpts)
 		assert.NoError(t, err)
 
-		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
+		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
 			Include: &([]AdminWorkspaceIncludeOps{AdminWorkspaceCurrentRun}),
 		})
 

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -15,7 +15,7 @@ var _ AgentPools = (*agentPools)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/agents.html
 type AgentPools interface {
 	// List all the agent pools of the given organization.
-	List(ctx context.Context, organization string, options AgentPoolListOptions) (*AgentPoolList, error)
+	List(ctx context.Context, organization string, options *AgentPoolListOptions) (*AgentPoolList, error)
 
 	// Create a new agent pool with the given options.
 	Create(ctx context.Context, organization string, options AgentPoolCreateOptions) (*AgentPool, error)
@@ -56,13 +56,13 @@ type AgentPoolListOptions struct {
 }
 
 // List all the agent pools of the given organization.
-func (s *agentPools) List(ctx context.Context, organization string, options AgentPoolListOptions) (*AgentPoolList, error) {
+func (s *agentPools) List(ctx context.Context, organization string, options *AgentPoolListOptions) (*AgentPoolList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/agent-pools", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -25,7 +25,7 @@ func TestAgentPoolsList(t *testing.T) {
 	defer agentPoolCleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		pools, err := client.AgentPools.List(ctx, orgTest.Name, AgentPoolListOptions{})
+		pools, err := client.AgentPools.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 		assert.Contains(t, pools.Items, agentPool)
 
@@ -37,7 +37,7 @@ func TestAgentPoolsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		pools, err := client.AgentPools.List(ctx, orgTest.Name, AgentPoolListOptions{
+		pools, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -50,7 +50,7 @@ func TestAgentPoolsList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		pools, err := client.AgentPools.List(ctx, badIdentifier, AgentPoolListOptions{})
+		pools, err := client.AgentPools.List(ctx, badIdentifier, nil)
 		assert.Nil(t, pools)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -21,7 +21,7 @@ var _ ConfigurationVersions = (*configurationVersions)(nil)
 // https://www.terraform.io/docs/enterprise/api/configuration-versions.html
 type ConfigurationVersions interface {
 	// List returns all configuration versions of a workspace.
-	List(ctx context.Context, workspaceID string, options ConfigurationVersionListOptions) (*ConfigurationVersionList, error)
+	List(ctx context.Context, workspaceID string, options *ConfigurationVersionListOptions) (*ConfigurationVersionList, error)
 
 	// Create is used to create a new configuration version. The created
 	// configuration version will be usable once data is uploaded to it.
@@ -146,13 +146,13 @@ type IngressAttributes struct {
 }
 
 // List returns all configuration versions of a workspace.
-func (s *configurationVersions) List(ctx context.Context, workspaceID string, options ConfigurationVersionListOptions) (*ConfigurationVersionList, error) {
+func (s *configurationVersions) List(ctx context.Context, workspaceID string, options *ConfigurationVersionListOptions) (*ConfigurationVersionList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -27,9 +27,7 @@ func TestConfigurationVersionsList(t *testing.T) {
 	defer cvTest2Cleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		options := ConfigurationVersionListOptions{}
-
-		cvl, err := client.ConfigurationVersions.List(ctx, wTest.ID, options)
+		cvl, err := client.ConfigurationVersions.List(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 
 		// We need to strip the upload URL as that is a dynamic link.
@@ -51,7 +49,7 @@ func TestConfigurationVersionsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		options := ConfigurationVersionListOptions{
+		options := &ConfigurationVersionListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -66,9 +64,7 @@ func TestConfigurationVersionsList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		options := ConfigurationVersionListOptions{}
-
-		cvl, err := client.ConfigurationVersions.List(ctx, badIdentifier, options)
+		cvl, err := client.ConfigurationVersions.List(ctx, badIdentifier, nil)
 		assert.Nil(t, cvl)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})

--- a/mocks/admin_organization_mocks.go
+++ b/mocks/admin_organization_mocks.go
@@ -50,7 +50,7 @@ func (mr *MockAdminOrganizationsMockRecorder) Delete(ctx, organization interface
 }
 
 // List mocks base method.
-func (m *MockAdminOrganizations) List(ctx context.Context, options tfe.AdminOrganizationListOptions) (*tfe.AdminOrganizationList, error) {
+func (m *MockAdminOrganizations) List(ctx context.Context, options *tfe.AdminOrganizationListOptions) (*tfe.AdminOrganizationList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.AdminOrganizationList)

--- a/mocks/admin_run_mocks.go
+++ b/mocks/admin_run_mocks.go
@@ -50,7 +50,7 @@ func (mr *MockAdminRunsMockRecorder) ForceCancel(ctx, runID, options interface{}
 }
 
 // List mocks base method.
-func (m *MockAdminRuns) List(ctx context.Context, options tfe.AdminRunsListOptions) (*tfe.AdminRunsList, error) {
+func (m *MockAdminRuns) List(ctx context.Context, options *tfe.AdminRunsListOptions) (*tfe.AdminRunsList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.AdminRunsList)

--- a/mocks/admin_terraform_version_mocks.go
+++ b/mocks/admin_terraform_version_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockAdminTerraformVersionsMockRecorder) Delete(ctx, id interface{}) *g
 }
 
 // List mocks base method.
-func (m *MockAdminTerraformVersions) List(ctx context.Context, options tfe.AdminTerraformVersionsListOptions) (*tfe.AdminTerraformVersionsList, error) {
+func (m *MockAdminTerraformVersions) List(ctx context.Context, options *tfe.AdminTerraformVersionsListOptions) (*tfe.AdminTerraformVersionsList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.AdminTerraformVersionsList)

--- a/mocks/admin_user_mocks.go
+++ b/mocks/admin_user_mocks.go
@@ -80,7 +80,7 @@ func (mr *MockAdminUsersMockRecorder) GrantAdmin(ctx, userID interface{}) *gomoc
 }
 
 // List mocks base method.
-func (m *MockAdminUsers) List(ctx context.Context, options tfe.AdminUserListOptions) (*tfe.AdminUserList, error) {
+func (m *MockAdminUsers) List(ctx context.Context, options *tfe.AdminUserListOptions) (*tfe.AdminUserList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.AdminUserList)

--- a/mocks/admin_workspace_mocks.go
+++ b/mocks/admin_workspace_mocks.go
@@ -50,7 +50,7 @@ func (mr *MockAdminWorkspacesMockRecorder) Delete(ctx, workspaceID interface{}) 
 }
 
 // List mocks base method.
-func (m *MockAdminWorkspaces) List(ctx context.Context, options tfe.AdminWorkspaceListOptions) (*tfe.AdminWorkspaceList, error) {
+func (m *MockAdminWorkspaces) List(ctx context.Context, options *tfe.AdminWorkspaceListOptions) (*tfe.AdminWorkspaceList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.AdminWorkspaceList)

--- a/mocks/agent_pool_mocks.go
+++ b/mocks/agent_pool_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockAgentPoolsMockRecorder) Delete(ctx, agentPoolID interface{}) *gomo
 }
 
 // List mocks base method.
-func (m *MockAgentPools) List(ctx context.Context, organization string, options tfe.AgentPoolListOptions) (*tfe.AgentPoolList, error) {
+func (m *MockAgentPools) List(ctx context.Context, organization string, options *tfe.AgentPoolListOptions) (*tfe.AgentPoolList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.AgentPoolList)

--- a/mocks/configuration_version_mocks.go
+++ b/mocks/configuration_version_mocks.go
@@ -51,7 +51,7 @@ func (mr *MockConfigurationVersionsMockRecorder) Create(ctx, workspaceID, option
 }
 
 // List mocks base method.
-func (m *MockConfigurationVersions) List(ctx context.Context, workspaceID string, options tfe.ConfigurationVersionListOptions) (*tfe.ConfigurationVersionList, error) {
+func (m *MockConfigurationVersions) List(ctx context.Context, workspaceID string, options *tfe.ConfigurationVersionListOptions) (*tfe.ConfigurationVersionList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, workspaceID, options)
 	ret0, _ := ret[0].(*tfe.ConfigurationVersionList)

--- a/mocks/notification_configuration_mocks.go
+++ b/mocks/notification_configuration_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockNotificationConfigurationsMockRecorder) Delete(ctx, notificationCo
 }
 
 // List mocks base method.
-func (m *MockNotificationConfigurations) List(ctx context.Context, workspaceID string, options tfe.NotificationConfigurationListOptions) (*tfe.NotificationConfigurationList, error) {
+func (m *MockNotificationConfigurations) List(ctx context.Context, workspaceID string, options *tfe.NotificationConfigurationListOptions) (*tfe.NotificationConfigurationList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, workspaceID, options)
 	ret0, _ := ret[0].(*tfe.NotificationConfigurationList)

--- a/mocks/oauth_client_mocks.go
+++ b/mocks/oauth_client_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockOAuthClientsMockRecorder) Delete(ctx, oAuthClientID interface{}) *
 }
 
 // List mocks base method.
-func (m *MockOAuthClients) List(ctx context.Context, organization string, options tfe.OAuthClientListOptions) (*tfe.OAuthClientList, error) {
+func (m *MockOAuthClients) List(ctx context.Context, organization string, options *tfe.OAuthClientListOptions) (*tfe.OAuthClientList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.OAuthClientList)

--- a/mocks/oauth_token_mocks.go
+++ b/mocks/oauth_token_mocks.go
@@ -50,7 +50,7 @@ func (mr *MockOAuthTokensMockRecorder) Delete(ctx, oAuthTokenID interface{}) *go
 }
 
 // List mocks base method.
-func (m *MockOAuthTokens) List(ctx context.Context, organization string, options tfe.OAuthTokenListOptions) (*tfe.OAuthTokenList, error) {
+func (m *MockOAuthTokens) List(ctx context.Context, organization string, options *tfe.OAuthTokenListOptions) (*tfe.OAuthTokenList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.OAuthTokenList)

--- a/mocks/organization_membership_mocks.go
+++ b/mocks/organization_membership_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockOrganizationMembershipsMockRecorder) Delete(ctx, organizationMembe
 }
 
 // List mocks base method.
-func (m *MockOrganizationMemberships) List(ctx context.Context, organization string, options tfe.OrganizationMembershipListOptions) (*tfe.OrganizationMembershipList, error) {
+func (m *MockOrganizationMemberships) List(ctx context.Context, organization string, options *tfe.OrganizationMembershipListOptions) (*tfe.OrganizationMembershipList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.OrganizationMembershipList)

--- a/mocks/organization_mocks.go
+++ b/mocks/organization_mocks.go
@@ -95,7 +95,7 @@ func (mr *MockOrganizationsMockRecorder) Entitlements(ctx, organization interfac
 }
 
 // List mocks base method.
-func (m *MockOrganizations) List(ctx context.Context, options tfe.OrganizationListOptions) (*tfe.OrganizationList, error) {
+func (m *MockOrganizations) List(ctx context.Context, options *tfe.OrganizationListOptions) (*tfe.OrganizationList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.OrganizationList)

--- a/mocks/policy_check_mocks.go
+++ b/mocks/policy_check_mocks.go
@@ -37,7 +37,7 @@ func (m *MockPolicyChecks) EXPECT() *MockPolicyChecksMockRecorder {
 }
 
 // List mocks base method.
-func (m *MockPolicyChecks) List(ctx context.Context, runID string, options tfe.PolicyCheckListOptions) (*tfe.PolicyCheckList, error) {
+func (m *MockPolicyChecks) List(ctx context.Context, runID string, options *tfe.PolicyCheckListOptions) (*tfe.PolicyCheckList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, runID, options)
 	ret0, _ := ret[0].(*tfe.PolicyCheckList)

--- a/mocks/policy_mocks.go
+++ b/mocks/policy_mocks.go
@@ -80,7 +80,7 @@ func (mr *MockPoliciesMockRecorder) Download(ctx, policyID interface{}) *gomock.
 }
 
 // List mocks base method.
-func (m *MockPolicies) List(ctx context.Context, organization string, options tfe.PolicyListOptions) (*tfe.PolicyList, error) {
+func (m *MockPolicies) List(ctx context.Context, organization string, options *tfe.PolicyListOptions) (*tfe.PolicyList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.PolicyList)

--- a/mocks/policy_set_mocks.go
+++ b/mocks/policy_set_mocks.go
@@ -93,7 +93,7 @@ func (mr *MockPolicySetsMockRecorder) Delete(ctx, policyID interface{}) *gomock.
 }
 
 // List mocks base method.
-func (m *MockPolicySets) List(ctx context.Context, organization string, options tfe.PolicySetListOptions) (*tfe.PolicySetList, error) {
+func (m *MockPolicySets) List(ctx context.Context, organization string, options *tfe.PolicySetListOptions) (*tfe.PolicySetList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.PolicySetList)

--- a/mocks/policy_set_parameter_mocks.go
+++ b/mocks/policy_set_parameter_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockPolicySetParametersMockRecorder) Delete(ctx, policySetID, paramete
 }
 
 // List mocks base method.
-func (m *MockPolicySetParameters) List(ctx context.Context, policySetID string, options tfe.PolicySetParameterListOptions) (*tfe.PolicySetParameterList, error) {
+func (m *MockPolicySetParameters) List(ctx context.Context, policySetID string, options *tfe.PolicySetParameterListOptions) (*tfe.PolicySetParameterList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, policySetID, options)
 	ret0, _ := ret[0].(*tfe.PolicySetParameterList)

--- a/mocks/run_mocks.go
+++ b/mocks/run_mocks.go
@@ -107,7 +107,7 @@ func (mr *MockRunsMockRecorder) ForceCancel(ctx, runID, options interface{}) *go
 }
 
 // List mocks base method.
-func (m *MockRuns) List(ctx context.Context, workspaceID string, options tfe.RunListOptions) (*tfe.RunList, error) {
+func (m *MockRuns) List(ctx context.Context, workspaceID string, options *tfe.RunListOptions) (*tfe.RunList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, workspaceID, options)
 	ret0, _ := ret[0].(*tfe.RunList)

--- a/mocks/run_trigger_mocks.go
+++ b/mocks/run_trigger_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockRunTriggersMockRecorder) Delete(ctx, RunTriggerID interface{}) *go
 }
 
 // List mocks base method.
-func (m *MockRunTriggers) List(ctx context.Context, workspaceID string, options tfe.RunTriggerListOptions) (*tfe.RunTriggerList, error) {
+func (m *MockRunTriggers) List(ctx context.Context, workspaceID string, options *tfe.RunTriggerListOptions) (*tfe.RunTriggerList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, workspaceID, options)
 	ret0, _ := ret[0].(*tfe.RunTriggerList)

--- a/mocks/ssh_key_mocks.go
+++ b/mocks/ssh_key_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockSSHKeysMockRecorder) Delete(ctx, sshKeyID interface{}) *gomock.Cal
 }
 
 // List mocks base method.
-func (m *MockSSHKeys) List(ctx context.Context, organization string, options tfe.SSHKeyListOptions) (*tfe.SSHKeyList, error) {
+func (m *MockSSHKeys) List(ctx context.Context, organization string, options *tfe.SSHKeyListOptions) (*tfe.SSHKeyList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.SSHKeyList)

--- a/mocks/state_version_mocks.go
+++ b/mocks/state_version_mocks.go
@@ -96,7 +96,7 @@ func (mr *MockStateVersionsMockRecorder) Download(ctx, url interface{}) *gomock.
 }
 
 // List mocks base method.
-func (m *MockStateVersions) List(ctx context.Context, options tfe.StateVersionListOptions) (*tfe.StateVersionList, error) {
+func (m *MockStateVersions) List(ctx context.Context, options *tfe.StateVersionListOptions) (*tfe.StateVersionList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.StateVersionList)

--- a/mocks/team_access_mocks.go
+++ b/mocks/team_access_mocks.go
@@ -51,7 +51,7 @@ func (mr *MockTeamAccessesMockRecorder) Add(ctx, options interface{}) *gomock.Ca
 }
 
 // List mocks base method.
-func (m *MockTeamAccesses) List(ctx context.Context, options tfe.TeamAccessListOptions) (*tfe.TeamAccessList, error) {
+func (m *MockTeamAccesses) List(ctx context.Context, options *tfe.TeamAccessListOptions) (*tfe.TeamAccessList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, options)
 	ret0, _ := ret[0].(*tfe.TeamAccessList)

--- a/mocks/team_mocks.go
+++ b/mocks/team_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockTeamsMockRecorder) Delete(ctx, teamID interface{}) *gomock.Call {
 }
 
 // List mocks base method.
-func (m *MockTeams) List(ctx context.Context, organization string, options tfe.TeamListOptions) (*tfe.TeamList, error) {
+func (m *MockTeams) List(ctx context.Context, organization string, options *tfe.TeamListOptions) (*tfe.TeamList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.TeamList)

--- a/mocks/variable_mocks.go
+++ b/mocks/variable_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockVariablesMockRecorder) Delete(ctx, workspaceID, variableID interfa
 }
 
 // List mocks base method.
-func (m *MockVariables) List(ctx context.Context, workspaceID string, options tfe.VariableListOptions) (*tfe.VariableList, error) {
+func (m *MockVariables) List(ctx context.Context, workspaceID string, options *tfe.VariableListOptions) (*tfe.VariableList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, workspaceID, options)
 	ret0, _ := ret[0].(*tfe.VariableList)

--- a/mocks/workspace_mocks.go
+++ b/mocks/workspace_mocks.go
@@ -138,7 +138,7 @@ func (mr *MockWorkspacesMockRecorder) ForceUnlock(ctx, workspaceID interface{}) 
 }
 
 // List mocks base method.
-func (m *MockWorkspaces) List(ctx context.Context, organization string, options tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error) {
+func (m *MockWorkspaces) List(ctx context.Context, organization string, options *tfe.WorkspaceListOptions) (*tfe.WorkspaceList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "List", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.WorkspaceList)
@@ -316,7 +316,7 @@ func (mr *MockWorkspacesMockRecorder) RemoveVCSConnectionByID(ctx, workspaceID i
 }
 
 // Tags mocks base method.
-func (m *MockWorkspaces) Tags(ctx context.Context, workspaceID string, options tfe.WorkspaceTagListOptions) (*tfe.TagList, error) {
+func (m *MockWorkspaces) Tags(ctx context.Context, workspaceID string, options *tfe.WorkspaceTagListOptions) (*tfe.TagList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Tags", ctx, workspaceID, options)
 	ret0, _ := ret[0].(*tfe.TagList)

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -18,7 +18,7 @@ var _ NotificationConfigurations = (*notificationConfigurations)(nil)
 // https://www.terraform.io/docs/cloud/api/notification-configurations.html
 type NotificationConfigurations interface {
 	// List all the notification configurations within a workspace.
-	List(ctx context.Context, workspaceID string, options NotificationConfigurationListOptions) (*NotificationConfigurationList, error)
+	List(ctx context.Context, workspaceID string, options *NotificationConfigurationListOptions) (*NotificationConfigurationList, error)
 
 	// Create a new notification configuration with the given options.
 	Create(ctx context.Context, workspaceID string, options NotificationConfigurationCreateOptions) (*NotificationConfiguration, error)
@@ -107,7 +107,7 @@ type NotificationConfigurationListOptions struct {
 }
 
 // List all the notification configurations associated with a workspace.
-func (s *notificationConfigurations) List(ctx context.Context, workspaceID string, options NotificationConfigurationListOptions) (*NotificationConfigurationList, error) {
+func (s *notificationConfigurations) List(ctx context.Context, workspaceID string, options *NotificationConfigurationListOptions) (*NotificationConfigurationList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}

--- a/notification_configuration_integration_test.go
+++ b/notification_configuration_integration_test.go
@@ -27,7 +27,7 @@ func TestNotificationConfigurationList(t *testing.T) {
 		ncl, err := client.NotificationConfigurations.List(
 			ctx,
 			wTest.ID,
-			NotificationConfigurationListOptions{},
+			nil,
 		)
 		require.NoError(t, err)
 		assert.Contains(t, ncl.Items, ncTest1)
@@ -46,7 +46,7 @@ func TestNotificationConfigurationList(t *testing.T) {
 		ncl, err := client.NotificationConfigurations.List(
 			ctx,
 			wTest.ID,
-			NotificationConfigurationListOptions{
+			&NotificationConfigurationListOptions{
 				ListOptions: ListOptions{
 					PageNumber: 999,
 					PageSize:   100,
@@ -63,7 +63,7 @@ func TestNotificationConfigurationList(t *testing.T) {
 		ncl, err := client.NotificationConfigurations.List(
 			ctx,
 			badIdentifier,
-			NotificationConfigurationListOptions{},
+			nil,
 		)
 		assert.Nil(t, ncl)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -18,7 +18,7 @@ var _ OAuthClients = (*oAuthClients)(nil)
 // https://www.terraform.io/docs/enterprise/api/oauth-clients.html
 type OAuthClients interface {
 	// List all the OAuth clients for a given organization.
-	List(ctx context.Context, organization string, options OAuthClientListOptions) (*OAuthClientList, error)
+	List(ctx context.Context, organization string, options *OAuthClientListOptions) (*OAuthClientList, error)
 
 	// Create an OAuth client to connect an organization and a VCS provider.
 	Create(ctx context.Context, organization string, options OAuthClientCreateOptions) (*OAuthClient, error)
@@ -90,13 +90,13 @@ type OAuthClientListOptions struct {
 }
 
 // List all the OAuth clients for a given organization.
-func (s *oAuthClients) List(ctx context.Context, organization string, options OAuthClientListOptions) (*OAuthClientList, error) {
+func (s *oAuthClients) List(ctx context.Context, organization string, options *OAuthClientListOptions) (*OAuthClientList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -25,9 +25,7 @@ func TestOAuthClientsList(t *testing.T) {
 	defer ocTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		options := OAuthClientListOptions{}
-
-		ocl, err := client.OAuthClients.List(ctx, orgTest.Name, options)
+		ocl, err := client.OAuthClients.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		t.Run("the OAuth tokens relationship is decoded correcly", func(t *testing.T) {
@@ -55,7 +53,7 @@ func TestOAuthClientsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		options := OAuthClientListOptions{
+		options := &OAuthClientListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -70,9 +68,7 @@ func TestOAuthClientsList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		options := OAuthClientListOptions{}
-
-		ocl, err := client.OAuthClients.List(ctx, badIdentifier, options)
+		ocl, err := client.OAuthClients.List(ctx, badIdentifier, nil)
 		assert.Nil(t, ocl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -18,7 +18,7 @@ var _ OAuthTokens = (*oAuthTokens)(nil)
 // https://www.terraform.io/docs/cloud/api/oauth-tokens.html
 type OAuthTokens interface {
 	// List all the OAuth tokens for a given organization.
-	List(ctx context.Context, organization string, options OAuthTokenListOptions) (*OAuthTokenList, error)
+	List(ctx context.Context, organization string, options *OAuthTokenListOptions) (*OAuthTokenList, error)
 	// Read a OAuth token by its ID.
 	Read(ctx context.Context, oAuthTokenID string) (*OAuthToken, error)
 
@@ -60,13 +60,13 @@ type OAuthTokenListOptions struct {
 }
 
 // List all the OAuth tokens for a given organization.
-func (s *oAuthTokens) List(ctx context.Context, organization string, options OAuthTokenListOptions) (*OAuthTokenList, error) {
+func (s *oAuthTokens) List(ctx context.Context, organization string, options *OAuthTokenListOptions) (*OAuthTokenList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-tokens", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth_token_integration_test.go
+++ b/oauth_token_integration_test.go
@@ -25,9 +25,7 @@ func TestOAuthTokensList(t *testing.T) {
 	defer otTest2Cleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		options := OAuthTokenListOptions{}
-
-		otl, err := client.OAuthTokens.List(ctx, orgTest.Name, options)
+		otl, err := client.OAuthTokens.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		t.Run("the OAuth client relationship is decoded correcly", func(t *testing.T) {
@@ -56,7 +54,7 @@ func TestOAuthTokensList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		options := OAuthTokenListOptions{
+		options := &OAuthTokenListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -71,9 +69,7 @@ func TestOAuthTokensList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		options := OAuthTokenListOptions{}
-
-		otl, err := client.OAuthTokens.List(ctx, badIdentifier, options)
+		otl, err := client.OAuthTokens.List(ctx, badIdentifier, nil)
 		assert.Nil(t, otl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/organization.go
+++ b/organization.go
@@ -18,7 +18,7 @@ var _ Organizations = (*organizations)(nil)
 // https://www.terraform.io/docs/cloud/api/organizations.html
 type Organizations interface {
 	// List all the organizations visible to the current user.
-	List(ctx context.Context, options OrganizationListOptions) (*OrganizationList, error)
+	List(ctx context.Context, options *OrganizationListOptions) (*OrganizationList, error)
 
 	// Create a new organization with the given options.
 	Create(ctx context.Context, options OrganizationCreateOptions) (*Organization, error)
@@ -127,8 +127,8 @@ type OrganizationListOptions struct {
 }
 
 // List all the organizations visible to the current user.
-func (s *organizations) List(ctx context.Context, options OrganizationListOptions) (*OrganizationList, error) {
-	req, err := s.client.newRequest("GET", "organizations", &options)
+func (s *organizations) List(ctx context.Context, options *OrganizationListOptions) (*OrganizationList, error) {
+	req, err := s.client.newRequest("GET", "organizations", options)
 	if err != nil {
 		return nil, err
 	}

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -24,7 +24,7 @@ func TestOrganizationsList(t *testing.T) {
 	defer orgTest2Cleanup()
 
 	t.Run("with no list options", func(t *testing.T) {
-		orgl, err := client.Organizations.List(ctx, OrganizationListOptions{})
+		orgl, err := client.Organizations.List(ctx, nil)
 		require.NoError(t, err)
 		assert.Contains(t, orgl.Items, orgTest1)
 		assert.Contains(t, orgl.Items, orgTest2)
@@ -39,7 +39,7 @@ func TestOrganizationsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		orgl, err := client.Organizations.List(ctx, OrganizationListOptions{
+		orgl, err := client.Organizations.List(ctx, &OrganizationListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -17,7 +17,7 @@ var _ OrganizationMemberships = (*organizationMemberships)(nil)
 // https://www.terraform.io/docs/cloud/api/organization-memberships.html
 type OrganizationMemberships interface {
 	// List all the organization memberships of the given organization.
-	List(ctx context.Context, organization string, options OrganizationMembershipListOptions) (*OrganizationMembershipList, error)
+	List(ctx context.Context, organization string, options *OrganizationMembershipListOptions) (*OrganizationMembershipList, error)
 
 	// Create a new organization membership with the given options.
 	Create(ctx context.Context, organization string, options OrganizationMembershipCreateOptions) (*OrganizationMembership, error)
@@ -80,13 +80,13 @@ type OrganizationMembershipListOptions struct {
 }
 
 // List all the organization memberships of the given organization.
-func (s *organizationMemberships) List(ctx context.Context, organization string, options OrganizationMembershipListOptions) (*OrganizationMembershipList, error) {
+func (s *organizationMemberships) List(ctx context.Context, organization string, options *OrganizationMembershipListOptions) (*OrganizationMembershipList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -29,7 +29,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		memTest1.User = &User{ID: memTest1.User.ID}
 		memTest2.User = &User{ID: memTest2.User.ID}
 
-		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, OrganizationMembershipListOptions{})
+		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		assert.Contains(t, ml.Items, memTest1)
@@ -42,7 +42,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		_, memTest2Cleanup := createOrganizationMembership(t, client, orgTest)
 		defer memTest2Cleanup()
 
-		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, OrganizationMembershipListOptions{
+		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, &OrganizationMembershipListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -63,7 +63,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		memTest2, memTest2Cleanup := createOrganizationMembership(t, client, orgTest)
 		defer memTest2Cleanup()
 
-		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, OrganizationMembershipListOptions{
+		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, &OrganizationMembershipListOptions{
 			Include: []OrganizationMembershipIncludeOps{OrganizationMembershipUser},
 		})
 		require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		ml, err := client.OrganizationMemberships.List(ctx, badIdentifier, OrganizationMembershipListOptions{})
+		ml, err := client.OrganizationMemberships.List(ctx, badIdentifier, nil)
 		assert.Nil(t, ml)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
@@ -206,7 +206,7 @@ func TestOrganizationMembershipsDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		// Get a refreshed view from the API.
-		refreshed, err := client.OrganizationMemberships.List(ctx, orgTest.Name, OrganizationMembershipListOptions{})
+		refreshed, err := client.OrganizationMemberships.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 		assert.NotContains(t, refreshed.Items, mem)
 	})

--- a/organization_tags.go
+++ b/organization_tags.go
@@ -11,7 +11,7 @@ var _ OrganizationTags = (*organizationTags)(nil)
 
 type OrganizationTags interface {
 	// List all tags within an organization
-	List(ctx context.Context, organization string, options OrganizationTagsListOptions) (*OrganizationTagsList, error)
+	List(ctx context.Context, organization string, options *OrganizationTagsListOptions) (*OrganizationTagsList, error)
 
 	// Delete tags from an organization
 	Delete(ctx context.Context, organization string, options OrganizationTagsDeleteOptions) error
@@ -50,13 +50,13 @@ type OrganizationTagsListOptions struct {
 }
 
 // List all the tags in an organization. You can provide query params through OrganizationTagsListOptions
-func (s *organizationTags) List(ctx context.Context, organization string, options OrganizationTagsListOptions) (*OrganizationTagsList, error) {
+func (s *organizationTags) List(ctx context.Context, organization string, options *OrganizationTagsListOptions) (*OrganizationTagsList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/tags", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/organization_tags_integration_test.go
+++ b/organization_tags_integration_test.go
@@ -39,7 +39,7 @@ func TestOrganizationTagsList(t *testing.T) {
 	var testTagID string
 
 	t.Run("with no query params", func(t *testing.T) {
-		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, 10, len(tags.Items))
@@ -58,7 +58,7 @@ func TestOrganizationTagsList(t *testing.T) {
 	})
 
 	t.Run("with query params", func(t *testing.T) {
-		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, &OrganizationTagsListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 1,
 				PageSize:   5,
@@ -107,7 +107,7 @@ func TestOrganizationTagsDelete(t *testing.T) {
 	require.NoError(t, err)
 
 	t.Run("delete tags by id", func(t *testing.T) {
-		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		var tagIds []string
@@ -123,7 +123,7 @@ func TestOrganizationTagsDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		//sanity check ensure tags were deleted from the organization
-		tags, err = client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		tags, err = client.OrganizationTags.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, 5, len(tags.Items))
@@ -158,7 +158,7 @@ func TestOrganizationTagsAddWorkspace(t *testing.T) {
 
 	t.Run("add tags to new workspaces", func(t *testing.T) {
 		// fetch tag ids to associate to workspace
-		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, OrganizationTagsListOptions{})
+		tags, err := client.OrganizationTags.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		tagID := tags.Items[0].ID
@@ -176,11 +176,11 @@ func TestOrganizationTagsAddWorkspace(t *testing.T) {
 		require.NoError(t, err)
 
 		//Ensure the tag was properly associated with the workspaces
-		fetched, err := client.Workspaces.Tags(ctx, workspaceToAdd1.ID, WorkspaceTagListOptions{})
+		fetched, err := client.Workspaces.Tags(ctx, workspaceToAdd1.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, fetched.Items[0].ID, tagID)
 
-		fetched, err = client.Workspaces.Tags(ctx, workspaceToAdd2.ID, WorkspaceTagListOptions{})
+		fetched, err = client.Workspaces.Tags(ctx, workspaceToAdd2.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, fetched.Items[0].ID, tagID)
 	})

--- a/policy.go
+++ b/policy.go
@@ -18,7 +18,7 @@ var _ Policies = (*policies)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/policies.html
 type Policies interface {
 	// List all the policies for a given organization
-	List(ctx context.Context, organization string, options PolicyListOptions) (*PolicyList, error)
+	List(ctx context.Context, organization string, options *PolicyListOptions) (*PolicyList, error)
 
 	// Create a policy and associate it with an organization.
 	Create(ctx context.Context, organization string, options PolicyCreateOptions) (*Policy, error)
@@ -88,13 +88,13 @@ type PolicyListOptions struct {
 }
 
 // List all the policies for a given organization
-func (s *policies) List(ctx context.Context, organization string, options PolicyListOptions) (*PolicyList, error) {
+func (s *policies) List(ctx context.Context, organization string, options *PolicyListOptions) (*PolicyList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/policies", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/policy_check.go
+++ b/policy_check.go
@@ -20,7 +20,7 @@ var _ PolicyChecks = (*policyChecks)(nil)
 // https://www.terraform.io/docs/cloud/api/policy-checks.html
 type PolicyChecks interface {
 	// List all policy checks of the given run.
-	List(ctx context.Context, runID string, options PolicyCheckListOptions) (*PolicyCheckList, error)
+	List(ctx context.Context, runID string, options *PolicyCheckListOptions) (*PolicyCheckList, error)
 
 	// Read a policy check by its ID.
 	Read(ctx context.Context, policyCheckID string) (*PolicyCheck, error)
@@ -117,13 +117,13 @@ type PolicyCheckListOptions struct {
 }
 
 // List all policy checks of the given run.
-func (s *policyChecks) List(ctx context.Context, runID string, options PolicyCheckListOptions) (*PolicyCheckList, error) {
+func (s *policyChecks) List(ctx context.Context, runID string, options *PolicyCheckListOptions) (*PolicyCheckList, error) {
 	if !validStringID(&runID) {
 		return nil, ErrInvalidRunID
 	}
 
 	u := fmt.Sprintf("runs/%s/policy-checks", url.QueryEscape(runID))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -36,7 +36,7 @@ func TestPolicyChecksList(t *testing.T) {
 	defer runCleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
+		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(pcl.Items))
 		assert.NotEmpty(t, pcl.Items[0].Permissions)
@@ -51,7 +51,7 @@ func TestPolicyChecksList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{
+		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, &PolicyCheckListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -64,7 +64,7 @@ func TestPolicyChecksList(t *testing.T) {
 	})
 
 	t.Run("without a valid run ID", func(t *testing.T) {
-		pcl, err := client.PolicyChecks.List(ctx, badIdentifier, PolicyCheckListOptions{})
+		pcl, err := client.PolicyChecks.List(ctx, badIdentifier, nil)
 		assert.Nil(t, pcl)
 		assert.EqualError(t, err, ErrInvalidRunID.Error())
 	})
@@ -132,7 +132,7 @@ func TestPolicyChecksOverride(t *testing.T) {
 		rTest, tTestCleanup := createPolicyCheckedRun(t, client, wTest)
 		defer tTestCleanup()
 
-		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
+		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(pcl.Items))
 		require.Equal(t, PolicySoftFailed, pcl.Items[0].Status)
@@ -157,7 +157,7 @@ func TestPolicyChecksOverride(t *testing.T) {
 		rTest, rTestCleanup := createPolicyCheckedRun(t, client, wTest)
 		defer rTestCleanup()
 
-		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, PolicyCheckListOptions{})
+		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, nil)
 		require.NoError(t, err)
 		require.Equal(t, 1, len(pcl.Items))
 		require.Equal(t, PolicyPasses, pcl.Items[0].Status)

--- a/policy_integration_test.go
+++ b/policy_integration_test.go
@@ -30,7 +30,7 @@ func TestPoliciesList(t *testing.T) {
 	defer pTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		pl, err := client.Policies.List(ctx, orgTest.Name, PolicyListOptions{})
+		pl, err := client.Policies.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 		assert.Contains(t, pl.Items, pTest1)
 		assert.Contains(t, pl.Items, pTest2)
@@ -43,7 +43,7 @@ func TestPoliciesList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		pl, err := client.Policies.List(ctx, orgTest.Name, PolicyListOptions{
+		pl, err := client.Policies.List(ctx, orgTest.Name, &PolicyListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -59,7 +59,7 @@ func TestPoliciesList(t *testing.T) {
 	t.Run("with search", func(t *testing.T) {
 		// Search by one of the policy's names; we should get only that policy
 		// and pagination data should reflect the search as well
-		pl, err := client.Policies.List(ctx, orgTest.Name, PolicyListOptions{
+		pl, err := client.Policies.List(ctx, orgTest.Name, &PolicyListOptions{
 			Search: &pTest1.Name,
 		})
 		require.NoError(t, err)
@@ -71,7 +71,7 @@ func TestPoliciesList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		ps, err := client.Policies.List(ctx, badIdentifier, PolicyListOptions{})
+		ps, err := client.Policies.List(ctx, badIdentifier, nil)
 		assert.Nil(t, ps)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/policy_set.go
+++ b/policy_set.go
@@ -17,7 +17,7 @@ var _ PolicySets = (*policySets)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/policies.html
 type PolicySets interface {
 	// List all the policy sets for a given organization.
-	List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error)
+	List(ctx context.Context, organization string, options *PolicySetListOptions) (*PolicySetList, error)
 
 	// Create a policy set and associate it with an organization.
 	Create(ctx context.Context, organization string, options PolicySetCreateOptions) (*PolicySet, error)
@@ -97,13 +97,13 @@ type PolicySetListOptions struct {
 }
 
 // List all the policies for a given organization.
-func (s *policySets) List(ctx context.Context, organization string, options PolicySetListOptions) (*PolicySetList, error) {
+func (s *policySets) List(ctx context.Context, organization string, options *PolicySetListOptions) (*PolicySetList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -28,7 +28,7 @@ func TestPolicySetsList(t *testing.T) {
 	defer psTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		psl, err := client.PolicySets.List(ctx, orgTest.Name, PolicySetListOptions{})
+		psl, err := client.PolicySets.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
 		assert.Contains(t, psl.Items, psTest1)
@@ -41,7 +41,7 @@ func TestPolicySetsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		psl, err := client.PolicySets.List(ctx, orgTest.Name, PolicySetListOptions{
+		psl, err := client.PolicySets.List(ctx, orgTest.Name, &PolicySetListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -57,7 +57,7 @@ func TestPolicySetsList(t *testing.T) {
 	t.Run("with search", func(t *testing.T) {
 		// Search by one of the policy set's names; we should get only that policy
 		// set and pagination data should reflect the search as well
-		psl, err := client.PolicySets.List(ctx, orgTest.Name, PolicySetListOptions{
+		psl, err := client.PolicySets.List(ctx, orgTest.Name, &PolicySetListOptions{
 			Search: String(psTest1.Name),
 		})
 		require.NoError(t, err)
@@ -69,7 +69,7 @@ func TestPolicySetsList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		ps, err := client.PolicySets.List(ctx, badIdentifier, PolicySetListOptions{})
+		ps, err := client.PolicySets.List(ctx, badIdentifier, nil)
 		assert.Nil(t, ps)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/policy_set_parameter.go
+++ b/policy_set_parameter.go
@@ -16,7 +16,7 @@ var _ PolicySetParameters = (*policySetParameters)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/policy-set-params.html
 type PolicySetParameters interface {
 	// List all the parameters associated with the given policy-set.
-	List(ctx context.Context, policySetID string, options PolicySetParameterListOptions) (*PolicySetParameterList, error)
+	List(ctx context.Context, policySetID string, options *PolicySetParameterListOptions) (*PolicySetParameterList, error)
 
 	// Create is used to create a new parameter.
 	Create(ctx context.Context, policySetID string, options PolicySetParameterCreateOptions) (*PolicySetParameter, error)
@@ -59,21 +59,14 @@ type PolicySetParameterListOptions struct {
 	ListOptions
 }
 
-func (o PolicySetParameterListOptions) valid() error {
-	return nil
-}
-
 // List all the parameters associated with the given policy-set.
-func (s *policySetParameters) List(ctx context.Context, policySetID string, options PolicySetParameterListOptions) (*PolicySetParameterList, error) {
+func (s *policySetParameters) List(ctx context.Context, policySetID string, options *PolicySetParameterListOptions) (*PolicySetParameterList, error) {
 	if !validStringID(&policySetID) {
 		return nil, errors.New("invalid value for policy set ID")
 	}
-	if err := options.valid(); err != nil {
-		return nil, err
-	}
 
 	u := fmt.Sprintf("policy-sets/%s/parameters", policySetID)
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/policy_set_parameter_integration_test.go
+++ b/policy_set_parameter_integration_test.go
@@ -29,7 +29,7 @@ func TestPolicySetParametersList(t *testing.T) {
 	defer pTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		pl, err := client.PolicySetParameters.List(ctx, psTest.ID, PolicySetParameterListOptions{})
+		pl, err := client.PolicySetParameters.List(ctx, psTest.ID, nil)
 		require.NoError(t, err)
 		assert.Contains(t, pl.Items, pTest1)
 		assert.Contains(t, pl.Items, pTest2)
@@ -44,7 +44,7 @@ func TestPolicySetParametersList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		pl, err := client.PolicySetParameters.List(ctx, psTest.ID, PolicySetParameterListOptions{
+		pl, err := client.PolicySetParameters.List(ctx, psTest.ID, &PolicySetParameterListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -57,7 +57,7 @@ func TestPolicySetParametersList(t *testing.T) {
 	})
 
 	t.Run("when policy set ID is invalid ID", func(t *testing.T) {
-		pl, err := client.PolicySetParameters.List(ctx, badIdentifier, PolicySetParameterListOptions{})
+		pl, err := client.PolicySetParameters.List(ctx, badIdentifier, nil)
 		assert.Nil(t, pl)
 		assert.EqualError(t, err, "invalid value for policy set ID")
 	})

--- a/run.go
+++ b/run.go
@@ -17,7 +17,7 @@ var _ Runs = (*runs)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/run.html
 type Runs interface {
 	// List all the runs of the given workspace.
-	List(ctx context.Context, workspaceID string, options RunListOptions) (*RunList, error)
+	List(ctx context.Context, workspaceID string, options *RunListOptions) (*RunList, error)
 
 	// Create a new run with the given options.
 	Create(ctx context.Context, options RunCreateOptions) (*Run, error)
@@ -186,13 +186,13 @@ type RunVariable struct {
 }
 
 // List all the runs of the given workspace.
-func (s *runs) List(ctx context.Context, workspaceID string, options RunListOptions) (*RunList, error) {
+func (s *runs) List(ctx context.Context, workspaceID string, options *RunListOptions) (*RunList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s/runs", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -26,7 +26,7 @@ func TestRunsList(t *testing.T) {
 	rTest2, _ := createRun(t, client, wTest)
 
 	t.Run("without list options", func(t *testing.T) {
-		rl, err := client.Runs.List(ctx, wTest.ID, RunListOptions{})
+		rl, err := client.Runs.List(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 
 		found := []string{}
@@ -41,7 +41,7 @@ func TestRunsList(t *testing.T) {
 	})
 
 	t.Run("without list options and include as nil", func(t *testing.T) {
-		rl, err := client.Runs.List(ctx, wTest.ID, RunListOptions{
+		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
 			Include: nil,
 		})
 		require.NoError(t, err)
@@ -63,7 +63,7 @@ func TestRunsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		rl, err := client.Runs.List(ctx, wTest.ID, RunListOptions{
+		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -76,7 +76,7 @@ func TestRunsList(t *testing.T) {
 	})
 
 	t.Run("with workspace included", func(t *testing.T) {
-		rl, err := client.Runs.List(ctx, wTest.ID, RunListOptions{
+		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
 			Include: &([]RunIncludeOps{RunWorkspace}),
 		})
 
@@ -88,7 +88,7 @@ func TestRunsList(t *testing.T) {
 	})
 
 	t.Run("without a valid workspace ID", func(t *testing.T) {
-		rl, err := client.Runs.List(ctx, badIdentifier, RunListOptions{})
+		rl, err := client.Runs.List(ctx, badIdentifier, nil)
 		assert.Nil(t, rl)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -18,7 +18,7 @@ var _ RunTriggers = (*runTriggers)(nil)
 // https://www.terraform.io/docs/cloud/api/run-triggers.html
 type RunTriggers interface {
 	// List all the run triggers within a workspace.
-	List(ctx context.Context, workspaceID string, options RunTriggerListOptions) (*RunTriggerList, error)
+	List(ctx context.Context, workspaceID string, options *RunTriggerListOptions) (*RunTriggerList, error)
 
 	// Create a new run trigger with the given options.
 	Create(ctx context.Context, workspaceID string, options RunTriggerCreateOptions) (*RunTrigger, error)
@@ -61,24 +61,10 @@ type RunTriggerListOptions struct {
 	RunTriggerType *string `url:"filter[run-trigger][type]"`
 }
 
-func (o RunTriggerListOptions) valid() error {
-	if !validString(o.RunTriggerType) {
-		return errors.New("run-trigger type is required")
-	}
-	if *o.RunTriggerType != "inbound" && *o.RunTriggerType != "outbound" {
-		return errors.New("invalid value for run-trigger type")
-	}
-	return nil
-}
-
 // List all the run triggers associated with a workspace.
-func (s *runTriggers) List(ctx context.Context, workspaceID string, options RunTriggerListOptions) (*RunTriggerList, error) {
+func (s *runTriggers) List(ctx context.Context, workspaceID string, options *RunTriggerListOptions) (*RunTriggerList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
-	}
-
-	if err := options.valid(); err != nil {
-		return nil, err
 	}
 
 	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -36,7 +36,7 @@ func TestRunTriggerList(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
-			RunTriggerListOptions{
+			&RunTriggerListOptions{
 				RunTriggerType: String("inbound"),
 			},
 		)
@@ -54,7 +54,7 @@ func TestRunTriggerList(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
-			RunTriggerListOptions{
+			&RunTriggerListOptions{
 				ListOptions: ListOptions{
 					PageNumber: 999,
 					PageSize:   100,
@@ -72,7 +72,7 @@ func TestRunTriggerList(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			badIdentifier,
-			RunTriggerListOptions{
+			&RunTriggerListOptions{
 				RunTriggerType: String("inbound"),
 			},
 		)
@@ -84,22 +84,22 @@ func TestRunTriggerList(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
-			RunTriggerListOptions{},
+			nil,
 		)
 		assert.Nil(t, rtl)
-		assert.EqualError(t, err, "run-trigger type is required")
+		assert.EqualError(t, err, "bad request\n\nFilter parameter run-trigger type is required and must be either 'inbound' or 'outbound'")
 	})
 
 	t.Run("with invalid run-trigger type", func(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
-			RunTriggerListOptions{
+			&RunTriggerListOptions{
 				RunTriggerType: String("invalid"),
 			},
 		)
 		assert.Nil(t, rtl)
-		assert.EqualError(t, err, "invalid value for run-trigger type")
+		assert.EqualError(t, err, "bad request\n\nFilter parameter run-trigger type is required and must be either 'inbound' or 'outbound'")
 	})
 }
 

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -17,7 +17,7 @@ var _ SSHKeys = (*sshKeys)(nil)
 // https://www.terraform.io/docs/cloud/api/ssh-keys.html
 type SSHKeys interface {
 	// List all the SSH keys for a given organization
-	List(ctx context.Context, organization string, options SSHKeyListOptions) (*SSHKeyList, error)
+	List(ctx context.Context, organization string, options *SSHKeyListOptions) (*SSHKeyList, error)
 
 	// Create an SSH key and associate it with an organization.
 	Create(ctx context.Context, organization string, options SSHKeyCreateOptions) (*SSHKey, error)
@@ -55,13 +55,13 @@ type SSHKeyListOptions struct {
 }
 
 // List all the SSH keys for a given organization
-func (s *sshKeys) List(ctx context.Context, organization string, options SSHKeyListOptions) (*SSHKeyList, error) {
+func (s *sshKeys) List(ctx context.Context, organization string, options *SSHKeyListOptions) (*SSHKeyList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/ssh-keys", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/ssh_key_integration_test.go
+++ b/ssh_key_integration_test.go
@@ -24,7 +24,7 @@ func TestSSHKeysList(t *testing.T) {
 	defer kTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		kl, err := client.SSHKeys.List(ctx, orgTest.Name, SSHKeyListOptions{})
+		kl, err := client.SSHKeys.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 		assert.Contains(t, kl.Items, kTest1)
 		assert.Contains(t, kl.Items, kTest2)
@@ -39,7 +39,7 @@ func TestSSHKeysList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		kl, err := client.SSHKeys.List(ctx, orgTest.Name, SSHKeyListOptions{
+		kl, err := client.SSHKeys.List(ctx, orgTest.Name, &SSHKeyListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -52,7 +52,7 @@ func TestSSHKeysList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		kl, err := client.SSHKeys.List(ctx, badIdentifier, SSHKeyListOptions{})
+		kl, err := client.SSHKeys.List(ctx, badIdentifier, nil)
 		assert.Nil(t, kl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/state_version.go
+++ b/state_version.go
@@ -19,7 +19,7 @@ var _ StateVersions = (*stateVersions)(nil)
 // https://www.terraform.io/docs/cloud/api/state-versions.html
 type StateVersions interface {
 	// List all the state versions for a given workspace.
-	List(ctx context.Context, options StateVersionListOptions) (*StateVersionList, error)
+	List(ctx context.Context, options *StateVersionListOptions) (*StateVersionList, error)
 
 	// Create a new state version for the given workspace.
 	Create(ctx context.Context, workspaceID string, options StateVersionCreateOptions) (*StateVersion, error)
@@ -75,6 +75,7 @@ type StateVersionListOptions struct {
 	Workspace    *string `url:"filter[workspace][name]"`
 }
 
+//check that StateVersionListOptions fields had valid values
 func (o StateVersionListOptions) valid() error {
 	if !validString(o.Organization) {
 		return errors.New("organization is required")
@@ -86,12 +87,16 @@ func (o StateVersionListOptions) valid() error {
 }
 
 // List all the state versions for a given workspace.
-func (s *stateVersions) List(ctx context.Context, options StateVersionListOptions) (*StateVersionList, error) {
+func (s *stateVersions) List(ctx context.Context, options *StateVersionListOptions) (*StateVersionList, error) {
+	if options == nil {
+		return nil, errors.New("StateVersionListOptions is required")
+	}
+
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("GET", "state-versions", &options)
+	req, err := s.client.newRequest("GET", "state-versions", options)
 	if err != nil {
 		return nil, err
 	}

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -31,8 +31,14 @@ func TestStateVersionsList(t *testing.T) {
 	svTest2, svTestCleanup2 := createStateVersion(t, client, 1, wTest)
 	defer svTestCleanup2()
 
+	t.Run("without StateVersionListOptions", func(t *testing.T) {
+		svl, err := client.StateVersions.List(ctx, nil)
+		assert.Nil(t, svl)
+		assert.EqualError(t, err, "StateVersionListOptions is required")
+	})
+
 	t.Run("without list options", func(t *testing.T) {
-		options := StateVersionListOptions{
+		options := &StateVersionListOptions{
 			Organization: String(orgTest.Name),
 			Workspace:    String(wTest.Name),
 		}
@@ -67,7 +73,7 @@ func TestStateVersionsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		options := StateVersionListOptions{
+		options := &StateVersionListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -84,7 +90,7 @@ func TestStateVersionsList(t *testing.T) {
 	})
 
 	t.Run("without an organization", func(t *testing.T) {
-		options := StateVersionListOptions{
+		options := &StateVersionListOptions{
 			Workspace: String(wTest.Name),
 		}
 
@@ -94,7 +100,7 @@ func TestStateVersionsList(t *testing.T) {
 	})
 
 	t.Run("without a workspace", func(t *testing.T) {
-		options := StateVersionListOptions{
+		options := &StateVersionListOptions{
 			Organization: String(orgTest.Name),
 		}
 

--- a/team.go
+++ b/team.go
@@ -16,7 +16,7 @@ var _ Teams = (*teams)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/teams.html
 type Teams interface {
 	// List all the teams of the given organization.
-	List(ctx context.Context, organization string, options TeamListOptions) (*TeamList, error)
+	List(ctx context.Context, organization string, options *TeamListOptions) (*TeamList, error)
 
 	// Create a new team with the given options.
 	Create(ctx context.Context, organization string, options TeamCreateOptions) (*Team, error)
@@ -86,13 +86,13 @@ type TeamListOptions struct {
 }
 
 // List all the teams of the given organization.
-func (s *teams) List(ctx context.Context, organization string, options TeamListOptions) (*TeamList, error) {
+func (s *teams) List(ctx context.Context, organization string, options *TeamListOptions) (*TeamList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/team_access.go
+++ b/team_access.go
@@ -17,7 +17,7 @@ var _ TeamAccesses = (*teamAccesses)(nil)
 // https://www.terraform.io/docs/cloud/api/team-access.html
 type TeamAccesses interface {
 	// List all the team accesses for a given workspace.
-	List(ctx context.Context, options TeamAccessListOptions) (*TeamAccessList, error)
+	List(ctx context.Context, options *TeamAccessListOptions) (*TeamAccessList, error)
 
 	// Add team access for a workspace.
 	Add(ctx context.Context, options TeamAccessAddOptions) (*TeamAccess, error)
@@ -107,6 +107,7 @@ type TeamAccessListOptions struct {
 	WorkspaceID *string `url:"filter[workspace][id],omitempty"`
 }
 
+//check that workspaceID field has a valid value
 func (o TeamAccessListOptions) valid() error {
 	if !validString(o.WorkspaceID) {
 		return errors.New("workspace ID is required")
@@ -118,12 +119,16 @@ func (o TeamAccessListOptions) valid() error {
 }
 
 // List all the team accesses for a given workspace.
-func (s *teamAccesses) List(ctx context.Context, options TeamAccessListOptions) (*TeamAccessList, error) {
+func (s *teamAccesses) List(ctx context.Context, options *TeamAccessListOptions) (*TeamAccessList, error) {
+	if options == nil {
+		return nil, errors.New("TeamAccessListOptions is required")
+	}
+
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("GET", "team-workspaces", &options)
+	req, err := s.client.newRequest("GET", "team-workspaces", options)
 	if err != nil {
 		return nil, err
 	}

--- a/team_access_integration_test.go
+++ b/team_access_integration_test.go
@@ -34,7 +34,7 @@ func TestTeamAccessesList(t *testing.T) {
 	defer taTest2Cleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
-		tal, err := client.TeamAccess.List(ctx, TeamAccessListOptions{
+		tal, err := client.TeamAccess.List(ctx, &TeamAccessListOptions{
 			WorkspaceID: String(wTest.ID),
 		})
 		require.NoError(t, err)
@@ -51,7 +51,7 @@ func TestTeamAccessesList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		tal, err := client.TeamAccess.List(ctx, TeamAccessListOptions{
+		tal, err := client.TeamAccess.List(ctx, &TeamAccessListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -63,14 +63,25 @@ func TestTeamAccessesList(t *testing.T) {
 		assert.Equal(t, 2, tal.TotalCount)
 	})
 
-	t.Run("without list options", func(t *testing.T) {
-		tal, err := client.TeamAccess.List(ctx, TeamAccessListOptions{})
+	t.Run("without TeamAccessListOptions", func(t *testing.T) {
+		tal, err := client.TeamAccess.List(ctx, nil)
+		assert.Nil(t, tal)
+		assert.EqualError(t, err, "TeamAccessListOptions is required")
+	})
+
+	t.Run("without WorkspaceID options", func(t *testing.T) {
+		tal, err := client.TeamAccess.List(ctx, &TeamAccessListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 2,
+				PageSize:   25,
+			},
+		})
 		assert.Nil(t, tal)
 		assert.EqualError(t, err, "workspace ID is required")
 	})
 
-	t.Run("without a valid workspace ID", func(t *testing.T) {
-		tal, err := client.TeamAccess.List(ctx, TeamAccessListOptions{
+	t.Run("without a valid workspaceID", func(t *testing.T) {
+		tal, err := client.TeamAccess.List(ctx, &TeamAccessListOptions{
 			WorkspaceID: String(badIdentifier),
 		})
 		assert.Nil(t, tal)

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -29,7 +29,7 @@ func TestTeamsList(t *testing.T) {
 	defer tmTest2Cleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		tl, err := client.Teams.List(ctx, orgTest.Name, TeamListOptions{})
+		tl, err := client.Teams.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 		assert.Contains(t, tl.Items, tmTest1)
 		assert.Contains(t, tl.Items, tmTest2)
@@ -44,7 +44,7 @@ func TestTeamsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		tl, err := client.Teams.List(ctx, orgTest.Name, TeamListOptions{
+		tl, err := client.Teams.List(ctx, orgTest.Name, &TeamListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -57,7 +57,7 @@ func TestTeamsList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		tl, err := client.Teams.List(ctx, badIdentifier, TeamListOptions{})
+		tl, err := client.Teams.List(ctx, badIdentifier, nil)
 		assert.Nil(t, tl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -163,7 +163,7 @@ func TestClient_headers(t *testing.T) {
 	ctx := context.Background()
 
 	// Make a few calls so we can check they all send the expected headers.
-	_, _ = client.Organizations.List(ctx, OrganizationListOptions{})
+	_, _ = client.Organizations.List(ctx, nil)
 	_, _ = client.Plans.Logs(ctx, "plan-123456789")
 	_ = client.Runs.Apply(ctx, "run-123456789", RunApplyOptions{})
 	_, _ = client.Workspaces.Lock(ctx, "ws-123456789", WorkspaceLockOptions{})
@@ -210,7 +210,7 @@ func TestClient_userAgent(t *testing.T) {
 	ctx := context.Background()
 
 	// Make a few calls so we can check they all send the expected headers.
-	_, _ = client.Organizations.List(ctx, OrganizationListOptions{})
+	_, _ = client.Organizations.List(ctx, nil)
 	_, _ = client.Plans.Logs(ctx, "plan-123456789")
 	_ = client.Runs.Apply(ctx, "run-123456789", RunApplyOptions{})
 	_, _ = client.Workspaces.Lock(ctx, "ws-123456789", WorkspaceLockOptions{})

--- a/variable.go
+++ b/variable.go
@@ -16,7 +16,7 @@ var _ Variables = (*variables)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/workspace-variables.html
 type Variables interface {
 	// List all the variables associated with the given workspace.
-	List(ctx context.Context, workspaceID string, options VariableListOptions) (*VariableList, error)
+	List(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error)
 
 	// Create is used to create a new variable.
 	Create(ctx context.Context, workspaceID string, options VariableCreateOptions) (*Variable, error)
@@ -72,13 +72,13 @@ type VariableListOptions struct {
 }
 
 // List all the variables associated with the given workspace.
-func (s *variables) List(ctx context.Context, workspaceID string, options VariableListOptions) (*VariableList, error) {
+func (s *variables) List(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -27,7 +27,7 @@ func TestVariablesList(t *testing.T) {
 	defer vTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		vl, err := client.Variables.List(ctx, wTest.ID, VariableListOptions{})
+		vl, err := client.Variables.List(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Contains(t, vl.Items, vTest1)
 		assert.Contains(t, vl.Items, vTest2)
@@ -42,7 +42,7 @@ func TestVariablesList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		vl, err := client.Variables.List(ctx, wTest.ID, VariableListOptions{
+		vl, err := client.Variables.List(ctx, wTest.ID, &VariableListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -55,7 +55,7 @@ func TestVariablesList(t *testing.T) {
 	})
 
 	t.Run("when workspace ID is invalid ID", func(t *testing.T) {
-		vl, err := client.Variables.List(ctx, badIdentifier, VariableListOptions{})
+		vl, err := client.Variables.List(ctx, badIdentifier, nil)
 		assert.Nil(t, vl)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})

--- a/workspace.go
+++ b/workspace.go
@@ -19,7 +19,7 @@ var _ Workspaces = (*workspaces)(nil)
 // TFE API docs: https://www.terraform.io/docs/cloud/api/workspaces.html
 type Workspaces interface {
 	// List all the workspaces within an organization.
-	List(ctx context.Context, organization string, options WorkspaceListOptions) (*WorkspaceList, error)
+	List(ctx context.Context, organization string, options *WorkspaceListOptions) (*WorkspaceList, error)
 
 	// Create is used to create a new workspace.
 	Create(ctx context.Context, organization string, options WorkspaceCreateOptions) (*Workspace, error)
@@ -86,7 +86,7 @@ type Workspaces interface {
 	UpdateRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceUpdateRemoteStateConsumersOptions) error
 
 	// Tags reads the tags for a workspace.
-	Tags(ctx context.Context, workspaceID string, options WorkspaceTagListOptions) (*TagList, error)
+	Tags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error)
 
 	// AddTags appends tags to a workspace
 	AddTags(ctx context.Context, workspaceID string, options WorkspaceAddTagsOptions) error
@@ -240,13 +240,13 @@ type WorkspaceListOptions struct {
 }
 
 // List all the workspaces within an organization.
-func (s *workspaces) List(ctx context.Context, organization string, options WorkspaceListOptions) (*WorkspaceList, error) {
+func (s *workspaces) List(ctx context.Context, organization string, options *WorkspaceListOptions) (*WorkspaceList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -908,7 +908,7 @@ func (s *workspaces) RemoteStateConsumers(ctx context.Context, workspaceID strin
 
 	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
 
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -1036,14 +1036,14 @@ type WorkspaceTagListOptions struct {
 }
 
 // Tags returns the tags for a given workspace.
-func (s *workspaces) Tags(ctx context.Context, workspaceID string, options WorkspaceTagListOptions) (*TagList, error) {
+func (s *workspaces) Tags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.QueryEscape(workspaceID))
 
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -32,7 +32,7 @@ func TestWorkspacesList(t *testing.T) {
 	defer wTest2Cleanup()
 
 	t.Run("without list options", func(t *testing.T) {
-		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{})
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 		assert.Contains(t, wl.Items, wTest1)
 		assert.Contains(t, wl.Items, wTest2)
@@ -44,7 +44,7 @@ func TestWorkspacesList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -59,7 +59,7 @@ func TestWorkspacesList(t *testing.T) {
 	t.Run("when searching a known workspace", func(t *testing.T) {
 		// Use a known workspace prefix as search attribute. The result
 		// should be successful and only contain the matching workspace.
-		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
 			Search: String(wTest1.Name[:len(wTest1.Name)-5]),
 		})
 		require.NoError(t, err)
@@ -84,7 +84,7 @@ func TestWorkspacesList(t *testing.T) {
 
 		// The result should be successful and only contain the workspace with the
 		// new tag.
-		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
 			Tags: &tagName,
 		})
 		require.NoError(t, err)
@@ -96,7 +96,7 @@ func TestWorkspacesList(t *testing.T) {
 	t.Run("when searching an unknown workspace", func(t *testing.T) {
 		// Use a nonexisting workspace name as search attribute. The result
 		// should be successful, but return no results.
-		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
 			Search: String("nonexisting"),
 		})
 		require.NoError(t, err)
@@ -106,13 +106,13 @@ func TestWorkspacesList(t *testing.T) {
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
-		wl, err := client.Workspaces.List(ctx, badIdentifier, WorkspaceListOptions{})
+		wl, err := client.Workspaces.List(ctx, badIdentifier, nil)
 		assert.Nil(t, wl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("with organization included", func(t *testing.T) {
-		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
 			Include: []WSIncludeOps{WSOrganization},
 		})
 
@@ -127,7 +127,7 @@ func TestWorkspacesList(t *testing.T) {
 		_, rCleanup := createAppliedRun(t, client, wTest1)
 		t.Cleanup(rCleanup)
 
-		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
 			Include: []WSIncludeOps{WSCurrentStateVer, WSCurrentRun},
 		})
 
@@ -1177,7 +1177,7 @@ func TestWorkspaces_AddTags(t *testing.T) {
 		sort.Strings(w.TagNames)
 		assert.EqualValues(t, w.TagNames, []string{"tag1", "tag2", "tag3", "tag4"})
 
-		wt, err := client.Workspaces.Tags(ctx, wTest.ID, WorkspaceTagListOptions{})
+		wt, err := client.Workspaces.Tags(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 4, len(wt.Items))
 		assert.Equal(t, wt.Items[3].Name, "tag4")
@@ -1198,7 +1198,7 @@ func TestWorkspaces_AddTags(t *testing.T) {
 		require.NoError(t, err)
 
 		// get the id of the new tag
-		tags, err := client.Workspaces.Tags(ctx, wTest2.ID, WorkspaceTagListOptions{})
+		tags, err := client.Workspaces.Tags(ctx, wTest2.ID, nil)
 		require.NoError(t, err)
 
 		// add the tag to our workspace by id
@@ -1219,7 +1219,7 @@ func TestWorkspaces_AddTags(t *testing.T) {
 		assert.Equal(t, w.TagNames, []string{"tag1", "tag2", "tag3", "tag4", "tagbyid"})
 
 		// tag is now in our tag list
-		wt, err := client.Workspaces.Tags(ctx, wTest.ID, WorkspaceTagListOptions{})
+		wt, err := client.Workspaces.Tags(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 5, len(wt.Items))
 		assert.Equal(t, wt.Items[4].ID, tags.Items[0].ID)
@@ -1286,7 +1286,7 @@ func TestWorkspaces_RemoveTags(t *testing.T) {
 		assert.Equal(t, 1, len(w.TagNames))
 		assert.Equal(t, w.TagNames, []string{"tag3"})
 
-		wt, err := client.Workspaces.Tags(ctx, wTest.ID, WorkspaceTagListOptions{})
+		wt, err := client.Workspaces.Tags(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(wt.Items))
 		assert.EqualValues(t, wt.Items[0].Name, "tag3")


### PR DESCRIPTION
This PR contains breaking changes and it will get merge against `releases-1-0.x` branch. This is branch dedicated to all changes related to Go-TFE 1.0.

## Description

All listing functions should have pointer types, since they are optional.
There are a many locations where list options are not pointers, which is inconsistent with the
rest of the API.

## Expectations:

1. We want to pass all ListOptions for all API endpoints (like WorkspaceListOptions, WorkspaceTagListOptions, RunListOptions, PolicyCheckListOptions, etc) as pointers. 

2. To give a quick example, https://github.com/hashicorp/go-tfe/blob/26689edbfddfbf08037bcaea9a1a060533148992/workspace.go#L1017 has `WorkspaceTagListOptions` not as a  pointer type.  
So we would convert 
`Tags(ctx context.Context, workspaceID string, options WorkspaceTagListOptions) (*TagList, error)` 
into 
`Tags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error)`  

3. Most, if not all, readOptions params in reading functions, like this one https://github.com/hashicorp/go-tfe/blob/26689edbfddfbf08037bcaea9a1a060533148992/workspace.go#L31 are pointer type . So changing listOptions to be pointers as well, would create parity among all options params for GET endpoints (listing functions and reading functions) because they would match in type.

## Implementation Details

The amount of file changes in this PR is overwhelming, so let me give you a summary here of what you can expect to see for each API endpoint that got modified. 

I am going to use the List() function in workspace.go as an example, but then you can assume I repeated that same change pattern for other listing functions:

1. Refer to WorkspaceListOptions as a pointer type for the List method declared in Workspaces interface:

 https://github.com/hashicorp/go-tfe/blob/0ee09b9783faa294d51cc9b706ad41e794ff494d/workspace.go#L22

2. Refer to WorkspaceListOptions as a pointer in the definition of the function List():

https://github.com/hashicorp/go-tfe/blob/0ee09b9783faa294d51cc9b706ad41e794ff494d/workspace.go#L225

3. In the integration test that is testing this list() function, modified the WorkspaceListOptions accordingly:
   A) In the case where it was declare an empty struct (WorkspaceListOptions{}), we change it to `nil`:
      https://github.com/hashicorp/go-tfe/blob/0ee09b9783faa294d51cc9b706ad41e794ff494d/workspace_integration_test.go#L35

   B) In the case where it was assigning values to fields, we add the `&` reference symbol:
       https://github.com/hashicorp/go-tfe/blob/0ee09b9783faa294d51cc9b706ad41e794ff494d/workspace_integration_test.go#L47

4. Finally, we run `./generate_mocks.sh` so the interface for Workspaces can be updated with the new type pointer in its corresponding mock file.

## Additional-Exceptional changes to certain ListOptions:

1. Notice that in run_trigger.go file, I removed `func (o RunTriggerListOptions) valid() error`  as well as this check `if err := options.valid(); err != nil {` from within List() function.

I did this because now that RunTriggerListOptions can be `nil`, we would get a panic error for pointer dereference if we try to call `valid()` on `options`. We could make adjustments to not get this panic and still run that validation. However, the whole purpose of the `valid()` function was to verified that the fields for runTriggerListOptions do not go undefined or have invalid values. 
We no longer need this `valid()`  function. 
If we pass nil for options to GET request,  the `run_triggers_controller` would do the job of verify the validity of listOptions, and will return the error `bad request\n\nFilter parameter run-trigger type is required and must be either 'inbound' or 'outbound'` if the fields for runTriggerListOptions are not valid, yay.

I made a similar change in a couple of other listing functions.

2. In this code block:

https://github.com/hashicorp/go-tfe/blob/0ee09b9783faa294d51cc9b706ad41e794ff494d/state_version.go#L91-L97

I have added that check for options as nil.
Previously the behavior was that if a user passed `stateVersionListOptions{}` , then we would return the error "organization is required" or "workspace is required" coming from line 95 when those fields are undefined. I cannot removed the `valid()` function in this case. The controller for this get request will not an specific, well explained error (only a 500 internal error) if `stateVersionListOptions` is nil. So, we need to keep that validation check in go-tfe, and on top of that, add a check when options is nil.

I have done something similar for the listing function in team_access.go



