### PR TITLE
Add `integration` tag to lintFlags in vscode settings

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,8 @@
   "go.buildFlags": [
       "-tags=integration"
   ],
+  "go.lintFlags": [
+    "-tags=integration"
+  ],
   "go.testTags": "integration",
 }


### PR DESCRIPTION
## Description

VSCode's integration with the staticcheck linter was marking all our test helper
functions as unused code, which is untrue! The linter doesn't seem to inherit
the `buildFlags`, and has its own flags setting. With this change, it properly
notices that our test helpers are actually important.

The linter _does_ seem to inherit the `go.buildTags` setting, so that might be a
more complete way to address this. But I wasn't sure yet if that would have any
wider effects we don't want.

## Testing plan

1.  Open a fresh VSCode project window for the go-tfe directory, view helper_test.go, and wait for all the linters and language servers etc. to settle. The functions that are only used in integration tests shouldn't have little mustard squiggles under them.