### PR TITLE
prefix constants to prevent export

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -28,10 +28,10 @@ import (
 )
 
 const (
-	userAgent        = "go-tfe"
-	headerRateLimit  = "X-RateLimit-Limit"
-	headerRateReset  = "X-RateLimit-Reset"
-	headerAPIVersion = "TFP-API-Version"
+	_userAgent        = "go-tfe"
+	_headerRateLimit  = "X-RateLimit-Limit"
+	_headerRateReset  = "X-RateLimit-Reset"
+	_headerAPIVersion = "TFP-API-Version"
 
 	// DefaultAddress of Terraform Enterprise.
 	DefaultAddress = "https://app.terraform.io"
@@ -81,7 +81,7 @@ func DefaultConfig() *Config {
 	}
 
 	// Set the default user agent.
-	config.Headers.Set("User-Agent", userAgent)
+	config.Headers.Set("User-Agent", _userAgent)
 
 	return config
 }
@@ -367,8 +367,8 @@ func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Respons
 	// First create some jitter bounded by the min and max durations.
 	jitter := time.Duration(rnd.Float64() * float64(max-min))
 
-	if resp != nil && resp.Header.Get(headerRateReset) != "" {
-		v := resp.Header.Get(headerRateReset)
+	if resp != nil && resp.Header.Get(_headerRateReset) != "" {
+		v := resp.Header.Get(_headerRateReset)
 		reset, err := strconv.ParseFloat(v, 64)
 		if err != nil {
 			log.Fatal(err)
@@ -421,8 +421,8 @@ func (c *Client) getRawAPIMetadata() (rawAPIMetadata, error) {
 	}
 	resp.Body.Close()
 
-	meta.APIVersion = resp.Header.Get(headerAPIVersion)
-	meta.RateLimit = resp.Header.Get(headerRateLimit)
+	meta.APIVersion = resp.Header.Get(_headerAPIVersion)
+	meta.RateLimit = resp.Header.Get(_headerRateLimit)
 
 	return meta, nil
 }


### PR DESCRIPTION
## Description

This PR is intended to prevent constants in the `tfe.go` file from being exported. 

Top-level variables and constants have a package scope, meaning that all the constants declared on top of go-tfe files, even when they start with a lowercase letter, can be used in other go-tfe files. So all those generic names could accidentally get overwritten or use the wrong value in a different file.

## Testing plan

1. Find a constant in the `tfe.go` file that is prefixed with an underscore.
2. Verify that you are unable to reference that constant in a different file.

## External links

- [Asana](https://app.asana.com/0/1200894272253435/1201804478448342/f)

_Please run the tests locally for any files you changes and include the output here._
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
