### PR TITLE
Version and search version query params for List TF Versions endpoint

### DIFF
--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -54,6 +54,12 @@ type AdminTerraformVersion struct {
 // terraform versions.
 type AdminTerraformVersionsListOptions struct {
 	ListOptions
+
+	// A query string to find an exact version
+	Version *string `url:"version,omitempty"`
+
+	// A search query string to find all versions that match version substring
+	Search *string `url:"search[version],omitempty"`
 }
 
 // AdminTerraformVersionsList represents a list of terraform versions.

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -56,7 +56,7 @@ type AdminTerraformVersionsListOptions struct {
 	ListOptions
 
 	// A query string to find an exact version
-	Version *string `url:"version,omitempty"`
+	Filter *string `url:"filter[version],omitempty"`
 
 	// A search query string to find all versions that match version substring
 	Search *string `url:"search[version],omitempty"`

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -58,16 +58,16 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 		}
 	})
 
-	t.Run("with version query string", func(t *testing.T) {
+	t.Run("with filter query string", func(t *testing.T) {
 		tfList, err := client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
-			Version: String("1.0.4"),
+			Filter: String("1.0.4"),
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(tfList.Items))
 
 		// Query for a Terraform version that does not exist
 		tfList, err = client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
-			Version: String("1000.1000.42"),
+			Filter: String("1000.1000.42"),
 		})
 		require.NoError(t, err)
 		assert.Empty(t, tfList.Items)

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -56,6 +57,36 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 			assert.NotNil(t, item.CreatedAt)
 		}
 	})
+
+	t.Run("with version query string", func(t *testing.T) {
+		tfList, err := client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+			Version: String("1.0.4"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(tfList.Items))
+
+		// Query for a Terraform version that does not exist
+		tfList, err = client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+			Version: String("1000.1000.42"),
+		})
+		require.NoError(t, err)
+		assert.Empty(t, tfList.Items)
+	})
+
+	t.Run("with search version query string", func(t *testing.T) {
+		searchVersion := "1.0"
+		tfList, err := client.Admin.TerraformVersions.List(ctx, AdminTerraformVersionsListOptions{
+			Search: String(searchVersion),
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, tfList.Items)
+
+		t.Run("ensure each version matches substring", func(t *testing.T) {
+			for _, item := range tfList.Items {
+				assert.Equal(t, true, strings.Contains(item.Version, searchVersion))
+			}
+		})
+	})
 }
 
 func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
@@ -89,27 +120,27 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		assert.Equal(t, *opts.Beta, tfv.Beta)
 	})
 
-    t.Run("with only required options", func(t *testing.T) {
-	  opts := AdminTerraformVersionCreateOptions{
-		Version:  String("1.1.1"),
-		URL:      String("https://www.hashicorp.com"),
-		Sha:      String(genSha(t, "secret", "data")),
-	  }
-	  tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
-	  require.NoError(t, err)
+	t.Run("with only required options", func(t *testing.T) {
+		opts := AdminTerraformVersionCreateOptions{
+			Version: String("1.1.1"),
+			URL:     String("https://www.hashicorp.com"),
+			Sha:     String(genSha(t, "secret", "data")),
+		}
+		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
+		require.NoError(t, err)
 
-	  defer func() {
-		deleteErr := client.Admin.TerraformVersions.Delete(ctx, tfv.ID)
-		require.NoError(t, deleteErr)
-	  }()
+		defer func() {
+			deleteErr := client.Admin.TerraformVersions.Delete(ctx, tfv.ID)
+			require.NoError(t, deleteErr)
+		}()
 
-	  assert.Equal(t, *opts.Version, tfv.Version)
-	  assert.Equal(t, *opts.URL, tfv.URL)
-	  assert.Equal(t, *opts.Sha, tfv.Sha)
-	  assert.Equal(t, false, tfv.Official)
-	  assert.Equal(t, true, tfv.Enabled)
-	  assert.Equal(t, false, tfv.Beta)
-    })
+		assert.Equal(t, *opts.Version, tfv.Version)
+		assert.Equal(t, *opts.URL, tfv.URL)
+		assert.Equal(t, *opts.Sha, tfv.Sha)
+		assert.Equal(t, false, tfv.Official)
+		assert.Equal(t, true, tfv.Enabled)
+		assert.Equal(t, false, tfv.Beta)
+	})
 
 	t.Run("with empty options", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{}


### PR DESCRIPTION
## Description

This PR adds the two query parameters added to the [List Terraform Versions Endpoint](https://www.terraform.io/cloud-docs/api-docs/admin/terraform-versions#list-all-terraform-versions):

`filter[version]` (string) - Finds an exact Terraform version matching this version
`search[version]` (string) - Fuzzy finds Terraform versions whose version number matches the substring supplied. 


## Testing plan

To run the integration test:
```sh
ENABLE_TFE=1 go test -v ./... -run TestAdminTerraformVersions_List -tags=integration
```

**Note:** Since these changes are not yet available in the API, the CI tests will fail. I did however run them against my local TFE instance. Once these changes are available in TFC I'll re-run CI.

## Output from tests

```
=== RUN   TestAdminTerraformVersions_List
=== RUN   TestAdminTerraformVersions_List/without_list_options
=== RUN   TestAdminTerraformVersions_List/with_list_options
=== RUN   TestAdminTerraformVersions_List/with_version_query_string
=== RUN   TestAdminTerraformVersions_List/with_search_version_query_string
=== RUN   TestAdminTerraformVersions_List/with_search_version_query_string/ensure_each_version_matches_substring
--- PASS: TestAdminTerraformVersions_List (2.43s)
    --- PASS: TestAdminTerraformVersions_List/without_list_options (0.31s)
    --- PASS: TestAdminTerraformVersions_List/with_list_options (0.87s)
    --- PASS: TestAdminTerraformVersions_List/with_version_query_string (0.48s)
    --- PASS: TestAdminTerraformVersions_List/with_search_version_query_string (0.29s)
        --- PASS: TestAdminTerraformVersions_List/with_search_version_query_string/ensure_each_version_matches_substring (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     3.033s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files
```
