### PR TITLE
use %w to wrap upstream errors within fmt.Errorf

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -105,7 +105,7 @@ func (s *applies) Logs(ctx context.Context, applyID string) (io.Reader, error) {
 
 	u, err := url.Parse(a.LogReadURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid log URL: %v", err)
+		return nil, fmt.Errorf("invalid log URL: %w", err)
 	}
 
 	done := func() (bool, error) {

--- a/errors.go
+++ b/errors.go
@@ -135,3 +135,15 @@ var (
 	// ErrInvalidTerraformVersionType is returned when the type is not valid.
 	ErrInvalidTerraformVersionType = errors.New("invalid type for terraform version. Please use 'terraform-version'")
 )
+
+// Library errors that usually indicate a bug in the implementation of go-tfe
+var (
+	// ErrBugItemsSlice is returned when an API response attribute called Items is not a slice
+	ErrBugItemsSlice = errors.New(`model field "Items" must be a slice`)
+
+	// ErrBugRequestBodyType is returned when a request body for DELETE/PATCH/POST is not a reference type
+	ErrBugRequestBodyType = errors.New("go-tfe bug: DELETE/PATCH/POST body must be nil, ptr, or ptr slice")
+
+	// ErrBugStructFieldTags is returned when a mix of json and jsonapi tagged fields are used in the same struct
+	ErrBugStructFieldTags = errors.New("go-tfe bug: struct can't use both json and jsonapi attributes")
+)

--- a/plan.go
+++ b/plan.go
@@ -114,7 +114,7 @@ func (s *plans) Logs(ctx context.Context, planID string) (io.Reader, error) {
 
 	u, err := url.Parse(p.LogReadURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid log URL: %v", err)
+		return nil, fmt.Errorf("invalid log URL: %w", err)
 	}
 
 	done := func() (bool, error) {

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -471,7 +471,7 @@ func Test_unmarshalResponse(t *testing.T) {
 		}
 		err := unmarshalResponse(responseBody, &malformattedItemStruct)
 		require.Error(t, err)
-		assert.EqualError(t, err, "v.Items must be a slice")
+		assert.EqualError(t, err, "model field \"Items\" must be a slice")
 	})
 
 	t.Run("can only unmarshal a struct", func(t *testing.T) {


### PR DESCRIPTION
## Description

Finally get consistent with returning errors that contain other errors

also improves the error related to unmarshaling Items that are not defined as a slice
