### PR TITLE
Variable sets

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -145,6 +145,8 @@ var (
 	ErrInvalidVariableID = errors.New("invalid value for variable ID")
 
 	ErrInvalidNotificationTrigger = errors.New("invalid value for notification trigger")
+
+	ErrInvalidVariableSetID = errors.New("invalid variable set ID")
 )
 
 // Missing values for required field/option
@@ -248,4 +250,8 @@ var (
 	ErrRequiredOnlyOneField = errors.New("only one of usernames or organization membership ids can be provided")
 
 	ErrRequiredUsernameOrMembershipIds = errors.New("usernames or organization membership ids are required")
+
+	ErrRequiredGlobalFlag = errors.New("global flag is required")
+
+	ErrRequiredWorkspacesList = errors.New("no workspaces list provided")
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,7 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+<<<<<<< HEAD
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
@@ -20,6 +21,20 @@ github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2I
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB176G1HCwleORqCaXm/Vx0uUi0dL26I0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
+github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
+github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
+github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
+github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
+github.com/hashicorp/go-retryablehttp v0.5.2 h1:AoISa4P4IsW0/m4T6St8Yw38gTl5GtBAgfkhYh1xAz4=
+github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
+github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
+github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
+github.com/hashicorp/go-slug v0.7.0 h1:8HIi6oreWPtnhpYd8lIGQBgp4rXzDWQTOhfILZm+nok=
+github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
+github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
+github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
+github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3 h1:mzwkutymYIXR5oQT9YnfbLuuw7LZmksiHKRPUTN5ijo=
+github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/go.sum
+++ b/go.sum
@@ -1,7 +1,6 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-<<<<<<< HEAD
 github.com/golang/mock v1.6.0 h1:ErTB+efbowRARo13NNdxyJji2egdxLGQhRaY+DUumQc=
 github.com/golang/mock v1.6.0/go.mod h1:p6yTPP+5HYm5mzsMV8JkE6ZKdX+/wYM6Hr+LicevLPs=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
@@ -21,20 +20,6 @@ github.com/hashicorp/go-uuid v1.0.2 h1:cfejS+Tpcp13yd5nYHWDI6qVCny6wyX2Mt5SGur2I
 github.com/hashicorp/go-uuid v1.0.2/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d h1:9ARUJJ1VVynB176G1HCwleORqCaXm/Vx0uUi0dL26I0=
 github.com/hashicorp/jsonapi v0.0.0-20210826224640-ee7dae0fb22d/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
-github.com/google/go-querystring v1.0.0 h1:Xkwi/a1rcvNg1PPYe5vI8GbeBY/jrVuDX5ASuANWTrk=
-github.com/google/go-querystring v1.0.0/go.mod h1:odCYkC5MyYFN7vkCjXpyrEuKhc/BUO6wN/zVPAxq5ck=
-github.com/hashicorp/go-cleanhttp v0.5.0 h1:wvCrVc9TjDls6+YGAF2hAifE1E5U1+b4tH6KdvN3Gig=
-github.com/hashicorp/go-cleanhttp v0.5.0/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
-github.com/hashicorp/go-retryablehttp v0.5.2 h1:AoISa4P4IsW0/m4T6St8Yw38gTl5GtBAgfkhYh1xAz4=
-github.com/hashicorp/go-retryablehttp v0.5.2/go.mod h1:9B5zBasrRhHXnJnui7y6sL7es7NDiJgTc6Er0maI1Xs=
-github.com/hashicorp/go-slug v0.4.1 h1:/jAo8dNuLgSImoLXaX7Od7QB4TfYCVPam+OpAt5bZqc=
-github.com/hashicorp/go-slug v0.4.1/go.mod h1:I5tq5Lv0E2xcNXNkmx7BSfzi1PsJ2cNjs3cC3LwyhK8=
-github.com/hashicorp/go-slug v0.7.0 h1:8HIi6oreWPtnhpYd8lIGQBgp4rXzDWQTOhfILZm+nok=
-github.com/hashicorp/go-slug v0.7.0/go.mod h1:Ib+IWBYfEfJGI1ZyXMGNbu2BU+aa3Dzu41RKLH301v4=
-github.com/hashicorp/go-uuid v1.0.1 h1:fv1ep09latC32wFoVwnqcnKJGnMSdBanPczbHAYm1BE=
-github.com/hashicorp/go-uuid v1.0.1/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
-github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3 h1:mzwkutymYIXR5oQT9YnfbLuuw7LZmksiHKRPUTN5ijo=
-github.com/hashicorp/jsonapi v0.0.0-20210518035559-1e50d74c8db3/go.mod h1:Yog5+CPEM3c99L1CL2CFCYoSzgWm5vTU58idbRUaLik=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/helper_test.go
+++ b/helper_test.go
@@ -1143,10 +1143,6 @@ func createVariableSetVariable(t *testing.T, client *Client, vs *VariableSet, op
 		options.Sensitive = Bool(false)
 	}
 
-	out := bytes.NewBuffer(nil)
-	jsonstuff := jsonapi.MarshalOnePayloadEmbedded(out, options)
-	fmt.Printf("%+v\n", jsonstuff)
-
 	ctx := context.Background()
 	v, err := client.VariableSetVariables.Create(ctx, vs.ID, options)
 	if err != nil {

--- a/helper_test.go
+++ b/helper_test.go
@@ -1011,7 +1011,6 @@ func createWorkspaceWithVCS(t *testing.T, client *Client, org *Organization, opt
 	ctx := context.Background()
 	w, err := client.Workspaces.Create(ctx, org.Name, options)
 	if err != nil {
-
 		t.Fatal(err)
 	}
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -1127,6 +1127,10 @@ func createVariableSetVariable(t *testing.T, client *Client, vs *VariableSet, op
 		options.Value = String(randomString(t))
 	}
 
+	if options.Description == nil {
+		options.Description = String("")
+	}
+
 	if options.Category == nil {
 		options.Category = Category(CategoryTerraform)
 	}
@@ -1138,6 +1142,10 @@ func createVariableSetVariable(t *testing.T, client *Client, vs *VariableSet, op
 	if options.Sensitive == nil {
 		options.Sensitive = Bool(false)
 	}
+
+	out := bytes.NewBuffer(nil)
+	jsonstuff := jsonapi.MarshalOnePayloadEmbedded(out, options)
+	fmt.Printf("%+v\n", jsonstuff)
 
 	ctx := context.Background()
 	v, err := client.VariableSetVariables.Create(ctx, vs.ID, options)

--- a/helper_test.go
+++ b/helper_test.go
@@ -1093,7 +1093,7 @@ func createVariableSet(t *testing.T, client *Client, org *Organization, options 
 	}
 
 	ctx := context.Background()
-	vs, err := client.VariableSets.Create(ctx, org.Name, options)
+	vs, err := client.VariableSets.Create(ctx, org.Name, &options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1143,7 +1143,7 @@ func createVariableSetVariable(t *testing.T, client *Client, vs *VariableSet, op
 	}
 
 	ctx := context.Background()
-	v, err := client.VariableSetVariables.Create(ctx, vs.ID, options)
+	v, err := client.VariableSetVariables.Create(ctx, vs.ID, &options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/tfe.go
+++ b/tfe.go
@@ -142,6 +142,7 @@ type Client struct {
 	Users                      Users
 	UserTokens                 UserTokens
 	Variables                  Variables
+	VariableSets               VariableSets
 	Workspaces                 Workspaces
 	WorkspaceRunTasks          WorkspaceRunTasks
 
@@ -282,6 +283,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Users = &users{client: client}
 	client.UserTokens = &userTokens{client: client}
 	client.Variables = &variables{client: client}
+	client.VariableSets = &variableSets{client: client}
 	client.Workspaces = &workspaces{client: client}
 	client.WorkspaceRunTasks = &workspaceRunTasks{client: client}
 

--- a/tfe.go
+++ b/tfe.go
@@ -143,6 +143,7 @@ type Client struct {
 	UserTokens                 UserTokens
 	Variables                  Variables
 	VariableSets               VariableSets
+	VariableSetVariables       VariableSetVariables
 	Workspaces                 Workspaces
 	WorkspaceRunTasks          WorkspaceRunTasks
 
@@ -284,6 +285,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.UserTokens = &userTokens{client: client}
 	client.Variables = &variables{client: client}
 	client.VariableSets = &variableSets{client: client}
+	client.VariableSetVariables = &variableSetVariables{client: client}
 	client.Workspaces = &workspaces{client: client}
 	client.WorkspaceRunTasks = &workspaceRunTasks{client: client}
 

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -128,7 +128,7 @@ func TestVariablesCreate(t *testing.T) {
 		options := VariableCreateOptions{
 			Key:         String(randomString(t)),
 			Value:       String(randomString(t)),
-			Description: String("tortor aliquam nulla go lint is fussy about spelling cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla facilisi morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
+			Description: String("tortor aliquam nulla go lint is fussy about spelling cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla redacted morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
 			Category:    Category(CategoryTerraform),
 		}
 

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -128,7 +128,7 @@ func TestVariablesCreate(t *testing.T) {
 		options := VariableCreateOptions{
 			Key:         String(randomString(t)),
 			Value:       String(randomString(t)),
-			Description: String("tortor aliquam nulla facilisi cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla facilisi morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
+			Description: String("tortor aliquam nulla go lint is fussy about spelling cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla facilisi morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
 			Category:    Category(CategoryTerraform),
 		}
 

--- a/variable_set.go
+++ b/variable_set.go
@@ -16,22 +16,22 @@ var _ VariableSets = (*variableSets)(nil)
 // TFE API docs: https://www.terraform.io/cloud-docs/api-docs/variable-sets
 type VariableSets interface {
 	// List all the variable sets within an organization.
-	List(ctx context.Context, organization string, options VariableSetListOptions) (*VariableSetList, error)
+	List(ctx context.Context, organization string, options *VariableSetListOptions) (*VariableSetList, error)
 
 	// Create is used to create a new variable set.
-	Create(ctx context.Context, organization string, options VariableSetCreateOptions) (*VariableSet, error)
+	Create(ctx context.Context, organization string, options *VariableSetCreateOptions) (*VariableSet, error)
 
 	// Read a variable set by its ID.
-	Read(ctx context.Context, variableSetVariableSetReadOptionsID string, options VariableSetReadOptions) (*VariableSet, error)
+	Read(ctx context.Context, variableSetVariableSetReadOptionsID string, options *VariableSetReadOptions) (*VariableSet, error)
 
 	// Update an existing variable set.
-	Update(ctx context.Context, variableSetID string, options VariableSetUpdateOptions) (*VariableSet, error)
+	Update(ctx context.Context, variableSetID string, options *VariableSetUpdateOptions) (*VariableSet, error)
 
 	// Delete a variable set by ID.
 	Delete(ctx context.Context, variableSetID string) error
 
 	// Assign a variable set to workspaces
-	Assign(ctx context.Context, variableSetID string, options VariableSetAssignOptions) (*VariableSet, error)
+	Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error)
 }
 
 type variableSets struct {
@@ -73,16 +73,18 @@ func (o VariableSetListOptions) valid() error {
 }
 
 // List all Variable Sets in the organization
-func (s *variableSets) List(ctx context.Context, organization string, options VariableSetListOptions) (*VariableSetList, error) {
+func (s *variableSets) List(ctx context.Context, organization string, options *VariableSetListOptions) (*VariableSetList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
-	if err := options.valid(); err != nil {
-		return nil, err
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
 	}
 
 	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -127,16 +129,18 @@ func (o VariableSetCreateOptions) valid() error {
 }
 
 // Create is used to create a new variable set.
-func (s *variableSets) Create(ctx context.Context, organization string, options VariableSetCreateOptions) (*VariableSet, error) {
+func (s *variableSets) Create(ctx context.Context, organization string, options *VariableSetCreateOptions) (*VariableSet, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
-	if err := options.valid(); err != nil {
-		return nil, err
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
 	}
 
 	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.newRequest("POST", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -155,7 +159,7 @@ type VariableSetReadOptions struct {
 }
 
 // Read is used to inspect a given variable set based on ID
-func (s *variableSets) Read(ctx context.Context, variableSetID string, options VariableSetReadOptions) (*VariableSet, error) {
+func (s *variableSets) Read(ctx context.Context, variableSetID string, options *VariableSetReadOptions) (*VariableSet, error) {
 	if !validStringID(&variableSetID) {
 		return nil, errors.New("invalid variable set ID")
 	}
@@ -197,13 +201,13 @@ type VariableSetUpdateOptions struct {
 	Include *[]VariableSetIncludeOps `url:"include:omitempty"`
 }
 
-func (s *variableSets) Update(ctx context.Context, variableSetID string, options VariableSetUpdateOptions) (*VariableSet, error) {
+func (s *variableSets) Update(ctx context.Context, variableSetID string, options *VariableSetUpdateOptions) (*VariableSet, error) {
 	if !validStringID(&variableSetID) {
 		return nil, errors.New("invalid value for variable set ID")
 	}
 
 	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.newRequest("PATCH", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -248,8 +252,8 @@ type VariableSetAssignOptions struct {
 }
 
 // Use Update to assign a variable set to workspaces
-func (s *variableSets) Assign(ctx context.Context, variableSetID string, options VariableSetAssignOptions) (*VariableSet, error) {
-	if options.Workspaces == nil {
+func (s *variableSets) Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error) {
+	if options == nil || options.Workspaces == nil {
 		return nil, errors.New("No workspaces list provided")
 	}
 
@@ -257,7 +261,7 @@ func (s *variableSets) Assign(ctx context.Context, variableSetID string, options
 
 	// We force inclusion of workspaces as that is the primary data for which we are concerned with confirming changes.
 	u := fmt.Sprintf("varsets/%s?include=%s", url.QueryEscape(variableSetID), VariableSetWorkspaces)
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.newRequest("PATCH", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/variable_set.go
+++ b/variable_set.go
@@ -29,8 +29,8 @@ type VariableSets interface {
 	// Delete a variable set by ID.
 	Delete(ctx context.Context, variableSetID string) error
 
-	// Add and remove workspace assignments to match the supplied list
-	Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error)
+	// Update list of workspaces to which the variable set is applied to match the supplied list
+	Apply(ctx context.Context, variableSetID string, options *VariableSetApplyOptions) (*VariableSet, error)
 }
 
 type variableSets struct {
@@ -234,8 +234,8 @@ func (s *variableSets) Delete(ctx context.Context, variableSetID string) error {
 	return s.client.do(ctx, req, nil)
 }
 
-// VariableSetAssignOptions represents a subset of update options specifically for assigning variable sets to workspaces
-type VariableSetAssignOptions struct {
+// VariableSetApplyOptions represents a subset of update options specifically for applying variable sets to workspaces
+type VariableSetAapplyOptions struct {
 	// Type is a public field utilized by JSON:API to
 	// set the resource type via the field tag.
 	// It is not a user-defined value and does not need to be set.
@@ -245,12 +245,12 @@ type VariableSetAssignOptions struct {
 	// Used to set the variable set from Global to not Global if necessary
 	Global *bool `jsonapi:"attr,global"`
 
-	// The workspaces to be assigned to. An empty set means remove all assignments
+	// The workspaces to be applied to. An empty set means remove all applied
 	Workspaces []*Workspace `jsonapi:"relation,workspaces"`
 }
 
-// Update variable set assignments to match the supplied workspaces list.
-func (s *variableSets) Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error) {
+// Update variable set to be applied to only the workspaces in the supplied list.
+func (s *variableSets) Apply(ctx context.Context, variableSetID string, options *VariableSetApplyOptions) (*VariableSet, error) {
 	if options == nil || options.Workspaces == nil {
 		return nil, ErrRequiredWorkspacesList
 	}

--- a/variable_set.go
+++ b/variable_set.go
@@ -244,6 +244,9 @@ type VariableSetAssignOptions struct {
 
 	// Used to set the variable set from Global to not Global if necessary
 	Global *bool `jsonapi:"attr,global"`
+
+	// The workspaces to be assigned to. An empty set means remove all assignments
+	Workspaces []*Workspace `jsonapi:"relation,workspaces"`
 }
 
 // Update variable set assignments to match the supplied workspaces list.

--- a/variable_set.go
+++ b/variable_set.go
@@ -50,7 +50,8 @@ type VariableSet struct {
 	Global      bool   `jsonapi:"attr,global"`
 
 	// Relations
-	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`
+	Workspaces []*Workspace           `jsonapi:"relation,workspaces,omitempty"`
+	Variables  []*VariableSetVariable `jsonapi:"relation,vars,omitempty"`
 }
 
 type VariableSetListOptions struct {

--- a/variable_set.go
+++ b/variable_set.go
@@ -22,7 +22,7 @@ type VariableSets interface {
 	Create(ctx context.Context, organization string, options *VariableSetCreateOptions) (*VariableSet, error)
 
 	// Read a variable set by its ID.
-	Read(ctx context.Context, variableSetVariableSetReadOptionsID string, options *VariableSetReadOptions) (*VariableSet, error)
+	Read(ctx context.Context, variableSetID string, options *VariableSetReadOptions) (*VariableSet, error)
 
 	// Update an existing variable set.
 	Update(ctx context.Context, variableSetID string, options *VariableSetUpdateOptions) (*VariableSet, error)

--- a/variable_set.go
+++ b/variable_set.go
@@ -235,7 +235,7 @@ func (s *variableSets) Delete(ctx context.Context, variableSetID string) error {
 }
 
 // VariableSetApplyOptions represents a subset of update options specifically for applying variable sets to workspaces
-type VariableSetAapplyOptions struct {
+type VariableSetApplyOptions struct {
 	// Type is a public field utilized by JSON:API to
 	// set the resource type via the field tag.
 	// It is not a user-defined value and does not need to be set.

--- a/variable_set.go
+++ b/variable_set.go
@@ -96,7 +96,7 @@ type VariableSetCreateOptions struct {
 
 	// The name of the variable set.
 	// Affects variable precedence when there are conflicts between Variable Sets
-	// TODO: Add link to documentation
+	// https://www.terraform.io/cloud-docs/api-docs/variable-sets#apply-variable-set-to-workspaces
 	Name *string `jsonapi:"attr,name"`
 
 	// A description to provide context for the variable set.
@@ -171,7 +171,7 @@ type VariableSetUpdateOptions struct {
 
 	// The name of the variable set.
 	// Affects variable precedence when there are conflicts between Variable Sets
-	// TODO: Add link to documentation
+	// https://www.terraform.io/cloud-docs/api-docs/variable-sets#apply-variable-set-to-workspaces
 	Name *string `jsonapi:"attr,name"`
 
 	// A description to provide context for the variable set.

--- a/variable_set.go
+++ b/variable_set.go
@@ -2,7 +2,6 @@ package tfe
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 )
@@ -124,7 +123,7 @@ func (o VariableSetCreateOptions) valid() error {
 		return ErrRequiredName
 	}
 	if o.Global == nil {
-		return errors.New("global flag is required")
+		return ErrRequiredGlobalFlag
 	}
 	return nil
 }
@@ -162,7 +161,7 @@ type VariableSetReadOptions struct {
 // Read is used to inspect a given variable set based on ID
 func (s *variableSets) Read(ctx context.Context, variableSetID string, options *VariableSetReadOptions) (*VariableSet, error) {
 	if !validStringID(&variableSetID) {
-		return nil, errors.New("invalid variable set ID")
+		return nil, ErrInvalidVariableSetID
 	}
 
 	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
@@ -204,7 +203,7 @@ type VariableSetUpdateOptions struct {
 
 func (s *variableSets) Update(ctx context.Context, variableSetID string, options *VariableSetUpdateOptions) (*VariableSet, error) {
 	if !validStringID(&variableSetID) {
-		return nil, errors.New("invalid value for variable set ID")
+		return nil, ErrInvalidVariableSetID
 	}
 
 	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
@@ -225,7 +224,7 @@ func (s *variableSets) Update(ctx context.Context, variableSetID string, options
 // Delete a variable set by its ID.
 func (s *variableSets) Delete(ctx context.Context, variableSetID string) error {
 	if !validStringID(&variableSetID) {
-		return errors.New("invalid value for variable set ID")
+		return ErrInvalidVariableSetID
 	}
 
 	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
@@ -255,7 +254,7 @@ type VariableSetAssignOptions struct {
 // Use Update to assign a variable set to workspaces
 func (s *variableSets) Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error) {
 	if options == nil || options.Workspaces == nil {
-		return nil, errors.New("no workspaces list provided")
+		return nil, ErrRequiredWorkspacesList
 	}
 
 	options.Global = Bool(false)

--- a/variable_set.go
+++ b/variable_set.go
@@ -266,7 +266,7 @@ func (s *variableSets) UpdateWorkspaces(ctx context.Context, variableSetID strin
 		return nil, err
 	}
 
-	// Use private strcut to ensure global is set to false when applying to workspaces
+	// Use private struct to ensure global is set to false when applying to workspaces
 	o := privateVariableSetUpdateWorkspacesOptions{
 		Global:     bool(false),
 		Workspaces: options.Workspaces,

--- a/variable_set.go
+++ b/variable_set.go
@@ -113,10 +113,10 @@ type VariableSetCreateOptions struct {
 	Name *string `jsonapi:"attr,name"`
 
 	// A description to provide context for the variable set.
-	Description *string `jsonapi:"attr,description"`
+	Description *string `jsonapi:"attr,description,omitempty"`
 
 	// If true the variable set is considered in all runs in the organization.
-	Global *bool `jsonapi:"attr,global"`
+	Global *bool `jsonapi:"attr,global,omitempty"`
 }
 
 func (o VariableSetCreateOptions) valid() error {

--- a/variable_set.go
+++ b/variable_set.go
@@ -1,0 +1,254 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ VariableSets = (*variableSets)(nil)
+
+// VariableSets describes all the Variable Set related methods that the
+// Terraform Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/cloud-docs/api-docs/variable-sets
+type VariableSets interface {
+	// List all the variable sets within an organization.
+	List(ctx context.Context, organization string, options VariableSetListOptions) (*VariableSetList, error)
+
+	// Create is used to create a new variable set.
+	Create(ctx context.Context, organization string, options VariableSetCreateOptions) (*VariableSet, error)
+
+	// Read a variable set by its ID.
+	Read(ctx context.Context, variableSetID string) (*VariableSet, error)
+
+	// Update an existing variable set.
+	Update(ctx context.Context, variableSetID string, options VariableSetUpdateOptions) (*VariableSet, error)
+
+	// Delete a variable set by ID.
+	Delete(ctx context.Context, variableSetID string) error
+
+	// Assign a variable set to workspaces
+	Assign(ctx context.Context, variableSetID string, options VariableSetAssignOptions) (*VariableSet, error)
+}
+
+type variableSets struct {
+	client *Client
+}
+
+type VariableSetList struct {
+	*Pagination
+	Items []*VariableSet
+}
+
+type VariableSet struct {
+	ID          string `jsonapi:"primary,varsets"`
+	Name        string `jsonapi:"attr,name"`
+	Description string `jsonapi:"attr,description"`
+	Global      bool   `jsonapi:"attr,global"`
+
+	// Relations
+	Workspaces []*Workspace `jsonapi:"relation,workspaces,omitempty"`
+}
+
+type VariableSetListOptions struct {
+	ListOptions
+}
+
+func (o VariableSetListOptions) valid() error {
+	return nil
+}
+
+// List all Variable Sets in the organization
+func (s *variableSets) List(ctx context.Context, organization string, options VariableSetListOptions) (*VariableSetList, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	vl := &VariableSetList{}
+	err = s.client.do(ctx, req, vl)
+	if err != nil {
+		return nil, err
+	}
+
+	return vl, nil
+}
+
+// VariableSetCreateOptions represents the options for creating a new variable set within in a organization.
+type VariableSetCreateOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
+
+	// The name of the variable set.
+	// Affects variable precedence when there are conflicts between Variable Sets
+	// TODO: Add link to documentation
+	Name *string `jsonapi:"attr,name"`
+
+	// A description to provide context for the variable set.
+	Description *string `jsonapi:"attr,description"`
+
+	// If true the variable set is considered in all runs in the organization.
+	Global *bool `jsonapi:"attr,global"`
+}
+
+func (o VariableSetCreateOptions) valid() error {
+	if !validString(o.Name) {
+		return ErrRequiredName
+	}
+	if o.Global == nil {
+		return errors.New("global flag is required")
+	}
+	return nil
+}
+
+// Create is used to create a new variable set.
+func (s *variableSets) Create(ctx context.Context, organization string, options VariableSetCreateOptions) (*VariableSet, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	vl := &VariableSet{}
+	err = s.client.do(ctx, req, vl)
+	if err != nil {
+		return nil, err
+	}
+
+	return vl, nil
+}
+
+// Read is used to inspect a given variable set based on ID
+func (s *variableSets) Read(ctx context.Context, variableSetID string) (*VariableSet, error) {
+	if !validStringID(&variableSetID) {
+		return nil, errors.New("invalid variable set ID")
+	}
+
+	u := fmt.Sprintf("varsets/%s?include=workspaces", url.QueryEscape(variableSetID))
+	req, err := s.client.newRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	vs := &VariableSet{}
+	err = s.client.do(ctx, req, vs)
+	if err != nil {
+		return nil, err
+	}
+
+	return vs, err
+}
+
+// VariableSetUpdateOptions represents the options for updating a variable set.
+type VariableSetUpdateOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
+
+	// The name of the variable set.
+	// Affects variable precedence when there are conflicts between Variable Sets
+	// TODO: Add link to documentation
+	Name *string `jsonapi:"attr,name"`
+
+	// A description to provide context for the variable set.
+	Description *string `jsonapi:"attr,description"`
+
+	// If true the variable set is considered in all runs in the organization.
+	Global *bool `jsonapi:"attr,global"`
+}
+
+func (s *variableSets) Update(ctx context.Context, variableSetID string, options VariableSetUpdateOptions) (*VariableSet, error) {
+	if !validStringID(&variableSetID) {
+		return nil, errors.New("invalid value for variable set ID")
+	}
+
+	u := fmt.Sprintf("varsets/%s?include=workspaces", url.QueryEscape(variableSetID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &VariableSet{}
+	err = s.client.do(ctx, req, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Delete a variable set by its ID.
+func (s *variableSets) Delete(ctx context.Context, variableSetID string) error {
+	if !validStringID(&variableSetID) {
+		return errors.New("invalid value for variable set ID")
+	}
+
+	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// VariableSetAssignOptions represents a subset of update options specifically for assigning variable sets to workspaces
+type VariableSetAssignOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
+
+	// Used to set the variable set from Global to not Global if necessary
+	Global *bool `jsonapi:"attr,global"`
+
+	// The workspaces to be assigned to. An empty set means remove all assignments
+	Workspaces []*Workspace `jsonapi:"relation,workspaces"`
+}
+
+// Use Update to assign a variable set to workspaces
+func (s *variableSets) Assign(ctx context.Context, variableSetID string, options VariableSetAssignOptions) (*VariableSet, error) {
+	if options.Workspaces == nil {
+		return nil, errors.New("No workspaces list provided")
+	}
+
+	options.Global = Bool(false)
+
+	u := fmt.Sprintf("varsets/%s?include=workspaces", url.QueryEscape(variableSetID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &VariableSet{}
+	err = s.client.do(ctx, req, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}

--- a/variable_set.go
+++ b/variable_set.go
@@ -56,11 +56,11 @@ type VariableSet struct {
 
 // A list of relations to include. See available resources
 // https://www.terraform.io/docs/cloud/api/admin/organizations.html#available-related-resources
-type VariableSetIncludeOps string
+type VariableSetIncludeOpt string
 
 const (
-	VariableSetWorkspaces VariableSetIncludeOps = "workspaces"
-	VariableSetVars       VariableSetIncludeOps = "vars"
+	VariableSetWorkspaces VariableSetIncludeOpt = "workspaces"
+	VariableSetVars       VariableSetIncludeOpt = "vars"
 )
 
 type VariableSetListOptions struct {
@@ -155,7 +155,7 @@ func (s *variableSets) Create(ctx context.Context, organization string, options 
 }
 
 type VariableSetReadOptions struct {
-	Include *[]VariableSetIncludeOps `url:"include:omitempty"`
+	Include *[]VariableSetIncludeOpt `url:"include:omitempty"`
 }
 
 // Read is used to inspect a given variable set based on ID
@@ -190,15 +190,13 @@ type VariableSetUpdateOptions struct {
 	// The name of the variable set.
 	// Affects variable precedence when there are conflicts between Variable Sets
 	// https://www.terraform.io/cloud-docs/api-docs/variable-sets#apply-variable-set-to-workspaces
-	Name *string `jsonapi:"attr,name"`
+	Name *string `jsonapi:"attr,name,omitempty"`
 
 	// A description to provide context for the variable set.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
 	// If true the variable set is considered in all runs in the organization.
 	Global *bool `jsonapi:"attr,global,omitempty"`
-
-	Include *[]VariableSetIncludeOps `url:"include:omitempty"`
 }
 
 func (s *variableSets) Update(ctx context.Context, variableSetID string, options *VariableSetUpdateOptions) (*VariableSet, error) {
@@ -246,9 +244,6 @@ type VariableSetAssignOptions struct {
 
 	// Used to set the variable set from Global to not Global if necessary
 	Global *bool `jsonapi:"attr,global"`
-
-	// The workspaces to be assigned to. An empty set means remove all assignments
-	Workspaces []*Workspace `jsonapi:"relation,workspaces"`
 }
 
 // Update variable set assignments to match the supplied workspaces list.

--- a/variable_set.go
+++ b/variable_set.go
@@ -50,8 +50,9 @@ type VariableSet struct {
 	Global      bool   `jsonapi:"attr,global"`
 
 	// Relations
-	Workspaces []*Workspace           `jsonapi:"relation,workspaces,omitempty"`
-	Variables  []*VariableSetVariable `jsonapi:"relation,vars,omitempty"`
+	Organization *Organization          `jsonapi:"relation,organization"`
+	Workspaces   []*Workspace           `jsonapi:"relation,workspaces,omitempty"`
+	Variables    []*VariableSetVariable `jsonapi:"relation,vars,omitempty"`
 }
 
 // A list of relations to include. See available resources

--- a/variable_set.go
+++ b/variable_set.go
@@ -29,7 +29,7 @@ type VariableSets interface {
 	// Delete a variable set by ID.
 	Delete(ctx context.Context, variableSetID string) error
 
-	// Assign a variable set to workspaces
+	// Add and remove workspace assignments to match the supplied list
 	Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error)
 }
 
@@ -251,7 +251,7 @@ type VariableSetAssignOptions struct {
 	Workspaces []*Workspace `jsonapi:"relation,workspaces"`
 }
 
-// Use Update to assign a variable set to workspaces
+// Update variable set assignments to match the supplied workspaces list.
 func (s *variableSets) Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error) {
 	if options == nil || options.Workspaces == nil {
 		return nil, ErrRequiredWorkspacesList

--- a/variable_set.go
+++ b/variable_set.go
@@ -254,7 +254,7 @@ type VariableSetAssignOptions struct {
 // Use Update to assign a variable set to workspaces
 func (s *variableSets) Assign(ctx context.Context, variableSetID string, options *VariableSetAssignOptions) (*VariableSet, error) {
 	if options == nil || options.Workspaces == nil {
-		return nil, errors.New("No workspaces list provided")
+		return nil, errors.New("no workspaces list provided")
 	}
 
 	options.Global = Bool(false)

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -190,7 +190,7 @@ func TestVariableSetsDelete(t *testing.T) {
 	})
 }
 
-func TestVariableSetsApply(t *testing.T) {
+func TestVariableSetsUpdateWorkspaces(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -202,21 +202,21 @@ func TestVariableSetsApply(t *testing.T) {
 	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("with valid workspaces", func(t *testing.T) {
-		options := VariableSetApplyOptions{
+		options := VariableSetUpdateWorkspacesOptions{
 			Workspaces: []*Workspace{wTest},
 		}
 
-		vsAfter, err := client.VariableSets.Apply(ctx, vsTest.ID, &options)
+		vsAfter, err := client.VariableSets.UpdateWorkspaces(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))
 		assert.Equal(t, options.Workspaces[0].ID, vsAfter.Workspaces[0].ID)
 
-		options = VariableSetApplyOptions{
+		options = VariableSetUpdateWorkspacesOptions{
 			Workspaces: []*Workspace{},
 		}
 
-		vsAfter, err = client.VariableSets.Apply(ctx, vsTest.ID, &options)
+		vsAfter, err = client.VariableSets.UpdateWorkspaces(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -76,7 +76,7 @@ func TestVariableSetsCreate(t *testing.T) {
 		require.NoError(t, err)
 
 		//Get refreshed view from the API
-		refreshed, err := client.VariableSets.Read(ctx, vs.ID)
+		refreshed, err := client.VariableSets.Read(ctx, vs.ID, VariableSetReadOptions{})
 		require.NoError(t, err)
 
 		for _, item := range []*VariableSet{
@@ -118,13 +118,13 @@ func TestVariableSetsRead(t *testing.T) {
 	defer vsTestCleanup()
 
 	t.Run("when the variable set exists", func(t *testing.T) {
-		vs, err := client.VariableSets.Read(ctx, vsTest.ID)
+		vs, err := client.VariableSets.Read(ctx, vsTest.ID, VariableSetReadOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, vsTest, vs)
 	})
 
 	t.Run("when variable set does not exist", func(t *testing.T) {
-		vs, err := client.VariableSets.Read(ctx, "nonexisting")
+		vs, err := client.VariableSets.Read(ctx, "nonexisting", VariableSetReadOptions{})
 		assert.Nil(t, vs)
 		assert.Error(t, err)
 	})
@@ -183,7 +183,7 @@ func TestVariableSetsDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try loading the variable set - it should fail.
-		_, err = client.VariableSets.Read(ctx, vsTest.ID)
+		_, err = client.VariableSets.Read(ctx, vsTest.ID, VariableSetReadOptions{})
 		assert.Equal(t, ErrResourceNotFound, err)
 	})
 

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -190,7 +190,7 @@ func TestVariableSetsDelete(t *testing.T) {
 	})
 }
 
-func TestVariableSetsAssign(t *testing.T) {
+func TestVariableSetsApply(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -202,21 +202,21 @@ func TestVariableSetsAssign(t *testing.T) {
 	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("with valid workspaces", func(t *testing.T) {
-		options := VariableSetAssignOptions{
+		options := VariableSetApplyOptions{
 			Workspaces: []*Workspace{wTest},
 		}
 
-		vsAfter, err := client.VariableSets.Assign(ctx, vsTest.ID, &options)
+		vsAfter, err := client.VariableSets.Apply(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))
 		assert.Equal(t, options.Workspaces[0].ID, vsAfter.Workspaces[0].ID)
 
-		options = VariableSetAssignOptions{
+		options = VariableSetApplyOptions{
 			Workspaces: []*Workspace{},
 		}
 
-		vsAfter, err = client.VariableSets.Assign(ctx, vsTest.ID, &options)
+		vsAfter, err = client.VariableSets.Apply(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -24,7 +24,7 @@ func TestVariableSetsList(t *testing.T) {
 	defer vsTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		vsl, err := client.VariableSets.List(ctx, orgTest.Name, VariableSetListOptions{})
+		vsl, err := client.VariableSets.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 		assert.Contains(t, vsl.Items, vsTest1)
 		assert.Contains(t, vsl.Items, vsTest2)
@@ -39,7 +39,7 @@ func TestVariableSetsList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		vsl, err := client.VariableSets.List(ctx, orgTest.Name, VariableSetListOptions{
+		vsl, err := client.VariableSets.List(ctx, orgTest.Name, &VariableSetListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -52,7 +52,7 @@ func TestVariableSetsList(t *testing.T) {
 	})
 
 	t.Run("when Organization name is invalid ID", func(t *testing.T) {
-		vsl, err := client.VariableSets.List(ctx, badIdentifier, VariableSetListOptions{})
+		vsl, err := client.VariableSets.List(ctx, badIdentifier, nil)
 		assert.Nil(t, vsl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
@@ -72,11 +72,11 @@ func TestVariableSetsCreate(t *testing.T) {
 			Global:      Bool(false),
 		}
 
-		vs, err := client.VariableSets.Create(ctx, orgTest.Name, options)
+		vs, err := client.VariableSets.Create(ctx, orgTest.Name, &options)
 		require.NoError(t, err)
 
 		//Get refreshed view from the API
-		refreshed, err := client.VariableSets.Read(ctx, vs.ID, VariableSetReadOptions{})
+		refreshed, err := client.VariableSets.Read(ctx, vs.ID, nil)
 		require.NoError(t, err)
 
 		for _, item := range []*VariableSet{
@@ -91,7 +91,7 @@ func TestVariableSetsCreate(t *testing.T) {
 	})
 
 	t.Run("when options is missing name", func(t *testing.T) {
-		vs, err := client.VariableSets.Create(ctx, "foo", VariableSetCreateOptions{
+		vs, err := client.VariableSets.Create(ctx, "foo", &VariableSetCreateOptions{
 			Global: Bool(true),
 		})
 		assert.Nil(t, vs)
@@ -99,7 +99,7 @@ func TestVariableSetsCreate(t *testing.T) {
 	})
 
 	t.Run("when options is missing global flag", func(t *testing.T) {
-		vs, err := client.VariableSets.Create(ctx, "foo", VariableSetCreateOptions{
+		vs, err := client.VariableSets.Create(ctx, "foo", &VariableSetCreateOptions{
 			Name: String("foo"),
 		})
 		assert.Nil(t, vs)
@@ -118,13 +118,13 @@ func TestVariableSetsRead(t *testing.T) {
 	defer vsTestCleanup()
 
 	t.Run("when the variable set exists", func(t *testing.T) {
-		vs, err := client.VariableSets.Read(ctx, vsTest.ID, VariableSetReadOptions{})
+		vs, err := client.VariableSets.Read(ctx, vsTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, vsTest, vs)
 	})
 
 	t.Run("when variable set does not exist", func(t *testing.T) {
-		vs, err := client.VariableSets.Read(ctx, "nonexisting", VariableSetReadOptions{})
+		vs, err := client.VariableSets.Read(ctx, "nonexisting", nil)
 		assert.Nil(t, vs)
 		assert.Error(t, err)
 	})
@@ -150,7 +150,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 			Global:      Bool(true),
 		}
 
-		vsAfter, err := client.VariableSets.Update(ctx, vsTest.ID, options)
+		vsAfter, err := client.VariableSets.Update(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Name, vsAfter.Name)
@@ -159,7 +159,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 	})
 
 	t.Run("when options has an invalid variable set ID", func(t *testing.T) {
-		vsAfter, err := client.VariableSets.Update(ctx, badIdentifier, VariableSetUpdateOptions{
+		vsAfter, err := client.VariableSets.Update(ctx, badIdentifier, &VariableSetUpdateOptions{
 			Name:        String("UpdatedName"),
 			Description: String("Updated Description"),
 			Global:      Bool(true),
@@ -183,7 +183,7 @@ func TestVariableSetsDelete(t *testing.T) {
 		require.NoError(t, err)
 
 		// Try loading the variable set - it should fail.
-		_, err = client.VariableSets.Read(ctx, vsTest.ID, VariableSetReadOptions{})
+		_, err = client.VariableSets.Read(ctx, vsTest.ID, nil)
 		assert.Equal(t, ErrResourceNotFound, err)
 	})
 
@@ -209,7 +209,7 @@ func TestVariableSetsAssign(t *testing.T) {
 			Workspaces: []*Workspace{wTest},
 		}
 
-		vsAfter, err := client.VariableSets.Assign(ctx, vsTest.ID, options)
+		vsAfter, err := client.VariableSets.Assign(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))
@@ -219,7 +219,7 @@ func TestVariableSetsAssign(t *testing.T) {
 			Workspaces: []*Workspace{},
 		}
 
-		vsAfter, err = client.VariableSets.Assign(ctx, vsTest.ID, options)
+		vsAfter, err = client.VariableSets.Assign(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -1,0 +1,227 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestVariableSetsList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	//wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	//defer wTestCleanup()
+
+	vsTest1, vsTestCleanup1 := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+	defer vsTestCleanup1()
+	vsTest2, vsTestCleanup2 := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+	defer vsTestCleanup2()
+
+	t.Run("without list options", func(t *testing.T) {
+		vsl, err := client.VariableSets.List(ctx, orgTest.Name, VariableSetListOptions{})
+		require.NoError(t, err)
+		assert.Contains(t, vsl.Items, vsTest1)
+		assert.Contains(t, vsl.Items, vsTest2)
+
+		t.Skip("paging not supported yet in API")
+		assert.Equal(t, 1, vsl.CurrentPage)
+		assert.Equal(t, 2, vsl.TotalCount)
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		t.Skip("paging not supported yet in API")
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		vsl, err := client.VariableSets.List(ctx, orgTest.Name, VariableSetListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, vsl.Items)
+		assert.Equal(t, 999, vsl.CurrentPage)
+		assert.Equal(t, 2, vsl.TotalCount)
+	})
+
+	t.Run("when Organization name is invalid ID", func(t *testing.T) {
+		vsl, err := client.VariableSets.List(ctx, badIdentifier, VariableSetListOptions{})
+		assert.Nil(t, vsl)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
+	})
+}
+
+func TestVariableSetsCreate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	t.Run("with valid options", func(t *testing.T) {
+		options := VariableSetCreateOptions{
+			Name:        String("varset"),
+			Description: String("a variable set"),
+			Global:      Bool(false),
+		}
+
+		vs, err := client.VariableSets.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		//Get refreshed view from the API
+		refreshed, err := client.VariableSets.Read(ctx, vs.ID)
+		require.NoError(t, err)
+
+		for _, item := range []*VariableSet{
+			vs,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.Description, item.Description)
+			assert.Equal(t, *options.Global, item.Global)
+		}
+	})
+
+	t.Run("when options is missing name", func(t *testing.T) {
+		vs, err := client.VariableSets.Create(ctx, "foo", VariableSetCreateOptions{
+			Global: Bool(true),
+		})
+		assert.Nil(t, vs)
+		assert.EqualError(t, err, ErrRequiredName.Error())
+	})
+
+	t.Run("when options is missing global flag", func(t *testing.T) {
+		vs, err := client.VariableSets.Create(ctx, "foo", VariableSetCreateOptions{
+			Name: String("foo"),
+		})
+		assert.Nil(t, vs)
+		assert.EqualError(t, err, "global flag is required")
+	})
+}
+
+func TestVariableSetsRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	vsTest, vsTestCleanup := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+	defer vsTestCleanup()
+
+	t.Run("when the variable set exists", func(t *testing.T) {
+		vs, err := client.VariableSets.Read(ctx, vsTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, vsTest, vs)
+	})
+
+	t.Run("when variable set does not exist", func(t *testing.T) {
+		vs, err := client.VariableSets.Read(ctx, "nonexisting")
+		assert.Nil(t, vs)
+		assert.Error(t, err)
+	})
+}
+
+func TestVariableSetsUpdate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	vsTest, _ := createVariableSet(t, client, orgTest, VariableSetCreateOptions{
+		Name:        String("OrinigalName"),
+		Description: String("Original Description"),
+		Global:      Bool(false),
+	})
+
+	t.Run("when updating a subset of values", func(t *testing.T) {
+		options := VariableSetUpdateOptions{
+			Name:        String("UpdatedName"),
+			Description: String("Updated Description"),
+			Global:      Bool(true),
+		}
+
+		vsAfter, err := client.VariableSets.Update(ctx, vsTest.ID, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, *options.Name, vsAfter.Name)
+		assert.Equal(t, *options.Description, vsAfter.Description)
+		assert.Equal(t, *options.Global, vsAfter.Global)
+	})
+
+	t.Run("when options has an invalid variable set ID", func(t *testing.T) {
+		vsAfter, err := client.VariableSets.Update(ctx, badIdentifier, VariableSetUpdateOptions{
+			Name:        String("UpdatedName"),
+			Description: String("Updated Description"),
+			Global:      Bool(true),
+		})
+		assert.Nil(t, vsAfter)
+		assert.EqualError(t, err, "invalid value for variable set ID")
+	})
+}
+
+func TestVariableSetsDelete(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	vsTest, _ := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+
+	t.Run("with valid ID", func(t *testing.T) {
+		err := client.VariableSets.Delete(ctx, vsTest.ID)
+		require.NoError(t, err)
+
+		// Try loading the variable set - it should fail.
+		_, err = client.VariableSets.Read(ctx, vsTest.ID)
+		assert.Equal(t, ErrResourceNotFound, err)
+	})
+
+	t.Run("when ID is invlaid", func(t *testing.T) {
+		err := client.VariableSets.Delete(ctx, badIdentifier)
+		assert.EqualError(t, err, "invalid value for variable set ID")
+	})
+}
+
+func TestVariableSetsAssign(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	vsTest, _ := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+
+	wTest, _ := createWorkspace(t, client, orgTest)
+
+	t.Run("with valid workspaces", func(t *testing.T) {
+		options := VariableSetAssignOptions{
+			Workspaces: []*Workspace{wTest},
+		}
+
+		vsAfter, err := client.VariableSets.Assign(ctx, vsTest.ID, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))
+		assert.Equal(t, options.Workspaces[0].ID, vsAfter.Workspaces[0].ID)
+
+		options = VariableSetAssignOptions{
+			Workspaces: []*Workspace{},
+		}
+
+		vsAfter, err = client.VariableSets.Assign(ctx, vsTest.ID, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, len(options.Workspaces), len(vsAfter.Workspaces))
+	})
+}

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -135,7 +135,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 	defer orgTestCleanup()
 
 	vsTest, _ := createVariableSet(t, client, orgTest, VariableSetCreateOptions{
-		Name:        String("OrinigalName"),
+		Name:        String("OriginalName"),
 		Description: String("Original Description"),
 		Global:      Bool(false),
 	})

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -103,7 +103,7 @@ func TestVariableSetsCreate(t *testing.T) {
 			Name: String("foo"),
 		})
 		assert.Nil(t, vs)
-		assert.EqualError(t, err, "global flag is required")
+		assert.EqualError(t, err, ErrRequiredGlobalFlag.Error())
 	})
 }
 
@@ -165,7 +165,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 			Global:      Bool(true),
 		})
 		assert.Nil(t, vsAfter)
-		assert.EqualError(t, err, "invalid value for variable set ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 }
 
@@ -189,7 +189,7 @@ func TestVariableSetsDelete(t *testing.T) {
 
 	t.Run("when ID is invlaid", func(t *testing.T) {
 		err := client.VariableSets.Delete(ctx, badIdentifier)
-		assert.EqualError(t, err, "invalid value for variable set ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 }
 

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -15,9 +15,6 @@ func TestVariableSetsList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	//wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	//defer wTestCleanup()
-
 	vsTest1, vsTestCleanup1 := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
 	defer vsTestCleanup1()
 	vsTest2, vsTestCleanup2 := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
@@ -75,7 +72,7 @@ func TestVariableSetsCreate(t *testing.T) {
 		vs, err := client.VariableSets.Create(ctx, orgTest.Name, &options)
 		require.NoError(t, err)
 
-		//Get refreshed view from the API
+		// Get refreshed view from the API
 		refreshed, err := client.VariableSets.Read(ctx, vs.ID, nil)
 		require.NoError(t, err)
 

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -184,7 +184,7 @@ func TestVariableSetsDelete(t *testing.T) {
 		assert.Equal(t, ErrResourceNotFound, err)
 	})
 
-	t.Run("when ID is invlaid", func(t *testing.T) {
+	t.Run("when ID is invalid", func(t *testing.T) {
 		err := client.VariableSets.Delete(ctx, badIdentifier)
 		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -16,13 +16,13 @@ var _ VariableSetVariables = (*variableSetVariables)(nil)
 // TFE API docs: https://www.terraform.io/cloud-docs/api-docs/variable-sets#variable-relationships
 type VariableSetVariables interface {
 	// List all variables in the variable set.
-	List(ctx context.Context, variableSetID string, options VariableSetVariableListOptions) (*VariableSetVariableList, error)
+	List(ctx context.Context, variableSetID string, options *VariableSetVariableListOptions) (*VariableSetVariableList, error)
 
 	// Create is used to create a new variable within a given variable set
-	Create(ctx context.Context, variableSetID string, options VariableSetVariableCreateOptions) (*VariableSetVariable, error)
+	Create(ctx context.Context, variableSetID string, options *VariableSetVariableCreateOptions) (*VariableSetVariable, error)
 
 	// Update valuse of an existing variable
-	Update(ctx context.Context, variableSetID string, variableID string, options VariableSetVariableUpdateOptions) (*VariableSetVariable, error)
+	Update(ctx context.Context, variableSetID string, variableID string, options *VariableSetVariableUpdateOptions) (*VariableSetVariable, error)
 
 	// Delete a variable by its ID
 	Delete(ctx context.Context, variableSetID string, variableID string) error
@@ -59,16 +59,18 @@ func (o VariableSetVariableListOptions) valid() error {
 }
 
 // List all variables associated with the given variable set.
-func (s *variableSetVariables) List(ctx context.Context, variableSetID string, options VariableSetVariableListOptions) (*VariableSetVariableList, error) {
+func (s *variableSetVariables) List(ctx context.Context, variableSetID string, options *VariableSetVariableListOptions) (*VariableSetVariableList, error) {
 	if !validStringID(&variableSetID) {
 		return nil, errors.New("invalid value for variable set ID")
 	}
-	if err := options.valid(); err != nil {
-		return nil, err
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars", variableSetID)
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -120,16 +122,18 @@ func (o VariableSetVariableCreateOptions) valid() error {
 }
 
 // Create is used to create a new variable.
-func (s *variableSetVariables) Create(ctx context.Context, variableSetID string, options VariableSetVariableCreateOptions) (*VariableSetVariable, error) {
+func (s *variableSetVariables) Create(ctx context.Context, variableSetID string, options *VariableSetVariableCreateOptions) (*VariableSetVariable, error) {
 	if !validStringID(&variableSetID) {
 		return nil, errors.New("invalid value for variable set ID")
 	}
-	if err := options.valid(); err != nil {
-		return nil, err
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.newRequest("POST", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -168,7 +172,7 @@ type VariableSetVariableUpdateOptions struct {
 }
 
 // Update values of an existing variable.
-func (s *variableSetVariables) Update(ctx context.Context, variableSetID string, variableID string, options VariableSetVariableUpdateOptions) (*VariableSetVariable, error) {
+func (s *variableSetVariables) Update(ctx context.Context, variableSetID string, variableID string, options *VariableSetVariableUpdateOptions) (*VariableSetVariable, error) {
 	if !validStringID(&variableSetID) {
 		return nil, errors.New("invalid value for variable set ID")
 	}
@@ -177,7 +181,7 @@ func (s *variableSetVariables) Update(ctx context.Context, variableSetID string,
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.newRequest("PATCH", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -2,7 +2,6 @@ package tfe
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"net/url"
 )
@@ -64,7 +63,7 @@ func (o VariableSetVariableListOptions) valid() error {
 // List all variables associated with the given variable set.
 func (s *variableSetVariables) List(ctx context.Context, variableSetID string, options *VariableSetVariableListOptions) (*VariableSetVariableList, error) {
 	if !validStringID(&variableSetID) {
-		return nil, errors.New("invalid value for variable set ID")
+		return nil, ErrInvalidVariableSetID
 	}
 	if options != nil {
 		if err := options.valid(); err != nil {
@@ -116,10 +115,10 @@ type VariableSetVariableCreateOptions struct {
 
 func (o VariableSetVariableCreateOptions) valid() error {
 	if !validString(o.Key) {
-		return errors.New("key is required")
+		return ErrRequiredKey
 	}
 	if o.Category == nil {
-		return errors.New("category is required")
+		return ErrRequiredCategory
 	}
 	return nil
 }
@@ -127,7 +126,7 @@ func (o VariableSetVariableCreateOptions) valid() error {
 // Create is used to create a new variable.
 func (s *variableSetVariables) Create(ctx context.Context, variableSetID string, options *VariableSetVariableCreateOptions) (*VariableSetVariable, error) {
 	if !validStringID(&variableSetID) {
-		return nil, errors.New("invalid value for variable set ID")
+		return nil, ErrInvalidVariableSetID
 	}
 	if options != nil {
 		if err := options.valid(); err != nil {
@@ -151,12 +150,12 @@ func (s *variableSetVariables) Create(ctx context.Context, variableSetID string,
 }
 
 // Read a variable by its ID.
-func (s *variableSetVariables) Read(ctx context.Context, variableSetID string, variableID string) (*VariableSetVariable, error) {
+func (s *variableSetVariables) Read(ctx context.Context, variableSetID, variableID string) (*VariableSetVariable, error) {
 	if !validStringID(&variableSetID) {
-		return nil, errors.New("invalid value for variable set ID")
+		return nil, ErrInvalidVariableSetID
 	}
 	if !validStringID(&variableID) {
-		return nil, errors.New("invalid value for variable ID")
+		return nil, ErrInvalidVariableID
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
@@ -200,12 +199,12 @@ type VariableSetVariableUpdateOptions struct {
 }
 
 // Update values of an existing variable.
-func (s *variableSetVariables) Update(ctx context.Context, variableSetID string, variableID string, options *VariableSetVariableUpdateOptions) (*VariableSetVariable, error) {
+func (s *variableSetVariables) Update(ctx context.Context, variableSetID, variableID string, options *VariableSetVariableUpdateOptions) (*VariableSetVariable, error) {
 	if !validStringID(&variableSetID) {
-		return nil, errors.New("invalid value for variable set ID")
+		return nil, ErrInvalidVariableSetID
 	}
 	if !validStringID(&variableID) {
-		return nil, errors.New("invalid value for variable ID")
+		return nil, ErrInvalidVariableID
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
@@ -224,12 +223,12 @@ func (s *variableSetVariables) Update(ctx context.Context, variableSetID string,
 }
 
 // Delete a variable by its ID.
-func (s *variableSetVariables) Delete(ctx context.Context, variableSetID string, variableID string) error {
+func (s *variableSetVariables) Delete(ctx context.Context, variableSetID, variableID string) error {
 	if !validStringID(&variableSetID) {
-		return errors.New("invalid value for variable set ID")
+		return ErrInvalidVariableSetID
 	}
 	if !validStringID(&variableID) {
-		return errors.New("invalid value for variable ID")
+		return ErrInvalidVariableID
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -21,6 +21,9 @@ type VariableSetVariables interface {
 	// Create is used to create a new variable within a given variable set
 	Create(ctx context.Context, variableSetID string, options *VariableSetVariableCreateOptions) (*VariableSetVariable, error)
 
+	// Read a variable by its ID
+	Read(ctx context.Context, variableSetID string, variableId string) (*VariableSetVariable, error)
+
 	// Update valuse of an existing variable
 	Update(ctx context.Context, variableSetID string, variableID string, options *VariableSetVariableUpdateOptions) (*VariableSetVariable, error)
 
@@ -145,6 +148,31 @@ func (s *variableSetVariables) Create(ctx context.Context, variableSetID string,
 	}
 
 	return v, nil
+}
+
+// Read a variable by its ID.
+func (s *variableSetVariables) Read(ctx context.Context, variableSetID string, variableID string) (*VariableSetVariable, error) {
+	if !validStringID(&variableSetID) {
+		return nil, errors.New("invalid value for variable set ID")
+	}
+	if !validStringID(&variableID) {
+		return nil, errors.New("invalid value for variable ID")
+	}
+
+	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
+	req, err := s.client.newRequest("GET", u, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	v := &VariableSetVariable{}
+	err = s.client.do(ctx, req, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, err
 }
 
 // VariableSetVariableUpdateOptions represents the options for updating a variable.

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -1,0 +1,206 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ VariableSetVariables = (*variableSetVariables)(nil)
+
+// VariableSetVariables describes all variable variable related methods within the scope of
+// Variable Sets that the Terraform Enterprise API supports
+//
+// TFE API docs: https://www.terraform.io/cloud-docs/api-docs/variable-sets#variable-relationships
+type VariableSetVariables interface {
+	// List all variables in the variable set.
+	List(ctx context.Context, variableSetID string, options VariableSetVariableListOptions) (*VariableSetVariableList, error)
+
+	// Create is used to create a new variable within a given variable set
+	Create(ctx context.Context, variableSetID string, options VariableSetVariableCreateOptions) (*VariableSetVariable, error)
+
+	// Update valuse of an existing variable
+	Update(ctx context.Context, variableSetID string, variableID string, options VariableSetVariableUpdateOptions) (*VariableSetVariable, error)
+
+	// Delete a variable by its ID
+	Delete(ctx context.Context, variableSetID string, variableID string) error
+}
+
+type variableSetVariables struct {
+	client *Client
+}
+
+type VariableSetVariableList struct {
+	*Pagination
+	Items []*VariableSetVariable
+}
+
+type VariableSetVariable struct {
+	ID        string       `jsonapi:"primary,vars"`
+	Key       string       `jsonapi:"attr,key"`
+	Value     string       `jsonapi:"attr,value"`
+	Category  CategoryType `jsonapi:"attr,category"`
+	HCL       string       `jsonapi:"attr,hcl"`
+	Sensitive bool         `jsonapi:"attr,sensitive"`
+
+	// Relations
+	VariableSet *VariableSet `jsonapi:"relation,configurable"`
+}
+
+type VariableSetVariableListOptions struct {
+	ListOptions
+}
+
+func (o VariableSetVariableListOptions) valid() error {
+	return nil
+}
+
+// List all variables associated with the given variable set.
+func (s *variableSetVariables) List(ctx context.Context, variableSetID string, options VariableSetVariableListOptions) (*VariableSetVariableList, error) {
+	if !validStringID(&variableSetID) {
+		return nil, errors.New("invalid value for variable set ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("varsets/%s/relationships/vars", variableSetID)
+	req, err := s.client.newRequest("GET", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	vl := &VariableSetVariableList{}
+	err = s.client.do(ctx, req, vl)
+	if err != nil {
+		return nil, err
+	}
+
+	return vl, nil
+}
+
+// VariableSetVariableCreatOptions represents the options for creating a new variable within a variable set
+type VariableSetVariableCreateOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
+
+	// The name of the variable.
+	Key *string `jsonapi:"attr,key"`
+
+	// The value of the variable.
+	Value *string `jsonapi:"attr,value,omitempty"`
+
+	// Whether this is a Terraform or environment variable.
+	Category *CategoryType `jsonapi:"attr,category"`
+
+	// Whether to evaluate the value of the variable as a string of HCL code.
+	HCL *bool `jsonapi:"attr,hcl,omitempty"`
+
+	// Whether the value is sensitive.
+	Sensitive *bool `jsonapi:"attr,sensitive,omitempty"`
+}
+
+func (o VariableSetVariableCreateOptions) valid() error {
+	if !validString(o.Key) {
+		return errors.New("key is required")
+	}
+	if o.Category == nil {
+		return errors.New("category is required")
+	}
+	return nil
+}
+
+// Create is used to create a new variable.
+func (s *variableSetVariables) Create(ctx context.Context, variableSetID string, options VariableSetVariableCreateOptions) (*VariableSetVariable, error) {
+	if !validStringID(&variableSetID) {
+		return nil, errors.New("invalid value for variable set ID")
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &VariableSetVariable{}
+	err = s.client.do(ctx, req, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// VariableSetVariableUpdateOptions represents the options for updating a variable.
+type VariableSetVariableUpdateOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,vars"`
+
+	// The name of the variable.
+	Key *string `jsonapi:"attr,key,omitempty"`
+
+	// The value of the variable.
+	Value *string `jsonapi:"attr,value,omitempty"`
+
+	// The description of the variable.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
+	// Whether to evaluate the value of the variable as a string of HCL code.
+	HCL *bool `jsonapi:"attr,hcl,omitempty"`
+
+	// Whether the value is sensitive.
+	Sensitive *bool `jsonapi:"attr,sensitive,omitempty"`
+}
+
+// Update values of an existing variable.
+func (s *variableSetVariables) Update(ctx context.Context, variableSetID string, variableID string, options VariableSetVariableUpdateOptions) (*VariableSetVariable, error) {
+	if !validStringID(&variableSetID) {
+		return nil, errors.New("invalid value for variable set ID")
+	}
+	if !validStringID(&variableID) {
+		return nil, errors.New("invalid value for variable ID")
+	}
+
+	u := fmt.Sprintf("varsets/%s/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
+	req, err := s.client.newRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &VariableSetVariable{}
+	err = s.client.do(ctx, req, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Delete a variable by its ID.
+func (s *variableSetVariables) Delete(ctx context.Context, variableSetID string, variableID string) error {
+	if !validStringID(&variableSetID) {
+		return errors.New("invalid value for variable set ID")
+	}
+	if !validStringID(&variableID) {
+		return errors.New("invalid value for variable ID")
+	}
+
+	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
+	req, err := s.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -38,12 +38,13 @@ type VariableSetVariableList struct {
 }
 
 type VariableSetVariable struct {
-	ID        string       `jsonapi:"primary,vars"`
-	Key       string       `jsonapi:"attr,key"`
-	Value     string       `jsonapi:"attr,value"`
-	Category  CategoryType `jsonapi:"attr,category"`
-	HCL       string       `jsonapi:"attr,hcl"`
-	Sensitive bool         `jsonapi:"attr,sensitive"`
+	ID          string       `jsonapi:"primary,vars"`
+	Key         string       `jsonapi:"attr,key"`
+	Value       string       `jsonapi:"attr,value"`
+	Description string       `jsonapi:"attr,description"`
+	Category    CategoryType `jsonapi:"attr,category"`
+	HCL         string       `jsonapi:"attr,hcl"`
+	Sensitive   bool         `jsonapi:"attr,sensitive"`
 
 	// Relations
 	VariableSet *VariableSet `jsonapi:"relation,configurable"`
@@ -95,6 +96,9 @@ type VariableSetVariableCreateOptions struct {
 	// The value of the variable.
 	Value *string `jsonapi:"attr,value,omitempty"`
 
+	// The description of the variable.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
 	// Whether this is a Terraform or environment variable.
 	Category *CategoryType `jsonapi:"attr,category"`
 
@@ -123,6 +127,12 @@ func (s *variableSetVariables) Create(ctx context.Context, variableSetID string,
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
+
+	/*
+		out := bytes.NewBuffer(nil)
+		jsonstuff := jsonapi.MarshalOnePayloadEmbedded(out, i&options)
+		fmt.Printf("%+v\n", jsonstuff)
+	*/
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
 	req, err := s.client.newRequest("POST", u, &options)

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -22,7 +22,7 @@ type VariableSetVariables interface {
 	Create(ctx context.Context, variableSetID string, options *VariableSetVariableCreateOptions) (*VariableSetVariable, error)
 
 	// Read a variable by its ID
-	Read(ctx context.Context, variableSetID string, variableId string) (*VariableSetVariable, error)
+	Read(ctx context.Context, variableSetID string, variableID string) (*VariableSetVariable, error)
 
 	// Update valuse of an existing variable
 	Update(ctx context.Context, variableSetID string, variableID string, options *VariableSetVariableUpdateOptions) (*VariableSetVariable, error)

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -71,7 +71,7 @@ func (s *variableSetVariables) List(ctx context.Context, variableSetID string, o
 		}
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/vars", variableSetID)
+	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
 	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -43,7 +43,7 @@ type VariableSetVariable struct {
 	Value       string       `jsonapi:"attr,value"`
 	Description string       `jsonapi:"attr,description"`
 	Category    CategoryType `jsonapi:"attr,category"`
-	HCL         string       `jsonapi:"attr,hcl"`
+	HCL         bool         `jsonapi:"attr,hcl"`
 	Sensitive   bool         `jsonapi:"attr,sensitive"`
 
 	// Relations
@@ -128,12 +128,6 @@ func (s *variableSetVariables) Create(ctx context.Context, variableSetID string,
 		return nil, err
 	}
 
-	/*
-		out := bytes.NewBuffer(nil)
-		jsonstuff := jsonapi.MarshalOnePayloadEmbedded(out, i&options)
-		fmt.Printf("%+v\n", jsonstuff)
-	*/
-
 	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
@@ -182,7 +176,7 @@ func (s *variableSetVariables) Update(ctx context.Context, variableSetID string,
 		return nil, errors.New("invalid value for variable ID")
 	}
 
-	u := fmt.Sprintf("varsets/%s/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
 	req, err := s.client.newRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -1,0 +1,43 @@
+package tfe
+
+import (
+	"context"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"testing"
+)
+
+func TestVariableSetVariablesList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	vsTest, vsTestCleanup := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+	defer vsTestCleanup()
+
+	vTest1, vTestCleanup1 := createVariableSetVariable(t, client, vsTest, VariableSetVariableCreateOptions{
+		Key:      String("vTest1"),
+		Value:    String("vTest1"),
+		Category: Category(CategoryTerraform),
+	})
+	defer vTestCleanup1()
+	vTest2, vTestCleanup2 := createVariableSetVariable(t, client, vsTest, VariableSetVariableCreateOptions{
+		Key:      String("vTest2"),
+		Value:    String("vTest2"),
+		Category: Category(CategoryTerraform),
+	})
+	defer vTestCleanup2()
+
+	t.Run("without list options", func(t *testing.T) {
+		vl, err := client.VariableSetVariables.List(ctx, vsTest.ID, VariableSetVariableListOptions{})
+		require.NoError(t, err)
+		assert.Contains(t, vl.Items, vTest1)
+		assert.Contains(t, vl.Items, vTest2)
+
+		t.Skip("paging not supported yet in API")
+		assert.Equal(t, 1, vl.CurrentPage)
+		assert.Equal(t, 2, vl.TotalCount)
+	})
+}

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -61,7 +61,7 @@ func TestVariableSetVariablesList(t *testing.T) {
 	t.Run("when variable set ID is invalid ID", func(t *testing.T) {
 		vl, err := client.VariableSetVariables.List(ctx, badIdentifier, nil)
 		assert.Nil(t, vl)
-		assert.EqualError(t, err, "invalid value for variable set ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 }
 
@@ -165,7 +165,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		}
 
 		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
-		assert.EqualError(t, err, "key is required")
+		assert.EqualError(t, err, ErrRequiredKey.Error())
 	})
 
 	t.Run("when options has an empty key", func(t *testing.T) {
@@ -176,7 +176,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		}
 
 		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
-		assert.EqualError(t, err, "key is required")
+		assert.EqualError(t, err, ErrRequiredKey.Error())
 	})
 
 	t.Run("when options is missing category", func(t *testing.T) {
@@ -186,7 +186,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		}
 
 		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
-		assert.EqualError(t, err, "category is required")
+		assert.EqualError(t, err, ErrRequiredCategory.Error())
 	})
 
 	t.Run("when workspace ID is invalid", func(t *testing.T) {
@@ -197,7 +197,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		}
 
 		_, err := client.VariableSetVariables.Create(ctx, badIdentifier, &options)
-		assert.EqualError(t, err, "invalid value for variable set ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 }
 
@@ -234,13 +234,13 @@ func TestVariableSetVariablesRead(t *testing.T) {
 	t.Run("without a valid variable set ID", func(t *testing.T) {
 		v, err := client.VariableSetVariables.Read(ctx, badIdentifier, vTest.ID)
 		assert.Nil(t, v)
-		assert.EqualError(t, err, "invalid value for variable set ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 
 	t.Run("without a valid variable ID", func(t *testing.T) {
 		v, err := client.VariableSetVariables.Read(ctx, vsTest.ID, badIdentifier)
 		assert.Nil(t, v)
-		assert.EqualError(t, err, "invalid value for variable ID")
+		assert.EqualError(t, err, ErrInvalidVariableID.Error())
 	})
 }
 
@@ -314,12 +314,12 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 
 	t.Run("with invalid variable ID", func(t *testing.T) {
 		_, err := client.VariableSetVariables.Update(ctx, badIdentifier, vTest.ID, nil)
-		assert.EqualError(t, err, "invalid value for variable set ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 
 	t.Run("with invalid variable ID", func(t *testing.T) {
 		_, err := client.VariableSetVariables.Update(ctx, vsTest.ID, badIdentifier, nil)
-		assert.EqualError(t, err, "invalid value for variable ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 }
 
@@ -339,16 +339,16 @@ func TestVariableSetVariablesDelete(t *testing.T) {
 
 	t.Run("with non existing variable ID", func(t *testing.T) {
 		err := client.VariableSetVariables.Delete(ctx, vsTest.ID, "nonexisting")
-		assert.Equal(t, err, ErrResourceNotFound)
+		assert.Equal(t, err, ErrResourceNotFound.Error())
 	})
 
 	t.Run("with invalid workspace ID", func(t *testing.T) {
 		err := client.VariableSetVariables.Delete(ctx, badIdentifier, vTest.ID)
-		assert.EqualError(t, err, "invalid value for variable set ID")
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
 	})
 
 	t.Run("with invalid variable ID", func(t *testing.T) {
 		err := client.VariableSetVariables.Delete(ctx, vsTest.ID, badIdentifier)
-		assert.EqualError(t, err, "invalid value for variable ID")
+		assert.EqualError(t, err, ErrInvalidVariableID.Error())
 	})
 }

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -135,7 +135,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		options := VariableSetVariableCreateOptions{
 			Key:         String(randomString(t)),
 			Value:       String(randomString(t)),
-			Description: String("tortor aliquam nulla facilisi cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla facilisi morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
+			Description: String("tortor aliquam nulla redacted cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla redacted morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
 			Category:    Category(CategoryTerraform),
 		}
 

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -319,7 +319,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 
 	t.Run("with invalid variable ID", func(t *testing.T) {
 		_, err := client.VariableSetVariables.Update(ctx, vsTest.ID, badIdentifier, nil)
-		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
+		assert.EqualError(t, err, ErrInvalidVariableID.Error())
 	})
 }
 
@@ -339,7 +339,7 @@ func TestVariableSetVariablesDelete(t *testing.T) {
 
 	t.Run("with non existing variable ID", func(t *testing.T) {
 		err := client.VariableSetVariables.Delete(ctx, vsTest.ID, "nonexisting")
-		assert.Equal(t, err, ErrResourceNotFound.Error())
+		assert.EqualError(t, err, ErrResourceNotFound.Error())
 	})
 
 	t.Run("with invalid workspace ID", func(t *testing.T) {

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -31,7 +31,7 @@ func TestVariableSetVariablesList(t *testing.T) {
 	defer vTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
-		vl, err := client.VariableSetVariables.List(ctx, vsTest.ID, VariableSetVariableListOptions{})
+		vl, err := client.VariableSetVariables.List(ctx, vsTest.ID, nil)
 		require.NoError(t, err)
 		assert.Contains(t, vl.Items, vTest1)
 		assert.Contains(t, vl.Items, vTest2)
@@ -46,7 +46,7 @@ func TestVariableSetVariablesList(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		vl, err := client.VariableSetVariables.List(ctx, vsTest.ID, VariableSetVariableListOptions{
+		vl, err := client.VariableSetVariables.List(ctx, vsTest.ID, &VariableSetVariableListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -59,7 +59,7 @@ func TestVariableSetVariablesList(t *testing.T) {
 	})
 
 	t.Run("when variable set ID is invalid ID", func(t *testing.T) {
-		vl, err := client.VariableSetVariables.List(ctx, badIdentifier, VariableSetVariableListOptions{})
+		vl, err := client.VariableSetVariables.List(ctx, badIdentifier, nil)
 		assert.Nil(t, vl)
 		assert.EqualError(t, err, "invalid value for variable set ID")
 	})
@@ -85,7 +85,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Sensitive:   Bool(false),
 		}
 
-		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, v.ID)
@@ -103,7 +103,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Category:    Category(CategoryTerraform),
 		}
 
-		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, v.ID)
@@ -121,7 +121,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Category:    Category(CategoryTerraform),
 		}
 
-		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, v.ID)
@@ -139,7 +139,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Category:    Category(CategoryTerraform),
 		}
 
-		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		assert.Error(t, err)
 	})
 
@@ -149,7 +149,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Category: Category(CategoryTerraform),
 		}
 
-		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		v, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, v.ID)
@@ -164,7 +164,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Category: Category(CategoryTerraform),
 		}
 
-		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		assert.EqualError(t, err, "key is required")
 	})
 
@@ -175,7 +175,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Category: Category(CategoryTerraform),
 		}
 
-		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		assert.EqualError(t, err, "key is required")
 	})
 
@@ -185,7 +185,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Value: String(randomString(t)),
 		}
 
-		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, options)
+		_, err := client.VariableSetVariables.Create(ctx, vsTest.ID, &options)
 		assert.EqualError(t, err, "category is required")
 	})
 
@@ -196,7 +196,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 			Category: Category(CategoryTerraform),
 		}
 
-		_, err := client.VariableSetVariables.Create(ctx, badIdentifier, options)
+		_, err := client.VariableSetVariables.Create(ctx, badIdentifier, &options)
 		assert.EqualError(t, err, "invalid value for variable set ID")
 	})
 }
@@ -218,7 +218,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 			HCL:   Bool(true),
 		}
 
-		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, options)
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Key, v.Key)
@@ -232,7 +232,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 			HCL: Bool(false),
 		}
 
-		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, options)
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Key, v.Key)
@@ -244,7 +244,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 			Sensitive: Bool(true),
 		}
 
-		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, options)
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Sensitive, v.Sensitive)
@@ -255,7 +255,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 		vTest, vTestCleanup := createVariableSetVariable(t, client, vsTest, VariableSetVariableCreateOptions{})
 		defer vTestCleanup()
 
-		ua := VariableSetVariableUpdateOptions{
+		options := VariableSetVariableUpdateOptions{
 			Key:         String(vTest.Key),
 			Value:       String(vTest.Value),
 			Description: String(vTest.Description),
@@ -263,19 +263,19 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 			HCL:         Bool(vTest.HCL),
 		}
 
-		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, ua)
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, &options)
 		require.NoError(t, err)
 
 		assert.Equal(t, vTest, v)
 	})
 
 	t.Run("with invalid variable ID", func(t *testing.T) {
-		_, err := client.VariableSetVariables.Update(ctx, badIdentifier, vTest.ID, VariableSetVariableUpdateOptions{})
+		_, err := client.VariableSetVariables.Update(ctx, badIdentifier, vTest.ID, nil)
 		assert.EqualError(t, err, "invalid value for variable set ID")
 	})
 
 	t.Run("with invalid variable ID", func(t *testing.T) {
-		_, err := client.VariableSetVariables.Update(ctx, vsTest.ID, badIdentifier, VariableSetVariableUpdateOptions{})
+		_, err := client.VariableSetVariables.Update(ctx, vsTest.ID, badIdentifier, nil)
 		assert.EqualError(t, err, "invalid value for variable ID")
 	})
 }

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -201,6 +201,49 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 	})
 }
 
+func TestVariableSetVariablesRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	vsTest, vsTestCleanup := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+	defer vsTestCleanup()
+
+	vTest, vTestCleanup := createVariableSetVariable(t, client, vsTest, VariableSetVariableCreateOptions{})
+	defer vTestCleanup()
+
+	t.Run("when the variable exists", func(t *testing.T) {
+		v, err := client.VariableSetVariables.Read(ctx, vsTest.ID, vTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, vTest.ID, v.ID)
+		assert.Equal(t, vTest.Category, v.Category)
+		assert.Equal(t, vTest.HCL, v.HCL)
+		assert.Equal(t, vTest.Key, v.Key)
+		assert.Equal(t, vTest.Sensitive, v.Sensitive)
+		assert.Equal(t, vTest.Value, v.Value)
+	})
+
+	t.Run("when the variable does not exist", func(t *testing.T) {
+		v, err := client.VariableSetVariables.Read(ctx, vsTest.ID, "nonexisting")
+		assert.Nil(t, v)
+		assert.Equal(t, ErrResourceNotFound, err)
+	})
+
+	t.Run("without a valid variable set ID", func(t *testing.T) {
+		v, err := client.VariableSetVariables.Read(ctx, badIdentifier, vTest.ID)
+		assert.Nil(t, v)
+		assert.EqualError(t, err, "invalid value for variable set ID")
+	})
+
+	t.Run("without a valid variable ID", func(t *testing.T) {
+		v, err := client.VariableSetVariables.Read(ctx, vsTest.ID, badIdentifier)
+		assert.Nil(t, v)
+		assert.EqualError(t, err, "invalid value for variable ID")
+	})
+}
+
 func TestVariableSetVariablesUpdate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -205,7 +205,10 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	vTest, vTestCleanup := createVariableSetVariable(t, client, nil, VariableSetVariableCreateOptions{})
+	vsTest, vsTestCleanup := createVariableSet(t, client, nil, VariableSetCreateOptions{})
+	defer vsTestCleanup()
+
+	vTest, vTestCleanup := createVariableSetVariable(t, client, vsTest, VariableSetVariableCreateOptions{})
 	defer vTestCleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
@@ -215,7 +218,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 			HCL:   Bool(true),
 		}
 
-		v, err := client.VariableSetVariables.Update(ctx, vTest.VariableSet.ID, vTest.ID, options)
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, options)
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Key, v.Key)
@@ -229,7 +232,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 			HCL: Bool(false),
 		}
 
-		v, err := client.VariableSetVariables.Update(ctx, vTest.VariableSet.ID, vTest.ID, options)
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, options)
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Key, v.Key)
@@ -241,7 +244,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 			Sensitive: Bool(true),
 		}
 
-		v, err := client.VariableSetVariables.Update(ctx, vTest.VariableSet.ID, vTest.ID, options)
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, options)
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Sensitive, v.Sensitive)
@@ -249,10 +252,18 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 	})
 
 	t.Run("without any changes", func(t *testing.T) {
-		vTest, vTestCleanup := createVariableSetVariable(t, client, nil, VariableSetVariableCreateOptions{})
+		vTest, vTestCleanup := createVariableSetVariable(t, client, vsTest, VariableSetVariableCreateOptions{})
 		defer vTestCleanup()
 
-		v, err := client.VariableSetVariables.Update(ctx, vTest.VariableSet.ID, vTest.ID, VariableSetVariableUpdateOptions{})
+		ua := VariableSetVariableUpdateOptions{
+			Key:         String(vTest.Key),
+			Value:       String(vTest.Value),
+			Description: String(vTest.Description),
+			Sensitive:   Bool(vTest.Sensitive),
+			HCL:         Bool(vTest.HCL),
+		}
+
+		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, ua)
 		require.NoError(t, err)
 
 		assert.Equal(t, vTest, v)
@@ -264,7 +275,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 	})
 
 	t.Run("with invalid variable ID", func(t *testing.T) {
-		_, err := client.VariableSetVariables.Update(ctx, vTest.VariableSet.ID, badIdentifier, VariableSetVariableUpdateOptions{})
+		_, err := client.VariableSetVariables.Update(ctx, vsTest.ID, badIdentifier, VariableSetVariableUpdateOptions{})
 		assert.EqualError(t, err, "invalid value for variable ID")
 	})
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Fixes #284

This adds functionality for managing Variable Sets and their Variables. The plan is 

## Testing plan

1. CRUD a Variable Set.
2. CRUD some Variables against a Variable Set.
3. Assign a Variable Set to some workspaces.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/variable-sets)
- Related Terraform Provider PR soon to come.

-->

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->

NOTE: TFE Tests are expected to fail because of extant feature flagging.

```
🍔_alex: go-tfe $ envchain gotfe go test -run "^TestVariableSet.+" -v ./... -tags=integration
=== RUN   TestVariableSetsList
=== RUN   TestVariableSetsList/without_list_options
    variable_set_test.go:32: paging not supported yet in API
=== RUN   TestVariableSetsList/with_list_options
    variable_set_test.go:38: paging not supported yet in API
=== RUN   TestVariableSetsList/when_Organization_name_is_invalid_ID
--- PASS: TestVariableSetsList (1.53s)
    --- SKIP: TestVariableSetsList/without_list_options (0.19s)
    --- SKIP: TestVariableSetsList/with_list_options (0.00s)
    --- PASS: TestVariableSetsList/when_Organization_name_is_invalid_ID (0.00s)
=== RUN   TestVariableSetsCreate
=== RUN   TestVariableSetsCreate/with_valid_options
=== RUN   TestVariableSetsCreate/when_options_is_missing_name
=== RUN   TestVariableSetsCreate/when_options_is_missing_global_flag
--- PASS: TestVariableSetsCreate (0.98s)
    --- PASS: TestVariableSetsCreate/with_valid_options (0.20s)
    --- PASS: TestVariableSetsCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestVariableSetsCreate/when_options_is_missing_global_flag (0.00s)
=== RUN   TestVariableSetsRead
=== RUN   TestVariableSetsRead/when_the_variable_set_exists
=== RUN   TestVariableSetsRead/when_variable_set_does_not_exist
--- PASS: TestVariableSetsRead (1.27s)
    --- PASS: TestVariableSetsRead/when_the_variable_set_exists (0.10s)
    --- PASS: TestVariableSetsRead/when_variable_set_does_not_exist (0.19s)
=== RUN   TestVariableSetsUpdate
=== RUN   TestVariableSetsUpdate/when_updating_a_subset_of_values
=== RUN   TestVariableSetsUpdate/when_options_has_an_invalid_variable_set_ID
--- PASS: TestVariableSetsUpdate (0.92s)
    --- PASS: TestVariableSetsUpdate/when_updating_a_subset_of_values (0.10s)
    --- PASS: TestVariableSetsUpdate/when_options_has_an_invalid_variable_set_ID (0.00s)
=== RUN   TestVariableSetsDelete
=== RUN   TestVariableSetsDelete/with_valid_ID
=== RUN   TestVariableSetsDelete/when_ID_is_invlaid
--- PASS: TestVariableSetsDelete (0.99s)
    --- PASS: TestVariableSetsDelete/with_valid_ID (0.19s)
    --- PASS: TestVariableSetsDelete/when_ID_is_invlaid (0.00s)
=== RUN   TestVariableSetsAssign
=== RUN   TestVariableSetsAssign/with_valid_workspaces
--- PASS: TestVariableSetsAssign (1.36s)
    --- PASS: TestVariableSetsAssign/with_valid_workspaces (0.33s)
=== RUN   TestVariableSetVariablesList
=== RUN   TestVariableSetVariablesList/without_list_options
    variable_set_variable_test.go:39: paging not supported yet in API
=== RUN   TestVariableSetVariablesList/with_list_options
    variable_set_variable_test.go:45: paging not supported yet in API
=== RUN   TestVariableSetVariablesList/when_variable_set_ID_is_invalid_ID
--- PASS: TestVariableSetVariablesList (1.40s)
    --- SKIP: TestVariableSetVariablesList/without_list_options (0.17s)
    --- SKIP: TestVariableSetVariablesList/with_list_options (0.00s)
    --- PASS: TestVariableSetVariablesList/when_variable_set_ID_is_invalid_ID (0.00s)
=== RUN   TestVariableSetVariablesCreate
=== RUN   TestVariableSetVariablesCreate/with_valid_options
=== RUN   TestVariableSetVariablesCreate/when_options_has_an_empty_string_value
=== RUN   TestVariableSetVariablesCreate/when_options_has_an_empty_string_description
=== RUN   TestVariableSetVariablesCreate/when_options_has_a_too-long_description
=== RUN   TestVariableSetVariablesCreate/when_options_is_missing_value
=== RUN   TestVariableSetVariablesCreate/when_options_is_missing_key
=== RUN   TestVariableSetVariablesCreate/when_options_has_an_empty_key
=== RUN   TestVariableSetVariablesCreate/when_options_is_missing_category
=== RUN   TestVariableSetVariablesCreate/when_workspace_ID_is_invalid
--- PASS: TestVariableSetVariablesCreate (1.51s)
    --- PASS: TestVariableSetVariablesCreate/with_valid_options (0.13s)
    --- PASS: TestVariableSetVariablesCreate/when_options_has_an_empty_string_value (0.14s)
    --- PASS: TestVariableSetVariablesCreate/when_options_has_an_empty_string_description (0.11s)
    --- PASS: TestVariableSetVariablesCreate/when_options_has_a_too-long_description (0.09s)
    --- PASS: TestVariableSetVariablesCreate/when_options_is_missing_value (0.13s)
    --- PASS: TestVariableSetVariablesCreate/when_options_is_missing_key (0.00s)
    --- PASS: TestVariableSetVariablesCreate/when_options_has_an_empty_key (0.00s)
    --- PASS: TestVariableSetVariablesCreate/when_options_is_missing_category (0.00s)
    --- PASS: TestVariableSetVariablesCreate/when_workspace_ID_is_invalid (0.00s)
=== RUN   TestVariableSetVariablesRead
=== RUN   TestVariableSetVariablesRead/when_the_variable_exists
=== RUN   TestVariableSetVariablesRead/when_the_variable_does_not_exist
=== RUN   TestVariableSetVariablesRead/without_a_valid_variable_set_ID
=== RUN   TestVariableSetVariablesRead/without_a_valid_variable_ID
--- PASS: TestVariableSetVariablesRead (1.26s)
    --- PASS: TestVariableSetVariablesRead/when_the_variable_exists (0.13s)
    --- PASS: TestVariableSetVariablesRead/when_the_variable_does_not_exist (0.09s)
    --- PASS: TestVariableSetVariablesRead/without_a_valid_variable_set_ID (0.00s)
    --- PASS: TestVariableSetVariablesRead/without_a_valid_variable_ID (0.00s)
=== RUN   TestVariableSetVariablesUpdate
=== RUN   TestVariableSetVariablesUpdate/with_valid_options
=== RUN   TestVariableSetVariablesUpdate/when_updating_a_subset_of_values
=== RUN   TestVariableSetVariablesUpdate/with_sensitive_set
=== RUN   TestVariableSetVariablesUpdate/without_any_changes
=== RUN   TestVariableSetVariablesUpdate/with_invalid_variable_ID
=== RUN   TestVariableSetVariablesUpdate/with_invalid_variable_ID#01
--- PASS: TestVariableSetVariablesUpdate (1.66s)
    --- PASS: TestVariableSetVariablesUpdate/with_valid_options (0.11s)
    --- PASS: TestVariableSetVariablesUpdate/when_updating_a_subset_of_values (0.10s)
    --- PASS: TestVariableSetVariablesUpdate/with_sensitive_set (0.11s)
    --- PASS: TestVariableSetVariablesUpdate/without_any_changes (0.31s)
    --- PASS: TestVariableSetVariablesUpdate/with_invalid_variable_ID (0.00s)
    --- PASS: TestVariableSetVariablesUpdate/with_invalid_variable_ID#01 (0.00s)
=== RUN   TestVariableSetVariablesDelete
=== RUN   TestVariableSetVariablesDelete/with_valid_options
=== RUN   TestVariableSetVariablesDelete/with_non_existing_variable_ID
=== RUN   TestVariableSetVariablesDelete/with_invalid_workspace_ID
=== RUN   TestVariableSetVariablesDelete/with_invalid_variable_ID
--- PASS: TestVariableSetVariablesDelete (1.19s)
    --- PASS: TestVariableSetVariablesDelete/with_valid_options (0.13s)
    --- PASS: TestVariableSetVariablesDelete/with_non_existing_variable_ID (0.09s)
    --- PASS: TestVariableSetVariablesDelete/with_invalid_workspace_ID (0.00s)
    --- PASS: TestVariableSetVariablesDelete/with_invalid_variable_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	17.820s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```
