### PR TITLE
[WIP] Add API Changes for Agent Pools to Workspaces Feature

### DIFF
--- a/agent_pool.go
+++ b/agent_pool.go
@@ -46,12 +46,14 @@ type AgentPoolList struct {
 
 // AgentPool represents a Terraform Cloud agent pool.
 type AgentPool struct {
-	ID   string `jsonapi:"primary,agent-pools"`
-	Name string `jsonapi:"attr,name"`
+	ID                 string `jsonapi:"primary,agent-pools"`
+	Name               string `jsonapi:"attr,name"`
+	OrganizationScoped bool   `jsonapi:"attr,organization-scoped"`
 
 	// Relations
-	Organization *Organization `jsonapi:"relation,organization"`
-	Workspaces   []*Workspace  `jsonapi:"relation,workspaces"`
+	Organization      *Organization `jsonapi:"relation,organization"`
+	Workspaces        []*Workspace  `jsonapi:"relation,workspaces"`
+	AllowedWorkspaces []*Workspace  `jsonapi:"relation,allowed-workspaces"`
 }
 
 // A list of relations to include
@@ -172,6 +174,12 @@ type AgentPoolUpdateOptions struct {
 
 	// A new name to identify the agent pool.
 	Name *string `jsonapi:"attr,name"`
+
+	// True if the agent pool is organization scoped, false otherwise.
+	OrganizationScoped bool `jsonapi:"attr,organization-scoped"`
+
+	// A new list of workspaces that are associated with an agent pool.
+	AllowedWorkspaces []*Workspace `jsonapi:"relation,allowed-workspaces"`
 }
 
 // Update an agent pool by its ID.

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -200,6 +200,40 @@ func TestAgentPoolsUpdate(t *testing.T) {
 		assert.Nil(t, w)
 		assert.EqualError(t, err, ErrInvalidAgentPoolID.Error())
 	})
+
+	t.Run("when updating allowed-workspaces", func(t *testing.T) {
+		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
+		defer kTestCleanup()
+
+		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
+		defer workspaceTestCleanup()
+
+		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
+			Name: String(kBefore.Name),			
+			AllowedWorkspaces: []*Workspace{
+				workspaceTest,
+			},
+		})
+		require.NoError(t, err)
+
+		assert.NotEqual(t, kBefore.AllowedWorkspaces, kAfter.AllowedWorkspaces)
+		assert.Equal(t, 1, len(kAfter.AllowedWorkspaces))
+		assert.Equal(t, workspaceTest.ID, kAfter.AllowedWorkspaces[0].ID)
+	})
+
+	t.Run("when updating organization scope", func(t *testing.T) {
+		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
+		defer kTestCleanup()
+
+		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
+			Name: String(kBefore.Name),			
+			OrganizationScoped: false,
+		})
+		require.NoError(t, err)
+
+		assert.NotEqual(t, kBefore.OrganizationScoped, kAfter.OrganizationScoped)
+		assert.Equal(t, false, kAfter.OrganizationScoped)
+	})
 }
 
 func TestAgentPoolsDelete(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

In Atlas, new features were added where the user can change the scope for agent pools to either the entire organization or to specific workspaces. The user can specify a list of allowed workspaces.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links
- [Related PR](https://github.com/hashicorp/atlas/pull/12363/files#diff-eb00cadc62ed0d6de7e976b378f7d35acefb2848053c072ee9d37c5a29903756)
- [API documentation](https://docs.google.com/document/d/1Dp3Mpjyi9YDXV8kA5pua1sZcJzoUU8dsMIQB2_QVWfQ/edit)
- [Asana](https://app.asana.com/0/home/1202204588901413/1202415348311629)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ go-tfe % envchain go-tfe go test -run TestAgentPoolsUpdate -v ./... -tags=integration
=== RUN   TestAgentPoolsUpdate
=== RUN   TestAgentPoolsUpdate/with_valid_options
=== RUN   TestAgentPoolsUpdate/when_updating_the_name
=== RUN   TestAgentPoolsUpdate/without_a_valid_agent_pool_ID
=== RUN   TestAgentPoolsUpdate/when_updating_allowed-workspaces
=== RUN   TestAgentPoolsUpdate/when_updating_organization_scope
--- PASS: TestAgentPoolsUpdate (5.57s)
    --- PASS: TestAgentPoolsUpdate/with_valid_options (0.83s)
    --- PASS: TestAgentPoolsUpdate/when_updating_the_name (0.76s)
    --- PASS: TestAgentPoolsUpdate/without_a_valid_agent_pool_ID (0.00s)
    --- PASS: TestAgentPoolsUpdate/when_updating_allowed-workspaces (1.29s)
    --- PASS: TestAgentPoolsUpdate/when_updating_organization_scope (0.88s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
...
```
