### PR TITLE
Rename ext-state to json-state & base64 encoding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 * Adds `RetryServerErrors` field to the `Config` object by @sebasslash [#439](https://github.com/hashicorp/go-tfe/pull/439)
-
+* [beta] Renames the optional StateVersion field `ExtState` to `JSONState` and changes to string for base64 encoding by @annawinkler [#444](https://github.com/hashicorp/go-tfe/pull/444)
 # v1.3.0
 
 ## Enhancements

--- a/state_version.go
+++ b/state_version.go
@@ -3,7 +3,6 @@ package tfe
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"net/url"
 	"time"
@@ -140,13 +139,13 @@ type StateVersionCreateOptions struct {
 	// Optional: Specifies the run to associate the state with.
 	Run *Run `jsonapi:"relation,run,omitempty"`
 
-	// Optional: The external, json representation of state data.
+	// Optional: The external, json representation of state data, base64 encoded.
 	// https://www.terraform.io/internals/json-format#state-representation
 	// Supplying this state representation can provide more details to the platform
 	// about the current terraform state.
 	//
 	// **Note**: This field is in BETA, subject to change and not widely available yet.
-	ExtState json.RawMessage `jsonapi:"attr,ext-state,omitempty"`
+	JSONState *string `jsonapi:"attr,json-state,omitempty"`
 }
 
 // List all the state versions for a given workspace.

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -121,7 +121,7 @@ func TestStateVersionsCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	extState, err := ioutil.ReadFile("test-fixtures/ext-state-version/state.json")
+	jsonState, err := ioutil.ReadFile("test-fixtures/ext-state-version/state.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -169,11 +169,11 @@ func TestStateVersionsCreate(t *testing.T) {
 		}
 
 		sv, err := client.StateVersions.Create(ctx, wTest.ID, StateVersionCreateOptions{
-			Lineage:  String("741c4949-60b9-5bb1-5bf8-b14f4bb14af3"),
-			MD5:      String(fmt.Sprintf("%x", md5.Sum(state))),
-			Serial:   Int64(1),
-			State:    String(base64.StdEncoding.EncodeToString(state)),
-			ExtState: extState,
+			Lineage:   String("741c4949-60b9-5bb1-5bf8-b14f4bb14af3"),
+			MD5:       String(fmt.Sprintf("%x", md5.Sum(state))),
+			Serial:    Int64(1),
+			State:     String(base64.StdEncoding.EncodeToString(state)),
+			JSONState: String(base64.StdEncoding.EncodeToString(jsonState)),
 		})
 		require.NoError(t, err)
 


### PR DESCRIPTION
## Description


* rename ext-state to json-state
* Change the attribute to be base64 encoded (a string)

## Testing plan

Run: `envchain go-tfe go test --run TestStateVersions -v -tags=integration`

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
