### PR TITLE
(TER-183) Add Description for Run Tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 * [beta] Adds additional filter fields to `RunListOptions` by @mjyocca [#424](https://github.com/hashicorp/go-tfe/pull/424)
 * [beta] Renames the optional StateVersion field `ExtState` to `JSONStateOutputs` and changes the purpose and type by @annawinkler [#444](https://github.com/hashicorp/go-tfe/pull/444) and @brandoncroft [#452](https://github.com/hashicorp/go-tfe/pull/452)
 * Remove beta messaging for Run Tasks by @glennsarti [#447](https://github.com/hashicorp/go-tfe/pull/447)
+* Adds `Description` field to the `RunTask` object by @glennsarti [#447](https://github.com/hashicorp/go-tfe/pull/447)
 
 # v1.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Adds support for new `ExcludeTags` workspace list filter field by @Uk1288 [#438](https://github.com/hashicorp/go-tfe/pull/438)
 * [beta] Adds additional filter fields to `RunListOptions` by @mjyocca [#424](https://github.com/hashicorp/go-tfe/pull/424)
 * [beta] Renames the optional StateVersion field `ExtState` to `JSONStateOutputs` and changes the purpose and type by @annawinkler [#444](https://github.com/hashicorp/go-tfe/pull/444) and @brandoncroft [#452](https://github.com/hashicorp/go-tfe/pull/452)
+* Remove beta messaging for Run Tasks by @glennsarti [#447](https://github.com/hashicorp/go-tfe/pull/447)
 
 # v1.3.0
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -973,10 +973,12 @@ func createRunTask(t *testing.T, client *Client, org *Organization) (*RunTask, f
 	}
 
 	ctx := context.Background()
+	description := randomString(t)
 	r, err := client.RunTasks.Create(ctx, org.Name, RunTaskCreateOptions{
-		Name:     "tst-" + randomString(t),
-		URL:      runTaskURL,
-		Category: "task",
+		Name:        "tst-" + randomString(t),
+		URL:         runTaskURL,
+		Description: &description,
+		Category:    "task",
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/run_task.go
+++ b/run_task.go
@@ -11,8 +11,7 @@ var _ RunTasks = (*runTasks)(nil)
 
 // RunTasks represents all the run task related methods in the context of an organization
 // that the Terraform Cloud/Enterprise API supports.
-// **Note: This API is still in BETA and subject to change.**
-// https://www.terraform.io/cloud-docs/api-docs/run-tasks#run-tasks-api
+// https://www.terraform.io/cloud-docs/api-docs/run-tasks/run-tasks#run-tasks-api
 type RunTasks interface {
 	// Create a run task for an organization
 	Create(ctx context.Context, organization string, options RunTaskCreateOptions) (*RunTask, error)
@@ -61,7 +60,7 @@ type RunTaskList struct {
 }
 
 // RunTaskIncludeOpt represents the available options for include query params.
-// https://www.terraform.io/cloud-docs/api-docs/run-tasks#list-run-tasks
+// https://www.terraform.io/cloud-docs/api-docs/run-tasks/run-tasks#list-run-tasks
 type RunTaskIncludeOpt string
 
 const (
@@ -73,14 +72,14 @@ const (
 type RunTaskListOptions struct {
 	ListOptions
 	// Optional: A list of relations to include with a run task. See available resources:
-	// https://www.terraform.io/cloud-docs/api-docs/run-tasks#list-run-tasks
+	// https://www.terraform.io/cloud-docs/api-docs/run-tasks/run-tasks#list-run-tasks
 	Include []RunTaskIncludeOpt `url:"include,omitempty"`
 }
 
 // RunTaskReadOptions represents the set of options for reading a run task
 type RunTaskReadOptions struct {
 	// Optional: A list of relations to include with a run task. See available resources:
-	// https://www.terraform.io/cloud-docs/api-docs/run-tasks#list-run-tasks
+	// https://www.terraform.io/cloud-docs/api-docs/run-tasks/run-tasks#list-run-tasks
 	Include []RunTaskIncludeOpt `url:"include,omitempty"`
 }
 

--- a/run_task.go
+++ b/run_task.go
@@ -42,12 +42,13 @@ type runTasks struct {
 
 // RunTask represents a TFC/E run task
 type RunTask struct {
-	ID       string  `jsonapi:"primary,tasks"`
-	Name     string  `jsonapi:"attr,name"`
-	URL      string  `jsonapi:"attr,url"`
-	Category string  `jsonapi:"attr,category"`
-	HMACKey  *string `jsonapi:"attr,hmac-key,omitempty"`
-	Enabled  bool    `jsonapi:"attr,enabled"`
+	ID          string  `jsonapi:"primary,tasks"`
+	Name        string  `jsonapi:"attr,name"`
+	URL         string  `jsonapi:"attr,url"`
+	Description string  `jsonapi:"attr,description"`
+	Category    string  `jsonapi:"attr,category"`
+	HMACKey     *string `jsonapi:"attr,hmac-key,omitempty"`
+	Enabled     bool    `jsonapi:"attr,enabled"`
 
 	Organization      *Organization       `jsonapi:"relation,organization"`
 	WorkspaceRunTasks []*WorkspaceRunTask `jsonapi:"relation,workspace-tasks"`
@@ -97,6 +98,9 @@ type RunTaskCreateOptions struct {
 	// Required: The URL to send a run task payload
 	URL string `jsonapi:"attr,url"`
 
+	// Optional: Description of the task
+	Description *string `jsonapi:"attr,description"`
+
 	// Required: Must be "task"
 	Category string `jsonapi:"attr,category"`
 
@@ -120,6 +124,9 @@ type RunTaskUpdateOptions struct {
 
 	// Optional: The URL to send a run task payload, defaults to previous value
 	URL *string `jsonapi:"attr,url,omitempty"`
+
+	// Optional: An optional description of the task
+	Description *string `jsonapi:"attr,description,omitempty"`
 
 	// Optional: Must be "task", defaults to "task"
 	Category *string `jsonapi:"attr,category,omitempty"`

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -27,13 +27,15 @@ func TestRunTasksCreate(t *testing.T) {
 	}
 
 	runTaskName := "tst-runtask-" + randomString(t)
+	runTaskDescription := "A Run Task Description"
 
 	t.Run("add run task to organization", func(t *testing.T) {
 		r, err := client.RunTasks.Create(ctx, orgTest.Name, RunTaskCreateOptions{
-			Name:     runTaskName,
-			URL:      runTaskServerURL,
-			Category: "task",
-			Enabled:  Bool(true),
+			Name:        runTaskName,
+			URL:         runTaskServerURL,
+			Description: &runTaskDescription,
+			Category:    "task",
+			Enabled:     Bool(true),
 		})
 		require.NoError(t, err)
 
@@ -41,6 +43,7 @@ func TestRunTasksCreate(t *testing.T) {
 		assert.Equal(t, r.Name, runTaskName)
 		assert.Equal(t, r.URL, runTaskServerURL)
 		assert.Equal(t, r.Category, "task")
+		assert.Equal(t, r.Description, runTaskDescription)
 
 		t.Run("ensure org is deserialized properly", func(t *testing.T) {
 			assert.Equal(t, r.Organization.Name, orgTest.Name)
@@ -93,6 +96,7 @@ func TestRunTasksRead(t *testing.T) {
 		assert.Equal(t, runTaskTest.ID, r.ID)
 		assert.Equal(t, runTaskTest.URL, r.URL)
 		assert.Equal(t, runTaskTest.Category, r.Category)
+		assert.Equal(t, runTaskTest.Description, r.Description)
 		assert.Equal(t, runTaskTest.HMACKey, r.HMACKey)
 		assert.Equal(t, runTaskTest.Enabled, r.Enabled)
 	})
@@ -147,6 +151,32 @@ func TestRunTasksUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, rename, r.Name)
+	})
+
+	t.Run("toggle enabled", func(t *testing.T) {
+		runTaskTest.Enabled = !runTaskTest.Enabled
+		r, err := client.RunTasks.Update(ctx, runTaskTest.ID, RunTaskUpdateOptions{
+			Enabled: &runTaskTest.Enabled,
+		})
+		require.NoError(t, err)
+
+		r, err = client.RunTasks.Read(ctx, r.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, runTaskTest.Enabled, r.Enabled)
+	})
+
+	t.Run("update description", func(t *testing.T) {
+		newDescription := "An updated task description"
+		r, err := client.RunTasks.Update(ctx, runTaskTest.ID, RunTaskUpdateOptions{
+			Description: &newDescription,
+		})
+		require.NoError(t, err)
+
+		r, err = client.RunTasks.Read(ctx, r.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, newDescription, r.Description)
 	})
 }
 

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestRunTasksCreate(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -49,7 +49,7 @@ func TestRunTasksCreate(t *testing.T) {
 }
 
 func TestRunTasksList(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -75,7 +75,7 @@ func TestRunTasksList(t *testing.T) {
 }
 
 func TestRunTasksRead(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -125,7 +125,7 @@ func TestRunTasksRead(t *testing.T) {
 }
 
 func TestRunTasksUpdate(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -151,7 +151,7 @@ func TestRunTasksUpdate(t *testing.T) {
 }
 
 func TestRunTasksDelete(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -181,7 +181,7 @@ func TestRunTasksDelete(t *testing.T) {
 }
 
 func TestRunTasksAttachToWorkspace(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -197,6 +197,11 @@ func TestRunTasksAttachToWorkspace(t *testing.T) {
 
 	t.Run("to a valid workspace", func(t *testing.T) {
 		wr, err := client.RunTasks.AttachToWorkspace(ctx, wkspaceTest.ID, runTaskTest.ID, Advisory)
+
+		defer func() {
+			client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+		}()
+
 		require.NoError(t, err)
 		require.NotNil(t, wr.ID)
 	})

--- a/workspace_run_task_integration_test.go
+++ b/workspace_run_task_integration_test.go
@@ -12,7 +12,7 @@ import (
 )
 
 func TestWorkspaceRunTasksCreate(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -33,6 +33,10 @@ func TestWorkspaceRunTasksCreate(t *testing.T) {
 		})
 
 		require.NoError(t, err)
+		defer func() {
+			client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+		}()
+
 		assert.NotEmpty(t, wr.ID)
 		assert.Equal(t, wr.EnforcementLevel, Mandatory)
 
@@ -43,7 +47,7 @@ func TestWorkspaceRunTasksCreate(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksList(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -77,7 +81,7 @@ func TestWorkspaceRunTasksList(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksRead(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -112,7 +116,7 @@ func TestWorkspaceRunTasksRead(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksUpdate(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -143,7 +147,7 @@ func TestWorkspaceRunTasksUpdate(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksDelete(t *testing.T) {
-	skipIfBeta(t)
+	skipIfFreeOnly(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -173,8 +177,7 @@ func TestWorkspaceRunTasksDelete(t *testing.T) {
 	})
 
 	t.Run("when the workspace does not exist", func(t *testing.T) {
-		wkspaceTestCleanup()
-		err := client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wrTaskTest.ID)
+		err := client.WorkspaceRunTasks.Delete(ctx, "does-not-exist", wrTaskTest.ID)
 		assert.EqualError(t, err, ErrResourceNotFound.Error())
 	})
 }


### PR DESCRIPTION
## Description

Previously Run Tasks was marked as beta in go-tfe. However Run Tasks is now
Generally Available. This commit updates go-tfe to mark Run Tasks as not
Beta.

Run Tasks now have an optional description field. This commit updates
the RunTask API endpoints to include the description where applicable
(Create/Read/Update).

## Testing plan

N/A Integration tests updated

## External links

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/run-tasks/run-tasks)

## Output from tests

N/A Circle CI output