### PR TITLE
Add AddComment on Run struct

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: test
 on:
-  pull_request:
+  push:
     branches: [ main, releases-1.0.x, feat/run-add-comment ]
 jobs:
   codegen:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   pull_request:
-    branches: [ main, releases-1.0.x, run-add-comment ]
+    branches: [ main, releases-1.0.x, feat/run-add-comment ]
 jobs:
   codegen:
     name: Codegen

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   pull_request:
-    branches: [ main, releases-1.0.x ]
+    branches: [ main, releases-1.0.x, run-add-comment ]
 jobs:
   codegen:
     name: Codegen

--- a/mocks/run_mocks.go
+++ b/mocks/run_mocks.go
@@ -35,6 +35,20 @@ func (m *MockRuns) EXPECT() *MockRunsMockRecorder {
 	return m.recorder
 }
 
+// AddComment mocks base method.
+func (m *MockRuns) AddComment(ctx context.Context, runID string, options tfe.RunCommentOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddComment", ctx, runID, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddComment indicates an expected call of AddComment.
+func (mr *MockRunsMockRecorder) AddComment(ctx, runID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddComment", reflect.TypeOf((*MockRuns)(nil).AddComment), ctx, runID, options)
+}
+
 // Apply mocks base method.
 func (m *MockRuns) Apply(ctx context.Context, runID string, options tfe.RunApplyOptions) error {
 	m.ctrl.T.Helper()

--- a/run.go
+++ b/run.go
@@ -38,6 +38,9 @@ type Runs interface {
 
 	// Discard a run by its ID.
 	Discard(ctx context.Context, runID string, options RunDiscardOptions) error
+
+	// AddComment to add a comment on a run.
+	AddComment(ctx context.Context, runID string, options RunCommentOptions) error
 }
 
 // runs implements Runs.
@@ -278,6 +281,13 @@ type RunDiscardOptions struct {
 	Comment *string `jsonapi:"attr,comment,omitempty"`
 }
 
+// RunCommentOptions represents the options for a run comment.
+type RunCommentOptions struct {
+	Type string  `jsonapi:"primary,comments"`
+	Body *string `jsonapi:"attr,body,omitempty"`
+	Run  *Run    `jsonapi:"relation,run"`
+}
+
 // List all the runs of the given workspace.
 func (s *runs) List(ctx context.Context, workspaceID string, options *RunListOptions) (*RunList, error) {
 	if !validStringID(&workspaceID) {
@@ -403,6 +413,21 @@ func (s *runs) Discard(ctx context.Context, runID string, options RunDiscardOpti
 	}
 
 	u := fmt.Sprintf("runs/%s/actions/discard", url.QueryEscape(runID))
+	req, err := s.client.newRequest("POST", u, &options)
+	if err != nil {
+		return err
+	}
+
+	return s.client.do(ctx, req, nil)
+}
+
+// AddComment to add a comment on a run.
+func (s *runs) AddComment(ctx context.Context, runID string, options RunCommentOptions) error {
+	if !validStringID(&runID) {
+		return ErrInvalidRunID
+	}
+
+	u := fmt.Sprintf("runs/%s/comments", url.QueryEscape(runID))
 	req, err := s.client.newRequest("POST", u, &options)
 	if err != nil {
 		return err


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Add the ability to use the endpoint `POST /runs/:run_id/comments` to add comments on a run.

## Testing plan

```
runComment := tfe.RunCommentOptions{
    Body: tfe.String("Test from fork of go-tfe"),
}
err = client.Runs.AddComment(ctx, run.ID, runComment)
if err != nil {
    log.Fatal(err)
}
```

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

This endpoint is not documented right now.

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
