### PR TITLE
Change Team SSOTeamID property from a pointer to a string

### DIFF
--- a/team.go
+++ b/team.go
@@ -49,7 +49,7 @@ type Team struct {
 	Visibility         string              `jsonapi:"attr,visibility"`
 	Permissions        *TeamPermissions    `jsonapi:"attr,permissions"`
 	UserCount          int                 `jsonapi:"attr,users-count"`
-	SSOTeamID          *string             `jsonapi:"attr,sso-team-id"`
+	SSOTeamID          string              `jsonapi:"attr,sso-team-id"`
 
 	// Relations
 	Users                   []*User                   `jsonapi:"relation,users"`

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -105,8 +105,8 @@ func TestTeamsCreate(t *testing.T) {
 		assert.Nil(t, err)
 		assert.Equal(t, *options.Name, team.Name)
 
-		assert.NotNil(t, options.SSOTeamID, team.SSOTeamID)
-		assert.Equal(t, *options.SSOTeamID, *team.SSOTeamID)
+		assert.NotNil(t, team.SSOTeamID)
+		assert.Equal(t, *options.SSOTeamID, team.SSOTeamID)
 	})
 
 	t.Run("when options is missing name", func(t *testing.T) {
@@ -171,7 +171,7 @@ func TestTeamsRead(t *testing.T) {
 			skipIfBeta(t)
 
 			assert.NotNil(t, ssoTeam.SSOTeamID)
-			assert.Equal(t, *opts.SSOTeamID, *ssoTeam.SSOTeamID)
+			assert.Equal(t, *opts.SSOTeamID, ssoTeam.SSOTeamID)
 		})
 	})
 
@@ -322,7 +322,7 @@ func TestTeam_Unmarshal(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, team.ID, "1")
 	assert.Equal(t, team.Name, "team hashi")
-	assert.Nil(t, team.SSOTeamID)
+	assert.Empty(t, team.SSOTeamID)
 	assert.Equal(t, team.OrganizationAccess.ManageWorkspaces, true)
 	assert.Equal(t, team.OrganizationAccess.ManageVCSSettings, true)
 	assert.Equal(t, team.OrganizationAccess.ManagePolicies, true)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Circle) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests or you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorportated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

For consistency with the other APIs, change the recently added `SSOTeamId` on `Team` from a pointer to a string.

## Testing plan

I am exercising this change with an [upcoming change to the terraform-provider-tfe](https://github.com/hashicorp/terraform-provider-tfe/pull/457)

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
ENABLE_BETA=1 TFE_ADDRESS=... TF_ACC=1 TFE_TOKEN=... go test -v ./... -tags=integration -run TestTeams
=== RUN   TestTeamsList
=== RUN   TestTeamsList/without_list_options
    team_integration_test.go:37: paging not supported yet in API
=== RUN   TestTeamsList/with_list_options
    team_integration_test.go:43: paging not supported yet in API
=== RUN   TestTeamsList/without_a_valid_organization
--- PASS: TestTeamsList (2.72s)
    --- SKIP: TestTeamsList/without_list_options (0.41s)
    --- SKIP: TestTeamsList/with_list_options (0.00s)
    --- PASS: TestTeamsList/without_a_valid_organization (0.00s)
=== RUN   TestTeamsCreate
=== RUN   TestTeamsCreate/with_valid_options
=== RUN   TestTeamsCreate/with_sso-team-id
=== RUN   TestTeamsCreate/when_options_is_missing_name
=== RUN   TestTeamsCreate/when_options_has_an_invalid_organization
--- PASS: TestTeamsCreate (2.00s)
    --- PASS: TestTeamsCreate/with_valid_options (0.51s)
    --- PASS: TestTeamsCreate/with_sso-team-id (0.29s)
    --- PASS: TestTeamsCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestTeamsCreate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestTeamsRead
=== RUN   TestTeamsRead/when_the_team_exists
=== RUN   TestTeamsRead/when_the_team_exists/visibility_is_returned
=== RUN   TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded
=== RUN   TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded
=== RUN   TestTeamsRead/when_the_team_exists/SSO_team_id_is_returned
=== RUN   TestTeamsRead/when_the_team_does_not_exist
=== RUN   TestTeamsRead/without_a_valid_team_ID
--- PASS: TestTeamsRead (3.26s)
    --- PASS: TestTeamsRead/when_the_team_exists (0.27s)
        --- PASS: TestTeamsRead/when_the_team_exists/visibility_is_returned (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/SSO_team_id_is_returned (0.00s)
    --- PASS: TestTeamsRead/when_the_team_does_not_exist (0.24s)
    --- PASS: TestTeamsRead/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsUpdate
=== RUN   TestTeamsUpdate/with_valid_options
=== RUN   TestTeamsUpdate/when_the_team_does_not_exist
=== RUN   TestTeamsUpdate/without_a_valid_team_ID
--- PASS: TestTeamsUpdate (2.15s)
    --- PASS: TestTeamsUpdate/with_valid_options (0.48s)
    --- PASS: TestTeamsUpdate/when_the_team_does_not_exist (0.18s)
    --- PASS: TestTeamsUpdate/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsDelete
=== RUN   TestTeamsDelete/with_valid_options
=== RUN   TestTeamsDelete/without_valid_team_ID
--- PASS: TestTeamsDelete (1.72s)
    --- PASS: TestTeamsDelete/with_valid_options (0.42s)
    --- PASS: TestTeamsDelete/without_valid_team_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```
