### PR TITLE
add omitempty to json tag for struct fields that are optional

### DIFF
--- a/admin_user.go
+++ b/admin_user.go
@@ -81,10 +81,10 @@ type AdminUserListOptions struct {
 	Query string `url:"q,omitempty"`
 
 	// Can be "true" or "false" to show only administrators or non-administrators.
-	Administrators string `url:"filter[admin]"`
+	Administrators string `url:"filter[admin],omitempty"`
 
 	// Can be "true" or "false" to show only suspended users or users who are not suspended.
-	SuspendedUsers string `url:"filter[suspended]"`
+	SuspendedUsers string `url:"filter[suspended],omitempty"`
 
 	Include []AdminUserIncludeOps `url:"include,omitempty"`
 }

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -109,7 +109,7 @@ type OAuthTokenUpdateOptions struct {
 	Type string `jsonapi:"primary,oauth-tokens"`
 
 	// A private SSH key to be used for git clone operations.
-	PrivateSSHKey *string `jsonapi:"attr,ssh-key"`
+	PrivateSSHKey *string `jsonapi:"attr,ssh-key,omitempty"`
 }
 
 // Update an existing OAuth token.

--- a/policy.go
+++ b/policy.go
@@ -127,7 +127,7 @@ type PolicyCreateOptions struct {
 
 // EnforcementOptions represents the enforcement options of a policy.
 type EnforcementOptions struct {
-	Path *string           `json:"path,omitempty"`
+	Path *string           `json:"path"`
 	Mode *EnforcementLevel `json:"mode"`
 }
 

--- a/state_version.go
+++ b/state_version.go
@@ -131,7 +131,7 @@ type StateVersionCreateOptions struct {
 
 	// Force can be set to skip certain validations. Wrong use
 	// of this flag can cause data loss, so USE WITH CAUTION!
-	Force *bool `jsonapi:"attr,force"`
+	Force *bool `jsonapi:"attr,force,omitempty"`
 
 	// Specifies the run to associate the state with.
 	Run *Run `jsonapi:"relation,run,omitempty"`

--- a/team_access.go
+++ b/team_access.go
@@ -103,7 +103,7 @@ type TeamAccess struct {
 // TeamAccessListOptions represents the options for listing team accesses.
 type TeamAccessListOptions struct {
 	ListOptions
-	WorkspaceID string `url:"filter[workspace][id],omitempty"`
+	WorkspaceID string `url:"filter[workspace][id]"`
 }
 
 //check that workspaceID field has a valid value


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

I audited the repo looking for options struct fields to update for omitempty json tag: 

The fields that are not required should have the tag because if their values are null then the fields will get omitted from the encoding.
The fields that are required should not have the tag.

This PR is bringing those two types of changes.

I have added omitempty to
Two url filter tags that are optional: https://www.terraform.io/cloud-docs/api-docs/admin/users#query-parameters
One shh key attribute said to be optional: https://www.terraform.io/cloud-docs/api-docs/oauth-tokens#request-body

And I have removed omitempty from three fields that are required. For those fields, I didn't need to look in the documentation to find out if they are optional or not. Right there, in the same go file, I can see that we are running a validation check (options.valid()) to verify that those fields are not empty values. 

There will be a follow up PR where I'll be adding a few more options.valid() for ListOptions that have required fields so we can match the other ones that already have this validation.


<!-- Describe why you're making this change. -->

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
