### PR TITLE
add support for new organization-specific workspace limit setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Adds `RetryServerErrors` field to the `Config` object by @sebasslash [#439](https://github.com/hashicorp/go-tfe/pull/439)
 * Adds support for the GPG Keys API by @sebasslash [#429](https://github.com/hashicorp/go-tfe/pull/429)
 * [beta] Renames the optional StateVersion field `ExtState` to `JSONState` and changes to string for base64 encoding by @annawinkler [#444](https://github.com/hashicorp/go-tfe/pull/444)
+* Add support for new `WorkspaceLimit` Admin setting for organizations [#425](https://github.com/hashicorp/go-tfe/pull/425)
 
 # v1.3.0
 

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -50,6 +50,7 @@ type AdminOrganization struct {
 	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
 	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
 	TerraformWorkerSudoEnabled       bool   `jsonapi:"attr,terraform-worker-sudo-enabled"`
+	WorkspaceLimit                   *int   `jsonapi:"attr,workspace-limit"`
 
 	// Relations
 	Owners []*User `jsonapi:"relation,owners"`
@@ -64,6 +65,7 @@ type AdminOrganizationUpdateOptions struct {
 	TerraformBuildWorkerApplyTimeout *string `jsonapi:"attr,terraform-build-worker-apply-timeout,omitempty"`
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
 	TerraformWorkerSudoEnabled       bool    `jsonapi:"attr,terraform-worker-sudo-enabled,omitempty"`
+	WorkspaceLimit                   *int    `jsonapi:"attr,workspace-limit,omitempty"`
 }
 
 // AdminOrganizationList represents a list of organizations via Admin API.

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -106,6 +106,7 @@ func TestAdminOrganizations_Read(t *testing.T) {
 		assert.NotNilf(t, adminOrg.NotificationEmail, "NotificationEmail is not nil")
 		assert.NotNilf(t, adminOrg.SsoEnabled, "SsoEnabled is not nil")
 		assert.NotNilf(t, adminOrg.TerraformWorkerSudoEnabled, "TerraformWorkerSudoEnabledis not nil")
+		assert.Nilf(t, adminOrg.WorkspaceLimit, "WorkspaceLimit is nil")
 	})
 }
 
@@ -238,39 +239,47 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		assert.NoError(t, err)
 
 		assert.Equal(t, accessBetaTools, adminOrg.AccessBetaTools)
-		assert.Equal(t, globalModuleSharing, adminOrg.GlobalModuleSharing)
+		assert.Equal(t, adminOrg.GlobalModuleSharing, &globalModuleSharing)
 		assert.Equal(t, isDisabled, adminOrg.IsDisabled)
 		assert.Equal(t, terraformBuildWorkerApplyTimeout, adminOrg.TerraformBuildWorkerApplyTimeout)
 		assert.Equal(t, terraformBuildWorkerPlanTimeout, adminOrg.TerraformBuildWorkerPlanTimeout)
 		assert.Equal(t, terraformWorkerSudoEnabled, adminOrg.TerraformWorkerSudoEnabled)
+		assert.Nil(t, adminOrg.WorkspaceLimit, "default workspace limit should be nil")
 
 		isDisabled = true
 		globalModuleSharing = true
+		workspaceLimit := 42
 		opts = AdminOrganizationUpdateOptions{
 			GlobalModuleSharing: &globalModuleSharing,
 			IsDisabled:          &isDisabled,
+			WorkspaceLimit:      &workspaceLimit,
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
 		assert.NoError(t, err)
 		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
 
-		assert.Equal(t, adminOrg.GlobalModuleSharing, globalModuleSharing)
+		assert.Equal(t, adminOrg.GlobalModuleSharing, &globalModuleSharing)
 		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
+		assert.Equal(t, &workspaceLimit, adminOrg.WorkspaceLimit)
 
 		globalModuleSharing = false
 		isDisabled = false
+		workspaceLimit = 0
 		opts = AdminOrganizationUpdateOptions{
 			GlobalModuleSharing: &globalModuleSharing,
 			IsDisabled:          &isDisabled,
+			WorkspaceLimit:      &workspaceLimit,
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
 		assert.NoError(t, err)
 		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
 
-		assert.Equal(t, adminOrg.GlobalModuleSharing, globalModuleSharing)
+		assert.Equal(t, &globalModuleSharing, adminOrg.GlobalModuleSharing)
 		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
+
+		assert.Equal(t, &workspaceLimit, adminOrg.WorkspaceLimit)
 	})
 }
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -12,7 +12,7 @@ Your registry module repository will need to be a [valid module](https://www.ter
 It will need the following: 
 1. To be named `terraform-<PROVIDER>-<NAME>`
 1. At least one valid SemVer tag in the format `x.y.z`
-[terraform-random-module](ttps://github.com/caseylang/terraform-random-module) is a good example repo. 
+[terraform-random-module](https://github.com/caseylang/terraform-random-module) is a good example repo. 
    
 ## 2. Set up environment variables (ENVVARS)
 


### PR DESCRIPTION
## Description

This change allows go-tfe to read/set/unset a newly created setting on the organization model. This setting is only available in TFE.

## Testing plan

1. Run local development version of TFE
2. Run the newly updated tests in [admin_organization_integration_test.go](admin_organization_integration_test.go)

# Output from tests

It's worth noting that I had to make a few changes to the existing test (specifically, assertions about the GlobalModuleSharing flag) in order to get these tests to pass. Since those tests don't get run in CI, I'm thinking they probably haven't run in a long while.

Looking at https://github.com/hashicorp/go-tfe/pull/278, I can't figure out how [the assertions](https://github.com/hashicorp/go-tfe/pull/278/files#diff-4527a001d099fd64c39587b6779f05a56736553af6d47bd1fd6fddddb8e90b25R197) could have passed, since `globalModuleSharing` was changed from a `bool` to `*bool`, shouldn't the assertions reflect that? Maybe the test library changed? I have no idea! 😅 This is my first PR for Golang, so if anyone could correct me here, I can happily revert my changes there and fix whatever is going on.

```
go tool test2json -t tmp/path-from/GoLand/___TestAdminOrganizations_Update_fetches_and_updates_organization_in_github_com_hashicorp_go_tfe.test -test.v -test.paniconexit0 -test.run ^\QTestAdminOrganizations_Update\E$/^\Qfetches_and_updates_organization\E$
=== RUN   TestAdminOrganizations_Update
--- PASS: TestAdminOrganizations_Update (3.37s)
=== RUN   TestAdminOrganizations_Update/fetches_and_updates_organization
    --- PASS: TestAdminOrganizations_Update/fetches_and_updates_organization (2.45s)
PASS
```