### PR TITLE
use options.valid for option fields that are required

### DIFF
--- a/admin_run.go
+++ b/admin_run.go
@@ -69,10 +69,8 @@ type AdminRunsListOptions struct {
 // List all the runs of the terraform enterprise installation.
 // https://www.terraform.io/docs/cloud/api/admin/runs.html#list-all-runs
 func (s *adminRuns) List(ctx context.Context, options *AdminRunsListOptions) (*AdminRunsList, error) {
-	if options != nil {
-		if err := options.valid(); err != nil {
-			return nil, err
-		}
+	if err := options.valid(); err != nil {
+		return nil, err
 	}
 
 	u := "admin/runs"
@@ -114,7 +112,10 @@ func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options Admin
 }
 
 // Check that the field RunStatus has a valid string value
-func (o AdminRunsListOptions) valid() error {
+func (o *AdminRunsListOptions) valid() error {
+	if o == nil { //no need to validate fields
+		return nil
+	}
 	if validString(&o.RunStatus) {
 		validRunStatus := map[string]int{
 			string(RunApplied):            1,
@@ -145,5 +146,6 @@ func (o AdminRunsListOptions) valid() error {
 			}
 		}
 	}
+
 	return nil
 }

--- a/admin_run.go
+++ b/admin_run.go
@@ -113,7 +113,7 @@ func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options Admin
 
 // Check that the field RunStatus has a valid string value
 func (o *AdminRunsListOptions) valid() error {
-	if o == nil { //no need to validate fields
+	if o == nil { // no need to validate fields
 		return nil
 	}
 	if validString(&o.RunStatus) {

--- a/admin_setting_smtp.go
+++ b/admin_setting_smtp.go
@@ -31,9 +31,9 @@ const (
 )
 
 var validSMTPAuthType = map[SMTPAuthType]struct{}{
-	SMTPAuthNone:  struct{}{},
-	SMTPAuthPlain: struct{}{},
-	SMTPAuthLogin: struct{}{},
+	SMTPAuthNone:  {},
+	SMTPAuthPlain: {},
+	SMTPAuthLogin: {},
 }
 
 // AdminSMTPSetting represents a the SMTP settings in Terraform Enterprise.
@@ -79,8 +79,8 @@ type AdminSMTPSettingsUpdateOptions struct {
 
 // Updat updates the SMTP settings.
 func (a *adminSMTPSettings) Update(ctx context.Context, options AdminSMTPSettingsUpdateOptions) (*AdminSMTPSetting, error) {
-	if !options.valid() {
-		return nil, ErrInvalidSMTPAuth
+	if err := options.valid(); err != nil {
+		return nil, err
 	}
 	req, err := a.client.newRequest("PATCH", "admin/smtp-settings", &options)
 	if err != nil {
@@ -96,7 +96,10 @@ func (a *adminSMTPSettings) Update(ctx context.Context, options AdminSMTPSetting
 	return smtp, nil
 }
 
-func (o AdminSMTPSettingsUpdateOptions) valid() bool {
+func (o AdminSMTPSettingsUpdateOptions) valid() error {
 	_, isValidType := validSMTPAuthType[*o.Auth]
-	return isValidType
+	if !isValidType {
+		return ErrInvalidSMTPAuth
+	}
+	return nil
 }

--- a/admin_setting_twilio.go
+++ b/admin_setting_twilio.go
@@ -81,10 +81,21 @@ type AdminTwilioSettingsVerifyOptions struct {
 
 // Verify verifies Twilio settings.
 func (a *adminTwilioSettings) Verify(ctx context.Context, options AdminTwilioSettingsVerifyOptions) error {
+	if err := options.valid(); err != nil {
+		return err
+	}
 	req, err := a.client.newRequest("PATCH", "admin/twilio-settings/verify", &options)
 	if err != nil {
 		return err
 	}
 
 	return a.client.do(ctx, req, nil)
+}
+
+func (o AdminTwilioSettingsVerifyOptions) valid() error {
+	if !validString(o.TestNumber) {
+		return ErrRequiredTestNumber
+	}
+
+	return nil
 }

--- a/admin_setting_twilio_integration_test.go
+++ b/admin_setting_twilio_integration_test.go
@@ -39,3 +39,14 @@ func TestAdminSettings_Twilio_Update(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, false, twilioSettings.Enabled)
 }
+
+func TestAdminSettings_Twilio_Verify(t *testing.T) {
+	skipIfCloud(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	err := client.Admin.Settings.Twilio.Verify(ctx, AdminTwilioSettingsVerifyOptions{})
+
+	assert.Equal(t, err, ErrRequiredTestNumber)
+}

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -123,6 +123,9 @@ type AdminTerraformVersionCreateOptions struct {
 
 // Create a new terraform version.
 func (a *adminTerraformVersions) Create(ctx context.Context, options AdminTerraformVersionCreateOptions) (*AdminTerraformVersion, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 	req, err := a.client.newRequest("POST", "admin/terraform-versions", &options)
 	if err != nil {
 		return nil, err
@@ -185,4 +188,21 @@ func (a *adminTerraformVersions) Delete(ctx context.Context, id string) error {
 	}
 
 	return a.client.do(ctx, req, nil)
+}
+
+func (o AdminTerraformVersionCreateOptions) valid() error {
+	if (o == AdminTerraformVersionCreateOptions{}) {
+		return ErrRequiredTFVerCreateOps
+	}
+	if !validString(o.Version) {
+		return ErrRequiredVersion
+	}
+	if !validString(o.URL) {
+		return ErrRequiredURL
+	}
+	if !validString(o.Sha) {
+		return ErrRequiredSha
+	}
+
+	return nil
 }

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -155,10 +155,8 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 	})
 
 	t.Run("with empty options", func(t *testing.T) {
-		opts := AdminTerraformVersionCreateOptions{}
-
-		_, err := client.Admin.TerraformVersions.Create(ctx, opts)
-		require.Error(t, err)
+		_, err := client.Admin.TerraformVersions.Create(ctx, AdminTerraformVersionCreateOptions{})
+		require.Equal(t, err, ErrRequiredTFVerCreateOps)
 	})
 }
 

--- a/errors.go
+++ b/errors.go
@@ -108,6 +108,8 @@ var (
 
 	ErrInvalidRunTriggerID = errors.New("invalid value for run trigger ID")
 
+	ErrInvalidRunTriggerType = errors.New(`invalid value for RunTriggerType. It must be either "inbound" or "outbound"`)
+
 	ErrInvalidSHHKeyID = errors.New("invalid value for SSH key ID")
 
 	ErrInvalidStateVerID = errors.New("invalid value for state version ID")
@@ -131,7 +133,7 @@ var (
 	ErrInvalidVariableID = errors.New("invalid value for variable ID")
 )
 
-// Missing required field/option
+// Missing values for required field/option
 var (
 	ErrRequiredAccess = errors.New("access is required")
 
@@ -175,6 +177,8 @@ var (
 
 	ErrRequiredOauthTokenID = errors.New("oauth token ID is required")
 
+	ErrRequiredTestNumber = errors.New("TestNumber is required")
+
 	ErrMissingTagIdentifier = errors.New("must specify at least one tag by ID or name")
 
 	ErrAgentTokenDescription = errors.New("agent token description can't be blank")
@@ -203,6 +207,8 @@ var (
 
 	ErrRequiredDisplayIdentifier = errors.New("display identifier is required")
 
+	ErrRequiredSha = errors.New("sha is required")
+
 	ErrRequiredSourceable = errors.New("sourceable is required")
 
 	ErrRequiredValue = errors.New("value is required")
@@ -213,7 +219,11 @@ var (
 
 	ErrRequiredStateVerListOps = errors.New("StateVersionListOptions is required")
 
-	ErrRequireTeamAccessListOps = errors.New("TeamAccessListOptions is required")
+	ErrRequiredTeamAccessListOps = errors.New("TeamAccessListOptions is required")
+
+	ErrRequiredRunTriggerListOps = errors.New("RunTriggerListOptions is required")
+
+	ErrRequiredTFVerCreateOps = errors.New("version, URL and sha is required for AdminTerraformVersionCreateOptions")
 
 	ErrRequiredSerial = errors.New("serial is required")
 

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -61,6 +61,12 @@ const (
 	RunTriggerInbound  RunTriggerFilterOps = "inbound"
 )
 
+// List of available filter options for RunTriggerType
+var validRunTriggerType = map[RunTriggerFilterOps]struct{}{
+	RunTriggerOutbound: {},
+	RunTriggerInbound:  {}, // we set it to empty struct because it has the smallest memory footprint and we only need keys, not values
+}
+
 // RunTriggerListOptions represents the options for listing
 // run triggers.
 type RunTriggerListOptions struct {
@@ -72,6 +78,9 @@ type RunTriggerListOptions struct {
 func (s *runTriggers) List(ctx context.Context, workspaceID string, options *RunTriggerListOptions) (*RunTriggerList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
 	}
 
 	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
@@ -167,4 +176,15 @@ func (s *runTriggers) Delete(ctx context.Context, runTriggerID string) error {
 	}
 
 	return s.client.do(ctx, req, nil)
+}
+
+func (o *RunTriggerListOptions) valid() error {
+	if o == nil {
+		return ErrRequiredRunTriggerListOps
+	}
+	_, isValidRunTriggerType := validRunTriggerType[o.RunTriggerType]
+	if !isValidRunTriggerType {
+		return ErrInvalidRunTriggerType
+	}
+	return nil
 }

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -87,7 +87,7 @@ func TestRunTriggerList(t *testing.T) {
 			nil,
 		)
 		assert.Nil(t, rtl)
-		assert.EqualError(t, err, "bad request\n\nFilter parameter run-trigger type is required and must be either 'inbound' or 'outbound'")
+		assert.Equal(t, err, ErrRequiredRunTriggerListOps)
 	})
 
 	t.Run("with invalid option for runTriggerType", func(t *testing.T) {
@@ -99,7 +99,7 @@ func TestRunTriggerList(t *testing.T) {
 			},
 		)
 		assert.Nil(t, rtl)
-		assert.EqualError(t, err, "bad request\n\nFilter parameter run-trigger type is required and must be either 'inbound' or 'outbound'")
+		assert.Equal(t, err, ErrInvalidRunTriggerType)
 	})
 }
 

--- a/state_version.go
+++ b/state_version.go
@@ -75,7 +75,10 @@ type StateVersionListOptions struct {
 }
 
 //check that StateVersionListOptions fields had valid values
-func (o StateVersionListOptions) valid() error {
+func (o *StateVersionListOptions) valid() error {
+	if o == nil {
+		return ErrRequiredStateVerListOps
+	}
 	if !validString(&o.Organization) {
 		return ErrRequiredOrg
 	}
@@ -87,10 +90,6 @@ func (o StateVersionListOptions) valid() error {
 
 // List all the state versions for a given workspace.
 func (s *stateVersions) List(ctx context.Context, options *StateVersionListOptions) (*StateVersionList, error) {
-	if options == nil {
-		return nil, ErrRequiredStateVerListOps
-	}
-
 	if err := options.valid(); err != nil {
 		return nil, err
 	}

--- a/team_access.go
+++ b/team_access.go
@@ -107,22 +107,22 @@ type TeamAccessListOptions struct {
 }
 
 //check that workspaceID field has a valid value
-func (o TeamAccessListOptions) valid() error {
+func (o *TeamAccessListOptions) valid() error {
+	if o == nil {
+		return ErrRequiredTeamAccessListOps
+	}
 	if !validString(&o.WorkspaceID) {
 		return ErrRequiredWorkspaceID
 	}
 	if !validStringID(&o.WorkspaceID) {
 		return ErrInvalidWorkspaceID
 	}
+
 	return nil
 }
 
 // List all the team accesses for a given workspace.
 func (s *teamAccesses) List(ctx context.Context, options *TeamAccessListOptions) (*TeamAccessList, error) {
-	if options == nil {
-		return nil, ErrRequireTeamAccessListOps
-	}
-
 	if err := options.valid(); err != nil {
 		return nil, err
 	}

--- a/team_access_integration_test.go
+++ b/team_access_integration_test.go
@@ -66,7 +66,7 @@ func TestTeamAccessesList(t *testing.T) {
 	t.Run("without TeamAccessListOptions", func(t *testing.T) {
 		tal, err := client.TeamAccess.List(ctx, nil)
 		assert.Nil(t, tal)
-		assert.Equal(t, err, ErrRequireTeamAccessListOps)
+		assert.Equal(t, err, ErrRequiredTeamAccessListOps)
 	})
 
 	t.Run("without WorkspaceID options", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Create consistency around the usage of options.valid()

This PR implements three changes for this purpose:

1. That all types of validations for the values of the `options` param happens within the valid function.  Previously there were a couple of validation checks happening outside of the valid function, like this one:

```
if options == nil {
		return nil, ErrRequireTeamAccessListOps
}

if err := options.valid(); err != nil {
		return nil, err
}
```

`if options == nil` should happen inside of valid().

2.  That when we call valid(), we follow the same syntax, that should be:

```
if err := options.valid(); err != nil {
		return nil, err
}
```

This syntax deviates:

```
if !options.valid() {
		return nil, ErrInvalidSMTPAuth
}
```

3. That all required fields for an options param validate that its fields have values assigned. These were the options params that were missing validation for their fields:

AdminTwilioSettingsVerifyOptions
AdminTerraformVersionCreateOptions
RunTriggerListOptions

4. Finally, add a map[RunTriggerFilterOps]struct{}{} to validate that the filter field for the options param is only allow to use a value present in that map. I followed the example set in Admin Settings SMTP.

```
var validSMTPAuthType = map[SMTPAuthType]struct{}{
	SMTPAuthNone:  {},
	SMTPAuthPlain: {},
	SMTPAuthLogin: {},
}
```


## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
