### PR TITLE
Extend config interface to support setting `retryServerErrors`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# v1.4.0 (Unreleased)
+
+## Enhancements
+* Adds `RetryServerErrors` field to the `Config` object by @sebasslash [#439](https://github.com/hashicorp/go-tfe/pull/439)
+
 # v1.3.0
 
 ## Enhancements

--- a/tfe.go
+++ b/tfe.go
@@ -66,17 +66,21 @@ type Config struct {
 
 	// RetryLogHook is invoked each time a request is retried.
 	RetryLogHook RetryLogHook
+
+	// RetryServerErrors enables the retry logic in the client.
+	RetryServerErrors bool
 }
 
 // DefaultConfig returns a default config structure.
 
 func DefaultConfig() *Config {
 	config := &Config{
-		Address:    os.Getenv("TFE_ADDRESS"),
-		BasePath:   DefaultBasePath,
-		Token:      os.Getenv("TFE_TOKEN"),
-		Headers:    make(http.Header),
-		HTTPClient: cleanhttp.DefaultPooledClient(),
+		Address:           os.Getenv("TFE_ADDRESS"),
+		BasePath:          DefaultBasePath,
+		Token:             os.Getenv("TFE_TOKEN"),
+		Headers:           make(http.Header),
+		HTTPClient:        cleanhttp.DefaultPooledClient(),
+		RetryServerErrors: false,
 	}
 
 	// Set the default address if none is given.
@@ -196,6 +200,7 @@ func NewClient(cfg *Config) (*Client, error) {
 		if cfg.RetryLogHook != nil {
 			config.RetryLogHook = cfg.RetryLogHook
 		}
+		config.RetryServerErrors = cfg.RetryServerErrors
 	}
 
 	// Parse the address to make sure its a valid URL.
@@ -216,10 +221,11 @@ func NewClient(cfg *Config) (*Client, error) {
 
 	// Create the client.
 	client := &Client{
-		baseURL:      baseURL,
-		token:        config.Token,
-		headers:      config.Headers,
-		retryLogHook: config.RetryLogHook,
+		baseURL:           baseURL,
+		token:             config.Token,
+		headers:           config.Headers,
+		retryLogHook:      config.RetryLogHook,
+		retryServerErrors: config.RetryServerErrors,
 	}
 
 	client.http = &retryablehttp.Client{


### PR DESCRIPTION
## Description

There were instances where users would experience a network failure during the metadata or `/ping` request when calling `NewClient()`. 

This PR adds a new field `RetryServerErrors` to the `Config` object, which sets the value for `c.retryServerErrors` during client initialization and has a default value of `false`. In short, the client exposes a receiver method `RetryServerErrors(bool)` which allows you to set the value of `c.retryServerErrors` which toggles the retry logic, however it requires an initialized client. This became a problem due to the network request made in `NewClient()` that wouldn't be retried should it fail -- there was no way for the user to enable the retry logic before calling `NewClient()`!

Making it an option in the client's configuration process will circumvent this issue.