### PR TITLE
Add more linters to our CI pipeline

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,6 +10,7 @@ linters:
     - nestif #https://github.com/nakabonne/nestif
     - exportloopref #https://github.com/kyoh86/exportloopref
     - bodyclose #https://github.com/timakin/bodyclose
+    - goconst #https://github.com/jgautheron/goconst
     - errcheck #https://github.com/kisielk/errcheck
     - stylecheck #https://github.com/dominikh/go-tools/tree/master/stylecheck
     - revive #golint is deprecated and golangci-lint recommends to use revive instead https://github.com/mgechev/revive
@@ -25,6 +26,10 @@ linters-settings:
     # https://github.com/kisielk/errcheck#excluding-functions
     check-type-assertions: true
     check-blank: true  
+  goconst:
+    min-len: 20 
+    min-occurrences: 5 
+    ignore-calls: false
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: false #recommended in their configuration

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,6 +16,8 @@ linters:
     - revive #golint is deprecated and golangci-lint recommends to use revive instead https://github.com/mgechev/revive
     #other deprecated lint libraries: maligned, scopelint, interfacer
     - gocritic
+    - unparam
+    - misspell
 issues:
   exclude-rules:
   - path: _test\.go

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,6 +15,7 @@ linters:
     - stylecheck #https://github.com/dominikh/go-tools/tree/master/stylecheck
     - revive #golint is deprecated and golangci-lint recommends to use revive instead https://github.com/mgechev/revive
     #other deprecated lint libraries: maligned, scopelint, interfacer
+    - gocritic
 issues:
   exclude-rules:
   - path: _test\.go
@@ -30,6 +31,11 @@ linters-settings:
     min-len: 20 
     min-occurrences: 5 
     ignore-calls: false
+  gocritic:
+    enabled-tags:
+      - diagnostic
+      - opinionated
+      - performance
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: false #recommended in their configuration

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,9 +15,9 @@ linters:
     - stylecheck #https://github.com/dominikh/go-tools/tree/master/stylecheck
     - revive #golint is deprecated and golangci-lint recommends to use revive instead https://github.com/mgechev/revive
     #other deprecated lint libraries: maligned, scopelint, interfacer
-    - gocritic
-    - unparam
-    - misspell
+    - gocritic #https://github.com/go-critic/go-critic
+    - unparam #https://github.com/mvdan/unparam
+    - misspell #https://github.com/client9/misspell
 issues:
   exclude-rules:
   - path: _test\.go
@@ -38,6 +38,11 @@ linters-settings:
       - diagnostic
       - opinionated
       - performance
+    disabled-checks:
+      - unnamedResult
+      - hugeParam
+      - singleCaseSwitch
+      - ifElseChain
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: false #recommended in their configuration

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -102,8 +102,8 @@ type AdminOrganizationID struct {
 
 // List all the organizations visible to the current user.
 func (s *adminOrganizations) List(ctx context.Context, options *AdminOrganizationListOptions) (*AdminOrganizationList, error) {
-	url := "admin/organizations"
-	req, err := s.client.newRequest("GET", url, options)
+	u := "admin/organizations"
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -122,9 +122,9 @@ func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organizati
 		return nil, ErrInvalidOrg
 	}
 
-	url := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
 
-	req, err := s.client.newRequest("GET", url, nil)
+	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -183,7 +183,7 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 		return ErrInvalidOrg
 	}
 
-	url := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
 
 	var organizations []*AdminOrganizationID
 	for _, id := range consumerOrganizationIDs {
@@ -193,7 +193,7 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 		organizations = append(organizations, &AdminOrganizationID{ID: id})
 	}
 
-	req, err := s.client.newRequest("PATCH", url, organizations)
+	req, err := s.client.newRequest("PATCH", u, organizations)
 	if err != nil {
 		return err
 	}

--- a/admin_user.go
+++ b/admin_user.go
@@ -27,10 +27,10 @@ type AdminUsers interface {
 	// Unsuspend a user by its ID.
 	Unsuspend(ctx context.Context, userID string) (*AdminUser, error)
 
-	// GrantAdmin grants admin privilages to a user by its ID.
+	// GrantAdmin grants admin privileges to a user by its ID.
 	GrantAdmin(ctx context.Context, userID string) (*AdminUser, error)
 
-	// RevokeAdmin revokees admin privilages to a user by its ID.
+	// RevokeAdmin revokees admin privileges to a user by its ID.
 	RevokeAdmin(ctx context.Context, userID string) (*AdminUser, error)
 
 	// Disable2FA disables a user's two-factor authentication in the situation
@@ -163,7 +163,7 @@ func (a *adminUsers) Unsuspend(ctx context.Context, userID string) (*AdminUser, 
 	return au, nil
 }
 
-// GrantAdmin grants admin privilages to a user by its ID.
+// GrantAdmin grants admin privileges to a user by its ID.
 func (a *adminUsers) GrantAdmin(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue
@@ -184,7 +184,7 @@ func (a *adminUsers) GrantAdmin(ctx context.Context, userID string) (*AdminUser,
 	return au, nil
 }
 
-// RevokeAdmin revokes admin privilages to a user by its ID.
+// RevokeAdmin revokes admin privileges to a user by its ID.
 func (a *adminUsers) RevokeAdmin(ctx context.Context, userID string) (*AdminUser, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserValue

--- a/apply.go
+++ b/apply.go
@@ -31,7 +31,7 @@ type applies struct {
 // ApplyStatus represents an apply state.
 type ApplyStatus string
 
-//List all available apply statuses.
+// List all available apply statuses.
 const (
 	ApplyCanceled    ApplyStatus = "canceled"
 	ApplyCreated     ApplyStatus = "created"

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -47,7 +47,7 @@ type configurationVersions struct {
 // ConfigurationStatus represents a configuration version status.
 type ConfigurationStatus string
 
-//List all available configuration version statuses.
+// List all available configuration version statuses.
 const (
 	ConfigurationErrored  ConfigurationStatus = "errored"
 	ConfigurationPending  ConfigurationStatus = "pending"
@@ -234,7 +234,7 @@ func (s *configurationVersions) ReadWithOptions(ctx context.Context, cvID string
 // Upload packages and uploads Terraform configuration files. It requires the
 // upload URL from a configuration version and the path to the configuration
 // files on disk.
-func (s *configurationVersions) Upload(ctx context.Context, url, path string) error {
+func (s *configurationVersions) Upload(ctx context.Context, u, path string) error {
 	file, err := os.Stat(path)
 	if err != nil {
 		return err
@@ -250,7 +250,7 @@ func (s *configurationVersions) Upload(ctx context.Context, url, path string) er
 		return err
 	}
 
-	req, err := s.client.newRequest("PUT", url, body)
+	req, err := s.client.newRequest("PUT", u, body)
 	if err != nil {
 		return err
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -23,7 +23,7 @@ var _testAccountDetails *TestAccountDetails
 
 func testClient(t *testing.T) *Client {
 	client, err := NewClient(nil)
-	client.RetryServerErrors(true) // because ocasionally we get a 500 internal when deleting an organization's workspace
+	client.RetryServerErrors(true) // because occasionally we get a 500 internal when deleting an organization's workspace
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -457,7 +457,7 @@ func createOrganizationToken(t *testing.T, client *Client, org *Organization) (*
 	}
 }
 
-func createRunTrigger(t *testing.T, client *Client, w *Workspace, sourceable *Workspace) (*RunTrigger, func()) {
+func createRunTrigger(t *testing.T, client *Client, w, sourceable *Workspace) (*RunTrigger, func()) {
 	var wCleanup func()
 	var sourceableCleanup func()
 

--- a/organization_tags_integration_test.go
+++ b/organization_tags_integration_test.go
@@ -122,7 +122,7 @@ func TestOrganizationTagsDelete(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		//sanity check ensure tags were deleted from the organization
+		// sanity check ensure tags were deleted from the organization
 		tags, err = client.OrganizationTags.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
 
@@ -175,7 +175,7 @@ func TestOrganizationTagsAddWorkspace(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		//Ensure the tag was properly associated with the workspaces
+		// Ensure the tag was properly associated with the workspaces
 		fetched, err := client.Workspaces.ListTags(ctx, workspaceToAdd1.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, fetched.Items[0].ID, tagID)

--- a/plan.go
+++ b/plan.go
@@ -35,7 +35,7 @@ type plans struct {
 // PlanStatus represents a plan state.
 type PlanStatus string
 
-//List all available plan statuses.
+// List all available plan statuses.
 const (
 	PlanCanceled    PlanStatus = "canceled"
 	PlanCreated     PlanStatus = "created"

--- a/policy_check.go
+++ b/policy_check.go
@@ -48,7 +48,7 @@ const (
 // PolicyStatus represents a policy check state.
 type PolicyStatus string
 
-//List all available policy check statuses.
+// List all available policy check statuses.
 const (
 	PolicyCanceled    PolicyStatus = "canceled"
 	PolicyErrored     PolicyStatus = "errored"

--- a/policy_set.go
+++ b/policy_set.go
@@ -236,7 +236,7 @@ type PolicySetUpdateOptions struct {
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,policy-sets"`
 
-	/// The name of the policy set.
+	// The name of the policy set.
 	Name *string `jsonapi:"attr,name,omitempty"`
 
 	// The description of the policy set.
@@ -293,7 +293,7 @@ func (s *policySets) Update(ctx context.Context, policySetID string, options Pol
 // PolicySetAddPoliciesOptions represents the options for adding policies
 // to a policy set.
 type PolicySetAddPoliciesOptions struct {
-	/// The policies to add to the policy set.
+	// The policies to add to the policy set.
 	Policies []*Policy
 }
 
@@ -328,7 +328,7 @@ func (s *policySets) AddPolicies(ctx context.Context, policySetID string, option
 // PolicySetRemovePoliciesOptions represents the options for removing
 // policies from a policy set.
 type PolicySetRemovePoliciesOptions struct {
-	/// The policies to remove from the policy set.
+	// The policies to remove from the policy set.
 	Policies []*Policy
 }
 
@@ -363,7 +363,7 @@ func (s *policySets) RemovePolicies(ctx context.Context, policySetID string, opt
 // PolicySetAddWorkspacesOptions represents the options for adding workspaces
 // to a policy set.
 type PolicySetAddWorkspacesOptions struct {
-	/// The workspaces to add to the policy set.
+	// The workspaces to add to the policy set.
 	Workspaces []*Workspace
 }
 
@@ -398,7 +398,7 @@ func (s *policySets) AddWorkspaces(ctx context.Context, policySetID string, opti
 // PolicySetRemoveWorkspacesOptions represents the options for removing
 // workspaces from a policy set.
 type PolicySetRemoveWorkspacesOptions struct {
-	/// The workspaces to remove from the policy set.
+	// The workspaces to remove from the policy set.
 	Workspaces []*Workspace
 }
 

--- a/policy_set_parameter.go
+++ b/policy_set_parameter.go
@@ -138,7 +138,7 @@ func (s *policySetParameters) Create(ctx context.Context, policySetID string, op
 }
 
 // Read a parameter by its ID.
-func (s *policySetParameters) Read(ctx context.Context, policySetID string, parameterID string) (*PolicySetParameter, error) {
+func (s *policySetParameters) Read(ctx context.Context, policySetID, parameterID string) (*PolicySetParameter, error) {
 	if !validStringID(&policySetID) {
 		return nil, ErrInvalidPolicySetID
 	}
@@ -180,7 +180,7 @@ type PolicySetParameterUpdateOptions struct {
 }
 
 // Update values of an existing parameter.
-func (s *policySetParameters) Update(ctx context.Context, policySetID string, parameterID string, options PolicySetParameterUpdateOptions) (*PolicySetParameter, error) {
+func (s *policySetParameters) Update(ctx context.Context, policySetID, parameterID string, options PolicySetParameterUpdateOptions) (*PolicySetParameter, error) {
 	if !validStringID(&policySetID) {
 		return nil, ErrInvalidPolicySetID
 	}
@@ -204,7 +204,7 @@ func (s *policySetParameters) Update(ctx context.Context, policySetID string, pa
 }
 
 // Delete a parameter by its ID.
-func (s *policySetParameters) Delete(ctx context.Context, policySetID string, parameterID string) error {
+func (s *policySetParameters) Delete(ctx context.Context, policySetID, parameterID string) error {
 	if !validStringID(&policySetID) {
 		return ErrInvalidPolicySetID
 	}

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -47,7 +47,7 @@ const (
 // PolicySetVersionStatus represents a policy set version status.
 type PolicySetVersionStatus string
 
-//List all available policy set version statuses.
+// List all available policy set version statuses.
 const (
 	PolicySetVersionErrored    PolicySetVersionStatus = "errored"
 	PolicySetVersionIngressing PolicySetVersionStatus = "ingressing"

--- a/registry_module.go
+++ b/registry_module.go
@@ -214,7 +214,7 @@ func (o RegistryModuleCreateVersionOptions) valid() error {
 }
 
 // Create a new registry module version
-func (r *registryModules) CreateVersion(ctx context.Context, organization string, name string, provider string, options RegistryModuleCreateVersionOptions) (*RegistryModuleVersion, error) {
+func (r *registryModules) CreateVersion(ctx context.Context, organization, name, provider string, options RegistryModuleCreateVersionOptions) (*RegistryModuleVersion, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
@@ -313,7 +313,7 @@ func (r *registryModules) CreateWithVCSConnection(ctx context.Context, options R
 }
 
 // Read a specific registry module
-func (r *registryModules) Read(ctx context.Context, organization string, name string, provider string) (*RegistryModule, error) {
+func (r *registryModules) Read(ctx context.Context, organization, name, provider string) (*RegistryModule, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
@@ -351,7 +351,7 @@ func (r *registryModules) Read(ctx context.Context, organization string, name st
 }
 
 // Delete is used to delete the entire registry module
-func (r *registryModules) Delete(ctx context.Context, organization string, name string) error {
+func (r *registryModules) Delete(ctx context.Context, organization, name string) error {
 	if !validStringID(&organization) {
 		return ErrInvalidOrg
 	}
@@ -376,7 +376,7 @@ func (r *registryModules) Delete(ctx context.Context, organization string, name 
 }
 
 // DeleteProvider is used to delete the specific registry module provider
-func (r *registryModules) DeleteProvider(ctx context.Context, organization string, name string, provider string) error {
+func (r *registryModules) DeleteProvider(ctx context.Context, organization, name, provider string) error {
 	if !validStringID(&organization) {
 		return ErrInvalidOrg
 	}
@@ -408,7 +408,7 @@ func (r *registryModules) DeleteProvider(ctx context.Context, organization strin
 }
 
 // DeleteVersion is used to delete the specific registry module version
-func (r *registryModules) DeleteVersion(ctx context.Context, organization string, name string, provider string, version string) error {
+func (r *registryModules) DeleteVersion(ctx context.Context, organization, name, provider, version string) error {
 	if !validStringID(&organization) {
 		return ErrInvalidOrg
 	}

--- a/run.go
+++ b/run.go
@@ -48,7 +48,7 @@ type runs struct {
 // RunStatus represents a run state.
 type RunStatus string
 
-//List all available run statuses.
+// List all available run statuses.
 const (
 	RunApplied            RunStatus = "applied"
 	RunApplyQueued        RunStatus = "apply_queued"

--- a/run_task.go
+++ b/run_task.go
@@ -267,7 +267,7 @@ func (s *runTasks) Delete(ctx context.Context, runTaskID string) error {
 }
 
 // Convenient method to attach a run task to a workspace. See: WorkspaceRunTasks.Create()
-func (s *runTasks) AttachToWorkspace(ctx context.Context, workspaceID string, runTaskID string, enforcement TaskEnforcementLevel) (*WorkspaceRunTask, error) {
+func (s *runTasks) AttachToWorkspace(ctx context.Context, workspaceID, runTaskID string, enforcement TaskEnforcementLevel) (*WorkspaceRunTask, error) {
 	return s.client.WorkspaceRunTasks.Create(ctx, workspaceID, WorkspaceRunTaskCreateOptions{
 		EnforcementLevel: enforcement,
 		RunTask:          &RunTask{ID: runTaskID},

--- a/state_version.go
+++ b/state_version.go
@@ -74,7 +74,6 @@ type StateVersionListOptions struct {
 	Workspace    string `url:"filter[workspace][name]"`
 }
 
-//check that StateVersionListOptions fields had valid values
 func (o *StateVersionListOptions) valid() error {
 	if o == nil {
 		return ErrRequiredStateVerListOps
@@ -247,8 +246,8 @@ func (s *stateVersions) ReadCurrent(ctx context.Context, workspaceID string) (*S
 }
 
 // Download retrieves the actual stored state of a state version
-func (s *stateVersions) Download(ctx context.Context, url string) ([]byte, error) {
-	req, err := s.client.newRequest("GET", url, nil)
+func (s *stateVersions) Download(ctx context.Context, u string) ([]byte, error) {
+	req, err := s.client.newRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/state_version_output.go
+++ b/state_version_output.go
@@ -9,9 +9,9 @@ import (
 // Compile-time proof of interface implementation.
 var _ StateVersionOutputs = (*stateVersionOutputs)(nil)
 
-//State version outputs are the output values from a Terraform state file.
-//They include the name and value of the output, as well as a sensitive boolean
-//if the value should be hidden by default in UIs.
+// State version outputs are the output values from a Terraform state file.
+// They include the name and value of the output, as well as a sensitive boolean
+// if the value should be hidden by default in UIs.
 //
 // TFE API docs: https://www.terraform.io/docs/cloud/api/state-version-outputs.html
 type StateVersionOutputs interface {

--- a/task_result.go
+++ b/task_result.go
@@ -21,10 +21,10 @@ type taskResults struct {
 	client *Client
 }
 
-//TaskResultStatus is an enum that represents all possible statuses for a task result
+// TaskResultStatus is an enum that represents all possible statuses for a task result
 type TaskResultStatus string
 
-//TaskEnforcementLevel is an enum that describes the enforcement levels for a run task
+// TaskEnforcementLevel is an enum that describes the enforcement levels for a run task
 type TaskEnforcementLevel string
 
 const (

--- a/team_access.go
+++ b/team_access.go
@@ -106,7 +106,7 @@ type TeamAccessListOptions struct {
 	WorkspaceID string `url:"filter[workspace][id]"`
 }
 
-//check that workspaceID field has a valid value
+// check that workspaceID field has a valid value
 func (o *TeamAccessListOptions) valid() error {
 	if o == nil {
 		return ErrRequiredTeamAccessListOps

--- a/team_member.go
+++ b/team_member.go
@@ -149,7 +149,7 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 	}
 
 	usersOrMemberships := options.kind()
-	URL := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
+	u := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
 
 	var req *retryablehttp.Request
 
@@ -159,7 +159,7 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 		for _, name := range options.Usernames {
 			members = append(members, &teamMemberUser{Username: name})
 		}
-		req, err = s.client.newRequest("POST", URL, members)
+		req, err = s.client.newRequest("POST", u, members)
 		if err != nil {
 			return err
 		}
@@ -169,7 +169,7 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 		for _, ID := range options.OrganizationMembershipIDs {
 			members = append(members, &teamMemberOrgMembership{ID: ID})
 		}
-		req, err = s.client.newRequest("POST", URL, members)
+		req, err = s.client.newRequest("POST", u, members)
 		if err != nil {
 			return err
 		}
@@ -220,7 +220,7 @@ func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMem
 	}
 
 	usersOrMemberships := options.kind()
-	URL := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
+	u := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
 
 	var req *retryablehttp.Request
 
@@ -230,7 +230,7 @@ func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMem
 		for _, name := range options.Usernames {
 			members = append(members, &teamMemberUser{Username: name})
 		}
-		req, err = s.client.newRequest("DELETE", URL, members)
+		req, err = s.client.newRequest("DELETE", u, members)
 		if err != nil {
 			return err
 		}
@@ -240,7 +240,7 @@ func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMem
 		for _, ID := range options.OrganizationMembershipIDs {
 			members = append(members, &teamMemberOrgMembership{ID: ID})
 		}
-		req, err = s.client.newRequest("DELETE", URL, members)
+		req, err = s.client.newRequest("DELETE", u, members)
 		if err != nil {
 			return err
 		}

--- a/tfe.go
+++ b/tfe.go
@@ -344,7 +344,7 @@ func (c *Client) retryHTTPBackoff(min, max time.Duration, attemptNum int, resp *
 
 	// Use the rate limit backoff function when we are rate limited.
 	if resp != nil && resp.StatusCode == 429 {
-		return rateLimitBackoff(min, max, attemptNum, resp)
+		return rateLimitBackoff(min, max, resp)
 	}
 
 	// Set custom duration's when we experience a service interruption.
@@ -361,7 +361,7 @@ func (c *Client) retryHTTPBackoff(min, max time.Duration, attemptNum int, resp *
 // min and max are mainly used for bounding the jitter that will be added to
 // the reset time retrieved from the headers. But if the final wait time is
 // less then min, min will be used instead.
-func rateLimitBackoff(min, max time.Duration, attemptNum int, resp *http.Response) time.Duration {
+func rateLimitBackoff(min, max time.Duration, resp *http.Response) time.Duration {
 	// rnd is used to generate pseudo-random numbers.
 	rnd := rand.New(rand.NewSource(time.Now().UnixNano()))
 
@@ -558,7 +558,7 @@ func serializeRequestBody(v interface{}) (interface{}, error) {
 	// case we want to choose the serialization type based on the
 	// individual record type. To determine that type, we need
 	// to either follow the pointer or examine the slice element type.
-	// There are other theoretical possiblities (e. g. maps,
+	// There are other theoretical possibilities (e. g. maps,
 	// non-pointers) but they wouldn't work anyway because the
 	// json-api library doesn't support serializing other things.
 	var modelType reflect.Type

--- a/validations.go
+++ b/validations.go
@@ -5,7 +5,7 @@ import (
 )
 
 // A regular expression used to validate common string ID patterns.
-var reStringID = regexp.MustCompile(`^[a-zA-Z0-9\-\._]+$`)
+var reStringID = regexp.MustCompile(`^[a-zA-Z0-9\-._]+$`)
 
 // validString checks if the given input is present and non-empty.
 func validString(v *string) bool {

--- a/variable.go
+++ b/variable.go
@@ -38,7 +38,7 @@ type variables struct {
 // CategoryType represents a category type.
 type CategoryType string
 
-//List all available categories.
+// List all available categories.
 const (
 	CategoryEnv       CategoryType = "env"
 	CategoryPolicySet CategoryType = "policy-set"
@@ -153,7 +153,7 @@ func (s *variables) Create(ctx context.Context, workspaceID string, options Vari
 }
 
 // Read a variable by its ID.
-func (s *variables) Read(ctx context.Context, workspaceID string, variableID string) (*Variable, error) {
+func (s *variables) Read(ctx context.Context, workspaceID, variableID string) (*Variable, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
@@ -201,7 +201,7 @@ type VariableUpdateOptions struct {
 }
 
 // Update values of an existing variable.
-func (s *variables) Update(ctx context.Context, workspaceID string, variableID string, options VariableUpdateOptions) (*Variable, error) {
+func (s *variables) Update(ctx context.Context, workspaceID, variableID string, options VariableUpdateOptions) (*Variable, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
@@ -225,7 +225,7 @@ func (s *variables) Update(ctx context.Context, workspaceID string, variableID s
 }
 
 // Delete a variable by its ID.
-func (s *variables) Delete(ctx context.Context, workspaceID string, variableID string) error {
+func (s *variables) Delete(ctx context.Context, workspaceID, variableID string) error {
 	if !validStringID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}

--- a/workspace.go
+++ b/workspace.go
@@ -417,7 +417,7 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 }
 
 // ReadWithOptions reads a workspace by name and organization name with given options.
-func (s *workspaces) ReadWithOptions(ctx context.Context, organization string, workspace string, options *WorkspaceReadOptions) (*Workspace, error) {
+func (s *workspaces) ReadWithOptions(ctx context.Context, organization, workspace string, options *WorkspaceReadOptions) (*Workspace, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
@@ -924,7 +924,7 @@ func (s *workspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID s
 // WorkspaceAddRemoteStateConsumersOptions represents the options for adding remote state consumers
 // to a workspace.
 type WorkspaceAddRemoteStateConsumersOptions struct {
-	/// The workspaces to add as remote state consumers to the workspace.
+	// The workspaces to add as remote state consumers to the workspace.
 	Workspaces []*Workspace
 }
 
@@ -959,7 +959,7 @@ func (s *workspaces) AddRemoteStateConsumers(ctx context.Context, workspaceID st
 // WorkspaceRemoveRemoteStateConsumersOptions represents the options for removing remote state
 // consumers from a workspace.
 type WorkspaceRemoveRemoteStateConsumersOptions struct {
-	/// The workspaces to remove as remote state consumers from the workspace.
+	// The workspaces to remove as remote state consumers from the workspace.
 	Workspaces []*Workspace
 }
 
@@ -994,7 +994,7 @@ func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID
 // WorkspaceUpdateRemoteStateConsumersOptions represents the options for
 // updatintg remote state consumers from a workspace.
 type WorkspaceUpdateRemoteStateConsumersOptions struct {
-	/// The workspaces to update remote state consumers for the workspace.
+	// The workspaces to update remote state consumers for the workspace.
 	Workspaces []*Workspace
 }
 

--- a/workspace_run_task.go
+++ b/workspace_run_task.go
@@ -75,7 +75,7 @@ func (s *workspaceRunTasks) List(ctx context.Context, workspaceID string, option
 }
 
 // Read a workspace run task by ID
-func (s *workspaceRunTasks) Read(ctx context.Context, workspaceID string, workspaceTaskID string) (*WorkspaceRunTask, error) {
+func (s *workspaceRunTasks) Read(ctx context.Context, workspaceID, workspaceTaskID string) (*WorkspaceRunTask, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
@@ -152,7 +152,7 @@ type WorkspaceRunTaskUpdateOptions struct {
 }
 
 // Update an existing workspace run task by ID
-func (s *workspaceRunTasks) Update(ctx context.Context, workspaceID string, workspaceTaskID string, options WorkspaceRunTaskUpdateOptions) (*WorkspaceRunTask, error) {
+func (s *workspaceRunTasks) Update(ctx context.Context, workspaceID, workspaceTaskID string, options WorkspaceRunTaskUpdateOptions) (*WorkspaceRunTask, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
@@ -181,7 +181,7 @@ func (s *workspaceRunTasks) Update(ctx context.Context, workspaceID string, work
 }
 
 // Delete a workspace run task by ID
-func (s *workspaceRunTasks) Delete(ctx context.Context, workspaceID string, workspaceTaskID string) error {
+func (s *workspaceRunTasks) Delete(ctx context.Context, workspaceID, workspaceTaskID string) error {
 	if !validStringID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}


### PR DESCRIPTION
## Description

As part of our 1.0 efforts, we're trying to enforce best Go practices and improve consistency in our codebase. Our current CI pipeline is in need of much improvement allowing for inconsistencies, redundancies, and errors to go unnoticed. This PR enables several linters can serve as beneficial tools in our refactoring efforts:

#### goconst
One thing we noticed across our codebase were duplicate error messages. Goconst enables us to find these duplicate strings that can be refactored into a constant. In this case, commonly thrown errors should be refactored into a constant that lives in `errors.go`

<img width="817" alt="Screen Shot 2022-02-16 at 5 08 56 PM" src="https://user-images.githubusercontent.com/7086531/155203483-9fad994f-e821-42cf-aec2-9620b01088e2.png">

#### gocritic
This linter will handle the brunt of our linter pipeline enforcing opinionated best practices for go. I've enabled several tags for `gocritic`:
* `diagnostic` - perform diagnostic checks to find potential programming errors.
* `opinionated` - enforces gocritic's opinionated style guide. 
* `performance` - find minor performance issues that can become bottlenecks.

Some interesting errors returned:

- Update and Create options are considered "heavy" in size and gocritic recommends we pass the parameter as a pointer.
- Some of our variable names are shadow imports of packages, i.e `var url string` or `var errors []string`
- Some of our regular expressions used in our validations can be simplified
- If/else chains rewritten as switch statements
- Comment formatting issues

Read more in the [docs](https://go-critic.com/overview) 

#### misspell 
Often times grammar mistakes make their way unnoticed into our documentation. While a simple spelling mistake won't necessarily hamper the development experience, with 1.0 we'd like to begin to enforce high documentation quality and that begins with the little things :) `misspell` will help us find these unnoticed buggers. 

#### unparam
unparam will help us find function parameters that are unused. 

## External links
- [golangci-lint configuration](https://golangci-lint.run/usage/configuration/)