### PR TITLE
Resolve TFE_HOSTNAME as fallback for TFE_ADDRESS env var

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -21,6 +21,8 @@ Tests are run against an actual backend so they require a valid backend address 
 1. `TFE_ADDRESS` - URL of a Terraform Cloud or Terraform Enterprise instance to be used for testing, including scheme. Example: `https://tfe.local`
 1. `TFE_TOKEN` - A [user API token](https://www.terraform.io/docs/cloud/users-teams-organizations/users.html#api-tokens) for the Terraform Cloud or Terraform Enterprise instance being used for testing.
 
+**Note:** Alternatively, you can set `TFE_HOSTNAME` which serves as a fallback for `TFE_ADDRESS`. It will only be used if `TFE_ADDRESS` is not set and will resolve the host to an `https` scheme. Example: `tfe.local` => resolves to `https://tfe.local`
+
 ##### Optional:
 1. `GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running any tests that use VCS (OAuth clients, policy sets, etc).
 1. `GITHUB_POLICY_SET_IDENTIFIER` - GitHub policy set repository identifier in the format `username/repository`. Required for running policy set tests.

--- a/tfe.go
+++ b/tfe.go
@@ -79,7 +79,11 @@ func DefaultConfig() *Config {
 
 	// Set the default address if none is given.
 	if config.Address == "" {
-		config.Address = DefaultAddress
+		if host := os.Getenv("TFE_HOSTNAME"); host != "" {
+			config.Address = fmt.Sprintf("https://%s", host)
+		} else {
+			config.Address = DefaultAddress
+		}
 	}
 
 	// Set the default user agent.

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -16,6 +16,7 @@ import (
 
 	"github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/jsonapi"
+	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"
 )
 
@@ -108,6 +109,27 @@ func TestClient_defaultConfig(t *testing.T) {
 
 	t.Run("with environment variables", func(t *testing.T) {
 		defer setupEnvVars("abcd1234", "https://mytfe.local")()
+	})
+
+	t.Run("performs address resolution", func(t *testing.T) {
+		t.Run("with TFE_ADDRESS set", func(t *testing.T) {
+			os.Setenv("TFE_ADDRESS", "https://terraform.io")
+			client := DefaultConfig()
+			assert.Equal(t, client.Address, "https://terraform.io")
+			os.Unsetenv("TFE_ADDRESS")
+		})
+
+		t.Run("with TFE_HOSTNAME set", func(t *testing.T) {
+			os.Setenv("TFE_HOSTNAME", "iloveterraform.io")
+			client := DefaultConfig()
+			assert.Equal(t, client.Address, "https://iloveterraform.io")
+			os.Unsetenv("TFE_HOSTNAME")
+		})
+
+		t.Run("with no env var set", func(t *testing.T) {
+			client := DefaultConfig()
+			assert.Equal(t, client.Address, DefaultAddress)
+		})
 	})
 }
 


### PR DESCRIPTION
We ran into a stale permission issue with Circle CI in #340. 