### PR TITLE
Add entitlements for Run Tasks

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -94,6 +94,7 @@ type Entitlements struct {
 	CostEstimation        bool   `jsonapi:"attr,cost-estimation"`
 	Operations            bool   `jsonapi:"attr,operations"`
 	PrivateModuleRegistry bool   `jsonapi:"attr,private-module-registry"`
+	RunTasks              bool   `jsonapi:"attr,run-tasks"`
 	SSO                   bool   `jsonapi:"attr,sso"`
 	Sentinel              bool   `jsonapi:"attr,sentinel"`
 	StateStorage          bool   `jsonapi:"attr,state-storage"`

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -481,3 +481,23 @@ func TestOrganizationsReadRunTasksPermission(t *testing.T) {
 		})
 	})
 }
+
+func TestOrganizationsReadRunTasksEntitlement(t *testing.T) {
+	skipIfEnterprise(t)
+	skipIfFreeOnly(t)
+	skipIfBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	t.Run("when the org exists", func(t *testing.T) {
+		entitlements, err := client.Organizations.ReadEntitlements(ctx, orgTest.Name)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, entitlements.ID)
+		assert.True(t, entitlements.RunTasks)
+	})
+}


### PR DESCRIPTION
## Description

This PR adds the beta API changes for the Run Tasks entitlement as per RFC TF-479

## Testing plan

1. Start up an instance of the development Terraform Cloud environment.
2. Run the Integration tests with `ENABLE_BETA`

## External links

- [Entitlements Documentation](https://www.terraform.io/cloud-docs/api-docs#feature-entitlements)
- [Feature Sets API documenation](https://www.terraform.io/cloud-docs/api-docs/feature-sets)