### PR TITLE
Fix potential name collision flakes in `TestAdminTerraformVersions`

### DIFF
--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -100,10 +100,11 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 
 	client := testClient(t)
 	ctx := context.Background()
+	version := genSafeRandomTerraformVersion()
 
 	t.Run("with valid options", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
-			Version:          String("1.1.100"),
+			Version:          String(version),
 			URL:              String("https://www.hashicorp.com"),
 			Sha:              String(genSha(t, "secret", "data")),
 			Deprecated:       Bool(true),
@@ -131,8 +132,9 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 	})
 
 	t.Run("with only required options", func(t *testing.T) {
+		version := genSafeRandomTerraformVersion()
 		opts := AdminTerraformVersionCreateOptions{
-			Version: String("1.1.100"),
+			Version: String(version),
 			URL:     String("https://www.hashicorp.com"),
 			Sha:     String(genSha(t, "secret", "data")),
 		}
@@ -167,8 +169,9 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("reads and updates", func(t *testing.T) {
+		version := genSafeRandomTerraformVersion()
 		opts := AdminTerraformVersionCreateOptions{
-			Version:          String("1.1.100"),
+			Version:          String(version),
 			URL:              String("https://www.hashicorp.com"),
 			Sha:              String(genSha(t, "secret", "data")),
 			Official:         Bool(false),
@@ -198,7 +201,7 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, *opts.Enabled, tfv.Enabled)
 		assert.Equal(t, *opts.Beta, tfv.Beta)
 
-		updateVersion := "1.1.200"
+		updateVersion := genSafeRandomTerraformVersion()
 		updateURL := "https://app.terraform.io/"
 		updateOpts := AdminTerraformVersionUpdateOptions{
 			Version:    String(updateVersion),

--- a/helper_test.go
+++ b/helper_test.go
@@ -1517,6 +1517,22 @@ func genSha(t *testing.T, secret, data string) string {
 	return sha
 }
 
+// genSafeRandomTerraformVersion returns a random version number of the form
+// `1.0.<RANDOM>`, which TFC won't ever select as the latest available
+// Terraform. (At the time of writing, a fresh TFC instance will include
+// official Terraforms 1.2 and higher.) This is necessary because newly created
+// workspaces default to the latest available version, and there's nothing
+// preventing unrelated processes from creating workspaces during these tests.
+func genSafeRandomTerraformVersion() string {
+	rInt := rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	// Avoid colliding with an official Terraform version. Highest 1.0 was
+	// 1.0.11, so add a little padding and call it good.
+	for rInt < 20 {
+		rInt = rand.New(rand.NewSource(time.Now().UnixNano())).Int()
+	}
+	return fmt.Sprintf("1.0.%d", rInt)
+}
+
 func randomString(t *testing.T) string {
 	v, err := uuid.GenerateUUID()
 	if err != nil {


### PR DESCRIPTION
## Description

I noticed this while diagnosing and fixing the cross-repository ultra-flakes
from https://github.com/hashicorp/terraform-provider-tfe/pull/520.

These `Admin.TerraformVersions` tests were already using version numbers that
were reliably smaller than the current official versions, so there was no risk
of workspaces created by concurrent processes defaulting to these unusable
versions. However, since the tests were using hardcoded version strings, it's
not safe to concurrently run multiple instances of _these_ tests against the
same test infrastructure; if the timing lines up just right, at least one of the
two test runs will flake.

I don't have an example of this flake in the wild, and I think we might be
protected in CI because of `skipIfCloud(t)`. But I think there's a good argument
for not hardcoding identifiers that must be globally unique on a given TFC
instance, even if it's not currently biting us.

This commit brings in the `genSafeRandomTerraformVersion()` function from the
terraform-provider-tfe tests, and uses it to generate a unique `1.0.<RANDOM>`
version number for each test case.

## Testing plan

1. Tests pass!

## External links

- [Related tfe provider PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/520)

## Output from tests

Alas, ENABLE_TFE is required here.

```
$ [SENSITIVE VARS REDACTED] TF_ACC="1" ENABLE_TFE=1 go test ./... -v -tags=integration -run TestAdminTerraformVersions
=== RUN   TestAdminTerraformVersions_List
=== RUN   TestAdminTerraformVersions_List/without_list_options
=== RUN   TestAdminTerraformVersions_List/with_list_options
=== RUN   TestAdminTerraformVersions_List/with_filter_query_string
=== RUN   TestAdminTerraformVersions_List/with_search_version_query_string
=== RUN   TestAdminTerraformVersions_List/with_search_version_query_string/ensure_each_version_matches_substring
--- PASS: TestAdminTerraformVersions_List (1.31s)
    --- PASS: TestAdminTerraformVersions_List/without_list_options (0.15s)
    --- PASS: TestAdminTerraformVersions_List/with_list_options (0.46s)
    --- PASS: TestAdminTerraformVersions_List/with_filter_query_string (0.22s)
    --- PASS: TestAdminTerraformVersions_List/with_search_version_query_string (0.15s)
        --- PASS: TestAdminTerraformVersions_List/with_search_version_query_string/ensure_each_version_matches_substring (0.00s)
=== RUN   TestAdminTerraformVersions_CreateDelete
=== RUN   TestAdminTerraformVersions_CreateDelete/with_valid_options
=== RUN   TestAdminTerraformVersions_CreateDelete/with_only_required_options
=== RUN   TestAdminTerraformVersions_CreateDelete/with_empty_options
--- PASS: TestAdminTerraformVersions_CreateDelete (0.77s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_valid_options (0.25s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_only_required_options (0.25s)
    --- PASS: TestAdminTerraformVersions_CreateDelete/with_empty_options (0.00s)
=== RUN   TestAdminTerraformVersions_ReadUpdate
=== RUN   TestAdminTerraformVersions_ReadUpdate/reads_and_updates
=== RUN   TestAdminTerraformVersions_ReadUpdate/with_non-existent_terraform_version
--- PASS: TestAdminTerraformVersions_ReadUpdate (1.07s)
    --- PASS: TestAdminTerraformVersions_ReadUpdate/reads_and_updates (0.61s)
    --- PASS: TestAdminTerraformVersions_ReadUpdate/with_non-existent_terraform_version (0.18s)
PASS
ok  	github.com/hashicorp/go-tfe	3.210s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```
