### PR TITLE
Add Microsoft Teams notification destination type

### DIFF
--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -59,9 +59,10 @@ type NotificationDestinationType string
 
 // List of available notification destination types.
 const (
-	NotificationDestinationTypeEmail   NotificationDestinationType = "email"
-	NotificationDestinationTypeGeneric NotificationDestinationType = "generic"
-	NotificationDestinationTypeSlack   NotificationDestinationType = "slack"
+	NotificationDestinationTypeEmail          NotificationDestinationType = "email"
+	NotificationDestinationTypeGeneric        NotificationDestinationType = "generic"
+	NotificationDestinationTypeSlack          NotificationDestinationType = "slack"
+	NotificationDestinationTypeMicrosoftTeams NotificationDestinationType = "microsoft_teams"
 )
 
 // NotificationConfigurationList represents a list of Notification
@@ -319,7 +320,10 @@ func (o NotificationConfigurationCreateOptions) valid() error {
 		return ErrInvalidNotificationTrigger
 	}
 
-	if *o.DestinationType == NotificationDestinationTypeGeneric || *o.DestinationType == NotificationDestinationTypeSlack {
+	if *o.DestinationType == NotificationDestinationTypeGeneric ||
+		*o.DestinationType == NotificationDestinationTypeSlack ||
+		*o.DestinationType == NotificationDestinationTypeMicrosoftTeams {
+
 		if o.URL == nil {
 			return ErrRequiredURL
 		}

--- a/notification_configuration_integration_test.go
+++ b/notification_configuration_integration_test.go
@@ -128,6 +128,32 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 		assert.Equal(t, err, ErrRequiredURL)
 	})
 
+	t.Run("without a required value URL when destination type is slack", func(t *testing.T) {
+		options := NotificationConfigurationCreateOptions{
+			DestinationType: NotificationDestination(NotificationDestinationTypeSlack),
+			Enabled:         Bool(false),
+			Name:            String(randomString(t)),
+			Triggers:        []NotificationTriggerType{NotificationTriggerCreated},
+		}
+
+		nc, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
+		assert.Nil(t, nc)
+		assert.Equal(t, err, ErrRequiredURL)
+	})
+
+	t.Run("without a required value URL when destination type is MS Teams", func(t *testing.T) {
+		options := NotificationConfigurationCreateOptions{
+			DestinationType: NotificationDestination(NotificationDestinationTypeMicrosoftTeams),
+			Enabled:         Bool(false),
+			Name:            String(randomString(t)),
+			Triggers:        []NotificationTriggerType{NotificationTriggerCreated},
+		}
+
+		nc, err := client.NotificationConfigurations.Create(ctx, wTest.ID, options)
+		assert.Nil(t, nc)
+		assert.Equal(t, err, ErrRequiredURL)
+	})
+
 	t.Run("without a valid workspace", func(t *testing.T) {
 		nc, err := client.NotificationConfigurations.Create(ctx, badIdentifier, NotificationConfigurationCreateOptions{})
 		assert.Nil(t, nc)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds `microsoft_teams` as a potential `destination` for notification configuration

The Terraform Cloud support for Microsoft Teams is currently being implemented, so queueing this (and the related `tfe` provider) change up fo

## Testing plan

Testing through use with the `tfe` provider, to check that terraform can be used to create, update, and destroy (+ validate) Microsoft Teams notification configurations on TFC

The required values for Teams notification config will be the same as for Slack notifications

## External links

- [Asana](https://app.asana.com/0/1201654039499505/1202142043071082/f)
- [Related Provider PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/484)


## Output from tests (HashiCorp employees only)

TODO blocked by dev environment

```
$ go test ./... -v -tags=integration -run TestNotificationConfigurationCreate
...
```
