### PR TITLE
add missing include field for listOptions

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -72,12 +72,12 @@ type AdminOrganizationList struct {
 	Items []*AdminOrganization
 }
 
-// AdminOrgIncludeOps represents the available options for include query params.
+// AdminOrgIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/docs/cloud/api/admin/organizations.html#available-related-resources
-type AdminOrgIncludeOps string
+type AdminOrgIncludeOpt string
 
 const (
-	AdminOrgOwners AdminOrgIncludeOps = "owners"
+	AdminOrgOwners AdminOrgIncludeOpt = "owners"
 )
 
 // AdminOrganizationListOptions represents the options for listing organizations via Admin API.
@@ -89,7 +89,7 @@ type AdminOrganizationListOptions struct {
 	Query string `url:"q,omitempty"`
 	// Optional: A list of relations to include. See available resources
 	// https://www.terraform.io/docs/cloud/api/admin/organizations.html#available-related-resources
-	Include []AdminOrgIncludeOps `url:"include,omitempty"`
+	Include []AdminOrgIncludeOpt `url:"include,omitempty"`
 }
 
 // AdminOrganizationListModuleConsumersOptions represents the options for listing organization module consumers through the Admin API

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -59,7 +59,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 
 	t.Run("with owners included", func(t *testing.T) {
 		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
-			Include: []AdminOrgIncludeOps{AdminOrgOwners},
+			Include: []AdminOrgIncludeOpt{AdminOrgOwners},
 		})
 		assert.NoError(t, err)
 

--- a/admin_run.go
+++ b/admin_run.go
@@ -43,14 +43,14 @@ type AdminRunsList struct {
 	Items []*AdminRun
 }
 
-// AdminRunIncludeOps represents the available options for include query params.
+// AdminRunIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/cloud-docs/api-docs/admin/runs#available-related-resources
-type AdminRunIncludeOps string
+type AdminRunIncludeOpt string
 
 const (
-	AdminRunWorkspace          AdminRunIncludeOps = "workspace"
-	AdminRunWorkspaceOrg       AdminRunIncludeOps = "workspace.organization"
-	AdminRunWorkspaceOrgOwners AdminRunIncludeOps = "workspace.organization.owners"
+	AdminRunWorkspace          AdminRunIncludeOpt = "workspace"
+	AdminRunWorkspaceOrg       AdminRunIncludeOpt = "workspace.organization"
+	AdminRunWorkspaceOrgOwners AdminRunIncludeOpt = "workspace.organization.owners"
 )
 
 // AdminRunsListOptions represents the options for listing runs.
@@ -62,7 +62,7 @@ type AdminRunsListOptions struct {
 	Query     string `url:"q,omitempty"`
 	// Optional: A list of relations to include. See available resources
 	// https://www.terraform.io/cloud-docs/api-docs/admin/runs#available-related-resources
-	Include []AdminRunIncludeOps `url:"include,omitempty"`
+	Include []AdminRunIncludeOpt `url:"include,omitempty"`
 }
 
 // adminRuns implements the AdminRuns interface.

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -69,7 +69,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with workspace included", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			Include: []AdminRunIncludeOps{AdminRunWorkspace},
+			Include: []AdminRunIncludeOpt{AdminRunWorkspace},
 		})
 
 		assert.NoError(t, err)
@@ -81,7 +81,7 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with workspace.organization included", func(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
-			Include: []AdminRunIncludeOps{AdminRunWorkspaceOrg},
+			Include: []AdminRunIncludeOpt{AdminRunWorkspaceOrg},
 		})
 
 		assert.NoError(t, err)

--- a/admin_user.go
+++ b/admin_user.go
@@ -64,12 +64,12 @@ type AdminUserList struct {
 	Items []*AdminUser
 }
 
-// AdminUserIncludeOps represents the available options for include query params.
+// AdminUserIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/docs/cloud/api/admin/users.html#available-related-resources
-type AdminUserIncludeOps string
+type AdminUserIncludeOpt string
 
 const (
-	AdminUserOrgs AdminUserIncludeOps = "organizations"
+	AdminUserOrgs AdminUserIncludeOpt = "organizations"
 )
 
 // AdminUserListOptions represents the options for listing users.
@@ -88,7 +88,7 @@ type AdminUserListOptions struct {
 
 	// Optional: A list of relations to include. See available resources
 	// https://www.terraform.io/docs/cloud/api/admin/users.html#available-related-resources
-	Include []AdminUserIncludeOps `url:"include,omitempty"`
+	Include []AdminUserIncludeOpt `url:"include,omitempty"`
 }
 
 // List all user accounts in the Terraform Enterprise installation

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -76,7 +76,7 @@ func TestAdminUsers_List(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		ul, err := client.Admin.Users.List(ctx, &AdminUserListOptions{
-			Include: []AdminUserIncludeOps{AdminUserOrgs},
+			Include: []AdminUserIncludeOpt{AdminUserOrgs},
 		})
 
 		assert.NoError(t, err)

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -46,14 +46,14 @@ type AdminWorkspace struct {
 	CurrentRun   *Run          `jsonapi:"relation,current-run"`
 }
 
-// AdminWorkspaceIncludeOps represents the available options for include query params.
+// AdminWorkspaceIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/docs/cloud/api/admin/workspaces.html#available-related-resources
-type AdminWorkspaceIncludeOps string
+type AdminWorkspaceIncludeOpt string
 
 const (
-	AdminWorkspaceOrg        AdminWorkspaceIncludeOps = "organization"
-	AdminWorkspaceCurrentRun AdminWorkspaceIncludeOps = "current_run"
-	AdminWorkspaceOrgOwners  AdminWorkspaceIncludeOps = "organization.owners"
+	AdminWorkspaceOrg        AdminWorkspaceIncludeOpt = "organization"
+	AdminWorkspaceCurrentRun AdminWorkspaceIncludeOpt = "current_run"
+	AdminWorkspaceOrgOwners  AdminWorkspaceIncludeOpt = "organization.owners"
 )
 
 // AdminWorkspaceListOptions represents the options for listing workspaces.
@@ -65,7 +65,7 @@ type AdminWorkspaceListOptions struct {
 	Query string `url:"q,omitempty"`
 	// Optional: A list of relations to include. See available resources
 	// https://www.terraform.io/docs/cloud/api/admin/workspaces.html#available-related-resources
-	Include []AdminWorkspaceIncludeOps `url:"include,omitempty"`
+	Include []AdminWorkspaceIncludeOpt `url:"include,omitempty"`
 }
 
 // AdminWorkspaceList represents a list of workspaces.

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -88,7 +88,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
-			Include: []AdminWorkspaceIncludeOps{AdminWorkspaceOrg},
+			Include: []AdminWorkspaceIncludeOpt{AdminWorkspaceOrg},
 		})
 
 		assert.NoError(t, err)
@@ -109,7 +109,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 		assert.NoError(t, err)
 
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
-			Include: []AdminWorkspaceIncludeOps{AdminWorkspaceCurrentRun},
+			Include: []AdminWorkspaceIncludeOpt{AdminWorkspaceCurrentRun},
 		})
 
 		assert.NoError(t, err)

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -50,9 +50,16 @@ type AgentPool struct {
 	Organization *Organization `jsonapi:"relation,organization"`
 }
 
+// A list of relations to include
+type AgentPoolIncludeOpt string
+
+const AgentPoolWorkspaces AgentPoolIncludeOpt = "workspaces"
+
 // AgentPoolListOptions represents the options for listing agent pools.
 type AgentPoolListOptions struct {
 	ListOptions
+
+	Include []AgentPoolIncludeOpt `url:"include,omitempty"`
 }
 
 // AgentPoolCreateOptions represents the options for creating an agent pool.

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -49,6 +49,14 @@ func TestAgentPoolsList(t *testing.T) {
 		assert.Equal(t, 1, pools.TotalCount)
 	})
 
+	t.Run("with Include options", func(t *testing.T) {
+		pools, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
+			Include: []AgentPoolIncludeOpt{AgentPoolWorkspaces},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, pools.Items[0].Organization.Name)
+	})
+
 	t.Run("without a valid organization", func(t *testing.T) {
 		pools, err := client.AgentPools.List(ctx, badIdentifier, nil)
 		assert.Nil(t, pools)

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -98,20 +98,20 @@ type CVStatusTimestamps struct {
 	StartedAt  time.Time `jsonapi:"attr,started-at,rfc3339"`
 }
 
-// ConfigurationVersionIncludeOps represents the available options for include query params.
+// ConfigurationVersionIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/docs/cloud/api/configuration-versions.html#available-related-resources
-type ConfigurationVersionIncludeOps string
+type ConfigurationVersionIncludeOpt string
 
 const (
-	ConfigurationVerIngressAttributes ConfigurationVersionIncludeOps = "ingress_attributes"
-	ConfigurationRun                  ConfigurationVersionIncludeOps = "run"
+	ConfigurationVerIngressAttributes ConfigurationVersionIncludeOpt = "ingress_attributes"
+	ConfigurationRun                  ConfigurationVersionIncludeOpt = "run"
 )
 
 // ConfigurationVersionReadOptions represents the options for reading a configuration version.
 type ConfigurationVersionReadOptions struct {
 	// Optional: A list of relations to include. See available resources:
 	// https://www.terraform.io/docs/cloud/api/configuration-versions.html#available-related-resources
-	Include []ConfigurationVersionIncludeOps `url:"include,omitempty"`
+	Include []ConfigurationVersionIncludeOpt `url:"include,omitempty"`
 }
 
 // ConfigurationVersionListOptions represents the options for listing
@@ -120,7 +120,7 @@ type ConfigurationVersionListOptions struct {
 	ListOptions
 	// Optional: A list of relations to include. See available resources:
 	// https://www.terraform.io/docs/cloud/api/configuration-versions.html#available-related-resources
-	Include []ConfigurationVersionIncludeOps `url:"include,omitempty"`
+	Include []ConfigurationVersionIncludeOpt `url:"include,omitempty"`
 }
 
 // ConfigurationVersionCreateOptions represents the options for creating a

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -158,7 +158,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 	time.Sleep(3 * time.Second)
 
 	w, err := client.Workspaces.ReadByIDWithOptions(ctx, wTest.ID, &WorkspaceReadOptions{
-		Include: []WSIncludeOps{WSCurrentRunConfigVer},
+		Include: []WSIncludeOpt{WSCurrentRunConfigVer},
 	})
 
 	if err != nil {
@@ -173,7 +173,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 
 	t.Run("when the configuration version exists", func(t *testing.T) {
 		options := &ConfigurationVersionReadOptions{
-			Include: []ConfigurationVersionIncludeOps{ConfigurationVerIngressAttributes},
+			Include: []ConfigurationVersionIncludeOpt{ConfigurationVerIngressAttributes},
 		}
 
 		cv, err := client.ConfigurationVersions.ReadWithOptions(ctx, cv.ID, options)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -130,12 +130,12 @@ func (s *example) Create(ctx context.Context, organization string, options Examp
 	return r, nil
 }
 
-// ExampleIncludeOps represents the available options for include query params.
+// ExampleIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/cloud-docs/api-docs/examples#list-examples (replace this URL with the actual documentation URL)
-type ExampleIncludeOps string
+type ExampleIncludeOpt string
 
 const (
-	ExampleOrganization ExampleIncludeOps = "organization"
+	ExampleOrganization ExampleIncludeOpt = "organization"
 )
 
 // ExampleListOptions represents the set of options for listing examples
@@ -144,7 +144,7 @@ type ExampleListOptions struct {
 
 	// Optional: A list of relations to include with an example. See available resources:
 	// https://www.terraform.io/cloud-docs/api-docs/examples#list-examples (replace this URL with the actual documentation URL)
-	Include []ExampleIncludeOps `url:"include,omitempty"`
+	Include []ExampleIncludeOpt `url:"include,omitempty"`
 }
 
 // List all the examples for an organization
@@ -177,7 +177,7 @@ func (s *example) Read(ctx context.Context, exampleID string) (*Example, error) 
 type ExampleReadOptions struct {
 	// Optional: A list of relations to include with an example. See available resources:
 	// https://www.terraform.io/cloud-docs/api-docs/examples#list-examples (replace this URL with the actual documentation URL)
-	Include []RunTaskIncludeOps `url:"include,omitempty"`
+	Include []RunTaskIncludeOpt `url:"include,omitempty"`
 }
 
 // Read is used to read an organization's example by ID with options

--- a/errors.go
+++ b/errors.go
@@ -21,6 +21,8 @@ var (
 	ErrUnsupportedOperations = errors.New("operations is deprecated and cannot be specified when execution mode is used")
 
 	ErrUnsupportedPrivateKey = errors.New("private Key can only be present with Azure DevOps Server service provider")
+
+	ErrUnsupportedRunTriggerType = errors.New(`"RunTriggerType" must be "inbound" when requesting "include" query params`)
 )
 
 // Library errors that usually indicate a bug in the implementation of go-tfe
@@ -116,7 +118,9 @@ var (
 
 	ErrInvalidRunTriggerID = errors.New("invalid value for run trigger ID")
 
-	ErrInvalidRunTriggerType = errors.New(`invalid value for RunTriggerType. It must be either "inbound" or "outbound"`)
+	ErrInvalidRunTriggerType = errors.New(`invalid value or no value for RunTriggerType. It must be either "inbound" or "outbound"`)
+
+	ErrInvalidRunTriggerInclude = errors.New(`invalid value for "include" field`)
 
 	ErrInvalidSHHKeyID = errors.New("invalid value for SSH key ID")
 

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -82,10 +82,17 @@ type OAuthClient struct {
 	OAuthTokens  []*OAuthToken `jsonapi:"relation,oauth-tokens"`
 }
 
+// A list of relations to include
+type OAuthClientIncludeOpt string
+
+const OauthClientOauthTokens OAuthClientIncludeOpt = "oauth_tokens"
+
 // OAuthClientListOptions represents the options for listing
 // OAuth clients.
 type OAuthClientListOptions struct {
 	ListOptions
+
+	Include []OAuthClientIncludeOpt `url:"include,omitempty"`
 }
 
 // OAuthClientCreateOptions represents the options for creating an OAuth client.

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -67,6 +67,14 @@ func TestOAuthClientsList(t *testing.T) {
 		assert.Equal(t, 2, ocl.TotalCount)
 	})
 
+	t.Run("with Include options", func(t *testing.T) {
+		ocl, err := client.OAuthClients.List(ctx, orgTest.Name, &OAuthClientListOptions{
+			Include: []OAuthClientIncludeOpt{OauthClientOauthTokens},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, ocl.Items[0].OAuthTokens[0].ID)
+	})
+
 	t.Run("without a valid organization", func(t *testing.T) {
 		ocl, err := client.OAuthClients.List(ctx, badIdentifier, nil)
 		assert.Nil(t, ocl)

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -62,13 +62,13 @@ type OrganizationMembership struct {
 	Teams        []*Team       `jsonapi:"relation,teams"`
 }
 
-// OrganizationMembershipIncludeOps represents the available options for include query params.
+// OrganizationMembershipIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/cloud-docs/api-docs/organization-memberships#available-related-resources
-type OrganizationMembershipIncludeOps string
+type OrganizationMembershipIncludeOpt string
 
 const (
-	OrganizationMembershipUser OrganizationMembershipIncludeOps = "user"
-	OrganizationMembershipTeam OrganizationMembershipIncludeOps = "teams"
+	OrganizationMembershipUser OrganizationMembershipIncludeOpt = "user"
+	OrganizationMembershipTeam OrganizationMembershipIncludeOpt = "teams"
 )
 
 // OrganizationMembershipListOptions represents the options for listing organization memberships.
@@ -76,7 +76,7 @@ type OrganizationMembershipListOptions struct {
 	ListOptions
 	// Optional: A list of relations to include. See available resources
 	// https://www.terraform.io/cloud-docs/api-docs/organization-memberships#available-related-resources
-	Include []OrganizationMembershipIncludeOps `url:"include,omitempty"`
+	Include []OrganizationMembershipIncludeOpt `url:"include,omitempty"`
 }
 
 // OrganizationMembershipCreateOptions represents the options for creating an organization membership.
@@ -95,7 +95,7 @@ type OrganizationMembershipCreateOptions struct {
 type OrganizationMembershipReadOptions struct {
 	// Optional: A list of relations to include. See available resources
 	// https://www.terraform.io/cloud-docs/api-docs/organization-memberships#available-related-resources
-	Include []OrganizationMembershipIncludeOps `url:"include,omitempty"`
+	Include []OrganizationMembershipIncludeOpt `url:"include,omitempty"`
 }
 
 // List all the organization memberships of the given organization.

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -64,7 +64,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		defer memTest2Cleanup()
 
 		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, &OrganizationMembershipListOptions{
-			Include: []OrganizationMembershipIncludeOps{OrganizationMembershipUser},
+			Include: []OrganizationMembershipIncludeOpt{OrganizationMembershipUser},
 		})
 		require.NoError(t, err)
 
@@ -96,7 +96,7 @@ func TestOrganizationMembershipsCreate(t *testing.T) {
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.OrganizationMemberships.ReadWithOptions(ctx, mem.ID, OrganizationMembershipReadOptions{
-			Include: []OrganizationMembershipIncludeOps{OrganizationMembershipUser},
+			Include: []OrganizationMembershipIncludeOpt{OrganizationMembershipUser},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, refreshed, mem)
@@ -169,7 +169,7 @@ func TestOrganizationMembershipsReadWithOptions(t *testing.T) {
 	defer memTestCleanup()
 
 	options := OrganizationMembershipReadOptions{
-		Include: []OrganizationMembershipIncludeOps{OrganizationMembershipUser},
+		Include: []OrganizationMembershipIncludeOpt{OrganizationMembershipUser},
 	}
 
 	t.Run("when the membership exists", func(t *testing.T) {

--- a/policy_check.go
+++ b/policy_check.go
@@ -110,9 +110,19 @@ type PolicyStatusTimestamps struct {
 	SoftFailedAt time.Time `jsonapi:"attr,soft-failed-at,rfc3339"`
 }
 
+// A list of relations to include
+type PolicyCheckIncludeOpt string
+
+const (
+	PolicyCheckRunWorkspace PolicyCheckIncludeOpt = "run.workspace"
+	PolicyCheckRun          PolicyCheckIncludeOpt = "run"
+)
+
 // PolicyCheckListOptions represents the options for listing policy checks.
 type PolicyCheckListOptions struct {
 	ListOptions
+
+	Include []PolicyCheckIncludeOpt `url:"include,omitempty"` // optional
 }
 
 // List all policy checks of the given run.

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -63,6 +63,14 @@ func TestPolicyChecksList(t *testing.T) {
 		assert.Equal(t, 1, pcl.TotalCount)
 	})
 
+	t.Run("with Include option", func(t *testing.T) {
+		pcl, err := client.PolicyChecks.List(ctx, rTest.ID, &PolicyCheckListOptions{
+			Include: []PolicyCheckIncludeOpt{PolicyCheckRun},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, pcl.Items[0].Run.Status)
+	})
+
 	t.Run("without a valid run ID", func(t *testing.T) {
 		pcl, err := client.PolicyChecks.List(ctx, badIdentifier, nil)
 		assert.Nil(t, pcl)

--- a/policy_set.go
+++ b/policy_set.go
@@ -87,14 +87,14 @@ type PolicySet struct {
 	CurrentVersion *PolicySetVersion `jsonapi:"relation,current-version"`
 }
 
-// PolicySetIncludeOps represents the available options for include query params.
-type PolicySetIncludeOps string
+// PolicySetIncludeOpt represents the available options for include query params.
+type PolicySetIncludeOpt string
 
 const (
-	PolicySetPolicies       PolicySetIncludeOps = "policies"
-	PolicySetWorkspaces     PolicySetIncludeOps = "workspaces"
-	PolicySetCurrentVersion PolicySetIncludeOps = "current_version"
-	PolicySetNewestVersion  PolicySetIncludeOps = "newest_version"
+	PolicySetPolicies       PolicySetIncludeOpt = "policies"
+	PolicySetWorkspaces     PolicySetIncludeOpt = "workspaces"
+	PolicySetCurrentVersion PolicySetIncludeOpt = "current_version"
+	PolicySetNewestVersion  PolicySetIncludeOpt = "newest_version"
 )
 
 // PolicySetListOptions represents the options for listing policy sets.
@@ -111,7 +111,7 @@ type PolicySetListOptions struct {
 type PolicySetReadOptions struct {
 	// Optional: A list of relations to include. See available resources
 	// https://www.terraform.io/cloud-docs/api-docs/policy-sets#relationships
-	Include []PolicySetIncludeOps `url:"include,omitempty"`
+	Include []PolicySetIncludeOpt `url:"include,omitempty"`
 }
 
 // PolicySetCreateOptions represents the options for creating a new policy set.

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -284,7 +284,7 @@ func TestPolicySetsRead(t *testing.T) {
 		require.NoError(t, err)
 
 		opts := &PolicySetReadOptions{
-			Include: []PolicySetIncludeOps{PolicySetCurrentVersion, PolicySetNewestVersion},
+			Include: []PolicySetIncludeOpt{PolicySetCurrentVersion, PolicySetNewestVersion},
 		}
 		psWithOptions, err := client.PolicySets.ReadWithOptions(ctx, psTest.ID, opts)
 		require.NoError(t, err)

--- a/run.go
+++ b/run.go
@@ -158,19 +158,19 @@ type RunStatusTimestamps struct {
 	PolicySoftFailedAt   time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
 }
 
-// RunIncludeOps represents the available options for include query params.
+// RunIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/docs/cloud/api/run.html#available-related-resources
-type RunIncludeOps string
+type RunIncludeOpt string
 
 const (
-	RunPlan             RunIncludeOps = "plan"
-	RunApply            RunIncludeOps = "apply"
-	RunCreatedBy        RunIncludeOps = "created_by"
-	RunCostEstimate     RunIncludeOps = "cost_estimate"
-	RunConfigVer        RunIncludeOps = "configuration_version"
-	RunConfigVerIngress RunIncludeOps = "configuration_version.ingress_attributes"
-	RunWorkspace        RunIncludeOps = "workspace"
-	RunTaskStages       RunIncludeOps = "task_stages"
+	RunPlan             RunIncludeOpt = "plan"
+	RunApply            RunIncludeOpt = "apply"
+	RunCreatedBy        RunIncludeOpt = "created_by"
+	RunCostEstimate     RunIncludeOpt = "cost_estimate"
+	RunConfigVer        RunIncludeOpt = "configuration_version"
+	RunConfigVerIngress RunIncludeOpt = "configuration_version.ingress_attributes"
+	RunWorkspace        RunIncludeOpt = "workspace"
+	RunTaskStages       RunIncludeOpt = "task_stages"
 )
 
 // RunListOptions represents the options for listing runs.
@@ -178,14 +178,14 @@ type RunListOptions struct {
 	ListOptions
 	// Optional: A list of relations to include. See available resources:
 	// https://www.terraform.io/docs/cloud/api/run.html#available-related-resources
-	Include []RunIncludeOps `url:"include,omitempty"`
+	Include []RunIncludeOpt `url:"include,omitempty"`
 }
 
 // RunReadOptions represents the options for reading a run.
 type RunReadOptions struct {
 	// Optional: A list of relations to include. See available resources:
 	// https://www.terraform.io/docs/cloud/api/run.html#available-related-resources
-	Include []RunIncludeOps `url:"include,omitempty"`
+	Include []RunIncludeOpt `url:"include,omitempty"`
 }
 
 // RunCreateOptions represents the options for creating a new run.

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -42,7 +42,7 @@ func TestRunsList(t *testing.T) {
 
 	t.Run("without list options and include as nil", func(t *testing.T) {
 		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
-			Include: []RunIncludeOps{},
+			Include: []RunIncludeOpt{},
 		})
 		require.NoError(t, err)
 
@@ -77,7 +77,7 @@ func TestRunsList(t *testing.T) {
 
 	t.Run("with workspace included", func(t *testing.T) {
 		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
-			Include: []RunIncludeOps{RunWorkspace},
+			Include: []RunIncludeOpt{RunWorkspace},
 		})
 
 		assert.NoError(t, err)
@@ -273,7 +273,7 @@ func TestRunsReadWithOptions(t *testing.T) {
 
 	t.Run("when the run exists", func(t *testing.T) {
 		curOpts := &RunReadOptions{
-			Include: []RunIncludeOps{RunCreatedBy},
+			Include: []RunIncludeOpt{RunCreatedBy},
 		}
 
 		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, curOpts)

--- a/run_task.go
+++ b/run_task.go
@@ -59,13 +59,13 @@ type RunTaskList struct {
 	Items []*RunTask
 }
 
-// RunTaskIncludeOps represents the available options for include query params.
+// RunTaskIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/cloud-docs/api-docs/run-tasks#list-run-tasks
-type RunTaskIncludeOps string
+type RunTaskIncludeOpt string
 
 const (
-	RunTaskWorkspaceTasks RunTaskIncludeOps = "workspace_tasks"
-	RunTaskWorkspace      RunTaskIncludeOps = "workspace_tasks.workspace"
+	RunTaskWorkspaceTasks RunTaskIncludeOpt = "workspace_tasks"
+	RunTaskWorkspace      RunTaskIncludeOpt = "workspace_tasks.workspace"
 )
 
 // RunTaskListOptions represents the set of options for listing run tasks
@@ -73,14 +73,14 @@ type RunTaskListOptions struct {
 	ListOptions
 	// Optional: A list of relations to include with a run task. See available resources:
 	// https://www.terraform.io/cloud-docs/api-docs/run-tasks#list-run-tasks
-	Include []RunTaskIncludeOps `url:"include,omitempty"`
+	Include []RunTaskIncludeOpt `url:"include,omitempty"`
 }
 
 // RunTaskReadOptions represents the set of options for reading a run task
 type RunTaskReadOptions struct {
 	// Optional: A list of relations to include with a run task. See available resources:
 	// https://www.terraform.io/cloud-docs/api-docs/run-tasks#list-run-tasks
-	Include []RunTaskIncludeOps `url:"include"`
+	Include []RunTaskIncludeOpt `url:"include,omitempty"`
 }
 
 // RunTaskCreateOptions represents the set of options for creating a run task

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -109,7 +109,7 @@ func TestRunTasksRead(t *testing.T) {
 		defer wrTest2Cleanup()
 
 		r, err := client.RunTasks.ReadWithOptions(ctx, runTaskTest.ID, &RunTaskReadOptions{
-			Include: []RunTaskIncludeOps{RunTaskWorkspaceTasks},
+			Include: []RunTaskIncludeOpt{RunTaskWorkspaceTasks},
 		})
 
 		require.NoError(t, err)

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -80,7 +80,7 @@ func TestRunTriggerList(t *testing.T) {
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})
 
-	t.Run("without defining RunTriggerFilterOps as a filter param", func(t *testing.T) {
+	t.Run("without defining RunTriggerListOptions", func(t *testing.T) {
 		rtl, err := client.RunTriggers.List(
 			ctx,
 			wTest.ID,
@@ -88,6 +88,21 @@ func TestRunTriggerList(t *testing.T) {
 		)
 		assert.Nil(t, rtl)
 		assert.Equal(t, err, ErrRequiredRunTriggerListOps)
+	})
+
+	t.Run("without defining RunTriggerFilterOp as a filter param", func(t *testing.T) {
+		rtl, err := client.RunTriggers.List(
+			ctx,
+			wTest.ID,
+			&RunTriggerListOptions{
+				ListOptions: ListOptions{
+					PageNumber: 999,
+					PageSize:   100,
+				},
+			},
+		)
+		assert.Nil(t, rtl)
+		assert.Equal(t, err, ErrInvalidRunTriggerType)
 	})
 
 	t.Run("with invalid option for runTriggerType", func(t *testing.T) {
@@ -100,6 +115,32 @@ func TestRunTriggerList(t *testing.T) {
 		)
 		assert.Nil(t, rtl)
 		assert.Equal(t, err, ErrInvalidRunTriggerType)
+	})
+
+	t.Run("with sourceable include option", func(t *testing.T) {
+		rtl, err := client.RunTriggers.List(
+			ctx,
+			wTest.ID,
+			&RunTriggerListOptions{
+				RunTriggerType: RunTriggerInbound,
+				Include:        []RunTriggerIncludeOpt{RunTriggerSourceable},
+			},
+		)
+		require.NoError(t, err)
+		assert.NotEmpty(t, rtl.Items)
+		assert.NotEmpty(t, rtl.Items[0].Sourceable.Name)
+	})
+
+	t.Run("with a RunTriggerType that does not return included data", func(t *testing.T) {
+		_, err := client.RunTriggers.List(
+			ctx,
+			wTest.ID,
+			&RunTriggerListOptions{
+				RunTriggerType: RunTriggerOutbound,
+				Include:        []RunTriggerIncludeOpt{RunTriggerSourceable},
+			},
+		)
+		assert.Equal(t, err, ErrUnsupportedRunTriggerType)
 	})
 }
 

--- a/state_version.go
+++ b/state_version.go
@@ -80,23 +80,23 @@ type StateVersionListOptions struct {
 	Workspace    string `url:"filter[workspace][name]"`
 }
 
-// StateVersionIncludeOps represents the available options for include query params.
+// StateVersionIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/cloud-docs/api-docs/state-versions#available-related-resources
-type StateVersionIncludeOps string
+type StateVersionIncludeOpt string
 
 const (
-	SVcreatedby               StateVersionIncludeOps = "created_by"
-	SVrun                     StateVersionIncludeOps = "run"
-	SVrunCreatedBy            StateVersionIncludeOps = "run.created_by"
-	SVrunConfigurationVersion StateVersionIncludeOps = "run.configuration_version"
-	SVoutputs                 StateVersionIncludeOps = "outputs"
+	SVcreatedby               StateVersionIncludeOpt = "created_by"
+	SVrun                     StateVersionIncludeOpt = "run"
+	SVrunCreatedBy            StateVersionIncludeOpt = "run.created_by"
+	SVrunConfigurationVersion StateVersionIncludeOpt = "run.configuration_version"
+	SVoutputs                 StateVersionIncludeOpt = "outputs"
 )
 
 // StateVersionReadOptions represents the options for reading state version.
 type StateVersionReadOptions struct {
 	// Optional: A list of relations to include. See available resources:
 	// https://www.terraform.io/cloud-docs/api-docs/state-versions#available-related-resources
-	Include []StateVersionIncludeOps `url:"include,omitempty"`
+	Include []StateVersionIncludeOpt `url:"include,omitempty"`
 }
 
 // StateVersionOutputsListOptions represents the options for listing state
@@ -109,7 +109,7 @@ type StateVersionOutputsListOptions struct {
 type StateVersionCurrentOptions struct {
 	// Optional: A list of relations to include. See available resources:
 	// https://www.terraform.io/cloud-docs/api-docs/state-versions#available-related-resources
-	Include []StateVersionIncludeOps `url:"include,omitempty"`
+	Include []StateVersionIncludeOpt `url:"include,omitempty"`
 }
 
 // StateVersionCreateOptions represents the options for creating a state version.

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -317,7 +317,7 @@ func TestStateVersionsReadWithOptions(t *testing.T) {
 
 	t.Run("when the state version exists", func(t *testing.T) {
 		curOpts := &StateVersionReadOptions{
-			Include: []StateVersionIncludeOps{SVoutputs},
+			Include: []StateVersionIncludeOpt{SVoutputs},
 		}
 
 		sv, err := client.StateVersions.ReadWithOptions(ctx, svTest.ID, curOpts)
@@ -385,7 +385,7 @@ func TestStateVersionsCurrentWithOptions(t *testing.T) {
 
 	t.Run("when the state version exists", func(t *testing.T) {
 		curOpts := &StateVersionCurrentOptions{
-			Include: []StateVersionIncludeOps{SVoutputs},
+			Include: []StateVersionIncludeOpt{SVoutputs},
 		}
 
 		sv, err := client.StateVersions.ReadCurrentWithOptions(ctx, wTest1.ID, curOpts)

--- a/state_version_output_integration_test.go
+++ b/state_version_output_integration_test.go
@@ -28,7 +28,7 @@ func TestStateVersionOutputsRead(t *testing.T) {
 	time.Sleep(waitForStateVersionOutputs)
 
 	curOpts := &StateVersionCurrentOptions{
-		Include: []StateVersionIncludeOps{SVoutputs},
+		Include: []StateVersionIncludeOpt{SVoutputs},
 	}
 
 	sv, err := client.StateVersions.ReadCurrentWithOptions(ctx, wTest1.ID, curOpts)

--- a/task_stages.go
+++ b/task_stages.go
@@ -59,17 +59,17 @@ type TaskStageStatusTimestamps struct {
 	PassedAt   time.Time `jsonapi:"attr,passed-at,rfc3339"`
 }
 
-// TaskStageIncludeOps represents the available options for include query params.
-type TaskStageIncludeOps string
+// TaskStageIncludeOpt represents the available options for include query params.
+type TaskStageIncludeOpt string
 
 const (
-	TaskStageTaskResults TaskStageIncludeOps = "task_results"
+	TaskStageTaskResults TaskStageIncludeOpt = "task_results"
 )
 
 // TaskStageReadOptions represents the set of options when reading a task stage
 type TaskStageReadOptions struct {
 	// Optional: A list of relations to include.
-	Include []TaskStageIncludeOps `url:"include,omitempty"`
+	Include []TaskStageIncludeOpt `url:"include,omitempty"`
 }
 
 // TaskStageListOptions represents the options for listing task stages for a run

--- a/task_stages_integration_test.go
+++ b/task_stages_integration_test.go
@@ -33,7 +33,7 @@ func TestTaskStagesRead(t *testing.T) {
 	defer rTestCleanup()
 
 	r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, &RunReadOptions{
-		Include: []RunIncludeOps{RunTaskStages},
+		Include: []RunIncludeOpt{RunTaskStages},
 	})
 	require.NoError(t, err)
 
@@ -59,7 +59,7 @@ func TestTaskStagesRead(t *testing.T) {
 
 	t.Run("with include param task_results", func(t *testing.T) {
 		taskStage, err := client.TaskStages.Read(ctx, r.TaskStages[0].ID, &TaskStageReadOptions{
-			Include: []TaskStageIncludeOps{TaskStageTaskResults},
+			Include: []TaskStageIncludeOpt{TaskStageTaskResults},
 		})
 		require.NoError(t, err)
 

--- a/team.go
+++ b/team.go
@@ -71,13 +71,13 @@ type TeamPermissions struct {
 	CanUpdateMembership bool `jsonapi:"attr,can-update-membership"`
 }
 
-// TeamIncludeOps represents the available options for include query params.
+// TeamIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/docs/cloud/api/teams.html#available-related-resources
-type TeamIncludeOps string
+type TeamIncludeOpt string
 
 const (
-	TeamUsers                   TeamIncludeOps = "users"
-	TeamOrganizationMemberships TeamIncludeOps = "organization-memberships"
+	TeamUsers                   TeamIncludeOpt = "users"
+	TeamOrganizationMemberships TeamIncludeOpt = "organization-memberships"
 )
 
 // TeamListOptions represents the options for listing teams.
@@ -85,7 +85,7 @@ type TeamListOptions struct {
 	ListOptions
 	// Optional: A list of relations to include.
 	// https://www.terraform.io/docs/cloud/api/teams.html#available-related-resources
-	Include []TeamIncludeOps `url:"include,omitempty"`
+	Include []TeamIncludeOpt `url:"include,omitempty"`
 }
 
 // TeamCreateOptions represents the options for creating a team.

--- a/team_member.go
+++ b/team_member.go
@@ -74,9 +74,9 @@ func (s *teamMembers) ListUsers(ctx context.Context, teamID string) ([]*User, er
 	}
 
 	options := struct {
-		Include []TeamIncludeOps `url:"include"`
+		Include []TeamIncludeOpt `url:"include,omitempty"`
 	}{
-		Include: []TeamIncludeOps{TeamUsers},
+		Include: []TeamIncludeOpt{TeamUsers},
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
@@ -101,9 +101,9 @@ func (s *teamMembers) ListOrganizationMemberships(ctx context.Context, teamID st
 	}
 
 	options := struct {
-		Include []TeamIncludeOps `url:"include,omitempty"`
+		Include []TeamIncludeOpt `url:"include,omitempty"`
 	}{
-		Include: []TeamIncludeOps{TeamOrganizationMemberships},
+		Include: []TeamIncludeOpt{TeamOrganizationMemberships},
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))

--- a/workspace.go
+++ b/workspace.go
@@ -202,29 +202,29 @@ type WorkspacePermissions struct {
 	CanUpdateVariable bool `jsonapi:"attr,can-update-variable"`
 }
 
-// WSIncludeOps represents the available options for include query params.
+// WSIncludeOpt represents the available options for include query params.
 // https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
-type WSIncludeOps string
+type WSIncludeOpt string
 
 const (
-	WSOrganization               WSIncludeOps = "organization"
-	WSCurrentConfigVer           WSIncludeOps = "current_configuration_version"
-	WSCurrentConfigVerIngress    WSIncludeOps = "current_configuration_version.ingress_attributes"
-	WSCurrentRun                 WSIncludeOps = "current_run"
-	WSCurrentRunPlan             WSIncludeOps = "current_run.plan"
-	WSCurrentRunConfigVer        WSIncludeOps = "current_run.configuration_version"
-	WSCurrentrunConfigVerIngress WSIncludeOps = "current_run.configuration_version.ingress_attributes"
-	WSLockedBy                   WSIncludeOps = "locked_by"
-	WSReadme                     WSIncludeOps = "readme"
-	WSOutputs                    WSIncludeOps = "outputs"
-	WSCurrentStateVer            WSIncludeOps = "current-state-version"
+	WSOrganization               WSIncludeOpt = "organization"
+	WSCurrentConfigVer           WSIncludeOpt = "current_configuration_version"
+	WSCurrentConfigVerIngress    WSIncludeOpt = "current_configuration_version.ingress_attributes"
+	WSCurrentRun                 WSIncludeOpt = "current_run"
+	WSCurrentRunPlan             WSIncludeOpt = "current_run.plan"
+	WSCurrentRunConfigVer        WSIncludeOpt = "current_run.configuration_version"
+	WSCurrentrunConfigVerIngress WSIncludeOpt = "current_run.configuration_version.ingress_attributes"
+	WSLockedBy                   WSIncludeOpt = "locked_by"
+	WSReadme                     WSIncludeOpt = "readme"
+	WSOutputs                    WSIncludeOpt = "outputs"
+	WSCurrentStateVer            WSIncludeOpt = "current-state-version"
 )
 
 // WorkspaceReadOptions represents the options for reading a workspace.
 type WorkspaceReadOptions struct {
 	// Optional: A list of relations to include.
 	// https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
-	Include []WSIncludeOps `url:"include,omitempty"`
+	Include []WSIncludeOpt `url:"include,omitempty"`
 }
 
 // WorkspaceListOptions represents the options for listing workspaces.
@@ -238,7 +238,7 @@ type WorkspaceListOptions struct {
 	Tags string `url:"search[tags],omitempty"`
 
 	// Optional: A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
-	Include []WSIncludeOps `url:"include,omitempty"`
+	Include []WSIncludeOpt `url:"include,omitempty"`
 }
 
 // WorkspaceCreateOptions represents the options for creating a new workspace.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -113,7 +113,7 @@ func TestWorkspacesList(t *testing.T) {
 
 	t.Run("with organization included", func(t *testing.T) {
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
-			Include: []WSIncludeOps{WSOrganization},
+			Include: []WSIncludeOpt{WSOrganization},
 		})
 
 		assert.NoError(t, err)
@@ -128,7 +128,7 @@ func TestWorkspacesList(t *testing.T) {
 		t.Cleanup(rCleanup)
 
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
-			Include: []WSIncludeOps{WSCurrentStateVer, WSCurrentRun},
+			Include: []WSIncludeOpt{WSCurrentStateVer, WSCurrentRun},
 		})
 
 		assert.NoError(t, err)
@@ -343,7 +343,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 
 	t.Run("when options to include resource", func(t *testing.T) {
 		opts := &WorkspaceReadOptions{
-			Include: []WSIncludeOps{WSOutputs},
+			Include: []WSIncludeOpt{WSOutputs},
 		}
 		w, err := client.Workspaces.ReadWithOptions(ctx, orgTest.Name, wTest.Name, opts)
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

Add "include" field to listOptions structs for API that allow for include values.

**These are the APIs and their include values listed in Atlas:**

agent pool API: "workspaces" 
oauth client API: "oauth_tokens" 
policy check API: "run.workspace", "run" 
run trigger API: "workspace", "sourceable"
organization API: "entitlement_set" 
policy set versions API: "policy_set"
policy API: "policy_sets"  

**I did not implemented the changes for:**
 
organizations API - because the relation for entitlement set was not part of `type Organization struct`. 
policy set version API - I did have the relation present but I did not have the listOptions or listing function present.
Policy API - Policies controller has the include value "policy_sets", but this value does not align with only relation listed under `type Policy struct`: `Organization *Organization `jsonapi:"relation,organization"`` What am I missing here?

**All the other include fields were added. This is how the implementation was made:** 

Step 1 - Add `include` struct field to SomeResourceListOptions
Step 2 - Create constants for the allowed include values that are typed strings
Step 3 - Add a test to make sure what are getting the "included" data

**Bonus Step:**

Change the pre-existing typed string named `SomePrefixIncludeOps` to `SomePrefixIncludeOp`, like `type OAuthClientIncludeOps string` becomes `type OAuthClientIncludeOp string`. I should have made the suffix singular from the beginning, but it is not too late to make that correction. 
To reduce noise coming from this change, you can focus on the changes made to:

1. agent_pool.go
2. agent_pool_integration_test.go
3. oauth_client.go
4. oauth_client_integration_test.go
5. policy_check.go
6. policy_check_integration_test.go
7. run_trigger.go
8. run_trigger_integration_test.go
9. errors.go


<!-- Describe why you're making this change. -->

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
