### PR TITLE
Add new runs list options

### DIFF
--- a/run.go
+++ b/run.go
@@ -83,6 +83,18 @@ const (
 	RunSourceUI                   RunSource = "tfe-ui"
 )
 
+// RunOperation represents an operation type of run.
+type RunOperation string
+
+// List all available run operations.
+const (
+	RunOperationPlanApply   RunOperation = "plan_and_apply"
+	RunOperationPlanOnly    RunOperation = "plan_only"
+	RunOperationRefreshOnly RunOperation = "refresh_only"
+	RunOperationDestroy     RunOperation = "destroy"
+	RunOperationEmptyApply  RunOperation = "empty_apply"
+)
+
 // RunList represents a list of runs.
 type RunList struct {
 	*Pagination
@@ -180,6 +192,27 @@ const (
 // RunListOptions represents the options for listing runs.
 type RunListOptions struct {
 	ListOptions
+
+	// Optional: Username of user who created the run
+	// **Note: This API is still in BETA and is subject to change.**
+	Name string `url:"search[name],omitempty"`
+
+	// Optional: Commit SHA for runs triggered via a vcs event
+	// **Note: This API is still in BETA and is subject to change.**
+	Commit string `url:"search[commit],omitempty"`
+
+	// Optional: Current status of the run
+	// **Note: This API is still in BETA and is subject to change.**
+	Status string `url:"filter[status],omitempty"`
+
+	// Optional: Source that triggered the run
+	// **Note: This API is still in BETA and is subject to change.**
+	Source string `url:"filter[source],omitempty"`
+
+	// Optional: Operation type for the run
+	// **Note: This API is still in BETA and is subject to change.**
+	Operation string `url:"filter[operation],omitempty"`
+
 	// Optional: A list of relations to include. See available resources:
 	// https://www.terraform.io/docs/cloud/api/run.html#available-related-resources
 	Include []RunIncludeOpt `url:"include,omitempty"`


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds new RunsListOption(s) to accompany new query parameters recently added to TFC. These parameters are still in the process of being rolled out. New tests are currently skipped. 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

API documentation has yet to be updated
[Task Link](https://app.asana.com/0/1201287664926243/1202132529172632/f)

## Output from tests

```bash
TFE_ADDRESS="https://example" \
TFE_TOKEN="example" \
TF_ACC="1" \
ENABLE_BETA="1" \
go test -run TestRunsListQueryParams -v -tags=integration
```

**Output**
```
=== RUN   TestRunsListQueryParams
=== RUN   TestRunsListQueryParams/with_status_query_parameter
=== RUN   TestRunsListQueryParams/with_source_query_parameter
=== RUN   TestRunsListQueryParams/with_operation_of_plan_only_parameter
=== RUN   TestRunsListQueryParams/with_name_parameter
=== RUN   TestRunsListQueryParams/with_name_&_commit_parameter
--- PASS: TestRunsListQueryParams (41.61s)
    --- PASS: TestRunsListQueryParams/with_status_query_parameter (0.45s)
    --- PASS: TestRunsListQueryParams/with_source_query_parameter (0.40s)
    --- PASS: TestRunsListQueryParams/with_operation_of_plan_only_parameter (0.34s)
    --- PASS: TestRunsListQueryParams/with_name_parameter (0.38s)
    --- PASS: TestRunsListQueryParams/with_name_&_commit_parameter (0.32s)
PASS
ok      github.com/hashicorp/go-tfe     42.556s
```