### PR TITLE
Add support for downloading configuration versions

### DIFF
--- a/mocks/configuration_version_mocks.go
+++ b/mocks/configuration_version_mocks.go
@@ -64,6 +64,21 @@ func (mr *MockConfigurationVersionsMockRecorder) Create(ctx, workspaceID, option
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockConfigurationVersions)(nil).Create), ctx, workspaceID, options)
 }
 
+// Download mocks base method.
+func (m *MockConfigurationVersions) Download(ctx context.Context, cvID string) ([]byte, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Download", ctx, cvID)
+	ret0, _ := ret[0].([]byte)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Download indicates an expected call of Download.
+func (mr *MockConfigurationVersionsMockRecorder) Download(ctx, cvID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Download", reflect.TypeOf((*MockConfigurationVersions)(nil).Download), ctx, cvID)
+}
+
 // List mocks base method.
 func (m *MockConfigurationVersions) List(ctx context.Context, workspaceID string, options *tfe.ConfigurationVersionListOptions) (*tfe.ConfigurationVersionList, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
## Description

Adds a `Download` method to the `ConfigurationVersions` interface to support downloading configuration versions.   

Note that only configuration versions in the `uploaded` state may be downloaded.

## Testing plan


## External links

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/configuration-versions#download-configuration-files)


## Output from tests (HashiCorp employees only)

```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test -run TestConfigurationVersionsDownload -v ./... -timeout=30m -tags=integration
=== RUN   TestConfigurationVersionsDownload
=== RUN   TestConfigurationVersionsDownload/with_a_valid_ID_for_downloadable_configuration_version
=== RUN   TestConfigurationVersionsDownload/with_a_valid_ID_for_a_non_downloadable_configuration_version
=== RUN   TestConfigurationVersionsDownload/with_an_invalid_ID
--- PASS: TestConfigurationVersionsDownload (7.26s)
    --- PASS: TestConfigurationVersionsDownload/with_a_valid_ID_for_downloadable_configuration_version (3.62s)
    --- PASS: TestConfigurationVersionsDownload/with_a_valid_ID_for_a_non_downloadable_configuration_version (2.47s)
    --- PASS: TestConfigurationVersionsDownload/with_an_invalid_ID (0.31s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```
