### PR TITLE
use %w to wrap upstream errors within fmt.Errorf

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -105,7 +105,7 @@ func (s *applies) Logs(ctx context.Context, applyID string) (io.Reader, error) {
 
 	u, err := url.Parse(a.LogReadURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid log URL: %v", err)
+		return nil, fmt.Errorf("invalid log URL: %w", err)
 	}
 
 	done := func() (bool, error) {

--- a/errors.go
+++ b/errors.go
@@ -23,14 +23,19 @@ var (
 	ErrUnsupportedPrivateKey = errors.New("private Key can only be present with Azure DevOps Server service provider")
 )
 
-// internal errors
+// Library errors that usually indicate a bug in the implementation of go-tfe
 var (
+	// ErrItemsMustBeSlice is returned when an API response attribute called Items is not a slice
+	ErrItemsMustBeSlice = errors.New(`model field "Items" must be a slice`)
+
+	// ErrInvalidRequestBody is returned when a request body for DELETE/PATCH/POST is not a reference type
 	ErrInvalidRequestBody = errors.New("go-tfe bug: DELETE/PATCH/POST body must be nil, ptr, or ptr slice")
 
+	// ErrInvalidStructFormat is returned when a mix of json and jsonapi tagged fields are used in the same struct
 	ErrInvalidStructFormat = errors.New("go-tfe bug: struct can't use both json and jsonapi attributes")
 )
 
-// Run Errors
+// Resource Errors
 var (
 	// ErrWorkspaceLocked is returned when trying to lock a
 	// locked workspace.

--- a/plan.go
+++ b/plan.go
@@ -113,7 +113,7 @@ func (s *plans) Logs(ctx context.Context, planID string) (io.Reader, error) {
 
 	u, err := url.Parse(p.LogReadURL)
 	if err != nil {
-		return nil, fmt.Errorf("invalid log URL: %v", err)
+		return nil, fmt.Errorf("invalid log URL: %w", err)
 	}
 
 	done := func() (bool, error) {

--- a/tfe.go
+++ b/tfe.go
@@ -183,7 +183,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	// Parse the address to make sure its a valid URL.
 	baseURL, err := url.Parse(config.Address)
 	if err != nil {
-		return nil, fmt.Errorf("invalid address: %v", err)
+		return nil, fmt.Errorf("invalid address: %w", err)
 	}
 
 	baseURL.Path = config.BasePath
@@ -665,22 +665,22 @@ func unmarshalResponse(responseBody io.Reader, model interface{}) error {
 	items := dst.FieldByName("Items")
 	pagination := dst.FieldByName("Pagination")
 
-	// Unmarshal a single value if v does not contain the
+	// Unmarshal a single value if model does not contain the
 	// Items and Pagination struct fields.
 	if !items.IsValid() || !pagination.IsValid() {
 		return jsonapi.UnmarshalPayload(responseBody, model)
 	}
 
-	// Return an error if v.Items is not a slice.
+	// Return an error if model.Items is not a slice.
 	if items.Type().Kind() != reflect.Slice {
-		return fmt.Errorf("v.Items must be a slice")
+		return ErrItemsMustBeSlice
 	}
 
 	// Create a temporary buffer and copy all the read data into it.
 	body := bytes.NewBuffer(nil)
 	reader := io.TeeReader(responseBody, body)
 
-	// Unmarshal as a list of values as v.Items is a slice.
+	// Unmarshal as a list of values as model.Items is a slice.
 	raw, err := jsonapi.UnmarshalManyPayload(reader, items.Type().Elem())
 	if err != nil {
 		return err

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -101,7 +101,7 @@ func Test_unmarshalResponse(t *testing.T) {
 		}
 		err := unmarshalResponse(responseBody, &malformattedItemStruct)
 		require.Error(t, err)
-		assert.EqualError(t, err, "v.Items must be a slice")
+		assert.Equal(t, err, ErrItemsMustBeSlice)
 	})
 
 	t.Run("can only unmarshal a struct", func(t *testing.T) {


### PR DESCRIPTION
## Description

Get more consistent with returning errors that wrap other errors

also improves the error related to unmarshaling Items that are not defined as a slice