### PR TITLE
Return correct error msg when unlocking a workspace during a run

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -32,6 +32,10 @@ var (
 	// a unlocked workspace.
 	ErrWorkspaceNotLocked = errors.New("workspace already unlocked")
 
+	// ErrWorkspaceLockedByRun is returned when trying to unlock a
+	// workspace locked by a run
+	ErrWorkspaceLockedByRun = errors.New("unable to unlock workspace locked by run")
+
 	// ErrInvalidWorkspaceID is returned when the workspace ID is invalid.
 	ErrInvalidWorkspaceID = errors.New("invalid value for workspace ID")
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -809,6 +809,17 @@ func TestWorkspacesUnlock(t *testing.T) {
 		assert.Equal(t, ErrWorkspaceNotLocked, err)
 	})
 
+	t.Run("when a workspace is locked by a run", func(t *testing.T) {
+		wTest2, wTest2Cleanup := createWorkspace(t, client, orgTest)
+		defer wTest2Cleanup()
+
+		_, rTestCleanup := createRun(t, client, wTest2)
+		defer rTestCleanup()
+
+		_, err := client.Workspaces.Unlock(ctx, wTest2.ID)
+		assert.Equal(t, ErrWorkspaceLockedByRun, err)
+	})
+
 	t.Run("without a valid workspace ID", func(t *testing.T) {
 		w, err := client.Workspaces.Unlock(ctx, badIdentifier)
 		assert.Nil(t, w)


### PR DESCRIPTION
## Description

This PR aims to close #236 where the tfe client would return an incorrect error message whenever a user attempted to unlock a workspace during a run. 

The current implementation of this client would [default to "workspaces already unlocked"](https://github.com/hashicorp/go-tfe/blob/690857219f9e5ef42feb191d903177904ed0e975/tfe.go#L725) whenever a status 409 is received from the workspace unlock endpoint. This however paints half the picture since the endpoint can also return a 409 error whenever a workspace is locked by a run. The current implementation for the method responsible for returning the correct error message would then need to parse the error payload in order to determine if the workspace is indeed locked by a run:

The logic that parses the error payload was refactored into its own method, so we can extract error details when a status 409 is handled and determine which is the correct error message to return.

A simple matcher function `errorPayloadHasMatch` was written to see if the error detail contains a specific substring to look for. In this case,  "locked by Run" was the substring that indicates the workspace was locked by a run. 

## Testing plan

To run integration test:
```sh
go test -run TestWorkspacesUnlock -v ./... -tags=integration
```

Because I've modified `tfe.go`, it's always good to do a sanity check:

```
go test -run TestClient -v ./... -tags=integration
```

## External links

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/workspaces#unlock-a-workspace)
- [Related Issue](https://github.com/hashicorp/go-tfe/issues/236)

## Output from tests (HashiCorp employees only)

For `TestWorkspacesUnlock`:

```
=== RUN   TestWorkspacesUnlock
=== RUN   TestWorkspacesUnlock/with_valid_options
=== RUN   TestWorkspacesUnlock/when_workspace_is_already_unlocked
=== RUN   TestWorkspacesUnlock/when_a_workspace_is_locked_by_a_run
=== RUN   TestWorkspacesUnlock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUnlock (4.54s)
    --- PASS: TestWorkspacesUnlock/with_valid_options (0.17s)
    --- PASS: TestWorkspacesUnlock/when_workspace_is_already_unlocked (0.14s)
    --- PASS: TestWorkspacesUnlock/when_a_workspace_is_locked_by_a_run (2.34s)
    --- PASS: TestWorkspacesUnlock/without_a_valid_workspace_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     5.398s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```

For `TestClient`:

```
=== RUN   TestClient_newClient
=== RUN   TestClient_newClient/uses_env_vars_if_values_are_missing
=== RUN   TestClient_newClient/fails_if_token_is_empty
=== RUN   TestClient_newClient/makes_a_new_client_with_good_settings
--- PASS: TestClient_newClient (0.00s)
    --- PASS: TestClient_newClient/uses_env_vars_if_values_are_missing (0.00s)
    --- PASS: TestClient_newClient/fails_if_token_is_empty (0.00s)
    --- PASS: TestClient_newClient/makes_a_new_client_with_good_settings (0.00s)
=== RUN   TestClient_defaultConfig
=== RUN   TestClient_defaultConfig/with_no_environment_variables
=== RUN   TestClient_defaultConfig/with_environment_variables
--- PASS: TestClient_defaultConfig (0.00s)
    --- PASS: TestClient_defaultConfig/with_no_environment_variables (0.00s)
    --- PASS: TestClient_defaultConfig/with_environment_variables (0.00s)
=== RUN   TestClient_headers
--- PASS: TestClient_headers (0.00s)
=== RUN   TestClient_userAgent
--- PASS: TestClient_userAgent (0.00s)
=== RUN   TestClient_requestBodySerialization
=== RUN   TestClient_requestBodySerialization/jsonapi_request
=== RUN   TestClient_requestBodySerialization/jsonapi_slice_of_pointers_request
=== RUN   TestClient_requestBodySerialization/plain_json_request
=== RUN   TestClient_requestBodySerialization/plain_json_slice_of_pointers_request
=== RUN   TestClient_requestBodySerialization/nil_request
=== RUN   TestClient_requestBodySerialization/invalid_struct_request
=== RUN   TestClient_requestBodySerialization/non-pointer_request
=== RUN   TestClient_requestBodySerialization/slice_of_non-pointer_request
=== RUN   TestClient_requestBodySerialization/map_request
=== RUN   TestClient_requestBodySerialization/string_request
--- PASS: TestClient_requestBodySerialization (4.34s)
    --- PASS: TestClient_requestBodySerialization/jsonapi_request (0.61s)
    --- PASS: TestClient_requestBodySerialization/jsonapi_slice_of_pointers_request (0.41s)
    --- PASS: TestClient_requestBodySerialization/plain_json_request (0.41s)
    --- PASS: TestClient_requestBodySerialization/plain_json_slice_of_pointers_request (0.44s)
    --- PASS: TestClient_requestBodySerialization/nil_request (0.42s)
    --- PASS: TestClient_requestBodySerialization/invalid_struct_request (0.42s)
    --- PASS: TestClient_requestBodySerialization/non-pointer_request (0.41s)
    --- PASS: TestClient_requestBodySerialization/slice_of_non-pointer_request (0.39s)
    --- PASS: TestClient_requestBodySerialization/map_request (0.40s)
    --- PASS: TestClient_requestBodySerialization/string_request (0.41s)
=== RUN   TestClient_configureLimiter
--- PASS: TestClient_configureLimiter (0.00s)
=== RUN   TestClient_retryHTTPCheck
--- PASS: TestClient_retryHTTPCheck (0.00s)
=== RUN   TestClient_retryHTTPBackoff
--- PASS: TestClient_retryHTTPBackoff (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     4.556s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```

