### PR TITLE
Use consistent naming across resource methods

### DIFF
--- a/agent_token.go
+++ b/agent_token.go
@@ -19,8 +19,8 @@ type AgentTokens interface {
 	// List all the agent tokens of the given agent pool.
 	List(ctx context.Context, agentPoolID string) (*AgentTokenList, error)
 
-	// Generate a new agent token with the given options.
-	Generate(ctx context.Context, agentPoolID string, options AgentTokenGenerateOptions) (*AgentToken, error)
+	// Create a new agent token with the given options.
+	Create(ctx context.Context, agentPoolID string, options AgentTokenCreateOptions) (*AgentToken, error)
 
 	// Read an agent token by its ID.
 	Read(ctx context.Context, agentTokenID string) (*AgentToken, error)
@@ -70,8 +70,8 @@ func (s *agentTokens) List(ctx context.Context, agentPoolID string) (*AgentToken
 	return tokenList, nil
 }
 
-// AgentTokenGenerateOptions represents the options for creating an agent token.
-type AgentTokenGenerateOptions struct {
+// AgentTokenCreateOptions represents the options for creating an agent token.
+type AgentTokenCreateOptions struct {
 	// Type is a public field utilized by JSON:API to
 	// set the resource type via the field tag.
 	// It is not a user-defined value and does not need to be set.
@@ -82,8 +82,8 @@ type AgentTokenGenerateOptions struct {
 	Description *string `jsonapi:"attr,description"`
 }
 
-// Generate a new agent token with the given options.
-func (s *agentTokens) Generate(ctx context.Context, agentPoolID string, options AgentTokenGenerateOptions) (*AgentToken, error) {
+// Create a new agent token with the given options.
+func (s *agentTokens) Create(ctx context.Context, agentPoolID string, options AgentTokenCreateOptions) (*AgentToken, error) {
 	if !validStringID(&agentPoolID) {
 		return nil, ErrInvalidAgentPoolID
 	}

--- a/agent_token_integration_test.go
+++ b/agent_token_integration_test.go
@@ -51,7 +51,7 @@ func TestAgentTokensList(t *testing.T) {
 	})
 }
 
-func TestAgentTokensGenerate(t *testing.T) {
+func TestAgentTokensCreate(t *testing.T) {
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -62,7 +62,7 @@ func TestAgentTokensGenerate(t *testing.T) {
 	defer apTestCleanup()
 
 	t.Run("with valid description", func(t *testing.T) {
-		token, err := client.AgentTokens.Generate(ctx, apTest.ID, AgentTokenGenerateOptions{
+		token, err := client.AgentTokens.Create(ctx, apTest.ID, AgentTokenCreateOptions{
 			Description: String(randomString(t)),
 		})
 		require.NoError(t, err)
@@ -70,13 +70,13 @@ func TestAgentTokensGenerate(t *testing.T) {
 	})
 
 	t.Run("without valid description", func(t *testing.T) {
-		at, err := client.AgentTokens.Generate(ctx, badIdentifier, AgentTokenGenerateOptions{})
+		at, err := client.AgentTokens.Create(ctx, badIdentifier, AgentTokenCreateOptions{})
 		assert.Nil(t, at)
 		assert.EqualError(t, err, ErrInvalidAgentPoolID.Error())
 	})
 
 	t.Run("without valid agent pool ID", func(t *testing.T) {
-		at, err := client.AgentTokens.Generate(ctx, badIdentifier, AgentTokenGenerateOptions{
+		at, err := client.AgentTokens.Create(ctx, badIdentifier, AgentTokenCreateOptions{
 			Description: String(randomString(t)),
 		})
 		assert.Nil(t, at)

--- a/helper_test.go
+++ b/helper_test.go
@@ -897,7 +897,7 @@ func createTeamToken(t *testing.T, client *Client, tm *Team) (*TeamToken, func()
 	}
 
 	ctx := context.Background()
-	tt, err := client.TeamTokens.Generate(ctx, tm.ID)
+	tt, err := client.TeamTokens.Create(ctx, tm.ID)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -74,7 +74,7 @@ func createAgentToken(t *testing.T, client *Client, ap *AgentPool) (*AgentToken,
 	}
 
 	ctx := context.Background()
-	at, err := client.AgentTokens.Generate(ctx, ap.ID, AgentTokenGenerateOptions{
+	at, err := client.AgentTokens.Create(ctx, ap.ID, AgentTokenCreateOptions{
 		Description: String(randomString(t)),
 	})
 	if err != nil {
@@ -439,7 +439,7 @@ func createOrganizationToken(t *testing.T, client *Client, org *Organization) (*
 	}
 
 	ctx := context.Background()
-	tk, err := client.OrganizationTokens.Generate(ctx, org.Name)
+	tk, err := client.OrganizationTokens.Create(ctx, org.Name)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mocks/agent_token_mocks.go
+++ b/mocks/agent_token_mocks.go
@@ -35,6 +35,21 @@ func (m *MockAgentTokens) EXPECT() *MockAgentTokensMockRecorder {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockAgentTokens) Create(ctx context.Context, agentPoolID string, options tfe.AgentTokenCreateOptions) (*tfe.AgentToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, agentPoolID, options)
+	ret0, _ := ret[0].(*tfe.AgentToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockAgentTokensMockRecorder) Create(ctx, agentPoolID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockAgentTokens)(nil).Create), ctx, agentPoolID, options)
+}
+
 // Delete mocks base method.
 func (m *MockAgentTokens) Delete(ctx context.Context, agentTokenID string) error {
 	m.ctrl.T.Helper()
@@ -47,21 +62,6 @@ func (m *MockAgentTokens) Delete(ctx context.Context, agentTokenID string) error
 func (mr *MockAgentTokensMockRecorder) Delete(ctx, agentTokenID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAgentTokens)(nil).Delete), ctx, agentTokenID)
-}
-
-// Generate mocks base method.
-func (m *MockAgentTokens) Generate(ctx context.Context, agentPoolID string, options tfe.AgentTokenGenerateOptions) (*tfe.AgentToken, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Generate", ctx, agentPoolID, options)
-	ret0, _ := ret[0].(*tfe.AgentToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Generate indicates an expected call of Generate.
-func (mr *MockAgentTokensMockRecorder) Generate(ctx, agentPoolID, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockAgentTokens)(nil).Generate), ctx, agentPoolID, options)
 }
 
 // List mocks base method.

--- a/mocks/organization_mocks.go
+++ b/mocks/organization_mocks.go
@@ -35,21 +35,6 @@ func (m *MockOrganizations) EXPECT() *MockOrganizationsMockRecorder {
 	return m.recorder
 }
 
-// Capacity mocks base method.
-func (m *MockOrganizations) Capacity(ctx context.Context, organization string) (*tfe.Capacity, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Capacity", ctx, organization)
-	ret0, _ := ret[0].(*tfe.Capacity)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Capacity indicates an expected call of Capacity.
-func (mr *MockOrganizationsMockRecorder) Capacity(ctx, organization interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Capacity", reflect.TypeOf((*MockOrganizations)(nil).Capacity), ctx, organization)
-}
-
 // Create mocks base method.
 func (m *MockOrganizations) Create(ctx context.Context, options tfe.OrganizationCreateOptions) (*tfe.Organization, error) {
 	m.ctrl.T.Helper()
@@ -77,21 +62,6 @@ func (m *MockOrganizations) Delete(ctx context.Context, organization string) err
 func (mr *MockOrganizationsMockRecorder) Delete(ctx, organization interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockOrganizations)(nil).Delete), ctx, organization)
-}
-
-// Entitlements mocks base method.
-func (m *MockOrganizations) Entitlements(ctx context.Context, organization string) (*tfe.Entitlements, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Entitlements", ctx, organization)
-	ret0, _ := ret[0].(*tfe.Entitlements)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Entitlements indicates an expected call of Entitlements.
-func (mr *MockOrganizationsMockRecorder) Entitlements(ctx, organization interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Entitlements", reflect.TypeOf((*MockOrganizations)(nil).Entitlements), ctx, organization)
 }
 
 // List mocks base method.
@@ -124,19 +94,49 @@ func (mr *MockOrganizationsMockRecorder) Read(ctx, organization interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockOrganizations)(nil).Read), ctx, organization)
 }
 
-// RunQueue mocks base method.
-func (m *MockOrganizations) RunQueue(ctx context.Context, organization string, options tfe.RunQueueOptions) (*tfe.RunQueue, error) {
+// ReadCapacity mocks base method.
+func (m *MockOrganizations) ReadCapacity(ctx context.Context, organization string) (*tfe.Capacity, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RunQueue", ctx, organization, options)
+	ret := m.ctrl.Call(m, "ReadCapacity", ctx, organization)
+	ret0, _ := ret[0].(*tfe.Capacity)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadCapacity indicates an expected call of ReadCapacity.
+func (mr *MockOrganizationsMockRecorder) ReadCapacity(ctx, organization interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadCapacity", reflect.TypeOf((*MockOrganizations)(nil).ReadCapacity), ctx, organization)
+}
+
+// ReadEntitlements mocks base method.
+func (m *MockOrganizations) ReadEntitlements(ctx context.Context, organization string) (*tfe.Entitlements, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadEntitlements", ctx, organization)
+	ret0, _ := ret[0].(*tfe.Entitlements)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadEntitlements indicates an expected call of ReadEntitlements.
+func (mr *MockOrganizationsMockRecorder) ReadEntitlements(ctx, organization interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadEntitlements", reflect.TypeOf((*MockOrganizations)(nil).ReadEntitlements), ctx, organization)
+}
+
+// ReadRunQueue mocks base method.
+func (m *MockOrganizations) ReadRunQueue(ctx context.Context, organization string, options tfe.ReadRunQueueOptions) (*tfe.RunQueue, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadRunQueue", ctx, organization, options)
 	ret0, _ := ret[0].(*tfe.RunQueue)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// RunQueue indicates an expected call of RunQueue.
-func (mr *MockOrganizationsMockRecorder) RunQueue(ctx, organization, options interface{}) *gomock.Call {
+// ReadRunQueue indicates an expected call of ReadRunQueue.
+func (mr *MockOrganizationsMockRecorder) ReadRunQueue(ctx, organization, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunQueue", reflect.TypeOf((*MockOrganizations)(nil).RunQueue), ctx, organization, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadRunQueue", reflect.TypeOf((*MockOrganizations)(nil).ReadRunQueue), ctx, organization, options)
 }
 
 // Update mocks base method.

--- a/mocks/organization_token_mocks.go
+++ b/mocks/organization_token_mocks.go
@@ -35,6 +35,21 @@ func (m *MockOrganizationTokens) EXPECT() *MockOrganizationTokensMockRecorder {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockOrganizationTokens) Create(ctx context.Context, organization string) (*tfe.OrganizationToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, organization)
+	ret0, _ := ret[0].(*tfe.OrganizationToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockOrganizationTokensMockRecorder) Create(ctx, organization interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockOrganizationTokens)(nil).Create), ctx, organization)
+}
+
 // Delete mocks base method.
 func (m *MockOrganizationTokens) Delete(ctx context.Context, organization string) error {
 	m.ctrl.T.Helper()
@@ -47,21 +62,6 @@ func (m *MockOrganizationTokens) Delete(ctx context.Context, organization string
 func (mr *MockOrganizationTokensMockRecorder) Delete(ctx, organization interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockOrganizationTokens)(nil).Delete), ctx, organization)
-}
-
-// Generate mocks base method.
-func (m *MockOrganizationTokens) Generate(ctx context.Context, organization string) (*tfe.OrganizationToken, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Generate", ctx, organization)
-	ret0, _ := ret[0].(*tfe.OrganizationToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Generate indicates an expected call of Generate.
-func (mr *MockOrganizationTokensMockRecorder) Generate(ctx, organization interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockOrganizationTokens)(nil).Generate), ctx, organization)
 }
 
 // Read mocks base method.

--- a/mocks/plan_mocks.go
+++ b/mocks/plan_mocks.go
@@ -36,21 +36,6 @@ func (m *MockPlans) EXPECT() *MockPlansMockRecorder {
 	return m.recorder
 }
 
-// JSONOutput mocks base method.
-func (m *MockPlans) JSONOutput(ctx context.Context, planID string) ([]byte, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "JSONOutput", ctx, planID)
-	ret0, _ := ret[0].([]byte)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// JSONOutput indicates an expected call of JSONOutput.
-func (mr *MockPlansMockRecorder) JSONOutput(ctx, planID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "JSONOutput", reflect.TypeOf((*MockPlans)(nil).JSONOutput), ctx, planID)
-}
-
 // Logs mocks base method.
 func (m *MockPlans) Logs(ctx context.Context, planID string) (io.Reader, error) {
 	m.ctrl.T.Helper()
@@ -79,4 +64,19 @@ func (m *MockPlans) Read(ctx context.Context, planID string) (*tfe.Plan, error) 
 func (mr *MockPlansMockRecorder) Read(ctx, planID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockPlans)(nil).Read), ctx, planID)
+}
+
+// ReadJSONOutput mocks base method.
+func (m *MockPlans) ReadJSONOutput(ctx context.Context, planID string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadJSONOutput", ctx, planID)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadJSONOutput indicates an expected call of ReadJSONOutput.
+func (mr *MockPlansMockRecorder) ReadJSONOutput(ctx, planID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadJSONOutput", reflect.TypeOf((*MockPlans)(nil).ReadJSONOutput), ctx, planID)
 }

--- a/mocks/state_version_mocks.go
+++ b/mocks/state_version_mocks.go
@@ -50,36 +50,6 @@ func (mr *MockStateVersionsMockRecorder) Create(ctx, workspaceID, options interf
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockStateVersions)(nil).Create), ctx, workspaceID, options)
 }
 
-// Current mocks base method.
-func (m *MockStateVersions) Current(ctx context.Context, workspaceID string) (*tfe.StateVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Current", ctx, workspaceID)
-	ret0, _ := ret[0].(*tfe.StateVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Current indicates an expected call of Current.
-func (mr *MockStateVersionsMockRecorder) Current(ctx, workspaceID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Current", reflect.TypeOf((*MockStateVersions)(nil).Current), ctx, workspaceID)
-}
-
-// CurrentWithOptions mocks base method.
-func (m *MockStateVersions) CurrentWithOptions(ctx context.Context, workspaceID string, options *tfe.StateVersionCurrentOptions) (*tfe.StateVersion, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CurrentWithOptions", ctx, workspaceID, options)
-	ret0, _ := ret[0].(*tfe.StateVersion)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// CurrentWithOptions indicates an expected call of CurrentWithOptions.
-func (mr *MockStateVersionsMockRecorder) CurrentWithOptions(ctx, workspaceID, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CurrentWithOptions", reflect.TypeOf((*MockStateVersions)(nil).CurrentWithOptions), ctx, workspaceID, options)
-}
-
 // Download mocks base method.
 func (m *MockStateVersions) Download(ctx context.Context, url string) ([]byte, error) {
 	m.ctrl.T.Helper()
@@ -110,19 +80,19 @@ func (mr *MockStateVersionsMockRecorder) List(ctx, options interface{}) *gomock.
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockStateVersions)(nil).List), ctx, options)
 }
 
-// Outputs mocks base method.
-func (m *MockStateVersions) Outputs(ctx context.Context, svID string, options *tfe.StateVersionOutputsListOptions) (*tfe.StateVersionOutputsList, error) {
+// ListOutputs mocks base method.
+func (m *MockStateVersions) ListOutputs(ctx context.Context, svID string, options *tfe.StateVersionOutputsListOptions) (*tfe.StateVersionOutputsList, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Outputs", ctx, svID, options)
+	ret := m.ctrl.Call(m, "ListOutputs", ctx, svID, options)
 	ret0, _ := ret[0].(*tfe.StateVersionOutputsList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Outputs indicates an expected call of Outputs.
-func (mr *MockStateVersionsMockRecorder) Outputs(ctx, svID, options interface{}) *gomock.Call {
+// ListOutputs indicates an expected call of ListOutputs.
+func (mr *MockStateVersionsMockRecorder) ListOutputs(ctx, svID, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Outputs", reflect.TypeOf((*MockStateVersions)(nil).Outputs), ctx, svID, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutputs", reflect.TypeOf((*MockStateVersions)(nil).ListOutputs), ctx, svID, options)
 }
 
 // Read mocks base method.
@@ -138,6 +108,36 @@ func (m *MockStateVersions) Read(ctx context.Context, svID string) (*tfe.StateVe
 func (mr *MockStateVersionsMockRecorder) Read(ctx, svID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockStateVersions)(nil).Read), ctx, svID)
+}
+
+// ReadCurrent mocks base method.
+func (m *MockStateVersions) ReadCurrent(ctx context.Context, workspaceID string) (*tfe.StateVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadCurrent", ctx, workspaceID)
+	ret0, _ := ret[0].(*tfe.StateVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadCurrent indicates an expected call of ReadCurrent.
+func (mr *MockStateVersionsMockRecorder) ReadCurrent(ctx, workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadCurrent", reflect.TypeOf((*MockStateVersions)(nil).ReadCurrent), ctx, workspaceID)
+}
+
+// ReadCurrentWithOptions mocks base method.
+func (m *MockStateVersions) ReadCurrentWithOptions(ctx context.Context, workspaceID string, options *tfe.StateVersionCurrentOptions) (*tfe.StateVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadCurrentWithOptions", ctx, workspaceID, options)
+	ret0, _ := ret[0].(*tfe.StateVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadCurrentWithOptions indicates an expected call of ReadCurrentWithOptions.
+func (mr *MockStateVersionsMockRecorder) ReadCurrentWithOptions(ctx, workspaceID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadCurrentWithOptions", reflect.TypeOf((*MockStateVersions)(nil).ReadCurrentWithOptions), ctx, workspaceID, options)
 }
 
 // ReadWithOptions mocks base method.

--- a/mocks/team_token_mocks.go
+++ b/mocks/team_token_mocks.go
@@ -35,6 +35,21 @@ func (m *MockTeamTokens) EXPECT() *MockTeamTokensMockRecorder {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockTeamTokens) Create(ctx context.Context, teamID string) (*tfe.TeamToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, teamID)
+	ret0, _ := ret[0].(*tfe.TeamToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockTeamTokensMockRecorder) Create(ctx, teamID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTeamTokens)(nil).Create), ctx, teamID)
+}
+
 // Delete mocks base method.
 func (m *MockTeamTokens) Delete(ctx context.Context, teamID string) error {
 	m.ctrl.T.Helper()
@@ -47,21 +62,6 @@ func (m *MockTeamTokens) Delete(ctx context.Context, teamID string) error {
 func (mr *MockTeamTokensMockRecorder) Delete(ctx, teamID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockTeamTokens)(nil).Delete), ctx, teamID)
-}
-
-// Generate mocks base method.
-func (m *MockTeamTokens) Generate(ctx context.Context, teamID string) (*tfe.TeamToken, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Generate", ctx, teamID)
-	ret0, _ := ret[0].(*tfe.TeamToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Generate indicates an expected call of Generate.
-func (mr *MockTeamTokensMockRecorder) Generate(ctx, teamID interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockTeamTokens)(nil).Generate), ctx, teamID)
 }
 
 // Read mocks base method.

--- a/mocks/user_mocks.go
+++ b/mocks/user_mocks.go
@@ -50,17 +50,17 @@ func (mr *MockUsersMockRecorder) ReadCurrent(ctx interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadCurrent", reflect.TypeOf((*MockUsers)(nil).ReadCurrent), ctx)
 }
 
-// Update mocks base method.
-func (m *MockUsers) Update(ctx context.Context, options tfe.UserUpdateOptions) (*tfe.User, error) {
+// UpdateCurrent mocks base method.
+func (m *MockUsers) UpdateCurrent(ctx context.Context, options tfe.UserUpdateOptions) (*tfe.User, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, options)
+	ret := m.ctrl.Call(m, "UpdateCurrent", ctx, options)
 	ret0, _ := ret[0].(*tfe.User)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// Update indicates an expected call of Update.
-func (mr *MockUsersMockRecorder) Update(ctx, options interface{}) *gomock.Call {
+// UpdateCurrent indicates an expected call of UpdateCurrent.
+func (mr *MockUsersMockRecorder) UpdateCurrent(ctx, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockUsers)(nil).Update), ctx, options)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateCurrent", reflect.TypeOf((*MockUsers)(nil).UpdateCurrent), ctx, options)
 }

--- a/mocks/user_token_mocks.go
+++ b/mocks/user_token_mocks.go
@@ -35,6 +35,21 @@ func (m *MockUserTokens) EXPECT() *MockUserTokensMockRecorder {
 	return m.recorder
 }
 
+// Create mocks base method.
+func (m *MockUserTokens) Create(ctx context.Context, userID string, options tfe.UserTokenCreateOptions) (*tfe.UserToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Create", ctx, userID, options)
+	ret0, _ := ret[0].(*tfe.UserToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Create indicates an expected call of Create.
+func (mr *MockUserTokensMockRecorder) Create(ctx, userID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockUserTokens)(nil).Create), ctx, userID, options)
+}
+
 // Delete mocks base method.
 func (m *MockUserTokens) Delete(ctx context.Context, tokenID string) error {
 	m.ctrl.T.Helper()
@@ -47,21 +62,6 @@ func (m *MockUserTokens) Delete(ctx context.Context, tokenID string) error {
 func (mr *MockUserTokensMockRecorder) Delete(ctx, tokenID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockUserTokens)(nil).Delete), ctx, tokenID)
-}
-
-// Generate mocks base method.
-func (m *MockUserTokens) Generate(ctx context.Context, userID string, options tfe.UserTokenGenerateOptions) (*tfe.UserToken, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Generate", ctx, userID, options)
-	ret0, _ := ret[0].(*tfe.UserToken)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Generate indicates an expected call of Generate.
-func (mr *MockUserTokensMockRecorder) Generate(ctx, userID, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockUserTokens)(nil).Generate), ctx, userID, options)
 }
 
 // List mocks base method.

--- a/mocks/workspace_mocks.go
+++ b/mocks/workspace_mocks.go
@@ -152,6 +152,36 @@ func (mr *MockWorkspacesMockRecorder) List(ctx, organization, options interface{
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockWorkspaces)(nil).List), ctx, organization, options)
 }
 
+// ListRemoteStateConsumers mocks base method.
+func (m *MockWorkspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID string, options *tfe.RemoteStateConsumersListOptions) (*tfe.WorkspaceList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListRemoteStateConsumers", ctx, workspaceID, options)
+	ret0, _ := ret[0].(*tfe.WorkspaceList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListRemoteStateConsumers indicates an expected call of ListRemoteStateConsumers.
+func (mr *MockWorkspacesMockRecorder) ListRemoteStateConsumers(ctx, workspaceID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListRemoteStateConsumers", reflect.TypeOf((*MockWorkspaces)(nil).ListRemoteStateConsumers), ctx, workspaceID, options)
+}
+
+// ListTags mocks base method.
+func (m *MockWorkspaces) ListTags(ctx context.Context, workspaceID string, options *tfe.WorkspaceTagListOptions) (*tfe.TagList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListTags", ctx, workspaceID, options)
+	ret0, _ := ret[0].(*tfe.TagList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListTags indicates an expected call of ListTags.
+func (mr *MockWorkspacesMockRecorder) ListTags(ctx, workspaceID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListTags", reflect.TypeOf((*MockWorkspaces)(nil).ListTags), ctx, workspaceID, options)
+}
+
 // Lock mocks base method.
 func (m *MockWorkspaces) Lock(ctx context.Context, workspaceID string, options tfe.WorkspaceLockOptions) (*tfe.Workspace, error) {
 	m.ctrl.T.Helper()
@@ -242,21 +272,6 @@ func (mr *MockWorkspacesMockRecorder) Readme(ctx, workspaceID interface{}) *gomo
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Readme", reflect.TypeOf((*MockWorkspaces)(nil).Readme), ctx, workspaceID)
 }
 
-// RemoteStateConsumers mocks base method.
-func (m *MockWorkspaces) RemoteStateConsumers(ctx context.Context, workspaceID string, options *tfe.RemoteStateConsumersListOptions) (*tfe.WorkspaceList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "RemoteStateConsumers", ctx, workspaceID, options)
-	ret0, _ := ret[0].(*tfe.WorkspaceList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// RemoteStateConsumers indicates an expected call of RemoteStateConsumers.
-func (mr *MockWorkspacesMockRecorder) RemoteStateConsumers(ctx, workspaceID, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoteStateConsumers", reflect.TypeOf((*MockWorkspaces)(nil).RemoteStateConsumers), ctx, workspaceID, options)
-}
-
 // RemoveRemoteStateConsumers mocks base method.
 func (m *MockWorkspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID string, options tfe.WorkspaceRemoveRemoteStateConsumersOptions) error {
 	m.ctrl.T.Helper()
@@ -313,21 +328,6 @@ func (m *MockWorkspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceI
 func (mr *MockWorkspacesMockRecorder) RemoveVCSConnectionByID(ctx, workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVCSConnectionByID", reflect.TypeOf((*MockWorkspaces)(nil).RemoveVCSConnectionByID), ctx, workspaceID)
-}
-
-// Tags mocks base method.
-func (m *MockWorkspaces) Tags(ctx context.Context, workspaceID string, options *tfe.WorkspaceTagListOptions) (*tfe.TagList, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Tags", ctx, workspaceID, options)
-	ret0, _ := ret[0].(*tfe.TagList)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// Tags indicates an expected call of Tags.
-func (mr *MockWorkspacesMockRecorder) Tags(ctx, workspaceID, options interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Tags", reflect.TypeOf((*MockWorkspaces)(nil).Tags), ctx, workspaceID, options)
 }
 
 // UnassignSSHKey mocks base method.

--- a/organization.go
+++ b/organization.go
@@ -31,14 +31,14 @@ type Organizations interface {
 	// Delete an organization by its name.
 	Delete(ctx context.Context, organization string) error
 
-	// Capacity shows the current run capacity of an organization.
-	Capacity(ctx context.Context, organization string) (*Capacity, error)
+	// ReadCapacity shows the current run capacity of an organization.
+	ReadCapacity(ctx context.Context, organization string) (*Capacity, error)
 
-	// Entitlements shows the entitlements of an organization.
-	Entitlements(ctx context.Context, organization string) (*Entitlements, error)
+	// ReadEntitlements shows the entitlements of an organization.
+	ReadEntitlements(ctx context.Context, organization string) (*Entitlements, error)
 
-	// RunQueue shows the current run queue of an organization.
-	RunQueue(ctx context.Context, organization string, options RunQueueOptions) (*RunQueue, error)
+	// ReadRunQueue shows the current run queue of an organization.
+	ReadRunQueue(ctx context.Context, organization string, options ReadRunQueueOptions) (*RunQueue, error)
 }
 
 // organizations implements Organizations.
@@ -297,8 +297,8 @@ func (s *organizations) Delete(ctx context.Context, organization string) error {
 	return s.client.do(ctx, req, nil)
 }
 
-// Capacity shows the currently used capacity of an organization.
-func (s *organizations) Capacity(ctx context.Context, organization string) (*Capacity, error) {
+// ReadCapacity shows the currently used capacity of an organization.
+func (s *organizations) ReadCapacity(ctx context.Context, organization string) (*Capacity, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
@@ -318,8 +318,8 @@ func (s *organizations) Capacity(ctx context.Context, organization string) (*Cap
 	return c, nil
 }
 
-// Entitlements shows the entitlements of an organization.
-func (s *organizations) Entitlements(ctx context.Context, organization string) (*Entitlements, error) {
+// ReadEntitlements shows the entitlements of an organization.
+func (s *organizations) ReadEntitlements(ctx context.Context, organization string) (*Entitlements, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
@@ -339,13 +339,13 @@ func (s *organizations) Entitlements(ctx context.Context, organization string) (
 	return e, nil
 }
 
-// RunQueueOptions represents the options for showing the queue.
-type RunQueueOptions struct {
+// ReadRunQueueOptions represents the options for showing the queue.
+type ReadRunQueueOptions struct {
 	ListOptions
 }
 
-// RunQueue shows the current run queue of an organization.
-func (s *organizations) RunQueue(ctx context.Context, organization string, options RunQueueOptions) (*RunQueue, error) {
+// ReadRunQueue shows the current run queue of an organization.
+func (s *organizations) ReadRunQueue(ctx context.Context, organization string, options ReadRunQueueOptions) (*RunQueue, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -235,7 +235,7 @@ func TestOrganizationsDelete(t *testing.T) {
 	})
 }
 
-func TestOrganizationsCapacity(t *testing.T) {
+func TestOrganizationsReadCapacity(t *testing.T) {
 	t.Skip("Capacity queues are not available in the API")
 	client := testClient(t)
 	ctx := context.Background()
@@ -253,7 +253,7 @@ func TestOrganizationsCapacity(t *testing.T) {
 	defer wTestCleanup4()
 
 	t.Run("without queued runs", func(t *testing.T) {
-		c, err := client.Organizations.Capacity(ctx, orgTest.Name)
+		c, err := client.Organizations.ReadCapacity(ctx, orgTest.Name)
 		require.NoError(t, err)
 		assert.Equal(t, 0, c.Pending)
 		assert.Equal(t, 0, c.Running)
@@ -271,7 +271,7 @@ func TestOrganizationsCapacity(t *testing.T) {
 		_, runCleanup4 := createRun(t, client, wTest4)
 		defer runCleanup4()
 
-		c, err := client.Organizations.Capacity(ctx, orgTest.Name)
+		c, err := client.Organizations.ReadCapacity(ctx, orgTest.Name)
 		require.NoError(t, err)
 		assert.Equal(t, 2, c.Pending)
 		assert.Equal(t, 2, c.Running)
@@ -289,7 +289,7 @@ func TestOrganizationsCapacity(t *testing.T) {
 	})
 }
 
-func TestOrganizationsEntitlements(t *testing.T) {
+func TestOrganizationsReadEntitlements(t *testing.T) {
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -300,7 +300,7 @@ func TestOrganizationsEntitlements(t *testing.T) {
 	defer orgTestCleanup()
 
 	t.Run("when the org exists", func(t *testing.T) {
-		entitlements, err := client.Organizations.Entitlements(ctx, orgTest.Name)
+		entitlements, err := client.Organizations.ReadEntitlements(ctx, orgTest.Name)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, entitlements.ID)
@@ -317,18 +317,18 @@ func TestOrganizationsEntitlements(t *testing.T) {
 	})
 
 	t.Run("with invalid name", func(t *testing.T) {
-		entitlements, err := client.Organizations.Entitlements(ctx, badIdentifier)
+		entitlements, err := client.Organizations.ReadEntitlements(ctx, badIdentifier)
 		assert.Nil(t, entitlements)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("when the org does not exist", func(t *testing.T) {
-		_, err := client.Organizations.Entitlements(ctx, randomString(t))
+		_, err := client.Organizations.ReadEntitlements(ctx, randomString(t))
 		assert.Equal(t, ErrResourceNotFound, err)
 	})
 }
 
-func TestOrganizationsRunQueue(t *testing.T) {
+func TestOrganizationsReadRunQueue(t *testing.T) {
 	t.Skip("Capacity queues are not available in the API")
 	client := testClient(t)
 	ctx := context.Background()
@@ -346,7 +346,7 @@ func TestOrganizationsRunQueue(t *testing.T) {
 	defer wTestCleanup4()
 
 	t.Run("without queued runs", func(t *testing.T) {
-		rq, err := client.Organizations.RunQueue(ctx, orgTest.Name, RunQueueOptions{})
+		rq, err := client.Organizations.ReadRunQueue(ctx, orgTest.Name, ReadRunQueueOptions{})
 		require.NoError(t, err)
 		assert.Equal(t, 0, len(rq.Items))
 	})
@@ -364,7 +364,7 @@ func TestOrganizationsRunQueue(t *testing.T) {
 	// For this test FRQ should be enabled and have a
 	// limit of 2 concurrent runs per organization.
 	t.Run("with queued runs", func(t *testing.T) {
-		rq, err := client.Organizations.RunQueue(ctx, orgTest.Name, RunQueueOptions{})
+		rq, err := client.Organizations.ReadRunQueue(ctx, orgTest.Name, ReadRunQueueOptions{})
 		require.NoError(t, err)
 
 		found := []string{}
@@ -379,7 +379,7 @@ func TestOrganizationsRunQueue(t *testing.T) {
 	})
 
 	t.Run("without queue options", func(t *testing.T) {
-		rq, err := client.Organizations.RunQueue(ctx, orgTest.Name, RunQueueOptions{})
+		rq, err := client.Organizations.ReadRunQueue(ctx, orgTest.Name, ReadRunQueueOptions{})
 		require.NoError(t, err)
 
 		found := []string{}
@@ -399,7 +399,7 @@ func TestOrganizationsRunQueue(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		rq, err := client.Organizations.RunQueue(ctx, orgTest.Name, RunQueueOptions{
+		rq, err := client.Organizations.ReadRunQueue(ctx, orgTest.Name, ReadRunQueueOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,

--- a/organization_tags_integration_test.go
+++ b/organization_tags_integration_test.go
@@ -176,11 +176,11 @@ func TestOrganizationTagsAddWorkspace(t *testing.T) {
 		require.NoError(t, err)
 
 		//Ensure the tag was properly associated with the workspaces
-		fetched, err := client.Workspaces.Tags(ctx, workspaceToAdd1.ID, nil)
+		fetched, err := client.Workspaces.ListTags(ctx, workspaceToAdd1.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, fetched.Items[0].ID, tagID)
 
-		fetched, err = client.Workspaces.Tags(ctx, workspaceToAdd2.ID, nil)
+		fetched, err = client.Workspaces.ListTags(ctx, workspaceToAdd2.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, fetched.Items[0].ID, tagID)
 	})

--- a/organization_token.go
+++ b/organization_token.go
@@ -16,8 +16,8 @@ var _ OrganizationTokens = (*organizationTokens)(nil)
 // TFE API docs:
 // https://www.terraform.io/docs/cloud/api/organization-tokens.html
 type OrganizationTokens interface {
-	// Generate a new organization token, replacing any existing token.
-	Generate(ctx context.Context, organization string) (*OrganizationToken, error)
+	// Create a new organization token, replacing any existing token.
+	Create(ctx context.Context, organization string) (*OrganizationToken, error)
 
 	// Read an organization token.
 	Read(ctx context.Context, organization string) (*OrganizationToken, error)
@@ -40,8 +40,8 @@ type OrganizationToken struct {
 	Token       string    `jsonapi:"attr,token"`
 }
 
-// Generate a new organization token, replacing any existing token.
-func (s *organizationTokens) Generate(ctx context.Context, organization string) (*OrganizationToken, error) {
+// Create a new organization token, replacing any existing token.
+func (s *organizationTokens) Create(ctx context.Context, organization string) (*OrganizationToken, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestOrganizationTokensGenerate(t *testing.T) {
+func TestOrganizationTokensCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -20,21 +20,21 @@ func TestOrganizationTokensGenerate(t *testing.T) {
 
 	var tkToken string
 	t.Run("with valid options", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Generate(ctx, orgTest.Name)
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		tkToken = ot.Token
 	})
 
 	t.Run("when a token already exists", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Generate(ctx, orgTest.Name)
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		assert.NotEqual(t, tkToken, ot.Token)
 	})
 
 	t.Run("without valid organization", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Generate(ctx, badIdentifier)
+		ot, err := client.OrganizationTokens.Create(ctx, badIdentifier)
 		assert.Nil(t, ot)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})

--- a/plan.go
+++ b/plan.go
@@ -24,7 +24,7 @@ type Plans interface {
 	Logs(ctx context.Context, planID string) (io.Reader, error)
 
 	// Retrieve the JSON execution plan
-	JSONOutput(ctx context.Context, planID string) ([]byte, error)
+	ReadJSONOutput(ctx context.Context, planID string) ([]byte, error)
 }
 
 // plans implements Plans.
@@ -139,7 +139,7 @@ func (s *plans) Logs(ctx context.Context, planID string) (io.Reader, error) {
 }
 
 // Retrieve the JSON execution plan
-func (s *plans) JSONOutput(ctx context.Context, planID string) ([]byte, error) {
+func (s *plans) ReadJSONOutput(ctx context.Context, planID string) ([]byte, error) {
 	if !validStringID(&planID) {
 		return nil, ErrInvalidPlanID
 	}

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -123,7 +123,7 @@ func TestPlansJSONOutput(t *testing.T) {
 	defer rTestCleanup()
 
 	t.Run("when the JSON output exists", func(t *testing.T) {
-		d, err := client.Plans.JSONOutput(ctx, rTest.Plan.ID)
+		d, err := client.Plans.ReadJSONOutput(ctx, rTest.Plan.ID)
 		require.NoError(t, err)
 		var m map[string]interface{}
 		err = json.Unmarshal(d, &m)
@@ -133,7 +133,7 @@ func TestPlansJSONOutput(t *testing.T) {
 	})
 
 	t.Run("when the JSON output does not exist", func(t *testing.T) {
-		d, err := client.Plans.JSONOutput(ctx, "nonexisting")
+		d, err := client.Plans.ReadJSONOutput(ctx, "nonexisting")
 		assert.Nil(t, d)
 		assert.Error(t, err)
 	})

--- a/state_version.go
+++ b/state_version.go
@@ -29,17 +29,17 @@ type StateVersions interface {
 	// ReadWithOptions reads a state version by its ID using the options supplied
 	ReadWithOptions(ctx context.Context, svID string, options *StateVersionReadOptions) (*StateVersion, error)
 
-	// Current reads the latest available state from the given workspace.
-	Current(ctx context.Context, workspaceID string) (*StateVersion, error)
+	// ReadCurrent reads the latest available state from the given workspace.
+	ReadCurrent(ctx context.Context, workspaceID string) (*StateVersion, error)
 
-	// CurrentWithOptions reads the latest available state from the given workspace using the options supplied
-	CurrentWithOptions(ctx context.Context, workspaceID string, options *StateVersionCurrentOptions) (*StateVersion, error)
+	// ReadCurrentWithOptions reads the latest available state from the given workspace using the options supplied
+	ReadCurrentWithOptions(ctx context.Context, workspaceID string, options *StateVersionCurrentOptions) (*StateVersion, error)
 
 	// Download retrieves the actual stored state of a state version
 	Download(ctx context.Context, url string) ([]byte, error)
 
-	// Outputs retrieves all the outputs of a state version by its ID.
-	Outputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
+	// ListOutputs retrieves all the outputs of a state version by its ID.
+	ListOutputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
 }
 
 // stateVersions implements StateVersions.
@@ -220,8 +220,8 @@ type StateVersionCurrentOptions struct {
 	Include []StateVersionIncludeOps `url:"include,omitempty"`
 }
 
-// CurrentWithOptions reads the latest available state from the given workspace using the options supplied.
-func (s *stateVersions) CurrentWithOptions(ctx context.Context, workspaceID string, options *StateVersionCurrentOptions) (*StateVersion, error) {
+// ReadCurrentWithOptions reads the latest available state from the given workspace using the options supplied.
+func (s *stateVersions) ReadCurrentWithOptions(ctx context.Context, workspaceID string, options *StateVersionCurrentOptions) (*StateVersion, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
@@ -241,9 +241,9 @@ func (s *stateVersions) CurrentWithOptions(ctx context.Context, workspaceID stri
 	return sv, nil
 }
 
-// Current reads the latest available state from the given workspace.
-func (s *stateVersions) Current(ctx context.Context, workspaceID string) (*StateVersion, error) {
-	return s.CurrentWithOptions(ctx, workspaceID, nil)
+// ReadCurrent reads the latest available state from the given workspace.
+func (s *stateVersions) ReadCurrent(ctx context.Context, workspaceID string) (*StateVersion, error) {
+	return s.ReadCurrentWithOptions(ctx, workspaceID, nil)
 }
 
 // Download retrieves the actual stored state of a state version
@@ -275,8 +275,8 @@ type StateVersionOutputsListOptions struct {
 	ListOptions
 }
 
-// Outputs retrieves all the outputs of a state version by its ID.
-func (s *stateVersions) Outputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {
+// ListOutputs retrieves all the outputs of a state version by its ID.
+func (s *stateVersions) ListOutputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {
 	if !validStringID(&svID) {
 		return nil, ErrInvalidStateVerID
 	}

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -341,7 +341,7 @@ func TestStateVersionsCurrent(t *testing.T) {
 	defer svTestCleanup()
 
 	t.Run("when a state version exists", func(t *testing.T) {
-		sv, err := client.StateVersions.Current(ctx, wTest1.ID)
+		sv, err := client.StateVersions.ReadCurrent(ctx, wTest1.ID)
 		require.NoError(t, err)
 
 		// Don't compare the DownloadURL because it will be generated twice
@@ -358,13 +358,13 @@ func TestStateVersionsCurrent(t *testing.T) {
 	})
 
 	t.Run("when a state version does not exist", func(t *testing.T) {
-		sv, err := client.StateVersions.Current(ctx, wTest2.ID)
+		sv, err := client.StateVersions.ReadCurrent(ctx, wTest2.ID)
 		assert.Nil(t, sv)
 		assert.Equal(t, ErrResourceNotFound, err)
 	})
 
 	t.Run("with invalid workspace id", func(t *testing.T) {
-		sv, err := client.StateVersions.Current(ctx, badIdentifier)
+		sv, err := client.StateVersions.ReadCurrent(ctx, badIdentifier)
 		assert.Nil(t, sv)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})
@@ -388,7 +388,7 @@ func TestStateVersionsCurrentWithOptions(t *testing.T) {
 			Include: []StateVersionIncludeOps{SVoutputs},
 		}
 
-		sv, err := client.StateVersions.CurrentWithOptions(ctx, wTest1.ID, curOpts)
+		sv, err := client.StateVersions.ReadCurrentWithOptions(ctx, wTest1.ID, curOpts)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, sv.Outputs)
@@ -441,7 +441,7 @@ func TestStateVersionOutputs(t *testing.T) {
 	time.Sleep(waitForStateVersionOutputs)
 
 	t.Run("when the state version exists", func(t *testing.T) {
-		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, nil)
+		outputs, err := client.StateVersions.ListOutputs(ctx, sv.ID, nil)
 		require.NoError(t, err)
 
 		assert.NotEmpty(t, outputs.Items)
@@ -469,7 +469,7 @@ func TestStateVersionOutputs(t *testing.T) {
 				PageSize:   100,
 			},
 		}
-		outputs, err := client.StateVersions.Outputs(ctx, sv.ID, options)
+		outputs, err := client.StateVersions.ListOutputs(ctx, sv.ID, options)
 		require.NoError(t, err)
 		assert.Empty(t, outputs.Items)
 		assert.Equal(t, 999, outputs.CurrentPage)
@@ -479,7 +479,7 @@ func TestStateVersionOutputs(t *testing.T) {
 	})
 
 	t.Run("when the state version does not exist", func(t *testing.T) {
-		outputs, err := client.StateVersions.Outputs(ctx, "sv-999999999", nil)
+		outputs, err := client.StateVersions.ListOutputs(ctx, "sv-999999999", nil)
 		assert.Nil(t, outputs)
 		assert.Error(t, err)
 	})

--- a/state_version_output_integration_test.go
+++ b/state_version_output_integration_test.go
@@ -31,7 +31,7 @@ func TestStateVersionOutputsRead(t *testing.T) {
 		Include: []StateVersionIncludeOps{SVoutputs},
 	}
 
-	sv, err := client.StateVersions.CurrentWithOptions(ctx, wTest1.ID, curOpts)
+	sv, err := client.StateVersions.ReadCurrentWithOptions(ctx, wTest1.ID, curOpts)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/team_token.go
+++ b/team_token.go
@@ -16,8 +16,8 @@ var _ TeamTokens = (*teamTokens)(nil)
 // TFE API docs:
 // https://www.terraform.io/docs/cloud/api/team-tokens.html
 type TeamTokens interface {
-	// Generate a new team token, replacing any existing token.
-	Generate(ctx context.Context, teamID string) (*TeamToken, error)
+	// Create a new team token, replacing any existing token.
+	Create(ctx context.Context, teamID string) (*TeamToken, error)
 
 	// Read a team token by its ID.
 	Read(ctx context.Context, teamID string) (*TeamToken, error)
@@ -40,8 +40,8 @@ type TeamToken struct {
 	Token       string    `jsonapi:"attr,token"`
 }
 
-// Generate a new team token, replacing any existing token.
-func (s *teamTokens) Generate(ctx context.Context, teamID string) (*TeamToken, error) {
+// Create a new team token, replacing any existing token.
+func (s *teamTokens) Create(ctx context.Context, teamID string) (*TeamToken, error) {
 	if !validStringID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTeamTokensGenerate(t *testing.T) {
+func TestTeamTokensCreate(t *testing.T) {
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -22,21 +22,21 @@ func TestTeamTokensGenerate(t *testing.T) {
 
 	var tmToken string
 	t.Run("with valid options", func(t *testing.T) {
-		tt, err := client.TeamTokens.Generate(ctx, tmTest.ID)
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		tmToken = tt.Token
 	})
 
 	t.Run("when a token already exists", func(t *testing.T) {
-		tt, err := client.TeamTokens.Generate(ctx, tmTest.ID)
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		assert.NotEqual(t, tmToken, tt.Token)
 	})
 
 	t.Run("without valid team ID", func(t *testing.T) {
-		tt, err := client.TeamTokens.Generate(ctx, badIdentifier)
+		tt, err := client.TeamTokens.Create(ctx, badIdentifier)
 		assert.Nil(t, tt)
 		assert.Equal(t, err, ErrInvalidTeamID)
 	})

--- a/user.go
+++ b/user.go
@@ -16,7 +16,7 @@ type Users interface {
 	ReadCurrent(ctx context.Context) (*User, error)
 
 	// Update attributes of the currently authenticated user.
-	Update(ctx context.Context, options UserUpdateOptions) (*User, error)
+	UpdateCurrent(ctx context.Context, options UserUpdateOptions) (*User, error)
 }
 
 // users implements Users.
@@ -77,7 +77,7 @@ type UserUpdateOptions struct {
 }
 
 // Update attributes of the currently authenticated user.
-func (s *users) Update(ctx context.Context, options UserUpdateOptions) (*User, error) {
+func (s *users) UpdateCurrent(ctx context.Context, options UserUpdateOptions) (*User, error) {
 	req, err := s.client.newRequest("PATCH", "account/update", &options)
 	if err != nil {
 		return nil, err

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -35,7 +35,7 @@ func TestUsersUpdate(t *testing.T) {
 
 	// Make sure we reset the current user when we're done.
 	defer func() {
-		_, err := client.Users.Update(ctx, UserUpdateOptions{
+		_, err := client.Users.UpdateCurrent(ctx, UserUpdateOptions{
 			Email:    String(uTest.Email),
 			Username: String(uTest.Username),
 		})
@@ -45,7 +45,7 @@ func TestUsersUpdate(t *testing.T) {
 	}()
 
 	t.Run("without any options", func(t *testing.T) {
-		_, err := client.Users.Update(ctx, UserUpdateOptions{})
+		_, err := client.Users.UpdateCurrent(ctx, UserUpdateOptions{})
 		require.NoError(t, err)
 
 		u, err := client.Users.ReadCurrent(ctx)
@@ -54,7 +54,7 @@ func TestUsersUpdate(t *testing.T) {
 	})
 
 	t.Run("with a new username", func(t *testing.T) {
-		_, err := client.Users.Update(ctx, UserUpdateOptions{
+		_, err := client.Users.UpdateCurrent(ctx, UserUpdateOptions{
 			Username: String("NewTestUsername"),
 		})
 		require.NoError(t, err)
@@ -65,7 +65,7 @@ func TestUsersUpdate(t *testing.T) {
 	})
 
 	t.Run("with a new email address", func(t *testing.T) {
-		_, err := client.Users.Update(ctx, UserUpdateOptions{
+		_, err := client.Users.UpdateCurrent(ctx, UserUpdateOptions{
 			Email: String("newtestemail@hashicorp.com"),
 		})
 		require.NoError(t, err)
@@ -86,7 +86,7 @@ func TestUsersUpdate(t *testing.T) {
 	})
 
 	t.Run("with invalid email address", func(t *testing.T) {
-		u, err := client.Users.Update(ctx, UserUpdateOptions{
+		u, err := client.Users.UpdateCurrent(ctx, UserUpdateOptions{
 			Email: String("notamailaddress"),
 		})
 		assert.Nil(t, u)

--- a/user_token.go
+++ b/user_token.go
@@ -19,8 +19,8 @@ type UserTokens interface {
 	// List all the tokens of the given user ID.
 	List(ctx context.Context, userID string) (*UserTokenList, error)
 
-	// Generate a new user token
-	Generate(ctx context.Context, userID string, options UserTokenGenerateOptions) (*UserToken, error)
+	// Create a new user token
+	Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error)
 
 	// Read a user token by its ID.
 	Read(ctx context.Context, tokenID string) (*UserToken, error)
@@ -49,14 +49,14 @@ type UserToken struct {
 	Token       string    `jsonapi:"attr,token"`
 }
 
-// UserTokenGenerateOptions the options for creating a user token.
-type UserTokenGenerateOptions struct {
+// UserTokenCreateOptions the options for creating a user token.
+type UserTokenCreateOptions struct {
 	// Description of the token
 	Description string `jsonapi:"attr,description,omitempty"`
 }
 
-// Generate a new user token
-func (s *userTokens) Generate(ctx context.Context, userID string, options UserTokenGenerateOptions) (*UserToken, error) {
+// Create a new user token
+func (s *userTokens) Create(ctx context.Context, userID string, options UserTokenCreateOptions) (*UserToken, error) {
 	if !validStringID(&userID) {
 		return nil, ErrInvalidUserID
 	}

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -41,8 +41,8 @@ func TestUserTokens_List(t *testing.T) {
 	})
 }
 
-// TestUserTokens_Generate tests basic creation of user tokens
-func TestUserTokens_Generate(t *testing.T) {
+// TestUserTokens_Create tests basic creation of user tokens
+func TestUserTokens_Create(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 	user, err := client.Users.ReadCurrent(ctx)
@@ -62,7 +62,7 @@ func TestUserTokens_Generate(t *testing.T) {
 	}(t)
 
 	t.Run("create token with no description", func(t *testing.T) {
-		token, err := client.UserTokens.Generate(ctx, user.ID, UserTokenGenerateOptions{})
+		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{})
 		tokens = append(tokens, token.ID)
 		if err != nil {
 			t.Fatal(err)
@@ -70,7 +70,7 @@ func TestUserTokens_Generate(t *testing.T) {
 	})
 
 	t.Run("create token with description", func(t *testing.T) {
-		token, err := client.UserTokens.Generate(ctx, user.ID, UserTokenGenerateOptions{
+		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
 			Description: fmt.Sprintf("go-tfe-user-token-test-%s", randomString(t)),
 		})
 		tokens = append(tokens, token.ID)
@@ -112,7 +112,7 @@ func createToken(t *testing.T, client *Client, user *User) (*UserToken, func()) 
 	if user == nil {
 		t.Fatal("Nil user in createToken")
 	}
-	token, err := client.UserTokens.Generate(ctx, user.ID, UserTokenGenerateOptions{
+	token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
 		Description: fmt.Sprintf("go-tfe-user-token-test-%s", randomString(t)),
 	})
 	if err != nil {

--- a/workspace.go
+++ b/workspace.go
@@ -71,8 +71,8 @@ type Workspaces interface {
 	// UnassignSSHKey from a workspace.
 	UnassignSSHKey(ctx context.Context, workspaceID string) (*Workspace, error)
 
-	// RemoteStateConsumers reads the remote state consumers for a workspace.
-	RemoteStateConsumers(ctx context.Context, workspaceID string, options *RemoteStateConsumersListOptions) (*WorkspaceList, error)
+	// ListRemoteStateConsumers reads the remote state consumers for a workspace.
+	ListRemoteStateConsumers(ctx context.Context, workspaceID string, options *RemoteStateConsumersListOptions) (*WorkspaceList, error)
 
 	// AddRemoteStateConsumers adds remote state consumers to a workspace.
 	AddRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceAddRemoteStateConsumersOptions) error
@@ -84,8 +84,8 @@ type Workspaces interface {
 	// to match the workspaces in the update options.
 	UpdateRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceUpdateRemoteStateConsumersOptions) error
 
-	// Tags reads the tags for a workspace.
-	Tags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error)
+	// ListTags reads the tags for a workspace.
+	ListTags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error)
 
 	// AddTags appends tags to a workspace
 	AddTags(ctx context.Context, workspaceID string, options WorkspaceAddTagsOptions) error
@@ -900,7 +900,7 @@ type RemoteStateConsumersListOptions struct {
 }
 
 // RemoteStateConsumers returns the remote state consumers for a given workspace.
-func (s *workspaces) RemoteStateConsumers(ctx context.Context, workspaceID string, options *RemoteStateConsumersListOptions) (*WorkspaceList, error) {
+func (s *workspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID string, options *RemoteStateConsumersListOptions) (*WorkspaceList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
@@ -1034,8 +1034,8 @@ type WorkspaceTagListOptions struct {
 	Query *string `url:"name,omitempty"`
 }
 
-// Tags returns the tags for a given workspace.
-func (s *workspaces) Tags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error) {
+// ListTags returns the tags for a given workspace.
+func (s *workspaces) ListTags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -351,7 +351,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 		assert.Equal(t, wTest.ID, w.ID)
 		assert.NotEmpty(t, w.Outputs)
 
-		svOutputs, err := client.StateVersions.Outputs(ctx, svTest.ID, nil)
+		svOutputs, err := client.StateVersions.ListOutputs(ctx, svTest.ID, nil)
 		require.NoError(t, err)
 
 		assert.Len(t, w.Outputs, len(svOutputs.Items))
@@ -974,7 +974,7 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 		_, err = client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 
-		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
+		rsc, err := client.Workspaces.ListRemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -1028,7 +1028,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
+		rsc, err := client.Workspaces.ListRemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 2, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -1042,7 +1042,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		_, err = client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
 		require.NoError(t, err)
 
-		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
+		rsc, err = client.Workspaces.ListRemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Contains(t, rsc.Items, wTestConsumer2)
 		assert.Equal(t, 1, len(rsc.Items))
@@ -1052,7 +1052,7 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
+		rsc, err = client.Workspaces.ListRemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Empty(t, len(rsc.Items))
 	})
@@ -1104,7 +1104,7 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err := client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
+		rsc, err := client.Workspaces.ListRemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer1)
@@ -1114,7 +1114,7 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		rsc, err = client.Workspaces.RemoteStateConsumers(ctx, wTest.ID, nil)
+		rsc, err = client.Workspaces.ListRemoteStateConsumers(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer2)
@@ -1188,7 +1188,7 @@ func TestWorkspaces_AddTags(t *testing.T) {
 		sort.Strings(w.TagNames)
 		assert.EqualValues(t, w.TagNames, []string{"tag1", "tag2", "tag3", "tag4"})
 
-		wt, err := client.Workspaces.Tags(ctx, wTest.ID, nil)
+		wt, err := client.Workspaces.ListTags(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 4, len(wt.Items))
 		assert.Equal(t, wt.Items[3].Name, "tag4")
@@ -1209,7 +1209,7 @@ func TestWorkspaces_AddTags(t *testing.T) {
 		require.NoError(t, err)
 
 		// get the id of the new tag
-		tags, err := client.Workspaces.Tags(ctx, wTest2.ID, nil)
+		tags, err := client.Workspaces.ListTags(ctx, wTest2.ID, nil)
 		require.NoError(t, err)
 
 		// add the tag to our workspace by id
@@ -1230,7 +1230,7 @@ func TestWorkspaces_AddTags(t *testing.T) {
 		assert.Equal(t, w.TagNames, []string{"tag1", "tag2", "tag3", "tag4", "tagbyid"})
 
 		// tag is now in our tag list
-		wt, err := client.Workspaces.Tags(ctx, wTest.ID, nil)
+		wt, err := client.Workspaces.ListTags(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 5, len(wt.Items))
 		assert.Equal(t, wt.Items[4].ID, tags.Items[0].ID)
@@ -1297,7 +1297,7 @@ func TestWorkspaces_RemoveTags(t *testing.T) {
 		assert.Equal(t, 1, len(w.TagNames))
 		assert.Equal(t, w.TagNames, []string{"tag3"})
 
-		wt, err := client.Workspaces.Tags(ctx, wTest.ID, nil)
+		wt, err := client.Workspaces.ListTags(ctx, wTest.ID, nil)
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(wt.Items))
 		assert.EqualValues(t, wt.Items[0].Name, "tag3")


### PR DESCRIPTION
## Description

This PR introduces a refactor for several methods that poorly express an action on a relationship between two resources. By using verbs, we can be more specific as to what action we're performing when calling these methods. An example would be
`ModuleConsumers()` -- from this method signature we can't necessarily tell what action this method is performing without
referring to the docs. Renaming it to `ListModuleConsumers()` we can now assess what the function does more conveniently.
