### PR TITLE
replace circleci image

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ test_results_dir: &test_results_dir /tmp/test_results
 jobs:
   run-tests:
     docker:
-      - image: docker.mirror.hashicorp.services/cimg/go:1.16.2
+      - image: docker.mirror.hashicorp.services/cimg/go:1.17
         environment:
           TEST_RESULTS_DIR: *test_results_dir
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ test_results_dir: &test_results_dir /tmp/test_results
 jobs:
   run-tests:
     docker:
-      - image: docker.mirror.hashicorp.services/circleci/golang:1.16.2
+      - image: docker.mirror.hashicorp.services/cimg/go:1.16.2
         environment:
           TEST_RESULTS_DIR: *test_results_dir
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,8 +12,6 @@ jobs:
         environment:
           TEST_RESULTS_DIR: *test_results_dir
 
-    working_directory: /go/src/github.com/hashicorp/go-tfe
-
     steps:
       - checkout
 


### PR DESCRIPTION
## Description

Update repo to migrate away from circleci/ docker namespaced images and towards cimg/ docker namespaced images.

For more on this topic:

https://circleci.com/developer/images/image/cimg/go

https://discuss.circleci.com/t/legacy-convenience-image-deprecation/41034

