### PR TITLE
Added WebhookURL to VCSRepo struct

### DIFF
--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -172,7 +172,7 @@ func TestPolicySetsCreate(t *testing.T) {
 		assert.Equal(t, ps.VCSRepo.OAuthTokenID, oc.ID)
 		assert.Equal(t, ps.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
 		assert.Equal(t, ps.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
-		assert.Regexp(t, "^https://app\.terraform\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
+		assert.Regexp(t, "^https://app\\.terraform\\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
 	})
 
 	t.Run("with vcs policy updated", func(t *testing.T) {
@@ -209,7 +209,7 @@ func TestPolicySetsCreate(t *testing.T) {
 		assert.Equal(t, ps.VCSRepo.OAuthTokenID, oc.ID)
 		assert.Equal(t, ps.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
 		assert.Equal(t, ps.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
-		assert.Regexp(t, "^https://app\.terraform\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
+		assert.Regexp(t, "^https://app\\.terraform\\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
 	})
 
 	t.Run("without a name provided", func(t *testing.T) {

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -165,15 +165,14 @@ func TestPolicySetsCreate(t *testing.T) {
 		assert.Equal(t, ps.Description, "")
 		assert.False(t, ps.Global)
 		assert.Equal(t, ps.PoliciesPath, "/policy-sets/foo")
-		assert.Equal(t, ps.VCSRepo, &VCSRepo{
-			Branch:            "policies",
-			DisplayIdentifier: githubIdentifier,
-			Identifier:        githubIdentifier,
-			OAuthTokenID:      oc.ID,
-			IngressSubmodules: true,
-			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
-			ServiceProvider:   string(ServiceProviderGithub),
-		})
+		assert.Equal(t, ps.VCSRepo.Branch, "policies")
+		assert.Equal(t, ps.VCSRepo.DisplayIdentifier, githubIdentifier)
+		assert.Equal(t, ps.VCSRepo.Identifier, githubIdentifier)
+		assert.Equal(t, ps.VCSRepo.IngressSubmodules, true)
+		assert.Equal(t, ps.VCSRepo.OAuthTokenID, oc.ID)
+		assert.Equal(t, ps.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
+		assert.Equal(t, ps.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
+		assert.Regexp(t, "^https://app\.terraform\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
 	})
 
 	t.Run("with vcs policy updated", func(t *testing.T) {
@@ -203,15 +202,14 @@ func TestPolicySetsCreate(t *testing.T) {
 		assert.Equal(t, ps.Description, "")
 		assert.False(t, ps.Global)
 		assert.Equal(t, ps.PoliciesPath, "/policy-sets/bar")
-		assert.Equal(t, ps.VCSRepo, &VCSRepo{
-			Branch:            "policies",
-			DisplayIdentifier: githubIdentifier,
-			Identifier:        githubIdentifier,
-			OAuthTokenID:      oc.ID,
-			IngressSubmodules: false,
-			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
-			ServiceProvider:   string(ServiceProviderGithub),
-		})
+		assert.Equal(t, ps.VCSRepo.Branch, "policies")
+		assert.Equal(t, ps.VCSRepo.DisplayIdentifier, githubIdentifier)
+		assert.Equal(t, ps.VCSRepo.Identifier, githubIdentifier)
+		assert.Equal(t, ps.VCSRepo.IngressSubmodules, false)
+		assert.Equal(t, ps.VCSRepo.OAuthTokenID, oc.ID)
+		assert.Equal(t, ps.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
+		assert.Equal(t, ps.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
+		assert.Regexp(t, "^https://app\.terraform\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
 	})
 
 	t.Run("without a name provided", func(t *testing.T) {

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"os"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -172,7 +173,7 @@ func TestPolicySetsCreate(t *testing.T) {
 		assert.Equal(t, ps.VCSRepo.OAuthTokenID, oc.ID)
 		assert.Equal(t, ps.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
 		assert.Equal(t, ps.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
-		assert.Regexp(t, "^https://app\\.terraform\\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
+		assert.Regexp(t, fmt.Sprintf("^%s/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", regexp.QuoteMeta(DefaultConfig().Address)), ps.VCSRepo.WebhookURL)
 	})
 
 	t.Run("with vcs policy updated", func(t *testing.T) {
@@ -209,7 +210,7 @@ func TestPolicySetsCreate(t *testing.T) {
 		assert.Equal(t, ps.VCSRepo.OAuthTokenID, oc.ID)
 		assert.Equal(t, ps.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
 		assert.Equal(t, ps.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
-		assert.Regexp(t, "^https://app\\.terraform\\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", ps.VCSRepo.WebhookURL)
+		assert.Regexp(t, fmt.Sprintf("^%s/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", regexp.QuoteMeta(DefaultConfig().Address)), ps.VCSRepo.WebhookURL)
 	})
 
 	t.Run("without a name provided", func(t *testing.T) {

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -746,6 +746,7 @@ func TestRegistryModule_Unmarshal(t *testing.T) {
 					"oauth-token-id":      "token",
 					"repository-http-url": "github.com",
 					"service-provider":    "github",
+					"webhook-url":         "https://app.terraform.io/webhooks/vcs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 				},
 				"version-statuses": []interface{}{
 					map[string]interface{}{
@@ -779,6 +780,7 @@ func TestRegistryModule_Unmarshal(t *testing.T) {
 	assert.Equal(t, rm.VCSRepo.OAuthTokenID, "token")
 	assert.Equal(t, rm.VCSRepo.RepositoryHTTPURL, "github.com")
 	assert.Equal(t, rm.VCSRepo.ServiceProvider, "github")
+	assert.Equal(t, rm.VCSRepo.WebhookURL, "https://app.terraform.io/webhooks/vcs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 	assert.Equal(t, rm.Status, RegistryModuleStatusPending)
 	assert.Equal(t, rm.VersionStatuses[0].Version, "1.1.1")
 	assert.Equal(t, rm.VersionStatuses[0].Status, RegistryModuleVersionStatusPending)

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -265,15 +265,14 @@ func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 		assert.NotEmpty(t, rm.ID)
 		assert.Equal(t, registryModuleName, rm.Name)
 		assert.Equal(t, registryModuleProvider, rm.Provider)
-		assert.Equal(t, &VCSRepo{
-			Branch:            "",
-			Identifier:        githubIdentifier,
-			OAuthTokenID:      oauthTokenTest.ID,
-			DisplayIdentifier: githubIdentifier,
-			IngressSubmodules: true,
-			RepositoryHTTPURL: fmt.Sprintf("https://github.com/%s", githubIdentifier),
-			ServiceProvider:   string(ServiceProviderGithub),
-		}, rm.VCSRepo)
+		assert.Equal(t, rm.VCSRepo.Branch, "")
+		assert.Equal(t, rm.VCSRepo.DisplayIdentifier, githubIdentifier)
+		assert.Equal(t, rm.VCSRepo.Identifier, githubIdentifier)
+		assert.Equal(t, rm.VCSRepo.IngressSubmodules, true)
+		assert.Equal(t, rm.VCSRepo.OAuthTokenID, oauthTokenTest.ID)
+		assert.Equal(t, rm.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
+		assert.Equal(t, rm.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
+		assert.Regexp(t, "^https://app\.terraform\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", rm.VCSRepo.WebhookURL)
 
 		t.Run("permissions are properly decoded", func(t *testing.T) {
 			assert.True(t, rm.Permissions.CanDelete)

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -272,7 +272,7 @@ func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 		assert.Equal(t, rm.VCSRepo.OAuthTokenID, oauthTokenTest.ID)
 		assert.Equal(t, rm.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
 		assert.Equal(t, rm.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
-		assert.Regexp(t, "^https://app\.terraform\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", rm.VCSRepo.WebhookURL)
+		assert.Regexp(t, "^https://app\\.terraform\\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", rm.VCSRepo.WebhookURL)
 
 		t.Run("permissions are properly decoded", func(t *testing.T) {
 			assert.True(t, rm.Permissions.CanDelete)

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -272,7 +273,7 @@ func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 		assert.Equal(t, rm.VCSRepo.OAuthTokenID, oauthTokenTest.ID)
 		assert.Equal(t, rm.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
 		assert.Equal(t, rm.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
-		assert.Regexp(t, "^https://app\\.terraform\\.io/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", rm.VCSRepo.WebhookURL)
+		assert.Regexp(t, fmt.Sprintf("^%s/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", regexp.QuoteMeta(DefaultConfig().Address)), rm.VCSRepo.WebhookURL)
 
 		t.Run("permissions are properly decoded", func(t *testing.T) {
 			assert.True(t, rm.Permissions.CanDelete)

--- a/workspace.go
+++ b/workspace.go
@@ -182,6 +182,7 @@ type VCSRepo struct {
 	OAuthTokenID      string `jsonapi:"attr,oauth-token-id"`
 	RepositoryHTTPURL string `jsonapi:"attr,repository-http-url"`
 	ServiceProvider   string `jsonapi:"attr,service-provider"`
+	WebhookURL        string `jsonapi:"attr,webhook-url"`
 }
 
 // WorkspaceActions represents the workspace actions.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1446,6 +1446,7 @@ func TestWorkspace_Unmarshal(t *testing.T) {
 					"oauth-token-id":      "token",
 					"repository-http-url": "github.com",
 					"service-provider":    "github",
+					"webhook-url":         "https://app.terraform.io/webhooks/vcs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
 				},
 				"actions": map[string]interface{}{
 					"is-destroyable": true,
@@ -1481,6 +1482,7 @@ func TestWorkspace_Unmarshal(t *testing.T) {
 	assert.Equal(t, ws.VCSRepo.OAuthTokenID, "token")
 	assert.Equal(t, ws.VCSRepo.RepositoryHTTPURL, "github.com")
 	assert.Equal(t, ws.VCSRepo.ServiceProvider, "github")
+	assert.Equal(t, ws.VCSRepo.WebhookURL, "https://app.terraform.io/webhooks/vcs/aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee")
 	assert.Equal(t, ws.Actions.IsDestroyable, true)
 	assert.Equal(t, ws.TriggerPrefixes, []string{"prefix-"})
 	assert.Equal(t, ws.TriggerPatterns, []string{"pattern1/**/*", "pattern2/**/submodule/*"})


### PR DESCRIPTION
## Description

Terraform creates a webhook URL for every workspace that is attached to a VCS Provider, but for some reason, this generated URL is not exposed to the users of the go-tfe client. This PR tries to fix that. If this PR gets merged, will need to wait for a new release and then send another PR to https://github.com/hashicorp/terraform-provider-tfe which would also expose the same information to TFE provider users.

This will be useful for people (at least for me) who wants to add custom logic between GitHub (or any other VCS) and Terraform Cloud/Enterprise.

I had to skip the test for the Policy Sets as I currently do not have a paid membership on TF Cloud.

## Output from tests
```
=== RUN   TestRegistryModulesCreateWithVCSConnection
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/without_options
--- PASS: TestRegistryModulesCreateWithVCSConnection (3.53s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options (0.80s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/without_options (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]


=== RUN   TestRegistryModule_Unmarshal
--- PASS: TestRegistryModule_Unmarshal (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]


=== RUN   TestWorkspace_Unmarshal
--- PASS: TestWorkspace_Unmarshal (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```