### PR TITLE
Update run-tests to large resource class in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -22,14 +22,15 @@ jobs:
       - run:
           name: Run tests
           command: |
-              export GO111MODULE=on
-              gotestsum --format short-verbose --junitfile \
-              $TEST_RESULTS_DIR/tests.xml -- -timeout=40m -tags=integration
+            export GO111MODULE=on
+            gotestsum --format short-verbose --junitfile \
+            $TEST_RESULTS_DIR/tests.xml -- -timeout=40m -tags=integration
           no_output_timeout: 1800
 
       - store_test_results:
           path: *test_results_dir
-
+    # The resource_class feature allows configuring CPU and RAM resources for each job. Different resource classes are available for different executors. https://circleci.com/docs/2.0/configuration-reference/#resourceclass
+    resource_class: large
 
 workflows:
   version: 2


### PR DESCRIPTION
## Description

With successful runs taking about 20 minutes in CircleCI, I'd like to see if we get any benefit from a larger resource class in CircleCI.

## Testing plan

1. Run the build in CircleCI and see how long it takes.

