### PR TITLE
convert run trigger filter options to a typed constant

### DIFF
--- a/run_trigger.go
+++ b/run_trigger.go
@@ -54,11 +54,19 @@ type RunTrigger struct {
 	Workspace  *Workspace `jsonapi:"relation,workspace"`
 }
 
+// https://www.terraform.io/cloud-docs/api-docs/run-triggers#query-parameters
+type RunTriggerFilterOps string
+
+const (
+	RunTriggerOutbound RunTriggerFilterOps = "outbound"
+	RunTriggerInbound  RunTriggerFilterOps = "inbound"
+)
+
 // RunTriggerListOptions represents the options for listing
 // run triggers.
 type RunTriggerListOptions struct {
 	ListOptions
-	RunTriggerType string `url:"filter[run-trigger][type]"`
+	RunTriggerType RunTriggerFilterOps `url:"filter[run-trigger][type]"`
 }
 
 // List all the run triggers associated with a workspace.

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -32,12 +32,12 @@ func TestRunTriggerList(t *testing.T) {
 	rtTest2, rtTestCleanup2 := createRunTrigger(t, client, wTest, sourceable2Test)
 	defer rtTestCleanup2()
 
-	t.Run("without list options", func(t *testing.T) {
+	t.Run("without ListOptions and with RunTriggerType", func(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
 			&RunTriggerListOptions{
-				RunTriggerType: "inbound",
+				RunTriggerType: RunTriggerInbound,
 			},
 		)
 		require.NoError(t, err)
@@ -47,7 +47,7 @@ func TestRunTriggerList(t *testing.T) {
 		assert.Equal(t, 2, rtl.TotalCount)
 	})
 
-	t.Run("with list options", func(t *testing.T) {
+	t.Run("with ListOptions and a RunTriggerType", func(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
@@ -59,7 +59,7 @@ func TestRunTriggerList(t *testing.T) {
 					PageNumber: 999,
 					PageSize:   100,
 				},
-				RunTriggerType: "inbound",
+				RunTriggerType: RunTriggerInbound,
 			},
 		)
 		require.NoError(t, err)
@@ -73,14 +73,14 @@ func TestRunTriggerList(t *testing.T) {
 			ctx,
 			badIdentifier,
 			&RunTriggerListOptions{
-				RunTriggerType: "inbound",
+				RunTriggerType: RunTriggerInbound,
 			},
 		)
 		assert.Nil(t, rtl)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})
 
-	t.Run("without run-trigger type", func(t *testing.T) {
+	t.Run("without defining RunTriggerFilterOps as a filter param", func(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
@@ -90,12 +90,12 @@ func TestRunTriggerList(t *testing.T) {
 		assert.EqualError(t, err, "bad request\n\nFilter parameter run-trigger type is required and must be either 'inbound' or 'outbound'")
 	})
 
-	t.Run("with invalid run-trigger type", func(t *testing.T) {
+	t.Run("with invalid option for runTriggerType", func(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
 			&RunTriggerListOptions{
-				RunTriggerType: "invalid",
+				RunTriggerType: "oubound",
 			},
 		)
 		assert.Nil(t, rtl)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Convert RunTriggerType string field to a typed constant as part of the go-tfe 1.0 efforts.
