### PR TITLE
avoid failing on wrapped errors

### DIFF
--- a/tfe.go
+++ b/tfe.go
@@ -1,6 +1,8 @@
 package tfe
 
 import (
+	"errors"
+	"io/fs"
 	"log"
 	"sort"
 
@@ -884,8 +886,12 @@ func packContents(path string) (*bytes.Buffer, error) {
 
 	file, err := os.Stat(path)
 	if err != nil {
-		return body, err
+		if errors.Is(err, fs.ErrNotExist) {
+			return body, fmt.Errorf(`failed to find files under the path "%v": %w`, path, err)
+		}
+		return body, fmt.Errorf(`unable to upload files from the path "%v": %w`, path, err)
 	}
+
 	if !file.Mode().IsDir() {
 		return body, ErrMissingDirectory
 	}

--- a/tfe.go
+++ b/tfe.go
@@ -872,8 +872,8 @@ func decodeErrorPayload(r *http.Response) ([]string, error) {
 	return errs, nil
 }
 
-func errorPayloadContains(errors []string, match string) bool {
-	for _, e := range errors {
+func errorPayloadContains(payloadErrors []string, match string) bool {
+	for _, e := range payloadErrors {
 		if strings.Contains(e, match) {
 			return true
 		}


### PR DESCRIPTION
## Description

I noticed logreader.go was using the old way of comparing errors `==`. This make sense because this file was implemented almost 4 years ago when `errors.Is` was not an available standardize practice yet: https://go.dev/blog/go1.13-errors

This could potentially fail an assertion if the error thrown by that external package had wrapped errors. So I change this implementation to use `errors.Is`.

The other small change I am introducing here is that instead of returning a semi-vague error thrown by an external library like so:

```
file, err := os.Stat(path)
	if err != nil {
            return err
```

I am unwrapping the error, adding additional information about the call site where things failed, and then wrapping back the error with `fmt.Errorf(...)`, like this:

```
if err != nil {
		if errors.Is(err, fs.ErrNotExist) {
			return fmt.Errorf(`failed to find terraform configuration files under the path "%v": %w`, path, err)
		}
		return fmt.Errorf(`unable to upload terraform configuration files from the path "%v": %w`, path, err)
	}
``` 

Adding some context to an error coming from a large external package, should make identifying the source of problems easier during debugging.



## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
