### PR TITLE
Testing the agent pool tests and their flakiness.

### DIFF
--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -81,6 +81,8 @@ func TestAgentPoolsCreate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	t.Run("with valid options", func(t *testing.T) {
 		options := AgentPoolCreateOptions{
 			Name: String("cool-pool"),


### PR DESCRIPTION
## Description

The agent pool tests are one of the set of flaky tests we have. Upgrade the org to a biz account for the tests to work. I looked in atlas and nothing stood out to me to cause this issue, so I'm a little confused about why it's happening, but if we can create an agent pool, then the other tests will work (list, update, delete).

## Testing plan

1. Run the test: `go test --run TestAgentPoolsCreate -v ./... -tags=integration` and it should pass.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
