### PR TITLE
Add helper script to setup envvars via envchain

### DIFF
--- a/scripts/setup-test-envvars.sh
+++ b/scripts/setup-test-envvars.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash -e
+
+# setup-test-envvars.sh
+#
+# A helper script that uses envchain (https://github.com/sorah/envchain) to set environment variables for tests.
+# It's required to have TFE_ADDRESS and TFE_TOKEN set, the others are optional.
+#
+type envchain >/dev/null 2>&1 || { echo >&2 "Required executable 'envchain' not found - install it via 'brew install envchain'. Exiting."; exit 1; }
+
+echo "Set environment variables (envvars) for running tests locally"
+echo " envchain will prompt you for values for 4 envvars"
+echo " TFE_ADDRESS and TFE_TOKEN are required, the others are optional,"
+echo " press 'return' to skip them"
+echo ""
+
+read -p "Enter the namespace you want to use in envchain [go-tfe]: " namespace
+namespace=${namespace:-go-tfe}
+envchain --set ${namespace} TFE_ADDRESS TFE_TOKEN GITHUB_TOKEN GITHUB_POLICY_SET_IDENTIFIER
+echo "Done! To see the values: envchain ${namespace} env"


### PR DESCRIPTION
## Description

Add a helper script to simplify setting env vars via envchain. Script prompts for an envchain workspace name, then invokes envchain with the environment variables.

## Testing plan

1. Pull this branch
2. Run `./scripts/setup-test-envvars.sh`
3. If you don't have envchain, the script will exit and request that it be installed via homebrew (this part could be more generic).
4. If you do have envchain, the script prompts for an envchain workspace name, then calls envchain with that workspace name and these 4 envvars: TFE_ADDRESS TFE_TOKEN GITHUB_TOKEN GITHUB_POLICY_SET_IDENTIFIER

## Output from tests (HashiCorp employees only)

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
