### PR TITLE
remove branch from github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: test
 on:
   pull_request:
-    branches: [ main, releases-1.0.x ]
+    branches: [ main ]
 jobs:
   codegen:
     name: Codegen

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,7 +1,7 @@
 name: golangci-lint
 on:
   push:
-    branches: [ main, releases-1.0.x ]
+    branches: [ main ]
   pull_request:
 jobs:
   golangci:


### PR DESCRIPTION
We are done using the releases 1.0 branch for now. The branch itself has not been deleted because is possible we want to go back to it in the future. But for now I am removing this branch from our PR checks (specifically the github actions one) before I forget that we need to remove it.
Lots of tests failing right now: Looks like the nightly build for the platform is running.

## Description

<!-- Describe why you're making this change. -->

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
