### PR TITLE
Add Run Tasks permissions for Org. and Workspace

### DIFF
--- a/organization.go
+++ b/organization.go
@@ -113,6 +113,7 @@ type OrganizationPermissions struct {
 	CanCreateWorkspace          bool `jsonapi:"attr,can-create-workspace"`
 	CanCreateWorkspaceMigration bool `jsonapi:"attr,can-create-workspace-migration"`
 	CanDestroy                  bool `jsonapi:"attr,can-destroy"`
+	CanManageRunTasks           bool `jsonapi:"attr,can-manage-run-tasks"`
 	CanTraverse                 bool `jsonapi:"attr,can-traverse"`
 	CanUpdate                   bool `jsonapi:"attr,can-update"`
 	CanUpdateAPIToken           bool `jsonapi:"attr,can-update-api-token"`

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -459,3 +459,25 @@ func TestOrganization_Unmarshal(t *testing.T) {
 	assert.NotEmpty(t, org.Permissions)
 	assert.Equal(t, org.Permissions.CanCreateTeam, true)
 }
+
+func TestOrganizationsReadRunTasksPermission(t *testing.T) {
+	skipIfFreeOnly(t)
+	skipIfBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	t.Run("when the org exists", func(t *testing.T) {
+		org, err := client.Organizations.Read(ctx, orgTest.Name)
+		require.NoError(t, err)
+		assert.Equal(t, orgTest, org)
+		assert.NotEmpty(t, org.Permissions)
+
+		t.Run("permissions are properly decoded", func(t *testing.T) {
+			assert.True(t, org.Permissions.CanManageRunTasks)
+		})
+	})
+}

--- a/team.go
+++ b/team.go
@@ -64,6 +64,7 @@ type OrganizationAccess struct {
 	ManageVCSSettings     bool `jsonapi:"attr,manage-vcs-settings"`
 	ManageProviders       bool `jsonapi:"attr,manage-providers"`
 	ManageModules         bool `jsonapi:"attr,manage-modules"`
+	ManageRunTasks        bool `jsonapi:"attr,manage-run-tasks"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -139,6 +140,7 @@ type OrganizationAccessOptions struct {
 	ManageVCSSettings     *bool `json:"manage-vcs-settings,omitempty"`
 	ManageProviders       *bool `json:"manage-providers,omitempty"`
 	ManageModules         *bool `json:"manage-modules,omitempty"`
+	ManageRunTasks        *bool `json:"manage-run-tasks,omitempty"`
 }
 
 // List all the teams of the given organization.

--- a/team_access.go
+++ b/team_access.go
@@ -98,6 +98,7 @@ type TeamAccess struct {
 	StateVersions    StateVersionsPermissionType `jsonapi:"attr,state-versions"`
 	SentinelMocks    SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks"`
 	WorkspaceLocking bool                        `jsonapi:"attr,workspace-locking"`
+	RunTasks         bool                        `jsonapi:"attr,run-tasks"`
 
 	// Relations
 	Team      *Team      `jsonapi:"relation,team"`
@@ -128,6 +129,7 @@ type TeamAccessAddOptions struct {
 	StateVersions    *StateVersionsPermissionType `jsonapi:"attr,state-versions,omitempty"`
 	SentinelMocks    *SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks,omitempty"`
 	WorkspaceLocking *bool                        `jsonapi:"attr,workspace-locking,omitempty"`
+	RunTasks         *bool                        `jsonapi:"attr,run-tasks,omitempty"`
 
 	// The team to add to the workspace
 	Team *Team `jsonapi:"relation,team"`
@@ -154,6 +156,7 @@ type TeamAccessUpdateOptions struct {
 	StateVersions    *StateVersionsPermissionType `jsonapi:"attr,state-versions,omitempty"`
 	SentinelMocks    *SentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks,omitempty"`
 	WorkspaceLocking *bool                        `jsonapi:"attr,workspace-locking,omitempty"`
+	RunTasks         *bool                        `jsonapi:"attr,run-tasks,omitempty"`
 }
 
 // List all the team accesses for a given workspace.

--- a/workspace.go
+++ b/workspace.go
@@ -193,6 +193,7 @@ type WorkspacePermissions struct {
 	CanDestroy        bool `jsonapi:"attr,can-destroy"`
 	CanForceUnlock    bool `jsonapi:"attr,can-force-unlock"`
 	CanLock           bool `jsonapi:"attr,can-lock"`
+	CanManageRunTasks bool `jsonapi:"attr,can-manage-run-tasks"`
 	CanQueueApply     bool `jsonapi:"attr,can-queue-apply"`
 	CanQueueDestroy   bool `jsonapi:"attr,can-queue-destroy"`
 	CanQueueRun       bool `jsonapi:"attr,can-queue-run"`

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1414,3 +1414,24 @@ func TestWorkspaceCreateOptions_Marshal(t *testing.T) {
 `
 	assert.Equal(t, expectedBody, string(bodyBytes))
 }
+
+func TestWorkspacesRunTasksPermission(t *testing.T) {
+	skipIfFreeOnly(t)
+	skipIfBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	defer wTestCleanup()
+
+	t.Run("when the workspace exists", func(t *testing.T) {
+		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
+		require.NoError(t, err)
+		assert.Equal(t, wTest, w)
+		assert.True(t, w.Permissions.CanManageRunTasks)
+	})
+}


### PR DESCRIPTION
## Description

This commit adds the beta API changes for the Run Tasks permissions
as per RFC TF-474:
* Permission to modify Organization level Run Tasks
* Permission to modify Workspace level Run Tasks

This commit also adds tests for these beta features.

## Testing plan

1. Create an Organization
2. Query the Organization permissions and ensure the manage run tasks permission is populated correctly
3. Create a Workspace
2. Query the Workspace permissions and ensure the manage run tasks permission is populated correctly

## External links

- [Permissions API Documentation](https://github.com/hashicorp/terraform-website/pull/2236)
