### PR TITLE
fix: API does not allow ssh key text value updating

### DIFF
--- a/ssh_key.go
+++ b/ssh_key.go
@@ -153,9 +153,6 @@ type SSHKeyUpdateOptions struct {
 
 	// A new name to identify the SSH key.
 	Name *string `jsonapi:"attr,name,omitempty"`
-
-	// Updated content of the SSH private key.
-	Value *string `jsonapi:"attr,value,omitempty"`
 }
 
 // Update an SSH key by its ID.

--- a/ssh_key_integration_test.go
+++ b/ssh_key_integration_test.go
@@ -153,8 +153,7 @@ func TestSSHKeysUpdate(t *testing.T) {
 		defer kTestCleanup()
 
 		kAfter, err := client.SSHKeys.Update(ctx, kBefore.ID, SSHKeyUpdateOptions{
-			Name:  String(randomString(t)),
-			Value: String(randomString(t)),
+			Name: String(randomString(t)),
 		})
 		require.NoError(t, err)
 
@@ -173,19 +172,6 @@ func TestSSHKeysUpdate(t *testing.T) {
 
 		assert.Equal(t, kBefore.ID, kAfter.ID)
 		assert.Equal(t, "updated-key-name", kAfter.Name)
-	})
-
-	t.Run("when updating the value", func(t *testing.T) {
-		kBefore, kTestCleanup := createSSHKey(t, client, orgTest)
-		defer kTestCleanup()
-
-		kAfter, err := client.SSHKeys.Update(ctx, kBefore.ID, SSHKeyUpdateOptions{
-			Value: String("updated-key-value"),
-		})
-		require.NoError(t, err)
-
-		assert.Equal(t, kBefore.ID, kAfter.ID)
-		assert.Equal(t, kBefore.Name, kAfter.Name)
 	})
 
 	t.Run("without a valid SSH key ID", func(t *testing.T) {


### PR DESCRIPTION
## Description

From the very beginning it's not been possible to update the value of an SSH key text. Indeed, the tests didn't even test that the value was updated!

The reason for this is the non-repudiation of security auditing. For example, if an attacker uses the ssh key to access a resource, the security audit of the ssh authentication can be trusted to mean key X was always key X and never updated.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation Related PR](https://github.com/hashicorp/terraform-website/pull/2105)

This should be merged into a major release branch!
