### PR TITLE
Add missing pointer type to listing functions

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -27,7 +27,7 @@ type AdminOrganizations interface {
 	Delete(ctx context.Context, organization string) error
 
 	// ListModuleConsumers lists specific organizations in the Terraform Enterprise installation that have permission to use an organization's modules.
-	ListModuleConsumers(ctx context.Context, organization string, options AdminOrganizationListModuleConsumersOptions) (*AdminOrganizationList, error)
+	ListModuleConsumers(ctx context.Context, organization string, options *AdminOrganizationListModuleConsumersOptions) (*AdminOrganizationList, error)
 
 	// UpdateModuleConsumers specifies a list of organizations that can use modules from the sharing organization's private registry. Setting a list of module consumers will turn off global module sharing for an organization.
 	UpdateModuleConsumers(ctx context.Context, organization string, consumerOrganizations []string) error
@@ -117,7 +117,7 @@ func (s *adminOrganizations) List(ctx context.Context, options *AdminOrganizatio
 	return orgl, nil
 }
 
-func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options AdminOrganizationListModuleConsumersOptions) (*AdminOrganizationList, error) {
+func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options *AdminOrganizationListModuleConsumersOptions) (*AdminOrganizationList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -170,7 +170,7 @@ func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
 		err := client.Admin.Organizations.UpdateModuleConsumers(ctx, org1.Name, []string{org2.Name})
 		assert.NoError(t, err)
 
-		adminModuleConsumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, AdminOrganizationListModuleConsumersOptions{})
+		adminModuleConsumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(adminModuleConsumerList.Items), 1)
@@ -182,7 +182,7 @@ func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org1.Name, []string{org3.Name})
 		assert.NoError(t, err)
 
-		adminModuleConsumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, AdminOrganizationListModuleConsumersOptions{})
+		adminModuleConsumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, nil)
 		require.NoError(t, err)
 
 		assert.Equal(t, len(adminModuleConsumerList.Items), 1)

--- a/mocks/admin_organization_mocks.go
+++ b/mocks/admin_organization_mocks.go
@@ -65,7 +65,7 @@ func (mr *MockAdminOrganizationsMockRecorder) List(ctx, options interface{}) *go
 }
 
 // ListModuleConsumers mocks base method.
-func (m *MockAdminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options tfe.AdminOrganizationListModuleConsumersOptions) (*tfe.AdminOrganizationList, error) {
+func (m *MockAdminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options *tfe.AdminOrganizationListModuleConsumersOptions) (*tfe.AdminOrganizationList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListModuleConsumers", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.AdminOrganizationList)

--- a/mocks/state_version_mocks.go
+++ b/mocks/state_version_mocks.go
@@ -111,7 +111,7 @@ func (mr *MockStateVersionsMockRecorder) List(ctx, options interface{}) *gomock.
 }
 
 // Outputs mocks base method.
-func (m *MockStateVersions) Outputs(ctx context.Context, svID string, options tfe.StateVersionOutputsListOptions) (*tfe.StateVersionOutputsList, error) {
+func (m *MockStateVersions) Outputs(ctx context.Context, svID string, options *tfe.StateVersionOutputsListOptions) (*tfe.StateVersionOutputsList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Outputs", ctx, svID, options)
 	ret0, _ := ret[0].(*tfe.StateVersionOutputsList)

--- a/state_version.go
+++ b/state_version.go
@@ -40,7 +40,7 @@ type StateVersions interface {
 	Download(ctx context.Context, url string) ([]byte, error)
 
 	// Outputs retrieves all the outputs of a state version by its ID.
-	Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
+	Outputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
 }
 
 // stateVersions implements StateVersions.
@@ -278,7 +278,7 @@ type StateVersionOutputsListOptions struct {
 }
 
 // Outputs retrieves all the outputs of a state version by its ID.
-func (s *stateVersions) Outputs(ctx context.Context, svID string, options StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {
+func (s *stateVersions) Outputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {
 	if !validStringID(&svID) {
 		return nil, errors.New("invalid value for state version ID")
 	}

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -441,7 +441,7 @@ func TestStateVersionOutputs(t *testing.T) {
 	time.Sleep(waitForStateVersionOutputs)
 
 	t.Run("when the state version exists", func(t *testing.T) {
-		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, StateVersionOutputsListOptions{})
+		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, nil)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, outputs.Items)
@@ -463,7 +463,7 @@ func TestStateVersionOutputs(t *testing.T) {
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		options := StateVersionOutputsListOptions{
+		options := &StateVersionOutputsListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -479,7 +479,7 @@ func TestStateVersionOutputs(t *testing.T) {
 	})
 
 	t.Run("when the state version does not exist", func(t *testing.T) {
-		outputs, err := client.StateVersions.Outputs(ctx, "sv-999999999", StateVersionOutputsListOptions{})
+		outputs, err := client.StateVersions.Outputs(ctx, "sv-999999999", nil)
 		assert.Nil(t, outputs)
 		assert.Error(t, err)
 	})

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -351,7 +351,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 		assert.Equal(t, wTest.ID, w.ID)
 		assert.NotEmpty(t, w.Outputs)
 
-		svOutputs, err := client.StateVersions.Outputs(ctx, svTest.ID, StateVersionOutputsListOptions{})
+		svOutputs, err := client.StateVersions.Outputs(ctx, svTest.ID, nil)
 		require.NoError(t, err)
 
 		assert.Len(t, w.Outputs, len(svOutputs.Items))


### PR DESCRIPTION
This PR is just a quick follow-up to this other PR https://github.com/hashicorp/go-tfe/pull/291
We are just adding more pointers to other listOptions arguments that were not included in the previous PR.
