### PR TITLE
Check error before RetryServerErrors

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -52,8 +52,9 @@ type updateFeatureSetOptions struct {
 }
 
 func testClient(t *testing.T) *Client {
-	client, err := NewClient(nil)
-	client.RetryServerErrors(true) // because occasionally we get a 500 internal when deleting an organization's workspace
+	client, err := NewClient(&Config{
+		RetryServerErrors: true,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Small PR to surface errors when calling `NewClient` before a nil client has a chance to panic.