### PR TITLE
Add Manage Providers and Modules permissions

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -787,6 +787,8 @@ func createTeam(t *testing.T, client *Client, org *Organization) (*Team, func())
 		OrganizationAccess: &OrganizationAccessOptions{
 			ManagePolicies:        Bool(true),
 			ManagePolicyOverrides: Bool(true),
+			ManageProviders:       Bool(true),
+			ManageModules:         Bool(true),
 		},
 	})
 	if err != nil {

--- a/team.go
+++ b/team.go
@@ -62,6 +62,8 @@ type OrganizationAccess struct {
 	ManagePolicyOverrides bool `jsonapi:"attr,manage-policy-overrides"`
 	ManageWorkspaces      bool `jsonapi:"attr,manage-workspaces"`
 	ManageVCSSettings     bool `jsonapi:"attr,manage-vcs-settings"`
+	ManageProviders       bool `jsonapi:"attr,manage-providers"`
+	ManageModules         bool `jsonapi:"attr,manage-modules"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -122,6 +124,8 @@ type OrganizationAccessOptions struct {
 	ManagePolicyOverrides *bool `json:"manage-policy-overrides,omitempty"`
 	ManageWorkspaces      *bool `json:"manage-workspaces,omitempty"`
 	ManageVCSSettings     *bool `json:"manage-vcs-settings,omitempty"`
+	ManageProviders       *bool `json:"manage-providers,omitempty"`
+	ManageModules         *bool `json:"manage-modules,omitempty"`
 }
 
 func (o TeamCreateOptions) valid() error {

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -183,6 +183,8 @@ func TestTeamsUpdate(t *testing.T) {
 				ManagePolicies:        Bool(false),
 				ManageVCSSettings:     Bool(true),
 				ManagePolicyOverrides: Bool(true),
+				ManageProviders:       Bool(true),
+				ManageModules:         Bool(false),
 			},
 			Visibility: String("organization"),
 		}
@@ -213,6 +215,14 @@ func TestTeamsUpdate(t *testing.T) {
 			assert.Equal(t,
 				*options.OrganizationAccess.ManagePolicyOverrides,
 				item.OrganizationAccess.ManagePolicyOverrides,
+			)
+			assert.Equal(t,
+				*options.OrganizationAccess.ManageProviders,
+				item.OrganizationAccess.ManageProviders,
+			)
+			assert.Equal(t,
+				*options.OrganizationAccess.ManageModules,
+				item.OrganizationAccess.ManageModules,
 			)
 		}
 	})


### PR DESCRIPTION
## Description

Add manage providers and modules permissions

## External links

- [API documentation](https://www.terraform.io/cloud-docs/users-teams-organizations/permissions#organization-permissions)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/431)
