### PR TITLE
Remove dereference to pointer for include and query fields for ListOption structs

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -86,9 +86,9 @@ type AdminOrganizationListOptions struct {
 
 	// A query string used to filter organizations.
 	// Any organizations with a name or notification email partially matching this value will be returned.
-	Query *string `url:"q,omitempty"`
+	Query string `url:"q,omitempty"`
 
-	Include *[]AdminOrgIncludeOps `url:"include,omitempty"`
+	Include []AdminOrgIncludeOps `url:"include,omitempty"`
 }
 
 // AdminOrganizationListModuleConsumersOptions represents the options for listing organization module consumers through the Admin API

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -37,7 +37,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 		defer orgTestCleanup()
 
 		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
-			Query: &org.Name,
+			Query: org.Name,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, true, adminOrgItemsContainsName(adminOrgList.Items, org.Name))
@@ -49,7 +49,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 		randomName := "random-org-name"
 
 		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
-			Query: &randomName,
+			Query: randomName,
 		})
 		assert.NoError(t, err)
 		assert.Equal(t, false, adminOrgItemsContainsName(adminOrgList.Items, org.Name))
@@ -59,7 +59,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 
 	t.Run("with owners included", func(t *testing.T) {
 		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
-			Include: &([]AdminOrgIncludeOps{AdminOrgOwners}),
+			Include: []AdminOrgIncludeOps{AdminOrgOwners},
 		})
 		assert.NoError(t, err)
 

--- a/admin_run.go
+++ b/admin_run.go
@@ -62,9 +62,9 @@ const (
 type AdminRunsListOptions struct {
 	ListOptions
 
-	RunStatus *string               `url:"filter[status],omitempty"`
-	Query     *string               `url:"q,omitempty"`
-	Include   *[]AdminRunIncludeOps `url:"include,omitempty"`
+	RunStatus string               `url:"filter[status],omitempty"`
+	Query     string               `url:"q,omitempty"`
+	Include   []AdminRunIncludeOps `url:"include,omitempty"`
 }
 
 // List all the runs of the terraform enterprise installation.
@@ -116,7 +116,7 @@ func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options Admin
 
 // Check that the field RunStatus has a valid string value
 func (o AdminRunsListOptions) valid() error {
-	if validString(o.RunStatus) {
+	if validString(&o.RunStatus) {
 		validRunStatus := map[string]int{
 			string(RunApplied):            1,
 			string(RunApplyQueued):        1,
@@ -137,7 +137,7 @@ func (o AdminRunsListOptions) valid() error {
 			string(RunPolicyOverride):     1,
 			string(RunPolicySoftFailed):   1,
 		}
-		runStatus := strings.Split(*o.RunStatus, ",")
+		runStatus := strings.Split(o.RunStatus, ",")
 
 		// iterate over our statuses, and ensure it is valid.
 		for _, status := range runStatus {

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -69,7 +69,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with workspace included", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			Include: &([]AdminRunIncludeOps{AdminRunWorkspace}),
+			Include: []AdminRunIncludeOps{AdminRunWorkspace},
 		})
 
 		assert.NoError(t, err)
@@ -81,7 +81,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with workspace.organization included", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			Include: &([]AdminRunIncludeOps{AdminRunWorkspaceOrg}),
+			Include: []AdminRunIncludeOps{AdminRunWorkspaceOrg},
 		})
 
 		assert.NoError(t, err)
@@ -100,7 +100,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 		// There should be pending Runs
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			RunStatus: String(string(RunPending)),
+			RunStatus: string(RunPending),
 		})
 		assert.NoError(t, err)
 		assert.NotEmpty(t, rl.Items)
@@ -114,7 +114,7 @@ func TestAdminRuns_List(t *testing.T) {
 	t.Run("with RunStatus.applied filter", func(t *testing.T) {
 		// There should be no applied Runs
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			RunStatus: String(string(RunApplied)),
+			RunStatus: string(RunApplied),
 		})
 		assert.NoError(t, err)
 		assert.Empty(t, rl.Items)
@@ -122,7 +122,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with query", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			Query: String(rTest1.ID),
+			Query: rTest1.ID,
 		})
 		assert.NoError(t, err)
 
@@ -131,7 +131,7 @@ func TestAdminRuns_List(t *testing.T) {
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), false)
 
 		rl, err = client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			Query: String(rTest2.ID),
+			Query: rTest2.ID,
 		})
 		assert.NoError(t, err)
 
@@ -219,7 +219,7 @@ func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
 
 	t.Run("has valid status", func(t *testing.T) {
 		opts := AdminRunsListOptions{
-			RunStatus: String(string(RunPending)),
+			RunStatus: string(RunPending),
 		}
 
 		err := opts.valid()
@@ -228,7 +228,7 @@ func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
 
 	t.Run("has invalid status", func(t *testing.T) {
 		opts := AdminRunsListOptions{
-			RunStatus: String("random_status"),
+			RunStatus: "random_status",
 		}
 
 		err := opts.valid()
@@ -238,7 +238,7 @@ func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
 	t.Run("has invalid status, even with a valid one", func(t *testing.T) {
 		statuses := fmt.Sprintf("%s,%s", string(RunPending), "random_status")
 		opts := AdminRunsListOptions{
-			RunStatus: String(statuses),
+			RunStatus: statuses,
 		}
 
 		err := opts.valid()

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -58,10 +58,10 @@ type AdminTerraformVersionsListOptions struct {
 	ListOptions
 
 	// A query string to find an exact version
-	Filter *string `url:"filter[version],omitempty"`
+	Filter string `url:"filter[version],omitempty"`
 
 	// A search query string to find all versions that match version substring
-	Search *string `url:"search[version],omitempty"`
+	Search string `url:"search[version],omitempty"`
 }
 
 // AdminTerraformVersionsList represents a list of terraform versions.

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -66,14 +66,14 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 
 	t.Run("with filter query string", func(t *testing.T) {
 		tfList, err := client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
-			Filter: String("1.0.4"),
+			Filter: "1.0.4",
 		})
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(tfList.Items))
 
 		// Query for a Terraform version that does not exist
 		tfList, err = client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
-			Filter: String("1000.1000.42"),
+			Filter: "1000.1000.42",
 		})
 		require.NoError(t, err)
 		assert.Empty(t, tfList.Items)
@@ -82,7 +82,7 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 	t.Run("with search version query string", func(t *testing.T) {
 		searchVersion := "1.0"
 		tfList, err := client.Admin.TerraformVersions.List(ctx, &AdminTerraformVersionsListOptions{
-			Search: String(searchVersion),
+			Search: searchVersion,
 		})
 		require.NoError(t, err)
 		assert.NotEmpty(t, tfList.Items)

--- a/admin_user.go
+++ b/admin_user.go
@@ -78,15 +78,15 @@ type AdminUserListOptions struct {
 	ListOptions
 
 	// A search query string. Users are searchable by username and email address.
-	Query *string `url:"q,omitempty"`
+	Query string `url:"q,omitempty"`
 
 	// Can be "true" or "false" to show only administrators or non-administrators.
-	Administrators *string `url:"filter[admin]"`
+	Administrators string `url:"filter[admin]"`
 
 	// Can be "true" or "false" to show only suspended users or users who are not suspended.
-	SuspendedUsers *string `url:"filter[suspended]"`
+	SuspendedUsers string `url:"filter[suspended]"`
 
-	Include *[]AdminUserIncludeOps `url:"include,omitempty"`
+	Include []AdminUserIncludeOps `url:"include,omitempty"`
 }
 
 // List all user accounts in the Terraform Enterprise installation

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -55,7 +55,7 @@ func TestAdminUsers_List(t *testing.T) {
 
 	t.Run("query by username or email", func(t *testing.T) {
 		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
-			Query: String(currentUser.Username),
+			Query: currentUser.Username,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, currentUser.ID, ul.Items[0].ID)
@@ -66,7 +66,7 @@ func TestAdminUsers_List(t *testing.T) {
 		defer memberCleanup()
 
 		ul, err = client.Admin.Users.List(ctx, &AdminUserListOptions{
-			Query: String(member.User.Email),
+			Query: member.User.Email,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, member.User.Email, ul.Items[0].Email)
@@ -76,7 +76,7 @@ func TestAdminUsers_List(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
-			Include: &([]AdminUserIncludeOps{AdminUserOrgs}),
+			Include: []AdminUserIncludeOps{AdminUserOrgs},
 		})
 
 		assert.NoError(t, err)
@@ -88,7 +88,7 @@ func TestAdminUsers_List(t *testing.T) {
 
 	t.Run("filter by admin", func(t *testing.T) {
 		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
-			Administrators: String("true"),
+			Administrators: "true",
 		})
 
 		assert.NoError(t, err)
@@ -116,7 +116,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 		member, _ := createOrganizationMembership(t, client, org)
 
 		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
-			Query: String(member.User.Email),
+			Query: member.User.Email,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, member.User.Email, ul.Items[0].Email)
@@ -127,7 +127,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 		require.NoError(t, err)
 
 		ul, err = client.Admin.Users.List(ctx, &AdminUserListOptions{
-			Query: String(member.User.Email),
+			Query: member.User.Email,
 		})
 		require.NoError(t, err)
 		assert.Empty(t, ul.Items)

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -61,9 +61,9 @@ type AdminWorkspaceListOptions struct {
 
 	// A query string (partial workspace name) used to filter the results.
 	// https://www.terraform.io/docs/cloud/api/admin/workspaces.html#query-parameters
-	Query *string `url:"q,omitempty"`
+	Query string `url:"q,omitempty"`
 
-	Include *[]AdminWorkspaceIncludeOps `url:"include,omitempty"`
+	Include []AdminWorkspaceIncludeOps `url:"include,omitempty"`
 }
 
 // AdminWorkspaceList represents a list of workspaces.

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -65,7 +65,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		// Use a known workspace prefix as search attribute. The result
 		// should be successful and only contain the matching workspace.
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
-			Query: String(wTest1.Name),
+			Query: wTest1.Name,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, adminWorkspaceItemsContainsID(wl.Items, wTest1.ID), true)
@@ -78,7 +78,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		// Use a nonexisting workspace name as search attribute. The result
 		// should be successful, but return no results.
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
-			Query: String("nonexisting"),
+			Query: "nonexisting",
 		})
 		require.NoError(t, err)
 		assert.Empty(t, wl.Items)
@@ -88,7 +88,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
-			Include: &([]AdminWorkspaceIncludeOps{AdminWorkspaceOrg}),
+			Include: []AdminWorkspaceIncludeOps{AdminWorkspaceOrg},
 		})
 
 		assert.NoError(t, err)
@@ -109,7 +109,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		assert.NoError(t, err)
 
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
-			Include: &([]AdminWorkspaceIncludeOps{AdminWorkspaceCurrentRun}),
+			Include: []AdminWorkspaceIncludeOps{AdminWorkspaceCurrentRun},
 		})
 
 		assert.NoError(t, err)

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -117,7 +117,7 @@ type ConfigurationVersionReadOptions struct {
 type ConfigurationVersionListOptions struct {
 	ListOptions
 
-	Include *[]ConfigurationVersionIncludeOps `url:"include,omitempty"`
+	Include []ConfigurationVersionIncludeOps `url:"include,omitempty"`
 }
 
 // IngressAttributes include commit information associated with configuration versions sourced from VCS.

--- a/organization_tags.go
+++ b/organization_tags.go
@@ -46,7 +46,7 @@ type OrganizationTag struct {
 type OrganizationTagsListOptions struct {
 	ListOptions
 
-	Filter *string `url:"filter[exclude][taggable][id],omitempty"`
+	Filter string `url:"filter[exclude][taggable][id],omitempty"`
 }
 
 // List all the tags in an organization. You can provide query params through OrganizationTagsListOptions

--- a/organization_tags_integration_test.go
+++ b/organization_tags_integration_test.go
@@ -63,7 +63,7 @@ func TestOrganizationTagsList(t *testing.T) {
 				PageNumber: 1,
 				PageSize:   5,
 			},
-			Filter: &testTagID,
+			Filter: testTagID,
 		})
 		require.NoError(t, err)
 

--- a/policy.go
+++ b/policy.go
@@ -84,7 +84,7 @@ type PolicyListOptions struct {
 	ListOptions
 
 	// A search string (partial policy name) used to filter the results.
-	Search *string `url:"search[name],omitempty"`
+	Search string `url:"search[name],omitempty"`
 }
 
 // List all the policies for a given organization

--- a/policy_integration_test.go
+++ b/policy_integration_test.go
@@ -60,7 +60,7 @@ func TestPoliciesList(t *testing.T) {
 		// Search by one of the policy's names; we should get only that policy
 		// and pagination data should reflect the search as well
 		pl, err := client.Policies.List(ctx, orgTest.Name, &PolicyListOptions{
-			Search: &pTest1.Name,
+			Search: pTest1.Name,
 		})
 		require.NoError(t, err)
 

--- a/policy_set.go
+++ b/policy_set.go
@@ -93,7 +93,7 @@ type PolicySetListOptions struct {
 	ListOptions
 
 	// A search string (partial policy set name) used to filter the results.
-	Search *string `url:"search[name],omitempty"`
+	Search string `url:"search[name],omitempty"`
 }
 
 // List all the policies for a given organization.

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -58,7 +58,7 @@ func TestPolicySetsList(t *testing.T) {
 		// Search by one of the policy set's names; we should get only that policy
 		// set and pagination data should reflect the search as well
 		psl, err := client.PolicySets.List(ctx, orgTest.Name, &PolicySetListOptions{
-			Search: String(psTest1.Name),
+			Search: psTest1.Name,
 		})
 		require.NoError(t, err)
 

--- a/run.go
+++ b/run.go
@@ -174,7 +174,7 @@ const (
 type RunListOptions struct {
 	ListOptions
 
-	Include *[]RunIncludeOps `url:"include,omitempty"`
+	Include []RunIncludeOps `url:"include,omitempty"`
 }
 
 // RunVariable represents a variable that can be applied to a run. All values must be expressed as an HCL literal

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -42,7 +42,7 @@ func TestRunsList(t *testing.T) {
 
 	t.Run("without list options and include as nil", func(t *testing.T) {
 		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
-			Include: nil,
+			Include: []RunIncludeOps{},
 		})
 		require.NoError(t, err)
 
@@ -77,7 +77,7 @@ func TestRunsList(t *testing.T) {
 
 	t.Run("with workspace included", func(t *testing.T) {
 		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
-			Include: &([]RunIncludeOps{RunWorkspace}),
+			Include: []RunIncludeOps{RunWorkspace},
 		})
 
 		assert.NoError(t, err)

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -58,7 +58,7 @@ type RunTrigger struct {
 // run triggers.
 type RunTriggerListOptions struct {
 	ListOptions
-	RunTriggerType *string `url:"filter[run-trigger][type]"`
+	RunTriggerType string `url:"filter[run-trigger][type]"`
 }
 
 // List all the run triggers associated with a workspace.

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -37,7 +37,7 @@ func TestRunTriggerList(t *testing.T) {
 			ctx,
 			wTest.ID,
 			&RunTriggerListOptions{
-				RunTriggerType: String("inbound"),
+				RunTriggerType: "inbound",
 			},
 		)
 		require.NoError(t, err)
@@ -59,7 +59,7 @@ func TestRunTriggerList(t *testing.T) {
 					PageNumber: 999,
 					PageSize:   100,
 				},
-				RunTriggerType: String("inbound"),
+				RunTriggerType: "inbound",
 			},
 		)
 		require.NoError(t, err)
@@ -73,7 +73,7 @@ func TestRunTriggerList(t *testing.T) {
 			ctx,
 			badIdentifier,
 			&RunTriggerListOptions{
-				RunTriggerType: String("inbound"),
+				RunTriggerType: "inbound",
 			},
 		)
 		assert.Nil(t, rtl)
@@ -95,7 +95,7 @@ func TestRunTriggerList(t *testing.T) {
 			ctx,
 			wTest.ID,
 			&RunTriggerListOptions{
-				RunTriggerType: String("invalid"),
+				RunTriggerType: "invalid",
 			},
 		)
 		assert.Nil(t, rtl)

--- a/state_version.go
+++ b/state_version.go
@@ -71,16 +71,16 @@ type StateVersion struct {
 // StateVersionListOptions represents the options for listing state versions.
 type StateVersionListOptions struct {
 	ListOptions
-	Organization *string `url:"filter[organization][name]"`
-	Workspace    *string `url:"filter[workspace][name]"`
+	Organization string `url:"filter[organization][name]"`
+	Workspace    string `url:"filter[workspace][name]"`
 }
 
 //check that StateVersionListOptions fields had valid values
 func (o StateVersionListOptions) valid() error {
-	if !validString(o.Organization) {
+	if !validString(&o.Organization) {
 		return errors.New("organization is required")
 	}
-	if !validString(o.Workspace) {
+	if !validString(&o.Workspace) {
 		return errors.New("workspace is required")
 	}
 	return nil

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -39,8 +39,8 @@ func TestStateVersionsList(t *testing.T) {
 
 	t.Run("without list options", func(t *testing.T) {
 		options := &StateVersionListOptions{
-			Organization: String(orgTest.Name),
-			Workspace:    String(wTest.Name),
+			Organization: orgTest.Name,
+			Workspace:    wTest.Name,
 		}
 
 		svl, err := client.StateVersions.List(ctx, options)
@@ -78,8 +78,8 @@ func TestStateVersionsList(t *testing.T) {
 				PageNumber: 999,
 				PageSize:   100,
 			},
-			Organization: String(orgTest.Name),
-			Workspace:    String(wTest.Name),
+			Organization: orgTest.Name,
+			Workspace:    wTest.Name,
 		}
 
 		svl, err := client.StateVersions.List(ctx, options)
@@ -91,7 +91,7 @@ func TestStateVersionsList(t *testing.T) {
 
 	t.Run("without an organization", func(t *testing.T) {
 		options := &StateVersionListOptions{
-			Workspace: String(wTest.Name),
+			Workspace: wTest.Name,
 		}
 
 		svl, err := client.StateVersions.List(ctx, options)
@@ -101,7 +101,7 @@ func TestStateVersionsList(t *testing.T) {
 
 	t.Run("without a workspace", func(t *testing.T) {
 		options := &StateVersionListOptions{
-			Organization: String(orgTest.Name),
+			Organization: orgTest.Name,
 		}
 
 		svl, err := client.StateVersions.List(ctx, options)

--- a/team_access.go
+++ b/team_access.go
@@ -104,15 +104,15 @@ type TeamAccess struct {
 // TeamAccessListOptions represents the options for listing team accesses.
 type TeamAccessListOptions struct {
 	ListOptions
-	WorkspaceID *string `url:"filter[workspace][id],omitempty"`
+	WorkspaceID string `url:"filter[workspace][id],omitempty"`
 }
 
 //check that workspaceID field has a valid value
 func (o TeamAccessListOptions) valid() error {
-	if !validString(o.WorkspaceID) {
+	if !validString(&o.WorkspaceID) {
 		return errors.New("workspace ID is required")
 	}
-	if !validStringID(o.WorkspaceID) {
+	if !validStringID(&o.WorkspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 	return nil

--- a/team_access_integration_test.go
+++ b/team_access_integration_test.go
@@ -35,7 +35,7 @@ func TestTeamAccessesList(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		tal, err := client.TeamAccess.List(ctx, &TeamAccessListOptions{
-			WorkspaceID: String(wTest.ID),
+			WorkspaceID: wTest.ID,
 		})
 		require.NoError(t, err)
 		assert.Contains(t, tal.Items, taTest1)
@@ -82,7 +82,7 @@ func TestTeamAccessesList(t *testing.T) {
 
 	t.Run("without a valid workspaceID", func(t *testing.T) {
 		tal, err := client.TeamAccess.List(ctx, &TeamAccessListOptions{
-			WorkspaceID: String(badIdentifier),
+			WorkspaceID: badIdentifier,
 		})
 		assert.Nil(t, tal)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())

--- a/workspace.go
+++ b/workspace.go
@@ -230,10 +230,10 @@ type WorkspaceListOptions struct {
 	ListOptions
 
 	// A search string (partial workspace name) used to filter the results.
-	Search *string `url:"search[name],omitempty"`
+	Search string `url:"search[name],omitempty"`
 
 	// A search string (comma-separated tag names) used to filter the results.
-	Tags *string `url:"search[tags],omitempty"`
+	Tags string `url:"search[tags],omitempty"`
 
 	// A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
 	Include []WSIncludeOps `url:"include,omitempty"`

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -60,7 +60,7 @@ func TestWorkspacesList(t *testing.T) {
 		// Use a known workspace prefix as search attribute. The result
 		// should be successful and only contain the matching workspace.
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
-			Search: String(wTest1.Name[:len(wTest1.Name)-5]),
+			Search: wTest1.Name[:len(wTest1.Name)-5],
 		})
 		require.NoError(t, err)
 		assert.Contains(t, wl.Items, wTest1)
@@ -85,7 +85,7 @@ func TestWorkspacesList(t *testing.T) {
 		// The result should be successful and only contain the workspace with the
 		// new tag.
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
-			Tags: &tagName,
+			Tags: tagName,
 		})
 		require.NoError(t, err)
 		assert.Equal(t, wl.Items[0].ID, wTest1.ID)
@@ -97,7 +97,7 @@ func TestWorkspacesList(t *testing.T) {
 		// Use a nonexisting workspace name as search attribute. The result
 		// should be successful, but return no results.
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
-			Search: String("nonexisting"),
+			Search: "nonexisting",
 		})
 		require.NoError(t, err)
 		assert.Empty(t, wl.Items)


### PR DESCRIPTION
## Description 
The PR title says it all. This stems from an effort to make all list option structs pointers. Passing `omitempty` to the jsonapi serializer takes care of ignoring unset list options. 
