### PR TITLE
add  releases-1.0.x  to the list of branches in GH actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, releases-1.0.x ]
 jobs:
   codegen:
     name: Codegen

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,8 +1,7 @@
 name: golangci-lint
 on:
   push:
-    branches:
-      - main
+    branches: [ main, releases-1.0.x ]
   pull_request:
 jobs:
   golangci:


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Our github actions workflows are running for PRs that want to merge against main branch. We have a new branch "releases-1.0.x" for the purposes of releasing Go-TFE 1.0 and we should have the same github actions applied to this branch.
