### PR TITLE
changes to add trigger-nested-changes field to workspace

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -336,6 +336,7 @@ type WorkspaceCreateOptions struct {
 	// environment when multiple environments exist within the same repository.
 	WorkingDirectory *string `jsonapi:"attr,working-directory,omitempty"`
 
+	// **Note: This field is still in BETA and subject to change.**
 	// Optional: Whether to trigger a run when any nested file below the root or the
 	// working directory (if configured) is changed. By default, it is enabled. Setting
 	// this to false, any changes in any file will trigger a run only in the current
@@ -439,10 +440,11 @@ type WorkspaceUpdateOptions struct {
 	// repository.
 	WorkingDirectory *string `jsonapi:"attr,working-directory,omitempty"`
 
+	// **Note: This field is still in BETA and subject to change.**
 	// Optional: Whether to trigger a run when any nested file below the root or the
 	// working directory (if configured) is changed. By default, it is enabled. Setting this to false, will prevent
 	// the change in any nested files to trigger a run.
-	TriggerNestedChanges *bool `jsonapi:"attr,trigger-nested-changes"`
+	TriggerNestedChanges *bool `jsonapi:"attr,trigger-nested-changes,omitempty"`
 }
 
 // WorkspaceLockOptions represents the options for locking a workspace.

--- a/workspace.go
+++ b/workspace.go
@@ -133,6 +133,7 @@ type Workspace struct {
 	TriggerPrefixes            []string              `jsonapi:"attr,trigger-prefixes"`
 	VCSRepo                    *VCSRepo              `jsonapi:"attr,vcs-repo"`
 	WorkingDirectory           string                `jsonapi:"attr,working-directory"`
+	TriggerNestedChanges       bool                  `jsonapi:"attr,trigger-nested-changes"`
 	UpdatedAt                  time.Time             `jsonapi:"attr,updated-at,iso8601"`
 	ResourceCount              int                   `jsonapi:"attr,resource-count"`
 	ApplyDurationAverage       time.Duration         `jsonapi:"attr,apply-duration-average"`
@@ -335,6 +336,12 @@ type WorkspaceCreateOptions struct {
 	// environment when multiple environments exist within the same repository.
 	WorkingDirectory *string `jsonapi:"attr,working-directory,omitempty"`
 
+	// Optional: Whether to trigger a run when any nested file below the root or the
+	// working directory (if configured) is changed. By default, it is enabled. Setting
+	// this to false, any changes in any file will trigger a run only in the current
+	// directory
+	TriggerNestedChanges *bool `jsonapi:"attr,trigger-nested-changes,omitempty"`
+
 	// A list of tags to attach to the workspace. If the tag does not already
 	// exist, it is created and added to the workspace.
 	Tags []*Tag `jsonapi:"relation,tags,omitempty"`
@@ -431,6 +438,11 @@ type WorkspaceUpdateOptions struct {
 	// the environment when multiple environments exist within the same
 	// repository.
 	WorkingDirectory *string `jsonapi:"attr,working-directory,omitempty"`
+
+	// Optional: Whether to trigger a run when any nested file below the root or the
+	// working directory (if configured) is changed. By default, it is enabled. Setting this to false, will prevent
+	// the change in any nested files to trigger a run.
+	TriggerNestedChanges *bool `jsonapi:"attr,trigger-nested-changes"`
 }
 
 // WorkspaceLockOptions represents the options for locking a workspace.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -172,6 +172,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			TerraformVersion:           String("0.11.0"),
 			TriggerPrefixes:            []string{"/modules", "/shared"},
 			WorkingDirectory:           String("bar/"),
+			TriggerNestedChanges:       Bool(true),
 			Tags: []*Tag{
 				{
 					Name: "tag1",
@@ -210,6 +211,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
+			assert.Equal(t, *options.TriggerNestedChanges, item.TriggerNestedChanges)
 		}
 	})
 
@@ -495,6 +497,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 		assert.NotEqual(t, wTest.QueueAllRuns, wAfter.QueueAllRuns)
 		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
 		assert.Equal(t, wTest.WorkingDirectory, wAfter.WorkingDirectory)
+		assert.Equal(t, wTest.TriggerNestedChanges, wAfter.TriggerNestedChanges)
 	})
 
 	t.Run("with valid options", func(t *testing.T) {
@@ -511,6 +514,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			TerraformVersion:           String("0.11.1"),
 			TriggerPrefixes:            []string{"/modules", "/shared"},
 			WorkingDirectory:           String("baz/"),
+			TriggerNestedChanges:       Bool(true),
 		}
 
 		w, err := client.Workspaces.Update(ctx, orgTest.Name, wTest.Name, options)
@@ -536,6 +540,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
+			assert.Equal(t, *options.TriggerNestedChanges, item.TriggerNestedChanges)
 		}
 	})
 
@@ -609,6 +614,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 		assert.NotEqual(t, wTest.QueueAllRuns, wAfter.QueueAllRuns)
 		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
 		assert.Equal(t, wTest.WorkingDirectory, wAfter.WorkingDirectory)
+		assert.Equal(t, wTest.TriggerNestedChanges, wAfter.TriggerNestedChanges)
 	})
 
 	t.Run("with valid options", func(t *testing.T) {
@@ -624,6 +630,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 			TerraformVersion:           String("0.11.1"),
 			TriggerPrefixes:            []string{"/modules", "/shared"},
 			WorkingDirectory:           String("baz/"),
+			TriggerNestedChanges:       Bool(false),
 		}
 
 		w, err := client.Workspaces.UpdateByID(ctx, wTest.ID, options)
@@ -648,6 +655,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
 			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
 			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
+			assert.Equal(t, *options.TriggerNestedChanges, item.TriggerNestedChanges)
 		}
 	})
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
 Adding a new field(trigger_nested_changes) to the workspace to address a fix for unclear behavior

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->


## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ go-tfe % envchain go-tfe go test -v ./... -run TestWorkspacesCreate -tags=integration    
=== RUN   TestWorkspacesCreate
=== RUN   TestWorkspacesCreate/with_valid_options
=== RUN   TestWorkspacesCreate/with_trigger_nested_changes
=== RUN   TestWorkspacesCreate/when_options_is_missing_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesCreate/when_options_has_an_invalid_organization
=== RUN   TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode
=== RUN   TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesCreate/when_an_error_is_returned_from_the_API
--- PASS: TestWorkspacesCreate (1.66s)
    --- PASS: TestWorkspacesCreate/with_valid_options (0.28s)
    --- PASS: TestWorkspacesCreate/with_trigger_nested_changes (0.41s)
    --- PASS: TestWorkspacesCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_has_an_invalid_organization (0.00s)
    --- PASS: TestWorkspacesCreate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_agent_pool_ID_is_specified_without_'agent'_execution_mode (0.00s)
    --- PASS: TestWorkspacesCreate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesCreate/when_an_error_is_returned_from_the_API (0.08s)
PASS
ok      github.com/hashicorp/go-tfe     2.332s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]

$ go-tfe % envchain go-tfe go test -v ./... -run TestWorkspacesUpdate -tags=integration
=== RUN   TestWorkspacesUpdate
=== RUN   TestWorkspacesUpdate/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdate/with_trigger_nested_changes
=== RUN   TestWorkspacesUpdate/with_valid_options
=== RUN   TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesUpdate/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_organization
--- PASS: TestWorkspacesUpdate (1.46s)
    --- PASS: TestWorkspacesUpdate/when_updating_a_subset_of_values (0.14s)
    --- PASS: TestWorkspacesUpdate/with_trigger_nested_changes (0.12s)
    --- PASS: TestWorkspacesUpdate/with_valid_options (0.26s)
    --- PASS: TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesUpdate/when_an_error_is_returned_from_the_api (0.08s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestWorkspacesUpdateByID
=== RUN   TestWorkspacesUpdateByID/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdateByID/with_valid_options
=== RUN   TestWorkspacesUpdateByID/with_trigger_nested_changes
=== RUN   TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdateByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUpdateByID (1.79s)
    --- PASS: TestWorkspacesUpdateByID/when_updating_a_subset_of_values (0.13s)
    --- PASS: TestWorkspacesUpdateByID/with_valid_options (0.27s)
    --- PASS: TestWorkspacesUpdateByID/with_trigger_nested_changes (0.25s)
    --- PASS: TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api (0.10s)
    --- PASS: TestWorkspacesUpdateByID/without_a_valid_workspace_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     3.456s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]

```