### PR TITLE
Include field string to an slice of typed strings

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -70,6 +70,14 @@ type AdminOrganizationList struct {
 	Items []*AdminOrganization
 }
 
+// A list of relations to include. See available resources
+// https://www.terraform.io/docs/cloud/api/admin/organizations.html#available-related-resources
+type AdminOrgIncludeOps string
+
+const (
+	AdminOrgOwners AdminOrgIncludeOps = "owners"
+)
+
 // AdminOrganizationListOptions represents the options for listing organizations via Admin API.
 type AdminOrganizationListOptions struct {
 	ListOptions
@@ -78,9 +86,7 @@ type AdminOrganizationListOptions struct {
 	// Any organizations with a name or notification email partially matching this value will be returned.
 	Query *string `url:"q,omitempty"`
 
-	// A list of relations to include. See available resources
-	// https://www.terraform.io/docs/cloud/api/admin/organizations.html#available-related-resources
-	Include *string `url:"include"`
+	Include *[]AdminOrgIncludeOps `url:"include,omitempty"`
 }
 
 // AdminOrganizationListModuleConsumersOptions represents the options for listing organization module consumers through the Admin API

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -59,7 +59,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 
 	t.Run("with owners included", func(t *testing.T) {
 		adminOrgList, err := client.Admin.Organizations.List(ctx, AdminOrganizationListOptions{
-			Include: String("owners"),
+			Include: &([]AdminOrgIncludeOps{AdminOrgOwners}),
 		})
 		assert.NoError(t, err)
 

--- a/admin_run.go
+++ b/admin_run.go
@@ -48,14 +48,23 @@ type AdminRunsList struct {
 	Items []*AdminRun
 }
 
+// https://www.terraform.io/cloud-docs/api-docs/admin/runs#available-related-resources
+type AdminRunIncludeOps string
+
+const (
+	AdminRunWorkspace          AdminRunIncludeOps = "workspace"
+	AdminRunWorkspaceOrg       AdminRunIncludeOps = "workspace.organization"
+	AdminRunWorkspaceOrgOwners AdminRunIncludeOps = "workspace.organization.owners"
+)
+
 // AdminRunsListOptions represents the options for listing runs.
 // https://www.terraform.io/docs/cloud/api/admin/runs.html#query-parameters
 type AdminRunsListOptions struct {
 	ListOptions
 
-	RunStatus *string `url:"filter[status],omitempty"`
-	Query     *string `url:"q,omitempty"`
-	Include   *string `url:"include,omitempty"`
+	RunStatus *string               `url:"filter[status],omitempty"`
+	Query     *string               `url:"q,omitempty"`
+	Include   *[]AdminRunIncludeOps `url:"include,omitempty"`
 }
 
 // List all the runs of the terraform enterprise installation.

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -69,7 +69,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with workspace included", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
-			Include: String("workspace"),
+			Include: &([]AdminRunIncludeOps{AdminRunWorkspace}),
 		})
 
 		assert.NoError(t, err)
@@ -81,7 +81,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with workspace.organization included", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, AdminRunsListOptions{
-			Include: String("workspace.organization"),
+			Include: &([]AdminRunIncludeOps{AdminRunWorkspaceOrg}),
 		})
 
 		assert.NoError(t, err)

--- a/admin_user.go
+++ b/admin_user.go
@@ -64,6 +64,14 @@ type AdminUserList struct {
 	Items []*AdminUser
 }
 
+// A list of relations to include. See available resources
+// https://www.terraform.io/docs/cloud/api/admin/users.html#available-related-resources
+type AdminUserIncludeOps string
+
+const (
+	AdminUserOrgs AdminUserIncludeOps = "organizations"
+)
+
 // AdminUserListOptions represents the options for listing users.
 // https://www.terraform.io/docs/cloud/api/admin/users.html#query-parameters
 type AdminUserListOptions struct {
@@ -78,9 +86,7 @@ type AdminUserListOptions struct {
 	// Can be "true" or "false" to show only suspended users or users who are not suspended.
 	SuspendedUsers *string `url:"filter[suspended]"`
 
-	// A list of relations to include. See available resources
-	// https://www.terraform.io/docs/cloud/api/admin/users.html#available-related-resources
-	Include *string `url:"include"`
+	Include *[]AdminUserIncludeOps `url:"include,omitempty"`
 }
 
 // List all user accounts in the Terraform Enterprise installation

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -76,7 +76,7 @@ func TestAdminUsers_List(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		ul, err := client.Admin.Users.List(ctx, AdminUserListOptions{
-			Include: String("organizations"),
+			Include: &([]AdminUserIncludeOps{AdminUserOrgs}),
 		})
 
 		assert.NoError(t, err)

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -45,6 +45,16 @@ type AdminWorkspace struct {
 	CurrentRun   *Run          `jsonapi:"relation,current-run"`
 }
 
+// A list of relations to include. See available resources
+// https://www.terraform.io/docs/cloud/api/admin/workspaces.html#available-related-resources
+type AdminWorkspaceIncludeOps string
+
+const (
+	AdminWorkspaceOrg        AdminWorkspaceIncludeOps = "organization"
+	AdminWorkspaceCurrentRun AdminWorkspaceIncludeOps = "current_run"
+	AdminWorkspaceOrgOwners  AdminWorkspaceIncludeOps = "organization.owners"
+)
+
 // AdminWorkspaceListOptions represents the options for listing workspaces.
 type AdminWorkspaceListOptions struct {
 	ListOptions
@@ -53,9 +63,7 @@ type AdminWorkspaceListOptions struct {
 	// https://www.terraform.io/docs/cloud/api/admin/workspaces.html#query-parameters
 	Query *string `url:"q,omitempty"`
 
-	// A list of relations to include. See available resources
-	// https://www.terraform.io/docs/cloud/api/admin/workspaces.html#available-related-resources
-	Include *string `url:"include"`
+	Include *[]AdminWorkspaceIncludeOps `url:"include,omitempty"`
 }
 
 // AdminWorkspaceList represents a list of workspaces.

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -88,7 +88,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
-			Include: String("organization"),
+			Include: &([]AdminWorkspaceIncludeOps{AdminWorkspaceOrg}),
 		})
 
 		assert.NoError(t, err)
@@ -109,7 +109,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		assert.NoError(t, err)
 
 		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
-			Include: String("current_run"),
+			Include: &([]AdminWorkspaceIncludeOps{AdminWorkspaceCurrentRun}),
 		})
 
 		assert.NoError(t, err)
@@ -117,15 +117,6 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		assert.NotEmpty(t, wl.Items)
 		assert.NotNil(t, wl.Items[0].CurrentRun)
 		assert.Equal(t, wl.Items[0].CurrentRun.ID, run.ID)
-	})
-
-	t.Run("with invalid resource included", func(t *testing.T) {
-		wl, err := client.Admin.Workspaces.List(ctx, AdminWorkspaceListOptions{
-			Include: String("invalid-included-resource"),
-		})
-		assert.Nil(t, wl)
-		assert.Error(t, err)
-		assert.EqualError(t, err, "bad request\n\nInvalid include parameter")
 	})
 }
 

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -98,9 +98,18 @@ type CVStatusTimestamps struct {
 	StartedAt  time.Time `jsonapi:"attr,started-at,rfc3339"`
 }
 
+// A list of relations to include. See available resources:
+// https://www.terraform.io/docs/cloud/api/configuration-versions.html#available-related-resources
+type ConfigurationVersionIncludeOps string
+
+const (
+	ConfigurationVerIngressAttributes ConfigurationVersionIncludeOps = "ingress_attributes"
+	ConfigurationRun                  ConfigurationVersionIncludeOps = "run"
+)
+
 // ConfigurationVersionReadOptions represents the options for reading a configuration version.
 type ConfigurationVersionReadOptions struct {
-	Include string `url:"include"`
+	Include []ConfigurationVersionIncludeOps `url:"include,omitempty"`
 }
 
 // ConfigurationVersionListOptions represents the options for listing
@@ -108,9 +117,7 @@ type ConfigurationVersionReadOptions struct {
 type ConfigurationVersionListOptions struct {
 	ListOptions
 
-	// A list of relations to include. See available resources:
-	// https://www.terraform.io/docs/cloud/api/configuration-versions.html#available-related-resources
-	Include *string `url:"include"`
+	Include *[]ConfigurationVersionIncludeOps `url:"include,omitempty"`
 }
 
 // IngressAttributes include commit information associated with configuration versions sourced from VCS.

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -162,7 +162,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	w, err := client.Workspaces.ReadByIDWithOptions(ctx, wTest.ID, &WorkspaceReadOptions{
-		Include: "current-run.configuration-version",
+		Include: []WSIncludeOps{WSCurrentRunConfigVer},
 	})
 
 	if err != nil {
@@ -177,7 +177,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 
 	t.Run("when the configuration version exists", func(t *testing.T) {
 		options := &ConfigurationVersionReadOptions{
-			Include: "ingress-attributes",
+			Include: []ConfigurationVersionIncludeOps{ConfigurationVerIngressAttributes},
 		}
 
 		cv, err := client.ConfigurationVersions.ReadWithOptions(ctx, cv.ID, options)

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -64,11 +64,19 @@ type OrganizationMembership struct {
 	Teams        []*Team       `jsonapi:"relation,teams"`
 }
 
+// https://www.terraform.io/cloud-docs/api-docs/organization-memberships#available-related-resources
+type OrganizationMembershipIncludeOps string
+
+const (
+	OrganizationMembershipUser OrganizationMembershipIncludeOps = "user"
+	OrganizationMembershipTeam OrganizationMembershipIncludeOps = "teams"
+)
+
 // OrganizationMembershipListOptions represents the options for listing organization memberships.
 type OrganizationMembershipListOptions struct {
 	ListOptions
 
-	Include string `url:"include"`
+	Include []OrganizationMembershipIncludeOps `url:"include,omitempty"`
 }
 
 // List all the organization memberships of the given organization.
@@ -142,7 +150,7 @@ func (s *organizationMemberships) Read(ctx context.Context, organizationMembersh
 
 // OrganizationMembershipReadOptions represents the options for reading organization memberships.
 type OrganizationMembershipReadOptions struct {
-	Include string `url:"include"`
+	Include []OrganizationMembershipIncludeOps `url:"include,omitempty"`
 }
 
 // Read an organization membership by ID with options

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -64,7 +64,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		defer memTest2Cleanup()
 
 		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, OrganizationMembershipListOptions{
-			Include: "user",
+			Include: []OrganizationMembershipIncludeOps{OrganizationMembershipUser},
 		})
 		require.NoError(t, err)
 
@@ -96,7 +96,7 @@ func TestOrganizationMembershipsCreate(t *testing.T) {
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.OrganizationMemberships.ReadWithOptions(ctx, mem.ID, OrganizationMembershipReadOptions{
-			Include: "user",
+			Include: []OrganizationMembershipIncludeOps{OrganizationMembershipUser},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, refreshed, mem)
@@ -169,7 +169,7 @@ func TestOrganizationMembershipsReadWithOptions(t *testing.T) {
 	defer memTestCleanup()
 
 	options := OrganizationMembershipReadOptions{
-		Include: "user",
+		Include: []OrganizationMembershipIncludeOps{OrganizationMembershipUser},
 	}
 
 	t.Run("when the membership exists", func(t *testing.T) {

--- a/policy_set.go
+++ b/policy_set.go
@@ -187,11 +187,20 @@ func (s *policySets) Create(ctx context.Context, organization string, options Po
 	return ps, err
 }
 
+type PolicySetIncludeOps string
+
+const (
+	PolicySetPolicies       PolicySetIncludeOps = "policies"
+	PolicySetWorkspaces     PolicySetIncludeOps = "workspaces"
+	PolicySetCurrentVersion PolicySetIncludeOps = "current_version"
+	PolicySetNewestVersion  PolicySetIncludeOps = "newest_version"
+)
+
 // PolicySetReadOptions are read options.
 // For a full list of relations, please see:
 // https://www.terraform.io/docs/cloud/api/policy-sets.html#relationships
 type PolicySetReadOptions struct {
-	Include string `url:"include"`
+	Include []PolicySetIncludeOps `url:"include,omitempty"`
 }
 
 // Read a policy set by its ID.

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -284,20 +284,20 @@ func TestPolicySetsRead(t *testing.T) {
 		require.NoError(t, err)
 
 		opts := &PolicySetReadOptions{
-			Include: "current-version,newest-version",
+			Include: []PolicySetIncludeOps{PolicySetCurrentVersion, PolicySetNewestVersion},
 		}
-		ps, err = client.PolicySets.ReadWithOptions(ctx, psTest.ID, opts)
+		psWithOptions, err := client.PolicySets.ReadWithOptions(ctx, psTest.ID, opts)
 		require.NoError(t, err)
 
 		// The newest policy set version is changed to the most recent one
 		// that was created.
-		assert.Equal(t, ps.NewestVersion.ID, psvNew.ID)
-		assert.Equal(t, ps.NewestVersion.Status, PolicySetVersionPending)
+		assert.Equal(t, psWithOptions.NewestVersion.ID, psvNew.ID)
+		assert.Equal(t, psWithOptions.NewestVersion.Status, PolicySetVersionPending)
 		// The current one is now set because policies were uploaded to the
 		// policy set version. Notice how it is set to the one that was uplaoded,
 		// not the newest policy set version.
-		assert.Equal(t, ps.CurrentVersion.ID, psv.ID)
-		assert.Equal(t, ps.CurrentVersion.Status, PolicySetVersionReady)
+		assert.Equal(t, psWithOptions.CurrentVersion.ID, psv.ID)
+		assert.Equal(t, psWithOptions.CurrentVersion.Status, PolicySetVersionReady)
 	})
 }
 

--- a/run.go
+++ b/run.go
@@ -156,13 +156,25 @@ type RunStatusTimestamps struct {
 	PolicySoftFailedAt   time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
 }
 
+// A list of relations to include. See available resources:
+// https://www.terraform.io/docs/cloud/api/run.html#available-related-resources
+type RunIncludeOps string
+
+const (
+	RunPlan             RunIncludeOps = "plan"
+	RunApply            RunIncludeOps = "apply"
+	RunCreatedBy        RunIncludeOps = "created_by"
+	RunCostEstimate     RunIncludeOps = "cost_estimate"
+	RunConfigVer        RunIncludeOps = "configuration_version"
+	RunConfigVerIngress RunIncludeOps = "configuration_version.ingress_attributes"
+	RunWorkspace        RunIncludeOps = "workspace"
+)
+
 // RunListOptions represents the options for listing runs.
 type RunListOptions struct {
 	ListOptions
 
-	// A list of relations to include. See available resources:
-	// https://www.terraform.io/docs/cloud/api/run.html#available-related-resources
-	Include *string `url:"include"`
+	Include *[]RunIncludeOps `url:"include,omitempty"`
 }
 
 // RunVariable represents a variable that can be applied to a run. All values must be expressed as an HCL literal
@@ -286,7 +298,7 @@ func (s *runs) Read(ctx context.Context, runID string) (*Run, error) {
 
 // RunReadOptions represents the options for reading a run.
 type RunReadOptions struct {
-	Include string `url:"include"`
+	Include []RunIncludeOps `url:"include,omitempty"`
 }
 
 // Read a run by its ID with the given options.

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -40,6 +40,23 @@ func TestRunsList(t *testing.T) {
 		assert.Equal(t, 2, rl.TotalCount)
 	})
 
+	t.Run("without list options and include as nil", func(t *testing.T) {
+		rl, err := client.Runs.List(ctx, wTest.ID, RunListOptions{
+			Include: nil,
+		})
+		require.NoError(t, err)
+
+		found := []string{}
+		for _, r := range rl.Items {
+			found = append(found, r.ID)
+		}
+
+		assert.Contains(t, found, rTest1.ID)
+		assert.Contains(t, found, rTest2.ID)
+		assert.Equal(t, 1, rl.CurrentPage)
+		assert.Equal(t, 2, rl.TotalCount)
+	})
+
 	t.Run("with list options", func(t *testing.T) {
 		t.Skip("paging not supported yet in API")
 
@@ -60,7 +77,7 @@ func TestRunsList(t *testing.T) {
 
 	t.Run("with workspace included", func(t *testing.T) {
 		rl, err := client.Runs.List(ctx, wTest.ID, RunListOptions{
-			Include: String("workspace"),
+			Include: &([]RunIncludeOps{RunWorkspace}),
 		})
 
 		assert.NoError(t, err)
@@ -256,7 +273,7 @@ func TestRunsReadWithOptions(t *testing.T) {
 
 	t.Run("when the run exists", func(t *testing.T) {
 		curOpts := &RunReadOptions{
-			Include: "created_by",
+			Include: []RunIncludeOps{RunCreatedBy},
 		}
 
 		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, curOpts)

--- a/state_version.go
+++ b/state_version.go
@@ -170,9 +170,20 @@ func (s *stateVersions) Create(ctx context.Context, workspaceID string, options 
 	return sv, nil
 }
 
+// https://www.terraform.io/cloud-docs/api-docs/state-versions#available-related-resources
+type StateVersionIncludeOps string
+
+const (
+	SVcreatedby               StateVersionIncludeOps = "created_by"
+	SVrun                     StateVersionIncludeOps = "run"
+	SVrunCreatedBy            StateVersionIncludeOps = "run.created_by"
+	SVrunConfigurationVersion StateVersionIncludeOps = "run.configuration_version"
+	SVoutputs                 StateVersionIncludeOps = "outputs"
+)
+
 // StateVersionReadOptions represents the options for reading state version.
 type StateVersionReadOptions struct {
-	Include string `url:"include"`
+	Include []StateVersionIncludeOps `url:"include,omitempty"`
 }
 
 // Read a state version by its ID.
@@ -203,7 +214,7 @@ func (s *stateVersions) Read(ctx context.Context, svID string) (*StateVersion, e
 
 // StateVersionCurrentOptions represents the options for reading the current state version.
 type StateVersionCurrentOptions struct {
-	Include string `url:"include"`
+	Include []StateVersionIncludeOps `url:"include,omitempty"`
 }
 
 // CurrentWithOptions reads the latest available state from the given workspace using the options supplied.

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -311,7 +311,7 @@ func TestStateVersionsReadWithOptions(t *testing.T) {
 
 	t.Run("when the state version exists", func(t *testing.T) {
 		curOpts := &StateVersionReadOptions{
-			Include: "outputs",
+			Include: []StateVersionIncludeOps{SVoutputs},
 		}
 
 		sv, err := client.StateVersions.ReadWithOptions(ctx, svTest.ID, curOpts)
@@ -379,7 +379,7 @@ func TestStateVersionsCurrentWithOptions(t *testing.T) {
 
 	t.Run("when the state version exists", func(t *testing.T) {
 		curOpts := &StateVersionCurrentOptions{
-			Include: "outputs",
+			Include: []StateVersionIncludeOps{SVoutputs},
 		}
 
 		sv, err := client.StateVersions.CurrentWithOptions(ctx, wTest1.ID, curOpts)

--- a/state_version_output_integration_test.go
+++ b/state_version_output_integration_test.go
@@ -28,7 +28,7 @@ func TestStateVersionOutputsRead(t *testing.T) {
 	time.Sleep(waitForStateVersionOutputs)
 
 	curOpts := &StateVersionCurrentOptions{
-		Include: "outputs",
+		Include: []StateVersionIncludeOps{SVoutputs},
 	}
 
 	sv, err := client.StateVersions.CurrentWithOptions(ctx, wTest1.ID, curOpts)

--- a/team.go
+++ b/team.go
@@ -70,11 +70,19 @@ type TeamPermissions struct {
 	CanUpdateMembership bool `jsonapi:"attr,can-update-membership"`
 }
 
+type TeamIncludeOps string
+
+// https://www.terraform.io/docs/cloud/api/teams.html#available-related-resources
+const (
+	TeamUsers                   TeamIncludeOps = "users"
+	TeamOrganizationMemberships TeamIncludeOps = "organization-memberships"
+)
+
 // TeamListOptions represents the options for listing teams.
 type TeamListOptions struct {
 	ListOptions
 
-	Include string `url:"include"`
+	Include []TeamIncludeOps `url:"include,omitempty"`
 }
 
 // List all the teams of the given organization.

--- a/team_member.go
+++ b/team_member.go
@@ -61,9 +61,9 @@ func (s *teamMembers) ListUsers(ctx context.Context, teamID string) ([]*User, er
 	}
 
 	options := struct {
-		Include string `url:"include"`
+		Include []TeamIncludeOps `url:"include"`
 	}{
-		Include: "users",
+		Include: []TeamIncludeOps{TeamUsers},
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
@@ -88,9 +88,9 @@ func (s *teamMembers) ListOrganizationMemberships(ctx context.Context, teamID st
 	}
 
 	options := struct {
-		Include string `url:"include"`
+		Include []TeamIncludeOps `url:"include,omitempty"`
 	}{
-		Include: "organization-memberships",
+		Include: []TeamIncludeOps{TeamOrganizationMemberships},
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -8,7 +8,6 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -17,8 +16,6 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/jsonapi"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
 
@@ -380,110 +377,6 @@ func createRequest(v interface{}) (*retryablehttp.Request, []byte, error) {
 		return request, nil, err
 	}
 	return request, body, nil
-}
-
-type tfeAPI struct {
-	ID                string                   `jsonapi:"primary,tfe"`
-	Name              string                   `jsonapi:"attr,name"`
-	CreatedAt         time.Time                `jsonapi:"attr,created-at,iso8601"`
-	Enalbed           bool                     `jsonapi:"attr,enalbed"`
-	Emails            []string                 `jsonapi:"attr,emails"`
-	Status            tfeAPIStatus             `jsonapi:"attr,status"`
-	StatusTimestamps  tfeAPITimestamps         `jsonapi:"attr,status-timestamps"`
-	DeliveryResponses []tfeAPIDeliveryResponse `jsonapi:"attr,delivery-responses"`
-}
-
-type tfeAPIDeliveryResponse struct {
-	Body string `jsonapi:"attr,body"`
-	Code int    `jsonapi:"attr,code"`
-}
-
-type tfeAPIStatus string
-
-const (
-	tfeAPIStatusNormal tfeAPIStatus = "normal"
-)
-
-type tfeAPITimestamps struct {
-	QueuedAt time.Time `jsonapi:"attr,queued-at,rfc3339"`
-}
-
-func Test_unmarshalResponse(t *testing.T) {
-	t.Run("unmarshal properly formatted json", func(t *testing.T) {
-		// This structure is intended to include multiple possible fields and
-		// formats that are valid for JSON:API
-		data := map[string]interface{}{
-			"data": map[string]interface{}{
-				"type": "tfe",
-				"id":   "1",
-				"attributes": map[string]interface{}{
-					"name":       "terraform",
-					"created-at": "2016-08-17T08:27:12Z",
-					"enabled":    "true",
-					"status":     tfeAPIStatusNormal,
-					"emails":     []string{"test@hashicorp.com"},
-					"delivery-responses": []interface{}{
-						map[string]interface{}{
-							"body": "<html>",
-							"code": 200,
-						},
-						map[string]interface{}{
-							"body": "<body>",
-							"code": 300,
-						},
-					},
-					"status-timestamps": map[string]string{
-						"queued-at": "2020-03-16T23:15:59+00:00",
-					},
-				},
-			},
-		}
-		byteData, _ := json.Marshal(data)
-		responseBody := bytes.NewReader(byteData)
-
-		unmarshalledRequestBody := tfeAPI{}
-		err := unmarshalResponse(responseBody, &unmarshalledRequestBody)
-		require.NoError(t, err)
-		queuedParsedTime, err := time.Parse(time.RFC3339, "2020-03-16T23:15:59+00:00")
-		require.NoError(t, err)
-
-		assert.Equal(t, unmarshalledRequestBody.ID, "1")
-		assert.Equal(t, unmarshalledRequestBody.Name, "terraform")
-		assert.Equal(t, unmarshalledRequestBody.Status, tfeAPIStatusNormal)
-		assert.Equal(t, len(unmarshalledRequestBody.Emails), 1)
-		assert.Equal(t, unmarshalledRequestBody.Emails[0], "test@hashicorp.com")
-		assert.Equal(t, unmarshalledRequestBody.StatusTimestamps.QueuedAt, queuedParsedTime)
-		assert.NotEmpty(t, unmarshalledRequestBody.DeliveryResponses)
-		assert.Equal(t, len(unmarshalledRequestBody.DeliveryResponses), 2)
-		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[0].Body, "<html>")
-		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[0].Code, 200)
-		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[1].Body, "<body>")
-		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[1].Code, 300)
-	})
-
-	t.Run("can only unmarshal Items that are slices", func(t *testing.T) {
-		responseBody := bytes.NewReader([]byte(""))
-		malformattedItemStruct := struct {
-			*Pagination
-			Items int
-		}{
-			Items: 1,
-		}
-		err := unmarshalResponse(responseBody, &malformattedItemStruct)
-		require.Error(t, err)
-		assert.EqualError(t, err, "v.Items must be a slice")
-	})
-
-	t.Run("can only unmarshal a struct", func(t *testing.T) {
-		payload := "random"
-		responseBody := bytes.NewReader([]byte(payload))
-
-		notStruct := "not a struct"
-		err := unmarshalResponse(responseBody, notStruct)
-		assert.Error(t, err)
-		assert.EqualError(t, err, fmt.Sprintf("%v must be a struct or an io.Writer", notStruct))
-	})
-
 }
 
 func TestClient_configureLimiter(t *testing.T) {

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -1,0 +1,133 @@
+package tfe
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type tfeAPI struct {
+	ID                string                   `jsonapi:"primary,tfe"`
+	Name              string                   `jsonapi:"attr,name"`
+	CreatedAt         time.Time                `jsonapi:"attr,created-at,iso8601"`
+	Enalbed           bool                     `jsonapi:"attr,enalbed"`
+	Emails            []string                 `jsonapi:"attr,emails"`
+	Status            tfeAPIStatus             `jsonapi:"attr,status"`
+	StatusTimestamps  tfeAPITimestamps         `jsonapi:"attr,status-timestamps"`
+	DeliveryResponses []tfeAPIDeliveryResponse `jsonapi:"attr,delivery-responses"`
+}
+
+type tfeAPIDeliveryResponse struct {
+	Body string `jsonapi:"attr,body"`
+	Code int    `jsonapi:"attr,code"`
+}
+
+type tfeAPIStatus string
+
+type tfeAPITimestamps struct {
+	QueuedAt time.Time `jsonapi:"attr,queued-at,rfc3339"`
+}
+
+const (
+	tfeAPIStatusNormal tfeAPIStatus = "normal"
+)
+
+func Test_unmarshalResponse(t *testing.T) {
+	t.Run("unmarshal properly formatted json", func(t *testing.T) {
+		// This structure is intended to include multiple possible fields and
+		// formats that are valid for JSON:API
+		data := map[string]interface{}{
+			"data": map[string]interface{}{
+				"type": "tfe",
+				"id":   "1",
+				"attributes": map[string]interface{}{
+					"name":       "terraform",
+					"created-at": "2016-08-17T08:27:12Z",
+					"enabled":    "true",
+					"status":     tfeAPIStatusNormal,
+					"emails":     []string{"test@hashicorp.com"},
+					"delivery-responses": []interface{}{
+						map[string]interface{}{
+							"body": "<html>",
+							"code": 200,
+						},
+						map[string]interface{}{
+							"body": "<body>",
+							"code": 300,
+						},
+					},
+					"status-timestamps": map[string]string{
+						"queued-at": "2020-03-16T23:15:59+00:00",
+					},
+				},
+			},
+		}
+		byteData, errMarshal := json.Marshal(data)
+		require.NoError(t, errMarshal)
+		responseBody := bytes.NewReader(byteData)
+
+		unmarshalledRequestBody := tfeAPI{}
+		err := unmarshalResponse(responseBody, &unmarshalledRequestBody)
+		require.NoError(t, err)
+		queuedParsedTime, err := time.Parse(time.RFC3339, "2020-03-16T23:15:59+00:00")
+		require.NoError(t, err)
+
+		assert.Equal(t, unmarshalledRequestBody.ID, "1")
+		assert.Equal(t, unmarshalledRequestBody.Name, "terraform")
+		assert.Equal(t, unmarshalledRequestBody.Status, tfeAPIStatusNormal)
+		assert.Equal(t, len(unmarshalledRequestBody.Emails), 1)
+		assert.Equal(t, unmarshalledRequestBody.Emails[0], "test@hashicorp.com")
+		assert.Equal(t, unmarshalledRequestBody.StatusTimestamps.QueuedAt, queuedParsedTime)
+		assert.NotEmpty(t, unmarshalledRequestBody.DeliveryResponses)
+		assert.Equal(t, len(unmarshalledRequestBody.DeliveryResponses), 2)
+		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[0].Body, "<html>")
+		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[0].Code, 200)
+		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[1].Body, "<body>")
+		assert.Equal(t, unmarshalledRequestBody.DeliveryResponses[1].Code, 300)
+	})
+
+	t.Run("can only unmarshal Items that are slices", func(t *testing.T) {
+		responseBody := bytes.NewReader([]byte(""))
+		malformattedItemStruct := struct {
+			*Pagination
+			Items int
+		}{
+			Items: 1,
+		}
+		err := unmarshalResponse(responseBody, &malformattedItemStruct)
+		require.Error(t, err)
+		assert.EqualError(t, err, "v.Items must be a slice")
+	})
+
+	t.Run("can only unmarshal a struct", func(t *testing.T) {
+		payload := "random"
+		responseBody := bytes.NewReader([]byte(payload))
+
+		notStruct := "not a struct"
+		err := unmarshalResponse(responseBody, notStruct)
+		assert.Error(t, err)
+		assert.EqualError(t, err, fmt.Sprintf("%v must be a struct or an io.Writer", notStruct))
+	})
+}
+
+func Test_EncodeQueryParams(t *testing.T) {
+	t.Run("with no listOptions and therefore no include field defined", func(t *testing.T) {
+		urlVals := map[string][]string{
+			"include": []string{},
+		}
+		requestURLquery := encodeQueryParams(urlVals)
+		assert.Equal(t, requestURLquery, "")
+	})
+	t.Run("with listOptions setting multiple include options", func(t *testing.T) {
+		urlVals := map[string][]string{
+			"include": []string{"workspace", "cost_estimate"},
+		}
+		requestURLquery := encodeQueryParams(urlVals)
+		assert.Equal(t, requestURLquery, "include=workspace%2Ccost_estimate")
+	})
+}

--- a/workspace.go
+++ b/workspace.go
@@ -203,9 +203,26 @@ type WorkspacePermissions struct {
 	CanUpdateVariable bool `jsonapi:"attr,can-update-variable"`
 }
 
+// https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
+type WSIncludeOps string
+
+const (
+	WSOrganization               WSIncludeOps = "organization"
+	WSCurrentConfigVer           WSIncludeOps = "current_configuration_version"
+	WSCurrentConfigVerIngress    WSIncludeOps = "current_configuration_version.ingress_attributes"
+	WSCurrentRun                 WSIncludeOps = "current_run"
+	WSCurrentRunPlan             WSIncludeOps = "current_run.plan"
+	WSCurrentRunConfigVer        WSIncludeOps = "current_run.configuration_version"
+	WSCurrentrunConfigVerIngress WSIncludeOps = "current_run.configuration_version.ingress_attributes"
+	WSLockedBy                   WSIncludeOps = "locked_by"
+	WSReadme                     WSIncludeOps = "readme"
+	WSOutputs                    WSIncludeOps = "outputs"
+	WSCurrentStateVer            WSIncludeOps = "current-state-version"
+)
+
 // WorkspaceReadOptions represents the options for reading a workspace.
 type WorkspaceReadOptions struct {
-	Include string `url:"include"`
+	Include []WSIncludeOps `url:"include,omitempty"`
 }
 
 // WorkspaceListOptions represents the options for listing workspaces.
@@ -219,7 +236,7 @@ type WorkspaceListOptions struct {
 	Tags *string `url:"search[tags],omitempty"`
 
 	// A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
-	Include *string `url:"include,omitempty"`
+	Include []WSIncludeOps `url:"include,omitempty"`
 }
 
 // List all the workspaces within an organization.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -113,7 +113,7 @@ func TestWorkspacesList(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
-			Include: String("organization"),
+			Include: []WSIncludeOps{WSOrganization},
 		})
 
 		assert.NoError(t, err)
@@ -128,7 +128,7 @@ func TestWorkspacesList(t *testing.T) {
 		t.Cleanup(rCleanup)
 
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, WorkspaceListOptions{
-			Include: String("current-state-version,current-run"),
+			Include: []WSIncludeOps{WSCurrentStateVer, WSCurrentRun},
 		})
 
 		assert.NoError(t, err)
@@ -343,7 +343,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 
 	t.Run("when options to include resource", func(t *testing.T) {
 		opts := &WorkspaceReadOptions{
-			Include: "outputs",
+			Include: []WSIncludeOps{WSOutputs},
 		}
 		w, err := client.Workspaces.ReadWithOptions(ctx, orgTest.Name, wTest.Name, opts)
 		require.NoError(t, err)


### PR DESCRIPTION
I leave this as a draft because this PR includes breaking changes. Please DO NOT MERGE.  The PR is ready for review though!

## Description

Many of our APIs offer an "include" capability to include other resources. For example, if we take a look at the Workspaces API, one can include many other resources: https://www.terraform.io/cloud-docs/api-docs/workspaces#available-related-resources for the GET endpoints.

In the go-tfe client, we just set this as a string for the `Include` Param in ReadOptions and ListOptions. 

```
type WorkspaceReadOptions struct {
	Include string `url:"include"`
}

// WorkspaceListOptions represents the options for listing workspaces.
type WorkspaceListOptions struct {
	ListOptions

	// A search string (partial workspace name) used to filter the results.
	Search *string `url:"search[name],omitempty"`

	// A search string (comma-separated tag names) used to filter the results.
	Tags *string `url:"search[tags],omitempty"`

	// A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
	Include *string `url:"include,omitempty"`
}
```

This is alright and it works, but its is not entirely useful as it requires someone using this client to then reference the API to see what are the strings available. Occasionally, they made even have a typo in there and not notice until a little late in their process, when they get the Atlas error for passing an incorrect include param.

It would make for a better client experience to know from the Go-tfe code what resources are possible.

This is doable via the use of a typed string in Golang.

## Implementation Details

Each resource that offers Include params will have a typed string that represents that string param that can be pass as part includes query in the GET request. Example:

```
type ConfigurationVersionReadOptions struct {
	Include string `url:"include"`
}
```

becomes:

```
type ConfigurationVersionIncludeOps string

const ConfigurationVerIngressAttributes ConfigurationVersionIncludeOps = "ingress_attributes"

type ConfigurationVersionReadOptions struct {
	Include []ConfigurationVersionIncludeOps `url:"include"`
}
```

Notice that we are defining `Include` struct field a slice of type ConfigurationVersionIncludeOps rather than just a type of ConfigurationVersionIncludeOps.

Most APIs allow for passing multiple Include query params, for which the user would write a string of comma separated values, like `Include : PolicySetReadOptions{"current-version,newest-version"}`. To keep that same behavior as we implement typed strings for those "current-version" and "newest-version" params, we can allow for slice of those typed strings. And now the user would have to do:
`Include: PolicySetReadOptions{[]PolicySetIncludeOps{PolicySetCurrentVersion, PolicySetNewestVersion}`

A trade off here, as we add new Include options for a resource, we'll have come to go-tfe every time to add a new typed string that represents that new Include option. This is an effort, but a small one, considering the value this change provides to the user experience.

Besides converting types, an additional relevant change I made, can be found in tfe.go. 

I added `func EncodeIncludeParams(v url.Values) string`. 

I am using this function to replace the previous work done by encode() method from the net/url standard go library. The `encode` method was working well, except  that now, with the changes, it will return a string that looks like this:

`include=current_version&include=newest_version` to represent the include query in the request URL. If we were to send that request URL, the server will only parse the last include param. With the function I added , we are able to get well-format string for the include query: `include=current-version%2Cnewest-version`
