### PR TITLE
✨ Add private registry provider version

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -155,6 +155,16 @@ var (
 	ErrInvalidCommentID = errors.New("invalid value for comment ID")
 
 	ErrInvalidCommentBody = errors.New("invalid value for comment body")
+
+	ErrInvalidNamespace = errors.New("invalid value for namespace")
+
+	ErrInvalidPrivateProviderNamespaceDoesntMatchOrganization = errors.New("invalid namespace must match organization name for private providers")
+
+	ErrInvalidRegistryName = errors.New("invalid value for registry-name")
+
+	ErrInvalidRegistryNameType = errors.New("invalid type for registry-name. Please use 'RegistryName'")
+
+	ErrInvalidKeyID = errors.New("invalid value for key-id")
 )
 
 // Missing values for required field/option
@@ -268,4 +278,6 @@ var (
 	ErrEmptyTeamName = errors.New("team name can not be empty")
 
 	ErrInvalidEmail = errors.New("email is invalid")
+
+	ErrRequiredPrivateRegistry = errors.New("only private registry is allowed")
 )

--- a/generate_mocks.sh
+++ b/generate_mocks.sh
@@ -35,6 +35,8 @@ mockgen -source=policy_set.go -destination=mocks/policy_set_mocks.go -package=mo
 mockgen -source=policy_set_parameter.go -destination=mocks/policy_set_parameter_mocks.go -package=mocks
 mockgen -source=policy_set_version.go -destination=mocks/policy_set_version_mocks.go -package=mocks
 mockgen -source=registry_module.go -destination=mocks/registry_module_mocks.go -package=mocks
+mockgen -source=registry_provider.go -destination=mocks/registry_provider_mocks.go -package=mocks
+mockgen -source=registry_provider_version.go -destination=mocks/registry_provider_version_mocks.go -package=mocks
 mockgen -source=run.go -destination=mocks/run_mocks.go -package=mocks
 mockgen -source=run_task.go -destination=mocks/run_tasks.go -package=mocks
 mockgen -source=run_trigger.go -destination=mocks/run_trigger_mocks.go -package=mocks

--- a/registry_provider.go
+++ b/registry_provider.go
@@ -1,0 +1,248 @@
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ RegistryProviders = (*registryProviders)(nil)
+
+// RegistryProviders describes all the registry provider related methods that the Terraform
+// Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/docs/cloud/api/providers.html
+type RegistryProviders interface {
+	// List all the providers within an organization.
+	List(ctx context.Context, organization string, options *RegistryProviderListOptions) (*RegistryProviderList, error)
+
+	// Create a registry provider
+	Create(ctx context.Context, organization string, options RegistryProviderCreateOptions) (*RegistryProvider, error)
+
+	// Read a registry provider
+	Read(ctx context.Context, organization string, registryName RegistryName, namespace string, name string, options *RegistryProviderReadOptions) (*RegistryProvider, error)
+
+	// Delete a registry provider
+	Delete(ctx context.Context, organization string, registryName RegistryName, namespace string, name string) error
+}
+
+// registryProviders implements RegistryProviders.
+type registryProviders struct {
+	client *Client
+}
+
+// RegistryName represents which registry is being targeted
+type RegistryName string
+
+// List of available registry names
+const (
+	PrivateRegistry RegistryName = "private"
+	PublicRegistry  RegistryName = "public"
+)
+
+// RegistryProvider represents a registry provider
+type RegistryProvider struct {
+	ID           string                       `jsonapi:"primary,registry-providers"`
+	Namespace    string                       `jsonapi:"attr,namespace"`
+	Name         string                       `jsonapi:"attr,name"`
+	RegistryName RegistryName                 `jsonapi:"attr,registry-name"`
+	Permissions  *RegistryProviderPermissions `jsonapi:"attr,permissions"`
+	CreatedAt    string                       `jsonapi:"attr,created-at"`
+	UpdatedAt    string                       `jsonapi:"attr,updated-at"`
+
+	// Relations
+	Organization             *Organization             `jsonapi:"relation,organization"`
+	RegistryProviderVersions []RegistryProviderVersion `jsonapi:"relation,registry-provider-version"`
+}
+
+type RegistryProviderPermissions struct {
+	CanDelete bool `jsonapi:"attr,can-delete"`
+}
+
+type RegistryProviderListOptions struct {
+	ListOptions
+	// A query string to filter by registry_name
+	RegistryName *RegistryName `url:"filter[registry_name],omitempty"`
+	// A query string to filter by organization
+	OrganizationName *string `url:"filter[organization_name],omitempty"`
+	// A query string to do a fuzzy search
+	Search *string `url:"q,omitempty"`
+}
+
+type RegistryProviderList struct {
+	*Pagination
+	Items []*RegistryProvider
+}
+
+func (o RegistryProviderListOptions) valid() error {
+	return nil
+}
+
+func (r *registryProviders) List(ctx context.Context, organization string, options *RegistryProviderListOptions) (*RegistryProviderList, error) {
+
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
+	}
+
+	u := fmt.Sprintf("organizations/%s/registry-providers", url.QueryEscape(organization))
+	req, err := r.client.newRequest("GET", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	pl := &RegistryProviderList{}
+	err = r.client.do(ctx, req, pl)
+	if err != nil {
+		return nil, err
+	}
+
+	return pl, nil
+}
+
+// RegistryProviderCreateOptions is used when creating a registry provider
+type RegistryProviderCreateOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,registry-providers"`
+
+	Namespace    *string       `jsonapi:"attr,namespace"`
+	Name         *string       `jsonapi:"attr,name"`
+	RegistryName *RegistryName `jsonapi:"attr,registry-name"`
+}
+
+func (o RegistryProviderCreateOptions) valid() error {
+	if !validString(o.Name) {
+		return ErrRequiredName
+	}
+	if !validStringID(o.Name) {
+		return ErrInvalidName
+	}
+	if !validString(o.Namespace) {
+		return errors.New("namespace is required")
+	}
+	if !validStringID(o.Namespace) {
+		return errors.New("invalid value for namespace")
+	}
+	if !validString((*string)(o.RegistryName)) {
+		return errors.New("registry-name is required")
+	}
+	return nil
+}
+
+func (r *registryProviders) Create(ctx context.Context, organization string, options RegistryProviderCreateOptions) (*RegistryProvider, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+	// Private providers must match their namespace and organization name
+	// This is enforced by the API as well
+	if *options.RegistryName == PrivateRegistry && organization != *options.Namespace {
+		return nil, errors.New("namespace must match organization name for private providers")
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-providers",
+		url.QueryEscape(organization),
+	)
+	req, err := r.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+	prv := &RegistryProvider{}
+	err = r.client.do(ctx, req, prv)
+	if err != nil {
+		return nil, err
+	}
+
+	return prv, nil
+}
+
+type RegistryProviderReadOptions struct {
+}
+
+func (r *registryProviders) Read(ctx context.Context, organization string, registryName RegistryName, namespace string, name string, options *RegistryProviderReadOptions) (*RegistryProvider, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+	if !validString(&name) {
+		return nil, ErrRequiredName
+	}
+	if !validStringID(&name) {
+		return nil, ErrInvalidName
+	}
+	if !validString(&namespace) {
+		return nil, errors.New("namespace is required")
+	}
+	if !validStringID(&namespace) {
+		return nil, errors.New("invalid value for namespace")
+	}
+	if !validString((*string)(&registryName)) {
+		return nil, errors.New("registry-name is required")
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-providers/%s/%s/%s",
+		url.QueryEscape(organization),
+		url.QueryEscape(string(registryName)),
+		url.QueryEscape(namespace),
+		url.QueryEscape(name),
+	)
+	req, err := r.client.newRequest("GET", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	prv := &RegistryProvider{}
+	err = r.client.do(ctx, req, prv)
+	if err != nil {
+		return nil, err
+	}
+
+	return prv, nil
+}
+
+func (r *registryProviders) Delete(ctx context.Context, organization string, registryName RegistryName, namespace string, name string) error {
+	if !validStringID(&organization) {
+		return ErrInvalidOrg
+	}
+	if !validString(&name) {
+		return ErrRequiredName
+	}
+	if !validStringID(&name) {
+		return ErrInvalidName
+	}
+	if !validString(&namespace) {
+		return errors.New("namespace is required")
+	}
+	if !validStringID(&namespace) {
+		return errors.New("invalid value for namespace")
+	}
+	if !validString((*string)(&registryName)) {
+		return errors.New("registry-name is required")
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-providers/%s/%s/%s",
+		url.QueryEscape(organization),
+		url.QueryEscape(string(registryName)),
+		url.QueryEscape(namespace),
+		url.QueryEscape(name),
+	)
+	req, err := r.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return r.client.do(ctx, req, nil)
+}

--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -1,0 +1,442 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryProvidersList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("with providers", func(t *testing.T) {
+		orgTest, orgTestCleanup := createOrganization(t, client)
+		defer orgTestCleanup()
+
+		createN := 10
+		providers := make([]*RegistryProvider, 0)
+		// these providers will be destroyed when the org is cleaned up
+		for i := 0; i < createN; i++ {
+			providerTest, _ := createPublicRegistryProvider(t, client, orgTest)
+			providers = append(providers, providerTest)
+		}
+		for i := 0; i < createN; i++ {
+			providerTest, _ := createPrivateRegistryProvider(t, client, orgTest)
+			providers = append(providers, providerTest)
+		}
+		providerN := len(providers)
+		publicProviderN := createN
+
+		t.Run("returns all providers", func(t *testing.T) {
+			returnedProviders, err := client.RegistryProviders.List(ctx, orgTest.Name, &RegistryProviderListOptions{
+				ListOptions: ListOptions{
+					PageNumber: 0,
+					PageSize:   providerN,
+				},
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, returnedProviders.Items)
+			assert.Equal(t, providerN, returnedProviders.TotalCount)
+			assert.Equal(t, 1, returnedProviders.TotalPages)
+			for _, rp := range returnedProviders.Items {
+				foundProvider := false
+				for _, p := range providers {
+					if rp.ID == p.ID {
+						foundProvider = true
+						break
+					}
+				}
+				assert.True(t, foundProvider, "Expected to find provider %s but did not:\nexpected:\n%v\nreturned\n%v", rp.ID, providers, returnedProviders)
+			}
+		})
+
+		t.Run("returns pages", func(t *testing.T) {
+			pageN := 2
+			pageSize := providerN / pageN
+
+			for page := 0; page < pageN; page++ {
+				testName := fmt.Sprintf("returns page %d of providers", page)
+				t.Run(testName, func(t *testing.T) {
+					returnedProviders, err := client.RegistryProviders.List(ctx, orgTest.Name, &RegistryProviderListOptions{
+						ListOptions: ListOptions{
+							PageNumber: page,
+							PageSize:   pageSize,
+						},
+					})
+					require.NoError(t, err)
+					assert.NotEmpty(t, returnedProviders.Items)
+					assert.Equal(t, providerN, returnedProviders.TotalCount)
+					assert.Equal(t, pageN, returnedProviders.TotalPages)
+					assert.Equal(t, pageSize, len(returnedProviders.Items))
+					for _, rp := range returnedProviders.Items {
+						foundProvider := false
+						for _, p := range providers {
+							if rp.ID == p.ID {
+								foundProvider = true
+								break
+							}
+						}
+						assert.True(t, foundProvider, "Expected to find provider %s but did not:\nexpected:\n%v\nreturned\n%v", rp.ID, providers, returnedProviders)
+					}
+				})
+			}
+		})
+
+		t.Run("filters on registry name", func(t *testing.T) {
+			publicName := PublicRegistry
+			returnedProviders, err := client.RegistryProviders.List(ctx, orgTest.Name, &RegistryProviderListOptions{
+				RegistryName: &publicName,
+				ListOptions: ListOptions{
+					PageNumber: 0,
+					PageSize:   providerN,
+				},
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, returnedProviders.Items)
+			assert.Equal(t, publicProviderN, returnedProviders.TotalCount)
+			assert.Equal(t, 1, returnedProviders.TotalPages)
+			for _, rp := range returnedProviders.Items {
+				foundProvider := false
+				for _, p := range providers {
+					if rp.ID == p.ID {
+						foundProvider = true
+						break
+					}
+				}
+				assert.Equal(t, publicName, rp.RegistryName)
+				assert.True(t, foundProvider, "Expected to find provider %s but did not:\nexpected:\n%v\nreturned\n%v", rp.ID, providers, returnedProviders)
+			}
+		})
+
+		t.Run("searches", func(t *testing.T) {
+			expectedProvider := providers[0]
+			returnedProviders, err := client.RegistryProviders.List(ctx, orgTest.Name, &RegistryProviderListOptions{
+				Search: &expectedProvider.Name,
+				ListOptions: ListOptions{
+					PageNumber: 0,
+					PageSize:   providerN,
+				},
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, returnedProviders.Items)
+			assert.Equal(t, 1, returnedProviders.TotalCount)
+			assert.Equal(t, 1, returnedProviders.TotalPages)
+			foundProvider := returnedProviders.Items[0]
+
+			assert.Equal(t, foundProvider.ID, expectedProvider.ID, "Expected to find provider %s but did not:\nexpected:\n%v\nreturned\n%v", expectedProvider.ID, providers, returnedProviders)
+		})
+	})
+
+	t.Run("without providers", func(t *testing.T) {
+		orgTest, orgTestCleanup := createOrganization(t, client)
+		defer orgTestCleanup()
+
+		providers, err := client.RegistryProviders.List(ctx, orgTest.Name, nil)
+		require.NoError(t, err)
+		assert.Empty(t, providers.Items)
+		assert.Equal(t, 0, providers.TotalCount)
+		assert.Equal(t, 0, providers.TotalPages)
+	})
+}
+
+func TestRegistryProvidersCreate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	publicName := PublicRegistry
+	privateName := PrivateRegistry
+
+	t.Run("with valid options", func(t *testing.T) {
+
+		publicProviderOptions := RegistryProviderCreateOptions{
+			Name:         String("provider_name"),
+			Namespace:    String("public_namespace"),
+			RegistryName: &publicName,
+		}
+		privateProviderOptions := RegistryProviderCreateOptions{
+			Name:         String("provider_name"),
+			Namespace:    &orgTest.Name,
+			RegistryName: &privateName,
+		}
+
+		registryOptions := []RegistryProviderCreateOptions{publicProviderOptions, privateProviderOptions}
+
+		for _, options := range registryOptions {
+			testName := fmt.Sprintf("with %s provider", *options.RegistryName)
+			t.Run(testName, func(t *testing.T) {
+				prv, err := client.RegistryProviders.Create(ctx, orgTest.Name, options)
+				require.NoError(t, err)
+				assert.NotEmpty(t, prv.ID)
+				assert.Equal(t, *options.Name, prv.Name)
+				assert.Equal(t, *options.Namespace, prv.Namespace)
+				assert.Equal(t, *options.RegistryName, prv.RegistryName)
+
+				t.Run("permissions are properly decoded", func(t *testing.T) {
+					assert.True(t, prv.Permissions.CanDelete)
+				})
+
+				t.Run("relationships are properly decoded", func(t *testing.T) {
+					assert.Equal(t, orgTest.Name, prv.Organization.Name)
+				})
+
+				t.Run("timestamps are properly decoded", func(t *testing.T) {
+					assert.NotEmpty(t, prv.CreatedAt)
+					assert.NotEmpty(t, prv.UpdatedAt)
+				})
+			})
+		}
+	})
+
+	t.Run("with invalid options", func(t *testing.T) {
+		t.Run("without a name", func(t *testing.T) {
+			options := RegistryProviderCreateOptions{
+				Namespace:    String("namespace"),
+				RegistryName: &publicName,
+			}
+			rm, err := client.RegistryProviders.Create(ctx, orgTest.Name, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, ErrRequiredName.Error())
+		})
+
+		t.Run("with an invalid name", func(t *testing.T) {
+			options := RegistryProviderCreateOptions{
+				Name:         String("invalid name"),
+				Namespace:    String("namespace"),
+				RegistryName: &publicName,
+			}
+			rm, err := client.RegistryProviders.Create(ctx, orgTest.Name, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, ErrInvalidName.Error())
+		})
+
+		t.Run("without a namespace", func(t *testing.T) {
+			options := RegistryProviderCreateOptions{
+				Name:         String("name"),
+				RegistryName: &publicName,
+			}
+			rm, err := client.RegistryProviders.Create(ctx, orgTest.Name, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, "namespace is required")
+		})
+
+		t.Run("with an invalid namespace", func(t *testing.T) {
+			options := RegistryProviderCreateOptions{
+				Name:         String("name"),
+				Namespace:    String("invalid namespace"),
+				RegistryName: &publicName,
+			}
+			rm, err := client.RegistryProviders.Create(ctx, orgTest.Name, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, "invalid value for namespace")
+		})
+
+		t.Run("without a registry-name", func(t *testing.T) {
+			options := RegistryProviderCreateOptions{
+				Name:      String("name"),
+				Namespace: String("namespace"),
+			}
+			rm, err := client.RegistryProviders.Create(ctx, orgTest.Name, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, "registry-name is required")
+		})
+	})
+
+	t.Run("without a valid organization", func(t *testing.T) {
+		options := RegistryProviderCreateOptions{
+			Name:         String("name"),
+			Namespace:    String("namespace"),
+			RegistryName: &publicName,
+		}
+		rm, err := client.RegistryProviders.Create(ctx, badIdentifier, options)
+		assert.Nil(t, rm)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
+	})
+
+	t.Run("without a matching namespace organization.name for private registry", func(t *testing.T) {
+		options := RegistryProviderCreateOptions{
+			Name:         String("name"),
+			Namespace:    String("namespace"),
+			RegistryName: &privateName,
+		}
+		rm, err := client.RegistryProviders.Create(ctx, orgTest.Name, options)
+		assert.Nil(t, rm)
+		assert.EqualError(t, err, "namespace must match organization name for private providers")
+	})
+}
+
+func TestRegistryProvidersRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	type ProviderContext struct {
+		ProviderCreator func(t *testing.T, client *Client, org *Organization) (*RegistryProvider, func())
+		RegistryName    RegistryName
+	}
+
+	providerContexts := []ProviderContext{
+		{
+			ProviderCreator: createPublicRegistryProvider,
+			RegistryName:    PublicRegistry,
+		},
+		{
+			ProviderCreator: createPrivateRegistryProvider,
+			RegistryName:    PrivateRegistry,
+		},
+	}
+
+	for _, prvCtx := range providerContexts {
+		testName := fmt.Sprintf("with %s provider", prvCtx.RegistryName)
+		t.Run(testName, func(t *testing.T) {
+			t.Run("with valid provider", func(t *testing.T) {
+				registryProviderTest, providerTestCleanup := prvCtx.ProviderCreator(t, client, orgTest)
+				defer providerTestCleanup()
+
+				prv, err := client.RegistryProviders.Read(ctx, orgTest.Name, registryProviderTest.RegistryName, registryProviderTest.Namespace, registryProviderTest.Name, nil)
+				assert.NoError(t, err)
+				assert.NotEmpty(t, prv.ID)
+				assert.Equal(t, registryProviderTest.Name, prv.Name)
+				assert.Equal(t, registryProviderTest.Namespace, prv.Namespace)
+				assert.Equal(t, registryProviderTest.RegistryName, prv.RegistryName)
+
+				t.Run("permissions are properly decoded", func(t *testing.T) {
+					assert.True(t, prv.Permissions.CanDelete)
+				})
+
+				t.Run("relationships are properly decoded", func(t *testing.T) {
+					assert.Equal(t, orgTest.Name, prv.Organization.Name)
+				})
+
+				t.Run("timestamps are properly decoded", func(t *testing.T) {
+					assert.NotEmpty(t, prv.CreatedAt)
+					assert.NotEmpty(t, prv.UpdatedAt)
+				})
+			})
+
+			t.Run("when the registry provider does not exist", func(t *testing.T) {
+				_, err := client.RegistryProviders.Read(ctx, orgTest.Name, prvCtx.RegistryName, "nonexistent", "nonexistent", nil)
+				assert.Error(t, err)
+				// Local TFC/E will return a forbidden here when TFC/E is in development mode
+				// In non development mode this returns a 404
+				assert.Equal(t, ErrResourceNotFound, err)
+			})
+
+			t.Run("without a name", func(t *testing.T) {
+				_, err := client.RegistryProviders.Read(ctx, orgTest.Name, prvCtx.RegistryName, "namespace", "", nil)
+				assert.EqualError(t, err, ErrRequiredName.Error())
+			})
+
+			t.Run("with an invalid name", func(t *testing.T) {
+				_, err := client.RegistryProviders.Read(ctx, orgTest.Name, prvCtx.RegistryName, "namespace", badIdentifier, nil)
+				assert.EqualError(t, err, ErrInvalidName.Error())
+			})
+
+			t.Run("without a namespace", func(t *testing.T) {
+				_, err := client.RegistryProviders.Read(ctx, orgTest.Name, prvCtx.RegistryName, "", "name", nil)
+				assert.EqualError(t, err, "namespace is required")
+			})
+
+			t.Run("with an invalid namespace", func(t *testing.T) {
+				_, err := client.RegistryProviders.Read(ctx, orgTest.Name, prvCtx.RegistryName, badIdentifier, "name", nil)
+				assert.EqualError(t, err, "invalid value for namespace")
+			})
+
+			t.Run("without a registry-name", func(t *testing.T) {
+				_, err := client.RegistryProviders.Read(ctx, orgTest.Name, "", "namespace", "name", nil)
+				assert.EqualError(t, err, "registry-name is required")
+			})
+
+			t.Run("without a valid organization", func(t *testing.T) {
+				_, err := client.RegistryProviders.Read(ctx, badIdentifier, prvCtx.RegistryName, "namespace", "name", nil)
+				assert.EqualError(t, err, ErrInvalidOrg.Error())
+			})
+		})
+	}
+}
+
+func TestRegistryProvidersDelete(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	type ProviderContext struct {
+		ProviderCreator func(t *testing.T, client *Client, org *Organization) (*RegistryProvider, func())
+		RegistryName    RegistryName
+	}
+
+	providerContexts := []ProviderContext{
+		{
+			ProviderCreator: createPublicRegistryProvider,
+			RegistryName:    PublicRegistry,
+		},
+		{
+			ProviderCreator: createPrivateRegistryProvider,
+			RegistryName:    PrivateRegistry,
+		},
+	}
+
+	for _, prvCtx := range providerContexts {
+		testName := fmt.Sprintf("with %s provider", prvCtx.RegistryName)
+		t.Run(testName, func(t *testing.T) {
+			t.Run("with valid provider", func(t *testing.T) {
+				registryProviderTest, _ := prvCtx.ProviderCreator(t, client, orgTest)
+
+				err := client.RegistryProviders.Delete(ctx, orgTest.Name, registryProviderTest.RegistryName, registryProviderTest.Namespace, registryProviderTest.Name)
+				require.NoError(t, err)
+
+				prv, err := client.RegistryProviders.Read(ctx, orgTest.Name, registryProviderTest.RegistryName, registryProviderTest.Namespace, registryProviderTest.Name, nil)
+				assert.Nil(t, prv)
+				assert.Error(t, err)
+			})
+
+			t.Run("when the registry provider does not exist", func(t *testing.T) {
+				err := client.RegistryProviders.Delete(ctx, orgTest.Name, prvCtx.RegistryName, "nonexistent", "nonexistent")
+				assert.Error(t, err)
+				// Local TFC/E will return a forbidden here when TFC/E is in development mode
+				// In non development mode this returns a 404
+				assert.Equal(t, ErrResourceNotFound, err)
+			})
+
+			t.Run("without a name", func(t *testing.T) {
+				err := client.RegistryProviders.Delete(ctx, orgTest.Name, prvCtx.RegistryName, "namespace", "")
+				assert.EqualError(t, err, ErrRequiredName.Error())
+			})
+
+			t.Run("with an invalid name", func(t *testing.T) {
+				err := client.RegistryProviders.Delete(ctx, orgTest.Name, prvCtx.RegistryName, "namespace", badIdentifier)
+				assert.EqualError(t, err, ErrInvalidName.Error())
+			})
+
+			t.Run("without a namespace", func(t *testing.T) {
+				err := client.RegistryProviders.Delete(ctx, orgTest.Name, prvCtx.RegistryName, "", "name")
+				assert.EqualError(t, err, "namespace is required")
+			})
+
+			t.Run("with an invalid namespace", func(t *testing.T) {
+				err := client.RegistryProviders.Delete(ctx, orgTest.Name, prvCtx.RegistryName, badIdentifier, "name")
+				assert.EqualError(t, err, "invalid value for namespace")
+			})
+
+			t.Run("without a registry-name", func(t *testing.T) {
+				err := client.RegistryProviders.Delete(ctx, orgTest.Name, "", "namespace", "name")
+				assert.EqualError(t, err, "registry-name is required")
+			})
+
+			t.Run("without a valid organization", func(t *testing.T) {
+				err := client.RegistryProviders.Delete(ctx, badIdentifier, prvCtx.RegistryName, "namespace", "name")
+				assert.EqualError(t, err, ErrInvalidOrg.Error())
+			})
+		})
+	}
+}

--- a/registry_provider_platform.go
+++ b/registry_provider_platform.go
@@ -1,0 +1,16 @@
+package tfe
+
+// RegistryProviderPlatform represents a registry provider platform
+type RegistryProviderPlatform struct {
+	ID       string `jsonapi:"primary,registry-provider-platforms"`
+	Os       string `jsonapi:"attr,os"`
+	Arch     string `jsonapi:"attr,arch"`
+	Filename string `jsonapi:"attr,filename"`
+	SHASUM   string `jsonapi:"attr,shasum"`
+
+	// Relations
+	RegistryProviderVersion *RegistryProviderVersion `jsonapi:"relation,registry-provider-version"`
+
+	// Links
+	Links map[string]interface{} `jsonapi:"links,omitempty"`
+}

--- a/registry_provider_version.go
+++ b/registry_provider_version.go
@@ -1,0 +1,16 @@
+package tfe
+
+// RegistryProviderVersion represents a registry provider version
+type RegistryProviderVersion struct {
+	ID        string   `jsonapi:"primary,registry-provider-versions"`
+	Version   string   `jsonapi:"attr,version"`
+	KeyID     string   `jsonapi:"attr,key-id"`
+	Protocols []string `jsonapi:"attr,protocols,omitempty"`
+
+	// Relations
+	RegistryProvider          *RegistryProvider          `jsonapi:"relation,registry-provider"`
+	RegistryProviderPlatforms []RegistryProviderPlatform `jsonapi:"relation,registry-provider-platform"`
+
+	// Links
+	Links map[string]interface{} `jsonapi:"links,omitempty"`
+}

--- a/registry_provider_version.go
+++ b/registry_provider_version.go
@@ -1,16 +1,264 @@
 package tfe
 
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ RegistryProviderVersions = (*registryProviderVersions)(nil)
+
+// RegistryProviderVersions describes the registry provider version methods that
+// the Terraform Enterprise API supports.
+//
+// TFE API docs: https://www.terraform.io/cloud-docs/api-docs/private-registry/provider-versions-platforms
+type RegistryProviderVersions interface {
+	// List all versions for a single provider.
+	List(ctx context.Context, providerID RegistryProviderID, options *RegistryProviderVersionListOptions) (*RegistryProviderVersionList, error)
+
+	// Create a registry provider version.
+	Create(ctx context.Context, providerID RegistryProviderID, options RegistryProviderVersionCreateOptions) (*RegistryProviderVersion, error)
+
+	// Read a registry provider version.
+	Read(ctx context.Context, versionID RegistryProviderVersionID, options *RegistryProviderVersionReadOptions) (*RegistryProviderVersion, error)
+
+	// Delete a registry provider version.
+	Delete(ctx context.Context, versionID RegistryProviderVersionID) error
+}
+
+// registryProviders implements RegistryProviders.
+type registryProviderVersions struct {
+	client *Client
+}
+
 // RegistryProviderVersion represents a registry provider version
 type RegistryProviderVersion struct {
 	ID        string   `jsonapi:"primary,registry-provider-versions"`
 	Version   string   `jsonapi:"attr,version"`
+	CreatedAt string   `jsonapi:"attr,created-at"`
+	UpdatedAt string   `jsonapi:"attr,updated-at"`
 	KeyID     string   `jsonapi:"attr,key-id"`
 	Protocols []string `jsonapi:"attr,protocols,omitempty"`
+	Permissions *RegistryProviderPermissions `jsonapi:"attr,permissions"`
+	ShasumsUploaded bool `jsonapi:"attr,shasums-uploaded"`
+	ShasumsSigUploaded bool `jsonapi:"attr,sasums-sig-uploaded"`
 
 	// Relations
-	RegistryProvider          *RegistryProvider          `jsonapi:"relation,registry-provider"`
-	RegistryProviderPlatforms []RegistryProviderPlatform `jsonapi:"relation,registry-provider-platform"`
+	RegistryProvider          *RegistryProvider           `jsonapi:"relation,registry-provider"`
+	RegistryProviderPlatforms []*RegistryProviderPlatform `jsonapi:"relation,platforms"`
 
 	// Links
 	Links map[string]interface{} `jsonapi:"links,omitempty"`
+}
+
+// RegistryProviderVersionID is the multi key ID for addressing a version provider
+type RegistryProviderVersionID struct {
+	RegistryProviderID
+	Version string `jsonapi:"attr,version"`
+}
+
+type RegistryProviderVersionList struct {
+	*Pagination
+	Items []*RegistryProviderVersion
+}
+
+type RegistryProviderVersionListOptions struct {
+	ListOptions
+}
+
+type RegistryProviderVersionReadOptions struct{}
+
+type RegistryProviderVersionCreateOptions struct {
+	Version   string   `jsonapi:"attr,version"`
+	KeyID     string   `jsonapi:"attr,key-id"`
+	Protocols []string `jsonapi:"attr,protocols"`
+}
+
+// List registry provider versions
+func (r *registryProviderVersions) List(ctx context.Context, providerID RegistryProviderID, options *RegistryProviderVersionListOptions) (*RegistryProviderVersionList, error) {
+	if err := providerID.valid(); err != nil {
+		return nil, err
+	}
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-providers/%s/%s/%s/versions",
+		url.QueryEscape(providerID.OrganizationName),
+		url.QueryEscape(string(providerID.RegistryName)),
+		url.QueryEscape(providerID.Namespace),
+		url.QueryEscape(providerID.Name),
+	)
+	req, err := r.client.newRequest("GET", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	pvl := &RegistryProviderVersionList{}
+	err = r.client.do(ctx, req, pvl)
+	if err != nil {
+		return nil, err
+	}
+
+	return pvl, nil
+}
+
+// Create a registry provider version
+func (r *registryProviderVersions) Create(ctx context.Context, providerID RegistryProviderID, options RegistryProviderVersionCreateOptions) (*RegistryProviderVersion, error) {
+	if err := providerID.valid(); err != nil {
+		return nil, err
+	}
+
+	if providerID.RegistryName != PrivateRegistry {
+		return nil, ErrRequiredPrivateRegistry
+	}
+
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-providers/%s/%s/%s/versions",
+		url.QueryEscape(providerID.OrganizationName),
+		url.QueryEscape(string(providerID.RegistryName)),
+		url.QueryEscape(providerID.Namespace),
+		url.QueryEscape(providerID.Name),
+	)
+	req, err := r.client.newRequest("POST", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	prvv := &RegistryProviderVersion{}
+	err = r.client.do(ctx, req, prvv)
+	if err != nil {
+		return nil, err
+	}
+
+	return prvv, nil
+}
+
+// Read a registry provider version
+func (r *registryProviderVersions) Read(ctx context.Context, versionID RegistryProviderVersionID, options *RegistryProviderVersionReadOptions) (*RegistryProviderVersion, error) {
+	if err := versionID.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-providers/%s/%s/%s/versions/%s",
+		url.QueryEscape(versionID.OrganizationName),
+		url.QueryEscape(string(versionID.RegistryName)),
+		url.QueryEscape(versionID.Namespace),
+		url.QueryEscape(versionID.Name),
+		url.QueryEscape(versionID.Version),
+	)
+	req, err := r.client.newRequest("GET", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	prvv := &RegistryProviderVersion{}
+	err = r.client.do(ctx, req, prvv)
+	if err != nil {
+		return nil, err
+	}
+
+	return prvv, nil
+}
+
+// Delete a registry provider version
+func (r *registryProviderVersions) Delete(ctx context.Context, versionID RegistryProviderVersionID) error {
+	if err := versionID.valid(); err != nil {
+		return err
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-providers/%s/%s/%s/versions/%s",
+		url.QueryEscape(versionID.OrganizationName),
+		url.QueryEscape(string(versionID.RegistryName)),
+		url.QueryEscape(versionID.Namespace),
+		url.QueryEscape(versionID.Name),
+		url.QueryEscape(versionID.Version),
+	)
+	req, err := r.client.newRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return r.client.do(ctx, req, nil)
+}
+
+func (v RegistryProviderVersion) ShasumsUploadURL() (string, error) {
+	uploadURL, ok := v.Links["shasums-upload"].(string)
+	if !ok {
+		return uploadURL, fmt.Errorf("the Registry Provider Version does not contain a shasums upload link")
+	}
+	if uploadURL == "" {
+		return uploadURL, fmt.Errorf("the Registry Provider Version shasums upload URL is empty")
+	}
+	return uploadURL, nil
+}
+
+func (v RegistryProviderVersion) ShasumsSigUploadURL() (string, error) {
+	uploadURL, ok := v.Links["shasums-sig-upload"].(string)
+	if !ok {
+		return uploadURL, fmt.Errorf("the Registry Provider Version does not contain a shasums sig upload link")
+	}
+	if uploadURL == "" {
+		return uploadURL, fmt.Errorf("the Registry Provider Version shasums sig upload URL is empty")
+	}
+	return uploadURL, nil
+}
+
+func (v RegistryProviderVersion) ShasumsDownloadURL() (string, error) {
+	downloadURL, ok := v.Links["shasums-download"].(string)
+	if !ok {
+		return downloadURL, fmt.Errorf("the Registry Provider Version does not contain a shasums download link")
+	}
+	if downloadURL == "" {
+		return downloadURL, fmt.Errorf("the Registry Provider Version shasums download URL is empty")
+	}
+	return downloadURL, nil
+}
+
+func (v RegistryProviderVersion) ShasumsSigDownloadURL() (string, error) {
+	downloadURL, ok := v.Links["shasums-sig-download"].(string)
+	if !ok {
+		return downloadURL, fmt.Errorf("the Registry Provider Version does not contain a shasums sig download link")
+	}
+	if downloadURL == "" {
+		return downloadURL, fmt.Errorf("the Registry Provider Version shasums sig download URL is empty")
+	}
+	return downloadURL, nil
+}
+
+func (id RegistryProviderVersionID) valid() error {
+	if !validStringID(&id.Version) {
+		return ErrInvalidVersion
+	}
+	if id.RegistryName != PrivateRegistry {
+		return ErrRequiredPrivateRegistry
+	}
+	if err := id.RegistryProviderID.valid(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func (o RegistryProviderVersionListOptions) valid() error {
+	return nil
+}
+
+func (o RegistryProviderVersionCreateOptions) valid() error {
+	if !validStringID(&o.Version) {
+		return ErrInvalidVersion
+	}
+	if !validStringID(&o.KeyID) {
+		return ErrInvalidKeyID
+	}
+	return nil
 }

--- a/registry_provider_version_integration_test.go
+++ b/registry_provider_version_integration_test.go
@@ -1,0 +1,405 @@
+//go:build integration
+// +build integration
+
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRegistryProviderVersionsIDValidation(t *testing.T) {
+	version := "1.0.0"
+	validRegistryProviderId := RegistryProviderID{
+		OrganizationName: "orgName",
+		RegistryName:     PrivateRegistry,
+		Namespace:        "namespace",
+		Name:             "name",
+	}
+	invalidRegistryProviderId := RegistryProviderID{
+		OrganizationName: badIdentifier,
+		RegistryName:     PrivateRegistry,
+		Namespace:        "namespace",
+		Name:             "name",
+	}
+	publicRegistryProviderId := RegistryProviderID{
+		OrganizationName: "orgName",
+		RegistryName:     PublicRegistry,
+		Namespace:        "namespace",
+		Name:             "name",
+	}
+
+	t.Run("valid", func(t *testing.T) {
+		id := RegistryProviderVersionID{
+			Version:            version,
+			RegistryProviderID: validRegistryProviderId,
+		}
+		assert.NoError(t, id.valid())
+	})
+
+	t.Run("without a version", func(t *testing.T) {
+		id := RegistryProviderVersionID{
+			Version:            "",
+			RegistryProviderID: validRegistryProviderId,
+		}
+		assert.EqualError(t, id.valid(), ErrInvalidVersion.Error())
+	})
+
+	t.Run("without a key-id", func(t *testing.T) {
+		id := RegistryProviderVersionID{
+			Version:            "",
+			RegistryProviderID: validRegistryProviderId,
+		}
+		assert.EqualError(t, id.valid(), ErrInvalidVersion.Error())
+	})
+
+	t.Run("invalid version", func(t *testing.T) {
+		t.Skip("This is skipped as we don't actually validate version is a valid semver - the registry does this validation")
+		id := RegistryProviderVersionID{
+			Version:            "foo",
+			RegistryProviderID: validRegistryProviderId,
+		}
+		assert.EqualError(t, id.valid(), ErrInvalidVersion.Error())
+	})
+
+	t.Run("invalid registry for parent provider", func(t *testing.T) {
+		id := RegistryProviderVersionID{
+			Version:            version,
+			RegistryProviderID: publicRegistryProviderId,
+		}
+		assert.EqualError(t, id.valid(), ErrRequiredPrivateRegistry.Error())
+	})
+
+	t.Run("without a valid registry provider id", func(t *testing.T) {
+		// this is a proxy for all permutations of an invalid registry provider id
+		// it is assumed that validity of the registry provider id is delegated to its own valid method
+		id := RegistryProviderVersionID{
+			Version:            version,
+			RegistryProviderID: invalidRegistryProviderId,
+		}
+		assert.EqualError(t, id.valid(), ErrInvalidOrg.Error())
+	})
+}
+
+func TestRegistryProviderVersionsCreate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	providerTest, providerTestCleanup := createPrivateRegistryProvider(t, client, nil)
+	defer providerTestCleanup()
+
+	providerId := RegistryProviderID{
+		OrganizationName: providerTest.Organization.Name,
+		RegistryName:     providerTest.RegistryName,
+		Namespace:        providerTest.Namespace,
+		Name:             providerTest.Name,
+	}
+
+	t.Run("with valid options", func(t *testing.T) {
+		options := RegistryProviderVersionCreateOptions{
+			Version: "1.0.0",
+			KeyID:   "abcdefg",
+		}
+		prvv, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+		require.NoError(t, err)
+		assert.NotEmpty(t, prvv.ID)
+		assert.Equal(t, options.Version, prvv.Version)
+		assert.Equal(t, options.KeyID, prvv.KeyID)
+
+		t.Run("relationships are properly decoded", func(t *testing.T) {
+			assert.Equal(t, providerTest.ID, prvv.RegistryProvider.ID)
+		})
+
+		t.Run("timestamps are properly decoded", func(t *testing.T) {
+			assert.NotEmpty(t, prvv.CreatedAt)
+			assert.NotEmpty(t, prvv.UpdatedAt)
+		})
+
+		t.Run("includes upload links", func(t *testing.T) {
+			_, err := prvv.ShasumsUploadURL()
+			assert.NoError(t, err)
+			_, err = prvv.ShasumsSigUploadURL()
+			assert.NoError(t, err)
+			expectedLinks := []string{
+				"shasums-upload",
+				"shasums-sig-upload",
+			}
+			for _, l := range expectedLinks {
+				_, ok := prvv.Links[l].(string)
+				assert.True(t, ok, "Expect upload link: %s", l)
+			}
+		})
+
+		t.Run("doesn't include download links", func(t *testing.T) {
+			_, err := prvv.ShasumsDownloadURL()
+			assert.Error(t, err)
+			_, err = prvv.ShasumsSigDownloadURL()
+			assert.Error(t, err)
+		})
+	})
+
+	t.Run("with invalid options", func(t *testing.T) {
+		t.Run("without a version", func(t *testing.T) {
+			options := RegistryProviderVersionCreateOptions{
+				Version: "",
+				KeyID:   "abcdefg",
+			}
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, ErrInvalidVersion.Error())
+		})
+
+		t.Run("without a key-id", func(t *testing.T) {
+			options := RegistryProviderVersionCreateOptions{
+				Version: "1.0.0",
+				KeyID:   "",
+			}
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, ErrInvalidKeyID.Error())
+		})
+
+		t.Run("with a public provider", func(t *testing.T) {
+			options := RegistryProviderVersionCreateOptions{
+				Version: "1.0.0",
+				KeyID:   "abcdefg",
+			}
+			providerId := RegistryProviderID{
+				OrganizationName: providerTest.Organization.Name,
+				RegistryName:     PublicRegistry,
+				Namespace:        providerTest.Namespace,
+				Name:             providerTest.Name,
+			}
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, ErrRequiredPrivateRegistry.Error())
+		})
+
+		t.Run("without a valid provider id", func(t *testing.T) {
+			options := RegistryProviderVersionCreateOptions{
+				Version: "1.0.0",
+				KeyID:   "abcdefg",
+			}
+			providerId := RegistryProviderID{
+				OrganizationName: badIdentifier,
+				RegistryName:     providerTest.RegistryName,
+				Namespace:        providerTest.Namespace,
+				Name:             providerTest.Name,
+			}
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			assert.Nil(t, rm)
+			assert.EqualError(t, err, ErrInvalidOrg.Error())
+		})
+	})
+}
+
+func TestRegistryProviderVersionsList(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("with versions", func(t *testing.T) {
+		provider, providerCleanup := createPrivateRegistryProvider(t, client, nil)
+		defer providerCleanup()
+
+		createN := 10
+		versions := make([]*RegistryProviderVersion, 0)
+		// these providers will be destroyed when the org is cleaned up
+		for i := 0; i < createN; i++ {
+			version, _ := createRegistryProviderVersion(t, client, provider)
+			versions = append(versions, version)
+		}
+		versionN := len(versions)
+
+		id := RegistryProviderID{
+			OrganizationName: provider.Organization.Name,
+			Namespace:        provider.Namespace,
+			Name:             provider.Name,
+			RegistryName:     provider.RegistryName,
+		}
+
+		t.Run("returns all versions", func(t *testing.T) {
+			returnedVersions, err := client.RegistryProviderVersions.List(ctx, id, &RegistryProviderVersionListOptions{
+				ListOptions: ListOptions{
+					PageNumber: 0,
+					PageSize:   versionN,
+				},
+			})
+			require.NoError(t, err)
+			assert.NotEmpty(t, returnedVersions.Items)
+			assert.Equal(t, versionN, returnedVersions.TotalCount)
+			assert.Equal(t, 1, returnedVersions.TotalPages)
+			for _, rv := range returnedVersions.Items {
+				foundVersion := false
+				for _, v := range versions {
+					if rv.ID == v.ID {
+						foundVersion = true
+						break
+					}
+				}
+				assert.True(t, foundVersion, "Expected to find version %s but did not:\nexpected:\n%v\nreturned\n%v", rv.ID, versions, returnedVersions)
+			}
+		})
+
+		t.Run("returns pages", func(t *testing.T) {
+			pageN := 2
+			pageSize := versionN / pageN
+
+			for page := 0; page < pageN; page++ {
+				testName := fmt.Sprintf("returns page %d of versions", page)
+				t.Run(testName, func(t *testing.T) {
+					returnedVersions, err := client.RegistryProviderVersions.List(ctx, id, &RegistryProviderVersionListOptions{
+						ListOptions: ListOptions{
+							PageNumber: page,
+							PageSize:   pageSize,
+						},
+					})
+					require.NoError(t, err)
+					assert.NotEmpty(t, returnedVersions.Items)
+					assert.Equal(t, versionN, returnedVersions.TotalCount)
+					assert.Equal(t, pageN, returnedVersions.TotalPages)
+					assert.Equal(t, pageSize, len(returnedVersions.Items))
+					for _, rv := range returnedVersions.Items {
+						foundVersion := false
+						for _, v := range versions {
+							if rv.ID == v.ID {
+								foundVersion = true
+								break
+							}
+						}
+						assert.True(t, foundVersion, "Expected to find version %s but did not:\nexpected:\n%v\nreturned\n%v", rv.ID, versions, returnedVersions)
+					}
+				})
+			}
+		})
+	})
+
+	t.Run("without versions", func(t *testing.T) {
+		provider, providerCleanup := createPrivateRegistryProvider(t, client, nil)
+		defer providerCleanup()
+
+		id := RegistryProviderID{
+			OrganizationName: provider.Organization.Name,
+			Namespace:        provider.Namespace,
+			Name:             provider.Name,
+			RegistryName:     provider.RegistryName,
+		}
+
+		versions, err := client.RegistryProviderVersions.List(ctx, id, nil)
+		require.NoError(t, err)
+		assert.Empty(t, versions.Items)
+		assert.Equal(t, 0, versions.TotalCount)
+		assert.Equal(t, 0, versions.TotalPages)
+	})
+
+	t.Run("with include provider platforms", func(t *testing.T) {
+	})
+}
+
+func TestRegistryProviderVersionsDelete(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	provider, providerCleanup := createPrivateRegistryProvider(t, client, nil)
+	defer providerCleanup()
+
+	t.Run("with valid version", func(t *testing.T) {
+		version, _ := createRegistryProviderVersion(t, client, provider)
+
+		versionId := RegistryProviderVersionID{
+			RegistryProviderID: RegistryProviderID{
+				OrganizationName: version.RegistryProvider.Organization.Name,
+				RegistryName:     version.RegistryProvider.RegistryName,
+				Namespace:        version.RegistryProvider.Namespace,
+				Name:             version.RegistryProvider.Name,
+			},
+			Version: version.Version,
+		}
+
+		err := client.RegistryProviderVersions.Delete(ctx, versionId)
+		assert.NoError(t, err)
+	})
+
+	t.Run("with non existing version", func(t *testing.T) {
+		versionId := RegistryProviderVersionID{
+			RegistryProviderID: RegistryProviderID{
+				OrganizationName: provider.Organization.Name,
+				RegistryName:     provider.RegistryName,
+				Namespace:        provider.Namespace,
+				Name:             provider.Name,
+			},
+			Version: "1.0.0",
+		}
+
+		err := client.RegistryProviderVersions.Delete(ctx, versionId)
+		assert.Error(t, err)
+	})
+}
+
+func TestRegistryProviderVersionsRead(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("with valid version", func(t *testing.T) {
+		version, versionCleanup := createRegistryProviderVersion(t, client, nil)
+		defer versionCleanup()
+
+		versionId := RegistryProviderVersionID{
+			RegistryProviderID: RegistryProviderID{
+				OrganizationName: version.RegistryProvider.Organization.Name,
+				RegistryName:     version.RegistryProvider.RegistryName,
+				Namespace:        version.RegistryProvider.Namespace,
+				Name:             version.RegistryProvider.Name,
+			},
+			Version: version.Version,
+		}
+
+		readVersion, err := client.RegistryProviderVersions.Read(ctx, versionId, nil)
+		assert.NoError(t, err)
+		assert.Equal(t, version.ID, readVersion.ID)
+		assert.Equal(t, version.Version, readVersion.Version)
+		assert.Equal(t, version.KeyID, readVersion.KeyID)
+
+		t.Run("relationships are properly decoded", func(t *testing.T) {
+			assert.Equal(t, version.RegistryProvider.ID, readVersion.RegistryProvider.ID)
+		})
+
+		t.Run("timestamps are properly decoded", func(t *testing.T) {
+			assert.NotEmpty(t, readVersion.CreatedAt)
+			assert.NotEmpty(t, readVersion.UpdatedAt)
+		})
+
+		t.Run("includes upload links", func(t *testing.T) {
+			expectedLinks := []string{
+				"shasums-upload",
+				"shasums-sig-upload",
+			}
+			for _, l := range expectedLinks {
+				_, ok := readVersion.Links[l].(string)
+				assert.True(t, ok, "Expect upload link: %s", l)
+			}
+		})
+	})
+
+	t.Run("with non existing version", func(t *testing.T) {
+		provider, providerCleanup := createPrivateRegistryProvider(t, client, nil)
+		defer providerCleanup()
+
+		versionId := RegistryProviderVersionID{
+			RegistryProviderID: RegistryProviderID{
+				OrganizationName: provider.Organization.Name,
+				RegistryName:     provider.RegistryName,
+				Namespace:        provider.Namespace,
+				Name:             provider.Name,
+			},
+			Version: "1.0.0",
+		}
+
+		_, err := client.RegistryProviderVersions.Read(ctx, versionId, nil)
+		assert.Error(t, err)
+	})
+
+}

--- a/tfe.go
+++ b/tfe.go
@@ -128,6 +128,7 @@ type Client struct {
 	PolicySetVersions          PolicySetVersions
 	PolicySets                 PolicySets
 	RegistryModules            RegistryModules
+	RegistryProviders          RegistryProviders
 	Runs                       Runs
 	RunTasks                   RunTasks
 	RunTriggers                RunTriggers
@@ -272,6 +273,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.PolicySetVersions = &policySetVersions{client: client}
 	client.PolicySets = &policySets{client: client}
 	client.RegistryModules = &registryModules{client: client}
+	client.RegistryProviders = &registryProviders{client: client}
 	client.Runs = &runs{client: client}
 	client.RunTasks = &runTasks{client: client}
 	client.RunTriggers = &runTriggers{client: client}

--- a/tfe.go
+++ b/tfe.go
@@ -129,6 +129,7 @@ type Client struct {
 	PolicySets                 PolicySets
 	RegistryModules            RegistryModules
 	RegistryProviders          RegistryProviders
+	RegistryProviderVersions   RegistryProviderVersions
 	Runs                       Runs
 	RunTasks                   RunTasks
 	RunTriggers                RunTriggers
@@ -274,6 +275,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.PolicySets = &policySets{client: client}
 	client.RegistryModules = &registryModules{client: client}
 	client.RegistryProviders = &registryProviders{client: client}
+	client.RegistryProviderVersions = &registryProviderVersions{client: client}
 	client.Runs = &runs{client: client}
 	client.RunTasks = &runTasks{client: client}
 	client.RunTriggers = &runTriggers{client: client}


### PR DESCRIPTION
## Description

This PR was broken out of this [PR](https://github.com/hashicorp/go-tfe/pull/313).

This PR adds support for the private registry provider version API. The first PR for these set of changes is [this](https://github.com/hashicorp/go-tfe/pull/404) one.

## Testing plan

To test these changes locally, create a local go project, and in the `go.mod` include a line similar to the following:

```
replace github.com/hashicorp/go-tfe => /Users/YOURUSER/go/src/github.com/hashicorp/go-tfe
```

Then, for a registry provider version, you can test:
* Create
* Delete
* Read
* List

## External links

- [Registry Providers API](https://www.terraform.io/cloud-docs/api-docs/private-registry/providers)
- [Private Registry Provider Requirements](https://github.com/hashicorp/go-tfe/pull/399)
- [Private Provider Versions and Platforms API](https://www.terraform.io/cloud-docs/api-docs/private-registry/provider-versions-platforms)


## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202295552965199