### PR TITLE
Notification Triggers are now a type string

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -143,6 +143,8 @@ var (
 	ErrInvalidPolicies = errors.New("must provide at least one policy")
 
 	ErrInvalidVariableID = errors.New("invalid value for variable ID")
+
+	ErrInvalidNotificationTrigger = errors.New("invalid value for notification trigger")
 )
 
 // Missing values for required field/option

--- a/helper_test.go
+++ b/helper_test.go
@@ -164,7 +164,7 @@ func createNotificationConfiguration(t *testing.T, client *Client, w *Workspace,
 			Name:            String(randomString(t)),
 			Token:           String(randomString(t)),
 			URL:             String("http://example.com"),
-			Triggers:        []string{NotificationTriggerCreated},
+			Triggers:        []NotificationTriggerType{NotificationTriggerCreated},
 		}
 	}
 

--- a/notification_configuration_integration_test.go
+++ b/notification_configuration_integration_test.go
@@ -93,7 +93,7 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 			Name:            String(randomString(t)),
 			Token:           String(randomString(t)),
 			URL:             String("http://example.com"),
-			Triggers:        []string{NotificationTriggerCreated},
+			Triggers:        []NotificationTriggerType{NotificationTriggerCreated},
 		}
 
 		_, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
@@ -106,7 +106,7 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 			Enabled:         Bool(false),
 			Token:           String(randomString(t)),
 			URL:             String("http://example.com"),
-			Triggers:        []string{NotificationTriggerCreated},
+			Triggers:        []NotificationTriggerType{NotificationTriggerCreated},
 		}
 
 		nc, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
@@ -120,7 +120,7 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 			Enabled:         Bool(false),
 			Name:            String(randomString(t)),
 			Token:           String(randomString(t)),
-			Triggers:        []string{NotificationTriggerCreated},
+			Triggers:        []NotificationTriggerType{NotificationTriggerCreated},
 		}
 
 		nc, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
@@ -132,6 +132,21 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 		nc, err := client.NotificationConfigurations.Create(ctx, badIdentifier, NotificationConfigurationCreateOptions{})
 		assert.Nil(t, nc)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
+	})
+
+	t.Run("with an invalid notification trigger", func(t *testing.T) {
+		options := NotificationConfigurationCreateOptions{
+			DestinationType: NotificationDestination(NotificationDestinationTypeGeneric),
+			Enabled:         Bool(false),
+			Name:            String(randomString(t)),
+			Token:           String(randomString(t)),
+			URL:             String("http://example.com"),
+			Triggers:        []NotificationTriggerType{"the beacons of gondor are lit"},
+		}
+
+		nc, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
+		assert.Nil(t, nc)
+		assert.EqualError(t, err, ErrInvalidNotificationTrigger.Error())
 	})
 
 	t.Run("with email users when destination type is email", func(t *testing.T) {
@@ -223,6 +238,16 @@ func TestNotificationConfigurationUpdate(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, nc.Enabled, true)
 		assert.Equal(t, nc.Name, "newName")
+	})
+
+	t.Run("with invalid notification trigger", func(t *testing.T) {
+		options := NotificationConfigurationUpdateOptions{
+			Triggers: []NotificationTriggerType{"fly you fools!"},
+		}
+
+		nc, err := client.NotificationConfigurations.Update(ctx, ncTest.ID, options)
+		assert.Nil(t, nc)
+		assert.EqualError(t, err, ErrInvalidNotificationTrigger.Error())
 	})
 
 	t.Run("with email users when destination type is email", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR converts the `Triggers` field in Create/UpdateNotificationConfigurationOpts from `[]string` to `[]NotificationTriggerType`. I've also added a validation function to ensure any value passed in the array is a valid `NotificationTriggerType`... the go compiler doesn't enforce it at compile time (See #341). 

The `Triggers` field for `NotificationConfiguration` will remain of type `[]string`. This is due to the inability of the `jsonapi` package to unmarshal strings into an array of typed strings. Performing some type casting after unmarshalling is an effort that was not deemed to be worthwhile since this is a specific use case. 

## Testing plan

To run integration tests:
```sh
go test -run TestNotificationConfiguration -v ./... -tags=integration
```

## Output from tests (HashiCorp employees only)
```
=== RUN   TestNotificationConfigurationList
=== RUN   TestNotificationConfigurationList/with_a_valid_workspace
    notification_configuration_integration_test.go:36: paging not supported yet in API
=== RUN   TestNotificationConfigurationList/with_list_options
    notification_configuration_integration_test.go:42: paging not supported yet in API
=== RUN   TestNotificationConfigurationList/without_a_valid_workspace
--- PASS: TestNotificationConfigurationList (2.58s)
    --- SKIP: TestNotificationConfigurationList/with_a_valid_workspace (0.17s)
    --- SKIP: TestNotificationConfigurationList/with_list_options (0.00s)
    --- PASS: TestNotificationConfigurationList/without_a_valid_workspace (0.00s)
=== RUN   TestNotificationConfigurationCreate
=== RUN   TestNotificationConfigurationCreate/with_all_required_values
=== RUN   TestNotificationConfigurationCreate/without_a_required_value
=== RUN   TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_generic
=== RUN   TestNotificationConfigurationCreate/without_a_valid_workspace
=== RUN   TestNotificationConfigurationCreate/with_an_invalid_notification_trigger
=== RUN   TestNotificationConfigurationCreate/with_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationCreate/without_email_users_when_destination_type_is_email
--- PASS: TestNotificationConfigurationCreate (2.35s)
    --- PASS: TestNotificationConfigurationCreate/with_all_required_values (0.20s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_generic (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_valid_workspace (0.00s)
    --- PASS: TestNotificationConfigurationCreate/with_an_invalid_notification_trigger (0.00s)
    --- PASS: TestNotificationConfigurationCreate/with_email_users_when_destination_type_is_email (0.18s)
    --- PASS: TestNotificationConfigurationCreate/without_email_users_when_destination_type_is_email (0.15s)
=== RUN   TestNotificationConfigurationRead
=== RUN   TestNotificationConfigurationRead/with_a_valid_ID
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationRead (1.84s)
    --- PASS: TestNotificationConfigurationRead/with_a_valid_ID (0.14s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist (0.12s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationUpdate
=== RUN   TestNotificationConfigurationUpdate/with_options
=== RUN   TestNotificationConfigurationUpdate/with_invalid_notification_trigger
=== RUN   TestNotificationConfigurationUpdate/with_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationUpdate/without_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationUpdate/without_options
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationUpdate (3.43s)
    --- PASS: TestNotificationConfigurationUpdate/with_options (0.31s)
    --- PASS: TestNotificationConfigurationUpdate/with_invalid_notification_trigger (0.00s)
    --- PASS: TestNotificationConfigurationUpdate/with_email_users_when_destination_type_is_email (0.20s)
    --- PASS: TestNotificationConfigurationUpdate/without_email_users_when_destination_type_is_email (0.15s)
    --- PASS: TestNotificationConfigurationUpdate/without_options (0.19s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist (0.12s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationDelete
=== RUN   TestNotificationConfigurationDelete/with_a_valid_ID
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationDelete (1.79s)
    --- PASS: TestNotificationConfigurationDelete/with_a_valid_ID (0.26s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist (0.12s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationVerify
=== RUN   TestNotificationConfigurationVerify/with_a_valid_ID
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationVerify (1.84s)
    --- PASS: TestNotificationConfigurationVerify/with_a_valid_ID (0.19s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists (0.11s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     14.622s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```