### PR TITLE
fix: run actions don't accept json-api resource request bodies

### DIFF
--- a/run.go
+++ b/run.go
@@ -253,13 +253,13 @@ type RunCreateOptions struct {
 // RunApplyOptions represents the options for applying a run.
 type RunApplyOptions struct {
 	// An optional comment about the run.
-	Comment *string `jsonapi:"attr,comment,omitempty"`
+	Comment *string `json:"comment,omitempty"`
 }
 
 // RunCancelOptions represents the options for canceling a run.
 type RunCancelOptions struct {
 	// An optional explanation for why the run was canceled.
-	Comment *string `jsonapi:"attr,comment,omitempty"`
+	Comment *string `json:"comment,omitempty"`
 }
 
 // RunVariable represents a variable that can be applied to a run. All values must be expressed as an HCL literal
@@ -273,13 +273,13 @@ type RunVariable struct {
 // RunForceCancelOptions represents the options for force-canceling a run.
 type RunForceCancelOptions struct {
 	// An optional comment explaining the reason for the force-cancel.
-	Comment *string `jsonapi:"attr,comment,omitempty"`
+	Comment *string `json:"comment,omitempty"`
 }
 
 // RunDiscardOptions represents the options for discarding a run.
 type RunDiscardOptions struct {
 	// An optional explanation for why the run was discarded.
-	Comment *string `jsonapi:"attr,comment,omitempty"`
+	Comment *string `json:"comment,omitempty"`
 }
 
 // List all the runs of the given workspace.

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -295,8 +295,19 @@ func TestRunsApply(t *testing.T) {
 	rTest, _ := createPlannedRun(t, client, wTest)
 
 	t.Run("when the run exists", func(t *testing.T) {
-		err := client.Runs.Apply(ctx, rTest.ID, RunApplyOptions{})
+		err := client.Runs.Apply(ctx, rTest.ID, RunApplyOptions{
+			Comment: String("Hello, Earl"),
+		})
 		assert.NoError(t, err)
+
+		r, err := client.Runs.Read(ctx, rTest.ID)
+		assert.NoError(t, err)
+
+		assert.Len(t, r.Comments, 1)
+
+		c, err := client.Comments.Read(ctx, r.Comments[0].ID)
+		assert.NoError(t, err)
+		assert.Equal(t, "Hello, Earl", c.Body)
 	})
 
 	t.Run("when the run does not exist", func(t *testing.T) {


### PR DESCRIPTION
## Description

According to the docs and in practice, the run actions group of endpoints commonly accept a request body with a single "comment" attribute. This isn't a json-api resource document, and it shouldn't be encoded into a "data" → "attributes" nesting.

As far as I know, these are the only request bodies that aren't compliant, and it's not worthwhile to convert these endpoints from actions to resources.

## Testing plan

I added an integration test for this in particular, but I also I wrote a simple program to POST a run apply to a [service like requestb.in](https://requestbin.com/r/env12e9eawjlf/28cdloPxOtlJmSk1N4Qk1zIVn1V) so you can see the request body:

```
package main

import (
	"context"

	"github.com/hashicorp/go-tfe"
)

func main() {
	client, err := tfe.NewClient(&tfe.Config{
		Address: "https://env12e9eawjlf.x.pipedream.net",
		Token:   "xxx.atlasv1.xxx",
	})

	if err != nil {
		panic(err)
	}

	err = client.Runs.Apply(context.Background(), "run-NjC97hxkfWZ4eHTA", tfe.RunApplyOptions{
		Comment: tfe.String("hello, world"),
	})

	if err != nil {
		panic(err)
	}
}
```

## External links

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/run#apply-a-run)
