### PR TITLE
Add run ID to debug statement to facilitate investigations

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -561,7 +561,10 @@ func createRunWithStatus(t *testing.T, client *Client, w *Workspace, timeout int
 		if i > timeout {
 			runStatus := r.Status
 			rCleanup()
-			t.Fatal(fmt.Printf("Timeout waiting for run to reach status %v, had status %s", desiredStatuses, runStatus))
+			t.Fatal(fmt.Printf("Timeout waiting for run ID %s to reach status %v, had status %s",
+				r.ID,
+				desiredStatuses,
+				runStatus))
 		}
 
 		time.Sleep(1 * time.Second)


### PR DESCRIPTION
## Description

Add the run ID when a run fails to facilitate investigations.

