### PR TITLE
Fix linting errors

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -1302,18 +1302,19 @@ func waitForRunLock(t *testing.T, client *Client, workspaceID string) {
 	wg.Wait()
 }
 
-func retry(f retryableFn) (interface{}, error) {
+func retry(f retryableFn) (interface{}, error) { //nolint
 	tick := time.NewTicker(tickDuration * time.Second)
-
 	retries := 0
 	maxRetries := 5
 
-	for {
+	defer tick.Stop()
+
+	for { //nolint
 		select {
 		case <-tick.C:
 			res, err := f()
 			if err == nil {
-				return res, err
+				return res, nil
 			}
 
 			if retries >= maxRetries {

--- a/tfe.go
+++ b/tfe.go
@@ -854,7 +854,7 @@ func checkResponseCode(r *http.Response) error {
 		return err
 	}
 
-	return fmt.Errorf(strings.Join(errs, "\n"))
+	return errors.New(strings.Join(errs, "\n"))
 }
 
 func decodeErrorPayload(r *http.Response) ([]string, error) {
@@ -863,7 +863,7 @@ func decodeErrorPayload(r *http.Response) ([]string, error) {
 	errPayload := &jsonapi.ErrorsPayload{}
 	err := json.NewDecoder(r.Body).Decode(errPayload)
 	if err != nil || len(errPayload.Errors) == 0 {
-		return errs, fmt.Errorf(r.Status)
+		return errs, errors.New(r.Status)
 	}
 
 	// Parse and format the errors.


### PR DESCRIPTION
## Description

Fix issues seen when running `golangci-lint run`

## Testing plan

1. When you run `golangci-lint run` on this branch, you should not see any issues.


## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
