### PR TITLE
Update validations

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -76,9 +76,7 @@ type AdminOrganizationList struct {
 // https://www.terraform.io/docs/cloud/api/admin/organizations.html#available-related-resources
 type AdminOrgIncludeOpt string
 
-const (
-	AdminOrgOwners AdminOrgIncludeOpt = "owners"
-)
+const AdminOrgOwners AdminOrgIncludeOpt = "owners"
 
 // AdminOrganizationListOptions represents the options for listing organizations via Admin API.
 type AdminOrganizationListOptions struct {
@@ -103,6 +101,9 @@ type AdminOrganizationID struct {
 
 // List all the organizations visible to the current user.
 func (s *adminOrganizations) List(ctx context.Context, options *AdminOrganizationListOptions) (*AdminOrganizationList, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 	u := "admin/organizations"
 	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
@@ -224,4 +225,29 @@ func (s *adminOrganizations) Delete(ctx context.Context, organization string) er
 	}
 
 	return s.client.do(ctx, req, nil)
+}
+
+func (o *AdminOrganizationListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateAdminOrgIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateAdminOrgIncludeParams(params []AdminOrgIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case AdminOrgOwners:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
+	return nil
 }

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -92,6 +92,14 @@ func TestAdminRuns_List(t *testing.T) {
 		assert.NotEmpty(t, rl.Items[0].Workspace.Organization.Name)
 	})
 
+	t.Run("with invalid Include option", func(t *testing.T) {
+		_, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
+			Include: []AdminRunIncludeOpt{"workpsace"},
+		})
+
+		assert.Equal(t, err, ErrInvalidIncludeValue)
+	})
+
 	t.Run("with RunStatus.pending filter", func(t *testing.T) {
 		r1, err := client.Runs.Read(ctx, rTest1.ID)
 		assert.NoError(t, err)
@@ -243,6 +251,15 @@ func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
 
 		err := opts.valid()
 		assert.Error(t, err)
+	})
+
+	t.Run("has trailing comma and trailing space", func(t *testing.T) {
+		opts := AdminRunsListOptions{
+			RunStatus: "pending, ",
+		}
+
+		err := opts.valid()
+		assert.NoError(t, err)
 	})
 }
 

--- a/admin_setting_smtp_integration_test.go
+++ b/admin_setting_smtp_integration_test.go
@@ -35,16 +35,17 @@ func TestAdminSettings_SMTP_Update(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	enabled := false
+	enabled := true
+	disabled := false
 
 	t.Run("with Auth option defined", func(t *testing.T) {
 		smtpSettings, err := client.Admin.Settings.SMTP.Update(ctx, AdminSMTPSettingsUpdateOptions{
-			Enabled: Bool(enabled),
+			Enabled: Bool(disabled),
 			Auth:    SMTPAuthValue(SMTPAuthNone),
 		})
 
 		require.NoError(t, err)
-		assert.Equal(t, enabled, smtpSettings.Enabled)
+		assert.Equal(t, disabled, smtpSettings.Enabled)
 	})
 	t.Run("with no Auth option", func(t *testing.T) {
 		smtpSettings, err := client.Admin.Settings.SMTP.Update(ctx, AdminSMTPSettingsUpdateOptions{
@@ -54,5 +55,14 @@ func TestAdminSettings_SMTP_Update(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, SMTPAuthNone, smtpSettings.Auth)
 		assert.Equal(t, enabled, smtpSettings.Enabled)
+	})
+	t.Run("with invalid Auth option", func(t *testing.T) {
+		var SMTPAuthPlained SMTPAuthType = "plained"
+		_, err := client.Admin.Settings.SMTP.Update(ctx, AdminSMTPSettingsUpdateOptions{
+			Enabled: Bool(enabled),
+			Auth:    &SMTPAuthPlained,
+		})
+
+		assert.Equal(t, err, ErrInvalidSMTPAuth)
 	})
 }

--- a/admin_user.go
+++ b/admin_user.go
@@ -68,9 +68,7 @@ type AdminUserList struct {
 // https://www.terraform.io/docs/cloud/api/admin/users.html#available-related-resources
 type AdminUserIncludeOpt string
 
-const (
-	AdminUserOrgs AdminUserIncludeOpt = "organizations"
-)
+const AdminUserOrgs AdminUserIncludeOpt = "organizations"
 
 // AdminUserListOptions represents the options for listing users.
 // https://www.terraform.io/docs/cloud/api/admin/users.html#query-parameters
@@ -93,6 +91,10 @@ type AdminUserListOptions struct {
 
 // List all user accounts in the Terraform Enterprise installation
 func (a *adminUsers) List(ctx context.Context, options *AdminUserListOptions) (*AdminUserList, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
 	u := "admin/users"
 	req, err := a.client.newRequest("GET", u, options)
 	if err != nil {
@@ -227,4 +229,28 @@ func (a *adminUsers) Disable2FA(ctx context.Context, userID string) (*AdminUser,
 	}
 
 	return au, nil
+}
+
+func (o *AdminUserListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateAdminUserIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateAdminUserIncludeParams(params []AdminUserIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case AdminUserOrgs:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+	return nil
 }

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -76,6 +76,10 @@ type AdminWorkspaceList struct {
 
 // List all the workspaces within a workspace.
 func (s *adminWorkspaces) List(ctx context.Context, options *AdminWorkspaceListOptions) (*AdminWorkspaceList, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
 	u := "admin/workspaces"
 	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
@@ -125,4 +129,29 @@ func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error 
 	}
 
 	return s.client.do(ctx, req, nil)
+}
+
+func (o *AdminWorkspaceListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateAdminWSIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateAdminWSIncludeParams(params []AdminWorkspaceIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case AdminWorkspaceOrg, AdminWorkspaceCurrentRun, AdminWorkspaceOrgOwners:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
+	return nil
 }

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -33,6 +33,21 @@ func TestAgentPoolsList(t *testing.T) {
 		assert.Equal(t, 1, pools.TotalCount)
 	})
 
+	t.Run("with Include option", func(t *testing.T) {
+		_, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{
+			Name:          String("bar"),
+			ExecutionMode: String("agent"),
+			AgentPoolID:   String(agentPool.ID),
+		})
+		defer wTestCleanup()
+
+		k, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
+			Include: []AgentPoolIncludeOpt{AgentPoolWorkspaces},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, k.Items[0].Workspaces[0])
+	})
+
 	t.Run("with list options", func(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
@@ -47,14 +62,6 @@ func TestAgentPoolsList(t *testing.T) {
 		assert.Empty(t, pools.Items)
 		assert.Equal(t, 999, pools.CurrentPage)
 		assert.Equal(t, 1, pools.TotalCount)
-	})
-
-	t.Run("with Include options", func(t *testing.T) {
-		pools, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
-			Include: []AgentPoolIncludeOpt{AgentPoolWorkspaces},
-		})
-		require.NoError(t, err)
-		assert.NotEmpty(t, pools.Items[0].Organization.Name)
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
@@ -138,6 +145,21 @@ func TestAgentPoolsRead(t *testing.T) {
 		k, err := client.AgentPools.Read(ctx, badIdentifier)
 		assert.Nil(t, k)
 		assert.EqualError(t, err, ErrInvalidAgentPoolID.Error())
+	})
+
+	t.Run("with Include option", func(t *testing.T) {
+		_, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{
+			Name:          String("foo"),
+			ExecutionMode: String("agent"),
+			AgentPoolID:   String(pool.ID),
+		})
+		defer wTestCleanup()
+
+		k, err := client.AgentPools.ReadWithOptions(ctx, pool.ID, &AgentPoolReadOptions{
+			Include: []AgentPoolIncludeOpt{AgentPoolWorkspaces},
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, k.Workspaces[0])
 	})
 }
 

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -173,7 +173,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 
 	t.Run("when the configuration version exists", func(t *testing.T) {
 		options := &ConfigurationVersionReadOptions{
-			Include: []ConfigurationVersionIncludeOpt{ConfigurationVerIngressAttributes},
+			Include: []ConfigVerIncludeOpt{ConfigVerIngressAttributes},
 		}
 
 		cv, err := client.ConfigurationVersions.ReadWithOptions(ctx, cv.ID, options)

--- a/errors.go
+++ b/errors.go
@@ -120,7 +120,7 @@ var (
 
 	ErrInvalidRunTriggerType = errors.New(`invalid value or no value for RunTriggerType. It must be either "inbound" or "outbound"`)
 
-	ErrInvalidRunTriggerInclude = errors.New(`invalid value for "include" field`)
+	ErrInvalidIncludeValue = errors.New(`invalid value for "include" field`)
 
 	ErrInvalidSHHKeyID = errors.New("invalid value for SSH key ID")
 

--- a/mocks/agent_pool_mocks.go
+++ b/mocks/agent_pool_mocks.go
@@ -94,6 +94,21 @@ func (mr *MockAgentPoolsMockRecorder) Read(ctx, agentPoolID interface{}) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockAgentPools)(nil).Read), ctx, agentPoolID)
 }
 
+// ReadWithOptions mocks base method.
+func (m *MockAgentPools) ReadWithOptions(ctx context.Context, agentPoolID string, options *tfe.AgentPoolReadOptions) (*tfe.AgentPool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadWithOptions", ctx, agentPoolID, options)
+	ret0, _ := ret[0].(*tfe.AgentPool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadWithOptions indicates an expected call of ReadWithOptions.
+func (mr *MockAgentPoolsMockRecorder) ReadWithOptions(ctx, agentPoolID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWithOptions", reflect.TypeOf((*MockAgentPools)(nil).ReadWithOptions), ctx, agentPoolID, options)
+}
+
 // Update mocks base method.
 func (m *MockAgentPools) Update(ctx context.Context, agentPool string, options tfe.AgentPoolUpdateOptions) (*tfe.AgentPool, error) {
 	m.ctrl.T.Helper()

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -162,6 +162,9 @@ func (s *oAuthClients) List(ctx context.Context, organization string, options *O
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
 	req, err := s.client.newRequest("GET", u, options)
@@ -275,5 +278,30 @@ func (o OAuthClientCreateOptions) valid() error {
 	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {
 		return ErrUnsupportedPrivateKey
 	}
+	return nil
+}
+
+func (o *OAuthClientListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateOauthClientIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateOauthClientIncludeParams(params []OAuthClientIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case OauthClientOauthTokens:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
 	return nil
 }

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -64,7 +64,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		defer memTest2Cleanup()
 
 		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, &OrganizationMembershipListOptions{
-			Include: []OrganizationMembershipIncludeOpt{OrganizationMembershipUser},
+			Include: []OrgMembershipIncludeOpt{OrgMembershipUser},
 		})
 		require.NoError(t, err)
 
@@ -96,7 +96,7 @@ func TestOrganizationMembershipsCreate(t *testing.T) {
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.OrganizationMemberships.ReadWithOptions(ctx, mem.ID, OrganizationMembershipReadOptions{
-			Include: []OrganizationMembershipIncludeOpt{OrganizationMembershipUser},
+			Include: []OrgMembershipIncludeOpt{OrgMembershipUser},
 		})
 		require.NoError(t, err)
 		assert.Equal(t, refreshed, mem)
@@ -169,7 +169,7 @@ func TestOrganizationMembershipsReadWithOptions(t *testing.T) {
 	defer memTestCleanup()
 
 	options := OrganizationMembershipReadOptions{
-		Include: []OrganizationMembershipIncludeOpt{OrganizationMembershipUser},
+		Include: []OrgMembershipIncludeOpt{OrgMembershipUser},
 	}
 
 	t.Run("when the membership exists", func(t *testing.T) {
@@ -177,6 +177,18 @@ func TestOrganizationMembershipsReadWithOptions(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, memTest, mem)
+	})
+
+	t.Run("without options", func(t *testing.T) {
+		_, err := client.OrganizationMemberships.ReadWithOptions(ctx, memTest.ID, OrganizationMembershipReadOptions{})
+		require.NoError(t, err)
+	})
+
+	t.Run("without invalid include option", func(t *testing.T) {
+		_, err := client.OrganizationMemberships.ReadWithOptions(ctx, memTest.ID, OrganizationMembershipReadOptions{
+			Include: []OrgMembershipIncludeOpt{"users"},
+		})
+		assert.Equal(t, err, ErrInvalidIncludeValue)
 	})
 
 	t.Run("when the membership does not exist", func(t *testing.T) {

--- a/policy_check.go
+++ b/policy_check.go
@@ -130,6 +130,9 @@ func (s *policyChecks) List(ctx context.Context, runID string, options *PolicyCh
 	if !validStringID(&runID) {
 		return nil, ErrInvalidRunID
 	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 
 	u := fmt.Sprintf("runs/%s/policy-checks", url.QueryEscape(runID))
 	req, err := s.client.newRequest("GET", u, options)
@@ -227,4 +230,29 @@ func (s *policyChecks) Logs(ctx context.Context, policyCheckID string) (io.Reade
 
 		return logs, nil
 	}
+}
+
+func (o *PolicyCheckListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validatePolicyCheckIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validatePolicyCheckIncludeParams(params []PolicyCheckIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case PolicyCheckRunWorkspace, PolicyCheckRun:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
+	return nil
 }

--- a/policy_set.go
+++ b/policy_set.go
@@ -264,6 +264,9 @@ func (s *policySets) ReadWithOptions(ctx context.Context, policySetID string, op
 	if !validStringID(&policySetID) {
 		return nil, ErrInvalidPolicySetID
 	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 
 	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
 	req, err := s.client.newRequest("GET", u, options)
@@ -445,5 +448,30 @@ func (o PolicySetAddWorkspacesOptions) valid() error {
 	if len(o.Workspaces) == 0 {
 		return ErrWorkspaceMinLimit
 	}
+	return nil
+}
+
+func (o *PolicySetReadOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validatePolicySetIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validatePolicySetIncludeParams(params []PolicySetIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case PolicySetPolicies, PolicySetWorkspaces, PolicySetCurrentVersion, PolicySetNewestVersion:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
 	return nil
 }

--- a/run_task.go
+++ b/run_task.go
@@ -155,6 +155,9 @@ func (s *runTasks) List(ctx context.Context, organization string, options *RunTa
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 
 	u := fmt.Sprintf("organizations/%s/tasks", url.QueryEscape(organization))
 	req, err := s.client.newRequest("GET", u, options)
@@ -180,6 +183,9 @@ func (s *runTasks) Read(ctx context.Context, runTaskID string) (*RunTask, error)
 func (s *runTasks) ReadWithOptions(ctx context.Context, runTaskID string, options *RunTaskReadOptions) (*RunTask, error) {
 	if !validStringID(&runTaskID) {
 		return nil, ErrInvalidRunTaskID
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
 	}
 
 	u := fmt.Sprintf("tasks/%s", url.QueryEscape(runTaskID))
@@ -272,6 +278,43 @@ func (o *RunTaskUpdateOptions) valid() error {
 
 	if o.Category != nil && *o.Category != "task" {
 		return ErrInvalidRunTaskCategory
+	}
+
+	return nil
+}
+
+func (o *RunTaskListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateRunTaskIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *RunTaskReadOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateRunTaskIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateRunTaskIncludeParams(params []RunTaskIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case RunTaskWorkspaceTasks, RunTaskWorkspace:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
 	}
 
 	return nil

--- a/state_version.go
+++ b/state_version.go
@@ -189,6 +189,9 @@ func (s *stateVersions) ReadWithOptions(ctx context.Context, svID string, option
 	if !validStringID(&svID) {
 		return nil, ErrInvalidStateVerID
 	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 
 	u := fmt.Sprintf("state-versions/%s", url.QueryEscape(svID))
 	req, err := s.client.newRequest("GET", u, options)
@@ -214,6 +217,9 @@ func (s *stateVersions) Read(ctx context.Context, svID string) (*StateVersion, e
 func (s *stateVersions) ReadCurrentWithOptions(ctx context.Context, workspaceID string, options *StateVersionCurrentOptions) (*StateVersion, error) {
 	if !validStringID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
 	}
 
 	u := fmt.Sprintf("workspaces/%s/current-state-version", url.QueryEscape(workspaceID))
@@ -298,5 +304,39 @@ func (o StateVersionCreateOptions) valid() error {
 	if !validString(o.State) {
 		return ErrRequiredState
 	}
+	return nil
+}
+
+func (o *StateVersionReadOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateStateVerIncludeParams(o.Include); err != nil {
+		return err
+	}
+	return nil
+}
+func (o *StateVersionCurrentOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateStateVerIncludeParams(o.Include); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateStateVerIncludeParams(params []StateVersionIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case SVcreatedby, SVrun, SVrunCreatedBy, SVrunConfigurationVersion, SVoutputs:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
 	return nil
 }

--- a/task_stages.go
+++ b/task_stages.go
@@ -62,9 +62,7 @@ type TaskStageStatusTimestamps struct {
 // TaskStageIncludeOpt represents the available options for include query params.
 type TaskStageIncludeOpt string
 
-const (
-	TaskStageTaskResults TaskStageIncludeOpt = "task_results"
-)
+const TaskStageTaskResults TaskStageIncludeOpt = "task_results"
 
 // TaskStageReadOptions represents the set of options when reading a task stage
 type TaskStageReadOptions struct {
@@ -81,6 +79,9 @@ type TaskStageListOptions struct {
 func (s *taskStages) Read(ctx context.Context, taskStageID string, options *TaskStageReadOptions) (*TaskStage, error) {
 	if !validStringID(&taskStageID) {
 		return nil, ErrInvalidTaskStageID
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
 	}
 
 	u := fmt.Sprintf("task-stages/%s", taskStageID)
@@ -118,4 +119,29 @@ func (s *taskStages) List(ctx context.Context, runID string, options *TaskStageL
 	}
 
 	return tlist, nil
+}
+
+func (o *TaskStageReadOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateTaskStageIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTaskStageIncludeParams(params []TaskStageIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case TaskStageTaskResults:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
+	return nil
 }

--- a/team.go
+++ b/team.go
@@ -139,7 +139,9 @@ func (s *teams) List(ctx context.Context, organization string, options *TeamList
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
-
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
 	req, err := s.client.newRequest("GET", u, options)
 	if err != nil {
@@ -240,5 +242,30 @@ func (o TeamCreateOptions) valid() error {
 	if !validString(o.Name) {
 		return ErrRequiredName
 	}
+	return nil
+}
+
+func (o *TeamListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateTeamIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateTeamIncludeParams(params []TeamIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case TeamUsers, TeamOrganizationMemberships:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
+		}
+	}
+
 	return nil
 }

--- a/workspace.go
+++ b/workspace.go
@@ -517,6 +517,9 @@ func (s *workspaces) List(ctx context.Context, organization string, options *Wor
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
 
 	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
 	req, err := s.client.newRequest("GET", u, options)
@@ -569,6 +572,9 @@ func (s *workspaces) ReadWithOptions(ctx context.Context, organization, workspac
 	}
 	if !validStringID(&workspace) {
 		return nil, ErrInvalidWorkspaceValue
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
 	}
 
 	u := fmt.Sprintf(
@@ -1124,6 +1130,43 @@ func (o WorkspaceRemoveTagsOptions) valid() error {
 	for _, s := range o.Tags {
 		if s.Name == "" && s.ID == "" {
 			return ErrMissingTagIdentifier
+		}
+	}
+
+	return nil
+}
+
+func (o *WorkspaceListOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateWorkspaceIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (o *WorkspaceReadOptions) valid() error {
+	if o == nil {
+		return nil // nothing to validate
+	}
+
+	if err := validateWorkspaceIncludeParams(o.Include); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func validateWorkspaceIncludeParams(params []WSIncludeOpt) error {
+	for _, p := range params {
+		switch p {
+		case WSOrganization, WSCurrentConfigVer, WSCurrentConfigVerIngress, WSCurrentRun, WSCurrentRunPlan, WSCurrentRunConfigVer, WSCurrentrunConfigVerIngress, WSLockedBy, WSReadme, WSOutputs, WSCurrentStateVer:
+			// do nothing
+		default:
+			return ErrInvalidIncludeValue
 		}
 	}
 


### PR DESCRIPTION
## Description

This PR introduces validation check for all "include" values. Previously we had 3 files that had helper functions to check that the values passed as "filter" option and "include" option were valid strings. This release seemed like a good opportunity to standardize this practice beyond those 3 files.

Also, as we have recently made all "include" options a typed string field, it makes validation of those values more convenient.

Keep in mind that throwing errors for invalid include params is a nice bonus that we are adding to go-tfe and not a required one because this behavior does not exactly align with the response you'd get from the platform. To understand this point with a better context, read the comment I left for one of those validations https://github.com/hashicorp/go-tfe/blob/76df95cb33cf241f5d301849ed53f321b5786d20/admin_run.go#L134-L147


## Implementation Details

I added

```
if err := options.valid(); err != nil {
		return nil, err
	}
```
to listing and reading functions that take in options with Include values.

Within the valid() func, I call a helper function that validates that those include values are the listed as constants IncludeOpt typed string

```
if err := validateAdminOrgIncludeParams(o.Include); err != nil {
		return err
	}
```

I added some tests to validate this new functionality.

## Important note

A change not directly related to this PR, but that the new functionality helped surface as an issue, is that a previous change I had introduced on PR #339 was invalid. So I reverted that change in this PR. You can find that change in the following files:

agent_pool.go
agent_pool_integration_test.go

