### PR TITLE
Upgrade org feature set [test helper]

### DIFF
--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -84,3 +84,7 @@ $ envchain YOUR_NAMESPACE_HERE go test ./... -timeout=30m -tags=integration
 ```sh
 $ TFE_TOKEN=xyz TFE_ADDRESS=xyz ENABLE_TFE=1 go test ./... -timeout=30m -tags=integration
 ```
+
+### Running tests for TFC features that require paid plans (HashiCorp Employees)
+
+You can use the test helper `upgradeOrganizationSubscription()` to upgrade your test organization to a Business Plan, giving the organization access to all features in Terraform Cloud. This method requires `TFE_TOKEN` to be a user token with administrator access in the target test environment. Furthermore, you **can not** have enterprise features enabled (`ENABLE_TFE=1`) in order to use this method since the API call fails against TFE test environments.


### PR DESCRIPTION
## Description

There are many tests that require an organization to be on upgraded subscription plans and each organization created with the test helper `createOrganization()` is automatically set to the free tier feature set. Currently, we put these kinds of tests behind an env flag called `SKIP_PAID` and these tests are subsequently skipped in CI. This is no bueno. 

I have added a test helper method `upgradeOrganizationSubscription()` which will _attempt_ to upgrade the organization. In the documentation I mention that it will fail if the test environment specified by `TFE_ADDRESS` is a TFE environment and not TFC. 

## Testing plan

I did not include a test for this method as we do not write tests for our helpers. However, I have included below a simple test you can use to verify this works as intended:

```go
func TestUpgradeSubscription(t *testing.T) {
  client := testClient(t)

  org, _ := createOrganization(t, client)
  // fmt.Println(org.Name) may be helpful 
  // we won't call the cleanup method here as you'll need to verify 
  // the organization was indeed upgraded using the UI 
  upgradeOrganizationSubscription(t, client, org)
}
```

**Soft Success Check:**  If the API call doesn't fail we've successfully created a new, upgraded subscription.
**Hard Success Check:** Visit the UI for your test environment and you should no longer see `Free Trial` in the navigation bar. Alternatively, you can visit the `Admin > Organizations` page, search for your test organization, and verify the subscription plan there. 