### PR TITLE
Adding missing Category to VariableUpdateOptions

### DIFF
--- a/variable.go
+++ b/variable.go
@@ -114,6 +114,9 @@ type VariableUpdateOptions struct {
 	// The description of the variable.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
+	// Whether this is a Terraform or environment variable.
+	Category *CategoryType `jsonapi:"attr,category,omitempty"`
+
 	// Whether to evaluate the value of the variable as a string of HCL code.
 	HCL *bool `jsonapi:"attr,hcl,omitempty"`
 

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -278,6 +278,18 @@ func TestVariablesUpdate(t *testing.T) {
 		assert.Empty(t, v.Value) // Because its now sensitive
 	})
 
+	t.Run("with category set", func(t *testing.T) {
+		category := CategoryEnv
+		options := VariableUpdateOptions{
+			Category: &category,
+		}
+
+		v, err := client.Variables.Update(ctx, vTest.Workspace.ID, vTest.ID, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, *options.Category, v.Category)
+	})
+
 	t.Run("without any changes", func(t *testing.T) {
 		vTest, vTestCleanup := createVariable(t, client, nil)
 		defer vTestCleanup()


### PR DESCRIPTION
## Description

This PR is adding missing `Categoiry` attribute to the `VariableUpdateOptions` method. Without this change, nobody can change the category of a Workspace variable and the only way how to remediate this is to delete the variable and create it again.

## Testing plan

1) Find a way how to change the category of a Workspace variable (there is none)

## External links

The official [API documentation](https://www.terraform.io/cloud-docs/api-docs/workspace-variables#update-variables) shows that it should be possible to change the `category` attribute.

## Output from tests (HashiCorp employees only)

I have tried to run the relevant test only but I'm getting an error:

```
TFE_TOKEN='<snip>' TFE_ADDRESS='https://app.terraform.io' ENABLE_TFE='1' go test -run TestVariablesUpdate -v ./... -tags=integration
=== RUN   TestVariablesUpdate
--- FAIL: TestVariablesUpdate (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x7227a6]

goroutine 19 [running]:
testing.tRunner.func1.2({0x806800, 0xb521a0})
	/usr/lib/go/src/testing/testing.go:1389 +0x24e
testing.tRunner.func1()
	/usr/lib/go/src/testing/testing.go:1392 +0x39f
panic({0x806800, 0xb521a0})
	/usr/lib/go/src/runtime/panic.go:838 +0x207
github.com/hashicorp/go-tfe.(*Client).RetryServerErrors(...)
	/path/to/the/go-tfe/tfe.go:335
github.com/hashicorp/go-tfe.testClient(0xc0001281a0)
	/path/to/the/go-tfe/helper_test.go:31 +0x26
github.com/hashicorp/go-tfe.TestVariablesUpdate(0x0?)
	/path/to/the/go-tfe/variable_integration_test.go:235 +0x33
testing.tRunner(0xc0001281a0, 0x8bb3c0)
	/usr/lib/go/src/testing/testing.go:1439 +0x102
created by testing.(*T).Run
	/usr/lib/go/src/testing/testing.go:1486 +0x35f
FAIL	github.com/hashicorp/go-tfe	0.006s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
FAIL
```

I think it's failing because I don't have my environment setup for the test properly. Please advise what could be missing so I can run the tests.