### PR TITLE
Allow for pagination of StateVersionOutputs

### DIFF
--- a/state_version.go
+++ b/state_version.go
@@ -40,7 +40,7 @@ type StateVersions interface {
 	Download(ctx context.Context, url string) ([]byte, error)
 
 	// Outputs retrieves all the outputs of a state version by its ID.
-	Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) ([]*StateVersionOutput, error)
+	Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
 }
 
 // stateVersions implements StateVersions.
@@ -262,7 +262,7 @@ type StateVersionOutputsListOptions struct {
 }
 
 // Outputs retrieves all the outputs of a state version by its ID.
-func (s *stateVersions) Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) ([]*StateVersionOutput, error) {
+func (s *stateVersions) Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {
 	if !validStringID(&svID) {
 		return nil, errors.New("invalid value for state version ID")
 	}
@@ -279,5 +279,5 @@ func (s *stateVersions) Outputs(ctx context.Context, svID string, options StateV
 		return nil, err
 	}
 
-	return sv.Items, nil
+	return sv, nil
 }

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -438,10 +438,10 @@ func TestStateVersionOutputs(t *testing.T) {
 		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, StateVersionOutputsListOptions{})
 		require.NoError(t, err)
 
-		assert.NotEmpty(t, outputs)
+		assert.NotEmpty(t, outputs.Items)
 
 		values := map[string]interface{}{}
-		for _, op := range outputs {
+		for _, op := range outputs.Items {
 			values[op.Name] = op.Value
 		}
 
@@ -465,12 +465,12 @@ func TestStateVersionOutputs(t *testing.T) {
 		}
 		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, options)
 		require.NoError(t, err)
-		assert.Empty(t, outputs)
+		assert.Empty(t, outputs.Items)
 	})
 
 	t.Run("when the state version does not exist", func(t *testing.T) {
 		outputs, err := client.StateVersions.Outputs(ctx, "sv-999999999", StateVersionOutputsListOptions{})
-		assert.Nil(t, outputs)
+		assert.Nil(t, outputs.Items)
 		assert.Error(t, err)
 	})
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -354,7 +354,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 		svOutputs, err := client.StateVersions.Outputs(ctx, svTest.ID, StateVersionOutputsListOptions{})
 		require.NoError(t, err)
 
-		assert.Len(t, w.Outputs, len(svOutputs))
+		assert.Len(t, w.Outputs, len(svOutputs.Items))
 
 		wsOutputs := map[string]interface{}{}
 		wsOutputsTypes := map[string]string{}
@@ -362,7 +362,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 			wsOutputs[op.Name] = op.Value
 			wsOutputsTypes[op.Name] = op.Type
 		}
-		for _, svop := range svOutputs {
+		for _, svop := range svOutputs.Items {
 			val, ok := wsOutputs[svop.Name]
 			assert.True(t, ok)
 			assert.Equal(t, svop.Value, val)


### PR DESCRIPTION
## Description

The current implementation does not return the pagination information needed to traverse all output pages. Support for the StateVersion Outputs API has been introduced in https://github.com/hashicorp/go-tfe/pull/246 but it seems like pagination was omitted.
