### PR TITLE
add exclude tags to workspace list options

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -240,6 +240,9 @@ type WorkspaceListOptions struct {
 	// Optional: A search string (comma-separated tag names) used to filter the results.
 	Tags string `url:"search[tags],omitempty"`
 
+	// Optional: A search string (comma-separated tag names to exclude) used to filter the results.
+	ExcludeTags string `url:"search[exclude-tags],omitempty"`
+
 	// Optional: A list of relations to include. See available resources https://www.terraform.io/docs/cloud/api/workspaces.html#available-related-resources
 	Include []WSIncludeOpt `url:"include,omitempty"`
 }

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -94,6 +94,28 @@ func TestWorkspacesList(t *testing.T) {
 		assert.Equal(t, 1, wl.TotalCount)
 	})
 
+	t.Run("when searching using exclude-tags", func(t *testing.T) {
+		for wsID, tag := range map[string]string{wTest1.ID: "foo", wTest2.ID: "bar"} {
+			err := client.Workspaces.AddTags(ctx, wsID, WorkspaceAddTagsOptions{
+				Tags: []*Tag{
+					{
+						Name: tag,
+					},
+				},
+			})
+			require.NoError(t, err)
+		}
+
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
+			ExcludeTags: "foo",
+		})
+
+		require.NoError(t, err)
+		assert.Contains(t, wl.Items[0].ID, wTest2.ID)
+		assert.Equal(t, 1, wl.CurrentPage)
+		assert.Equal(t, 1, wl.TotalCount)
+	})
+
 	t.Run("when searching an unknown workspace", func(t *testing.T) {
 		// Use a nonexisting workspace name as search attribute. The result
 		// should be successful, but return no results.


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
Currently the list of Workspaces within an Organization can be filtered with `Tags` string to include. This PR adds the ability to exclude workspaces by tags using the `ExcludeTags` option.

For example, given `workspace1` with tag `one` and `workspace2` with tag `two`, invoking
```
client.Workspaces.List(ctx, orgName, &WorkspaceListOptions{
			ExcludeTags: "two",
		})
```

should only return `workspace1`.

## Testing plan

- Create an organization
- Create workspaces with tags in that organization
- List workspaces using the ExcludeTags options, should list all workspaces excluding ones with the excluded tags.

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/523)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestWorkspacesList

=== RUN   TestWorkspacesList
=== RUN   TestWorkspacesList/without_list_options
=== RUN   TestWorkspacesList/with_list_options
=== RUN   TestWorkspacesList/when_searching_a_known_workspace
=== RUN   TestWorkspacesList/when_searching_using_a_tag
=== RUN   TestWorkspacesList/when_searching_using_exclude-tags
=== RUN   TestWorkspacesList/when_searching_an_unknown_workspace
=== RUN   TestWorkspacesList/without_a_valid_organization
=== RUN   TestWorkspacesList/with_organization_included
=== RUN   TestWorkspacesList/with_current-state-version,current-run_included
--- PASS: TestWorkspacesList (80.58s)
    --- PASS: TestWorkspacesList/without_list_options (0.29s)
    --- PASS: TestWorkspacesList/with_list_options (0.22s)
    --- PASS: TestWorkspacesList/when_searching_a_known_workspace (0.25s)
    --- PASS: TestWorkspacesList/when_searching_using_a_tag (0.55s)
    --- PASS: TestWorkspacesList/when_searching_using_exclude-tags (0.70s)
    --- PASS: TestWorkspacesList/when_searching_an_unknown_workspace (0.23s)
    --- PASS: TestWorkspacesList/without_a_valid_organization (0.00s)
    --- PASS: TestWorkspacesList/with_organization_included (0.33s)
    --- PASS: TestWorkspacesList/with_current-state-version,current-run_included (75.02s)
PASS
```