### PR TITLE
Return pagable state version outputs

### DIFF
--- a/mocks/state_version_mocks.go
+++ b/mocks/state_version_mocks.go
@@ -111,10 +111,10 @@ func (mr *MockStateVersionsMockRecorder) List(ctx, options interface{}) *gomock.
 }
 
 // Outputs mocks base method.
-func (m *MockStateVersions) Outputs(ctx context.Context, svID string, options tfe.StateVersionOutputsListOptions) ([]*tfe.StateVersionOutput, error) {
+func (m *MockStateVersions) Outputs(ctx context.Context, svID string, options tfe.StateVersionOutputsListOptions) (*tfe.StateVersionOutputsList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Outputs", ctx, svID, options)
-	ret0, _ := ret[0].([]*tfe.StateVersionOutput)
+	ret0, _ := ret[0].(*tfe.StateVersionOutputsList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/state_version.go
+++ b/state_version.go
@@ -40,7 +40,7 @@ type StateVersions interface {
 	Download(ctx context.Context, url string) ([]byte, error)
 
 	// Outputs retrieves all the outputs of a state version by its ID.
-	Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) ([]*StateVersionOutput, error)
+	Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
 }
 
 // stateVersions implements StateVersions.
@@ -262,7 +262,7 @@ type StateVersionOutputsListOptions struct {
 }
 
 // Outputs retrieves all the outputs of a state version by its ID.
-func (s *stateVersions) Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) ([]*StateVersionOutput, error) {
+func (s *stateVersions) Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {
 	if !validStringID(&svID) {
 		return nil, errors.New("invalid value for state version ID")
 	}
@@ -279,5 +279,5 @@ func (s *stateVersions) Outputs(ctx context.Context, svID string, options StateV
 		return nil, err
 	}
 
-	return sv.Items, nil
+	return sv, nil
 }

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -438,10 +438,10 @@ func TestStateVersionOutputs(t *testing.T) {
 		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, StateVersionOutputsListOptions{})
 		require.NoError(t, err)
 
-		assert.NotEmpty(t, outputs)
+		assert.NotEmpty(t, outputs.Items)
 
 		values := map[string]interface{}{}
-		for _, op := range outputs {
+		for _, op := range outputs.Items {
 			values[op.Name] = op.Value
 		}
 
@@ -465,12 +465,12 @@ func TestStateVersionOutputs(t *testing.T) {
 		}
 		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, options)
 		require.NoError(t, err)
-		assert.Empty(t, outputs)
+		assert.Empty(t, outputs.Items)
 	})
 
 	t.Run("when the state version does not exist", func(t *testing.T) {
 		outputs, err := client.StateVersions.Outputs(ctx, "sv-999999999", StateVersionOutputsListOptions{})
-		assert.Nil(t, outputs)
+		assert.Nil(t, outputs.Items)
 		assert.Error(t, err)
 	})
 

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -470,7 +470,7 @@ func TestStateVersionOutputs(t *testing.T) {
 
 	t.Run("when the state version does not exist", func(t *testing.T) {
 		outputs, err := client.StateVersions.Outputs(ctx, "sv-999999999", StateVersionOutputsListOptions{})
-		assert.Nil(t, outputs.Items)
+		assert.Nil(t, outputs)
 		assert.Error(t, err)
 	})
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -354,7 +354,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 		svOutputs, err := client.StateVersions.Outputs(ctx, svTest.ID, StateVersionOutputsListOptions{})
 		require.NoError(t, err)
 
-		assert.Len(t, w.Outputs, len(svOutputs))
+		assert.Len(t, w.Outputs, len(svOutputs.Items))
 
 		wsOutputs := map[string]interface{}{}
 		wsOutputsTypes := map[string]string{}
@@ -362,7 +362,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 			wsOutputs[op.Name] = op.Value
 			wsOutputsTypes[op.Name] = op.Type
 		}
-		for _, svop := range svOutputs {
+		for _, svop := range svOutputs.Items {
 			val, ok := wsOutputs[svop.Name]
 			assert.True(t, ok)
 			assert.Equal(t, svop.Value, val)


### PR DESCRIPTION
## Description

Previously, the StateVersions.Outputs method would strip the paging information from the API result and return a slice of items. This didn't match the method signature of accepting paging options.

Thanks to @elsesiy for fixing this in #295 - I brought this over to the repo in order to make mock/test changes.

## External links

_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/state-versions#list-state-version-outputs)

## Output from tests

_Please run the tests locally for any files you changes and include the output here._

```
$ TFE_ADDRESS=https://$(tfc_local_hostname) TFE_TOKEN=$(tfc_local_token) go test ./... -v -tags=integration -run TestStateVersionOutputs
=== RUN   TestStateVersionOutputs
=== RUN   TestStateVersionOutputs/when_the_state_version_exists
=== RUN   TestStateVersionOutputs/with_list_options
=== RUN   TestStateVersionOutputs/when_the_state_version_does_not_exist
--- PASS: TestStateVersionOutputs (4.11s)
    --- PASS: TestStateVersionOutputs/when_the_state_version_exists (0.29s)
    --- PASS: TestStateVersionOutputs/with_list_options (0.26s)
    --- PASS: TestStateVersionOutputs/when_the_state_version_does_not_exist (0.21s)
=== RUN   TestStateVersionOutputsRead
=== RUN   TestStateVersionOutputsRead/when_a_state_output_exists
=== RUN   TestStateVersionOutputsRead/when_a_state_output_does_not_exist
--- PASS: TestStateVersionOutputsRead (4.03s)
    --- PASS: TestStateVersionOutputsRead/when_a_state_output_exists (0.28s)
    --- PASS: TestStateVersionOutputsRead/when_a_state_output_does_not_exist (0.21s)
PASS
ok  	github.com/hashicorp/go-tfe	8.804s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]


$ TFE_ADDRESS=https://$(tfc_local_hostname) TFE_TOKEN=$(tfc_local_token) go test ./... -v -tags=integration -run TestWorkspacesReadWithOptions
=== RUN   TestWorkspacesReadWithOptions
=== RUN   TestWorkspacesReadWithOptions/when_options_to_include_resource
--- PASS: TestWorkspacesReadWithOptions (3.86s)
    --- PASS: TestWorkspacesReadWithOptions/when_options_to_include_resource (0.61s)
PASS
ok  	github.com/hashicorp/go-tfe	4.051s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```
