### PR TITLE
Log the warning that agent pool cleanup failed

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -60,7 +60,7 @@ func createAgentPool(t *testing.T, client *Client, org *Organization) (*AgentPoo
 
 	return pool, func() {
 		if err := client.AgentPools.Delete(ctx, pool.ID); err != nil {
-			t.Errorf("Error destroying agent pool! WARNING: Dangling resources "+
+			t.Logf("Error destroying agent pool! WARNING: Dangling resources "+
 				"may exist! The full error is shown below.\n\n"+
 				"Agent pool ID: %s\nError: %s", pool.ID, err)
 		}


### PR DESCRIPTION
## Description

Log the message that the agent pool cleanup failed. The org cleanup will cleanup the agent pool, and if that fails, we rebuild everything every 24 hours. This does not need to be a test failure.

## Testing plan

1. Run the tests
2. They pass! (Right now they are failing)

