### PR TITLE
re-add configuration version test, which was fixed by adding another configuration version

### DIFF
--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -201,7 +201,7 @@ func TestConfigurationVersionsUpload(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		WaitUntilStatus(t, client, ctx, cv, ConfigurationUploaded)
+		WaitUntilStatus(t, client, cv, ConfigurationUploaded, 60)
 	})
 
 	t.Run("without a valid upload URL", func(t *testing.T) {
@@ -241,7 +241,7 @@ func TestConfigurationVersionsArchive(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		WaitUntilStatus(t, client, ctx, cv, ConfigurationUploaded)
+		WaitUntilStatus(t, client, cv, ConfigurationUploaded, 60)
 
 		// configuration version should not be archived, since it's the latest version
 		err = client.ConfigurationVersions.Archive(ctx, cv.ID)
@@ -257,12 +257,12 @@ func TestConfigurationVersionsArchive(t *testing.T) {
 		)
 		require.NoError(t, err)
 		defer newCvCleanup()
-		WaitUntilStatus(t, client, ctx, newCv, ConfigurationUploaded)
+		WaitUntilStatus(t, client, newCv, ConfigurationUploaded, 60)
 
 		err = client.ConfigurationVersions.Archive(ctx, cv.ID)
 		require.NoError(t, err)
 
-		WaitUntilStatus(t, client, ctx, cv, ConfigurationArchived)
+		WaitUntilStatus(t, client, cv, ConfigurationArchived, 60)
 	})
 
 	t.Run("when the configuration version does not exist", func(t *testing.T) {
@@ -353,22 +353,4 @@ func TestConfigurationVersions_Unmarshal(t *testing.T) {
 	assert.Equal(t, cv.Status, ConfigurationUploaded)
 	assert.Equal(t, cv.StatusTimestamps.FinishedAt, finishedParsedTime)
 	assert.Equal(t, cv.StatusTimestamps.StartedAt, startedParsedTime)
-}
-
-// helper to wait until a configuration version has reached a certain status
-func WaitUntilStatus(t *testing.T, client *Client, ctx context.Context, cv *ConfigurationVersion, desiredStatus ConfigurationStatus) {
-	for i := 0; ; i++ {
-		refreshed, err := client.ConfigurationVersions.Read(ctx, cv.ID)
-		require.NoError(t, err)
-
-		if refreshed.Status == desiredStatus {
-			break
-		}
-
-		if i > 30 {
-			t.Fatal("Timeout waiting for the configuration version to be archived")
-		}
-
-		time.Sleep(1 * time.Second)
-	}
 }

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -257,7 +257,7 @@ func TestConfigurationVersionsArchive(t *testing.T) {
 		)
 		require.NoError(t, err)
 		defer newCvCleanup()
-		WaitUntilStatus(t, client, ctx, cv, ConfigurationUploaded)
+		WaitUntilStatus(t, client, ctx, newCv, ConfigurationUploaded)
 
 		err = client.ConfigurationVersions.Archive(ctx, cv.ID)
 		require.NoError(t, err)

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -242,6 +242,73 @@ func TestConfigurationVersionsArchive(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
+	w, wCleanup := createWorkspace(t, client, nil)
+	defer wCleanup()
+
+	cv, cvCleanup := createConfigurationVersion(t, client, w)
+	defer cvCleanup()
+
+	t.Run("when the configuration version exists and has been uploaded", func(t *testing.T) {
+		err := client.ConfigurationVersions.Upload(
+			ctx,
+			cv.UploadURL,
+			"test-fixtures/config-version",
+		)
+		require.NoError(t, err)
+
+		// We do this is a small loop, because it can take a second
+		// before the upload is finished.
+		for i := 0; ; i++ {
+			refreshed, err := client.ConfigurationVersions.Read(ctx, cv.ID)
+			require.NoError(t, err)
+
+			if refreshed.Status == ConfigurationUploaded {
+				break
+			}
+
+			if i > 10 {
+				t.Fatal("Timeout waiting for the configuration version to be uploaded")
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+
+		// configuration version should not be achievable, since it's the latest version
+		err = client.ConfigurationVersions.Archive(ctx, cv.ID)
+		assert.Error(t, err)
+		assert.EqualError(t, err, "transition not allowed")
+
+		// create subsequent version, since the latest configuration version cannot be archived
+		newCv, newCvCleanup := createConfigurationVersion(t, client, w)
+		err = client.ConfigurationVersions.Upload(
+			ctx,
+			newCv.UploadURL,
+			"test-fixtures/config-version",
+		)
+		require.NoError(t, err)
+		defer newCvCleanup()
+
+		err = client.ConfigurationVersions.Archive(ctx, cv.ID)
+		require.NoError(t, err)
+
+		// We do this is a small loop, because it can take a second
+		// before the archive is finished.
+		for i := 0; ; i++ {
+			refreshed, err := client.ConfigurationVersions.Read(ctx, cv.ID)
+			require.NoError(t, err)
+
+			if refreshed.Status == ConfigurationArchived {
+				break
+			}
+
+			if i > 10 {
+				t.Fatal("Timeout waiting for the configuration version to be archived")
+			}
+
+			time.Sleep(1 * time.Second)
+		}
+	})
+
 	t.Run("when the configuration version does not exist", func(t *testing.T) {
 		err := client.ConfigurationVersions.Archive(ctx, "nonexisting")
 		assert.Equal(t, err, ErrResourceNotFound)


### PR DESCRIPTION
## Description

This commit re-adds a test that was removed in the past due to a change in TFE, the issue was discovered by @radditude, who described it thusly:

> This is likely due to the [recent change](https://github.com/hashicorp/atlas/pull/12523) that prevents archiving a config version if it's the "current configuration version" for the workspace (aka the config version that's either been mostly recently uploaded, or the one that was used in the most recent run). We'll probably need to upload a second config version during that test so that the one we're trying to archive isn't the workspace's current config version.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
=== RUN   TestConfigurationVersionsArchive
--- PASS: TestConfigurationVersionsArchive (4.91s)
=== RUN   TestConfigurationVersionsArchive/when_the_configuration_version_exists_and_has_been_uploaded
    --- PASS: TestConfigurationVersionsArchive/when_the_configuration_version_exists_and_has_been_uploaded (2.02s)
=== RUN   TestConfigurationVersionsArchive/when_the_configuration_version_does_not_exist
    --- PASS: TestConfigurationVersionsArchive/when_the_configuration_version_does_not_exist (0.27s)
=== RUN   TestConfigurationVersionsArchive/with_invalid_configuration_version_id
    --- PASS: TestConfigurationVersionsArchive/with_invalid_configuration_version_id (0.00s)
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202446447509971