### PR TITLE
Sync run task changes with 1.0 effort

### DIFF
--- a/run.go
+++ b/run.go
@@ -170,6 +170,7 @@ const (
 	RunConfigVer        RunIncludeOps = "configuration_version"
 	RunConfigVerIngress RunIncludeOps = "configuration_version.ingress_attributes"
 	RunWorkspace        RunIncludeOps = "workspace"
+	RunTaskStages       RunIncludeOps = "task_stages"
 )
 
 // RunListOptions represents the options for listing runs.

--- a/run_task.go
+++ b/run_task.go
@@ -134,7 +134,7 @@ type RunTaskListOptions struct {
 	ListOptions
 
 	// A list of relations to include
-	Include []RunTaskIncludeOps `url:"include"`
+	Include []RunTaskIncludeOps `url:"include,omitempty"`
 }
 
 // List all the run tasks for an organization
@@ -165,7 +165,7 @@ func (s *runTasks) Read(ctx context.Context, runTaskID string) (*RunTask, error)
 
 // RunTaskReadOptions represents the set of options for reading a run task
 type RunTaskReadOptions struct {
-	Include []RunTaskIncludeOps `url:"include"`
+	Include []RunTaskIncludeOps `url:"include,omitempty"`
 }
 
 // Read is used to read an organization's run task by ID with options

--- a/task_stages.go
+++ b/task_stages.go
@@ -68,7 +68,7 @@ const (
 
 // TaskStageReadOptions represents the set of options when reading a task stage
 type TaskStageReadOptions struct {
-	Include []TaskStageIncludeOps `url:"include"`
+	Include []TaskStageIncludeOps `url:"include,omitempty"`
 }
 
 // Read a task stage by ID
@@ -78,7 +78,7 @@ func (s *taskStages) Read(ctx context.Context, taskStageID string, options *Task
 	}
 
 	u := fmt.Sprintf("task-stages/%s", taskStageID)
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -104,7 +104,7 @@ func (s *taskStages) List(ctx context.Context, runID string, options *TaskStageL
 	}
 
 	u := fmt.Sprintf("runs/%s/task-stages", runID)
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}

--- a/task_stages_integration_test.go
+++ b/task_stages_integration_test.go
@@ -32,12 +32,12 @@ func TestTaskStagesRead(t *testing.T) {
 	rTest, rTestCleanup := createRun(t, client, wkspaceTest)
 	defer rTestCleanup()
 
-	t.Run("without include param", func(t *testing.T) {
-		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, &RunReadOptions{
-			Include: []RunIncludeOps{RunTaskStages},
-		})
-		require.NoError(t, err)
+	r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, &RunReadOptions{
+		Include: []RunIncludeOps{RunTaskStages},
+	})
+	require.NoError(t, err)
 
+	t.Run("without read options", func(t *testing.T) {
 		taskStage, err := client.TaskStages.Read(ctx, r.TaskStages[0].ID, nil)
 		require.NoError(t, err)
 
@@ -58,11 +58,6 @@ func TestTaskStagesRead(t *testing.T) {
 	})
 
 	t.Run("with include param task_results", func(t *testing.T) {
-		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, &RunReadOptions{
-			Include: []RunIncludeOps{RunTaskStages},
-		})
-		require.NoError(t, err)
-
 		taskStage, err := client.TaskStages.Read(ctx, r.TaskStages[0].ID, &TaskStageReadOptions{
 			Include: []TaskStageIncludeOps{TaskStageTaskResults},
 		})

--- a/task_stages_integration_test.go
+++ b/task_stages_integration_test.go
@@ -34,7 +34,7 @@ func TestTaskStagesRead(t *testing.T) {
 
 	t.Run("without include param", func(t *testing.T) {
 		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, &RunReadOptions{
-			Include: "task_stages",
+			Include: []RunIncludeOps{RunTaskStages},
 		})
 		require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestTaskStagesRead(t *testing.T) {
 
 	t.Run("with include param task_results", func(t *testing.T) {
 		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, &RunReadOptions{
-			Include: "task_stages",
+			Include: []RunIncludeOps{RunTaskStages},
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
Updates the run task related changes to use some of the conventions established by the 1.0 release effort. 