### PR TITLE
fix: vscode go settings for test files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,6 @@
+{
+  "go.buildFlags": [
+      "-tags=integration"
+  ],
+  "go.testTags": "integration",
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,11 @@
+# Contributing to go-tfe
+
+If you find an issue with this package, please create an issue in GitHub. If you'd like, we welcome any contributions. Fork this repository and submit a pull request.
+
+### Writing Tests
+
+The test suite contains many acceptance tests that are run against the latest version of Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in [TESTS.md](TESTS.md). Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.
+
+### Editor Settings
+
+We've included VSCode settings to assist with configuring the go extension. For other editors that integrate with the [Go Language Server](https://github.com/golang/tools/tree/master/gopls), the main thing to do is to add the `integration` build tags so that the test files are found by the language server. See `.vscode/settings.json` for more details.

--- a/README.md
+++ b/README.md
@@ -66,12 +66,11 @@ See the [examples directory](https://github.com/hashicorp/go-tfe/tree/main/examp
 
 ## Running tests
 
-See [TESTS.md](https://github.com/hashicorp/go-tfe/tree/main/TESTS.md).
+See [TESTS.md](TESTS.md).
 
 ## Issues and Contributing
 
-If you find an issue with this package, please report an issue. If you'd like,
-we welcome any contributions. Fork this repository and submit a pull request.
+See [CONTRIBUTING.md](CONTRIBUTING.md)
 
 ## Releases
 
@@ -80,12 +79,12 @@ Documentation updates and test fixes that only touch test files don't require a 
 ### Creating a release
 
 1. [Create a new release in GitHub](https://help.github.com/en/github/administering-a-repository/creating-releases) by clicking on "Releases" and then "Draft a new release"
-1. Set the `Tag version` to a new tag, using [Semantic Versioning](https://semver.org/) as a guideline. 
+1. Set the `Tag version` to a new tag, using [Semantic Versioning](https://semver.org/) as a guideline.
 1. Set the `Target` as `main`.
 1. Set the `Release title` to the tag you created, `vX.Y.Z`
 1. Use the description section to describe why you're releasing and what changes you've made. You should include links to merged PRs. Use the following headers in the description of your release:
    - BREAKING CHANGES: Use this for any changes that aren't backwards compatible. Include details on how to handle these changes.
-   - FEATURES: Use this for any large new features added, 
+   - FEATURES: Use this for any large new features added,
    - ENHANCEMENTS: Use this for smaller new features added
    - BUG FIXES: Use this for any bugs that were fixed.
    - NOTES: Use this section if you need to include any additional notes on things like upgrading, upcoming deprecations, or any other information you might want to highlight.


### PR DESCRIPTION
This should fix the issue of the go language server not being able to give editor feedback in *_test.go files.
