### PR TITLE
Refactor run test helpers

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -107,13 +107,13 @@ func (s *adminOrganizations) List(ctx context.Context, options *AdminOrganizatio
 		return nil, err
 	}
 	u := "admin/organizations"
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	orgl := &AdminOrganizationList{}
-	err = s.client.do(ctx, req, orgl)
+	err = req.Do(ctx, orgl)
 	if err != nil {
 		return nil, err
 	}
@@ -129,13 +129,13 @@ func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organizati
 
 	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
 
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	orgl := &AdminOrganizationList{}
-	err = s.client.do(ctx, req, orgl)
+	err = req.Do(ctx, orgl)
 	if err != nil {
 		return nil, err
 	}
@@ -150,13 +150,13 @@ func (s *adminOrganizations) Read(ctx context.Context, organization string) (*Ad
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	org := &AdminOrganization{}
-	err = s.client.do(ctx, req, org)
+	err = req.Do(ctx, org)
 	if err != nil {
 		return nil, err
 	}
@@ -171,13 +171,13 @@ func (s *adminOrganizations) Update(ctx context.Context, organization string, op
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	org := &AdminOrganization{}
-	err = s.client.do(ctx, req, org)
+	err = req.Do(ctx, org)
 	if err != nil {
 		return nil, err
 	}
@@ -201,12 +201,12 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 		organizations = append(organizations, &AdminOrganizationID{ID: id})
 	}
 
-	req, err := s.client.newRequest("PATCH", u, organizations)
+	req, err := s.client.NewRequest("PATCH", u, organizations)
 	if err != nil {
 		return err
 	}
 
-	err = s.client.do(ctx, req, nil)
+	err = req.Do(ctx, nil)
 	if err != nil {
 		return err
 	}
@@ -221,12 +221,12 @@ func (s *adminOrganizations) Delete(ctx context.Context, organization string) er
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o *AdminOrganizationListOptions) valid() error {

--- a/admin_run.go
+++ b/admin_run.go
@@ -78,13 +78,13 @@ func (s *adminRuns) List(ctx context.Context, options *AdminRunsListOptions) (*A
 	}
 
 	u := "admin/runs"
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	rl := &AdminRunsList{}
-	err = s.client.do(ctx, req, rl)
+	err = req.Do(ctx, rl)
 	if err != nil {
 		return nil, err
 	}
@@ -107,12 +107,12 @@ func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options Admin
 	}
 
 	u := fmt.Sprintf("admin/runs/%s/actions/force-cancel", url.QueryEscape(runID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o *AdminRunsListOptions) valid() error {

--- a/admin_setting_cost_estimation.go
+++ b/admin_setting_cost_estimation.go
@@ -54,13 +54,13 @@ type AdminCostEstimationSettingOptions struct {
 
 // Read returns the cost estimation settings.
 func (a *adminCostEstimationSettings) Read(ctx context.Context) (*AdminCostEstimationSetting, error) {
-	req, err := a.client.newRequest("GET", "admin/cost-estimation-settings", nil)
+	req, err := a.client.NewRequest("GET", "admin/cost-estimation-settings", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	ace := &AdminCostEstimationSetting{}
-	err = a.client.do(ctx, req, ace)
+	err = req.Do(ctx, ace)
 	if err != nil {
 		return nil, err
 	}
@@ -70,13 +70,13 @@ func (a *adminCostEstimationSettings) Read(ctx context.Context) (*AdminCostEstim
 
 // Update updates the cost-estimation settings.
 func (a *adminCostEstimationSettings) Update(ctx context.Context, options AdminCostEstimationSettingOptions) (*AdminCostEstimationSetting, error) {
-	req, err := a.client.newRequest("PATCH", "admin/cost-estimation-settings", &options)
+	req, err := a.client.NewRequest("PATCH", "admin/cost-estimation-settings", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ace := &AdminCostEstimationSetting{}
-	err = a.client.do(ctx, req, ace)
+	err = req.Do(ctx, ace)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_setting_customization.go
+++ b/admin_setting_customization.go
@@ -33,13 +33,13 @@ type AdminCustomizationSetting struct {
 
 // Read returns the Customization settings.
 func (a *adminCustomizationSettings) Read(ctx context.Context) (*AdminCustomizationSetting, error) {
-	req, err := a.client.newRequest("GET", "admin/customization-settings", nil)
+	req, err := a.client.NewRequest("GET", "admin/customization-settings", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	cs := &AdminCustomizationSetting{}
-	err = a.client.do(ctx, req, cs)
+	err = req.Do(ctx, cs)
 	if err != nil {
 		return nil, err
 	}
@@ -60,13 +60,13 @@ type AdminCustomizationSettingsUpdateOptions struct {
 
 // Update updates the customization settings.
 func (a *adminCustomizationSettings) Update(ctx context.Context, options AdminCustomizationSettingsUpdateOptions) (*AdminCustomizationSetting, error) {
-	req, err := a.client.newRequest("PATCH", "admin/customization-settings", &options)
+	req, err := a.client.NewRequest("PATCH", "admin/customization-settings", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	cs := &AdminCustomizationSetting{}
-	err = a.client.do(ctx, req, cs)
+	err = req.Do(ctx, cs)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_setting_general.go
+++ b/admin_setting_general.go
@@ -54,13 +54,13 @@ type AdminGeneralSettingsUpdateOptions struct {
 
 // Read returns the general settings.
 func (a *adminGeneralSettings) Read(ctx context.Context) (*AdminGeneralSetting, error) {
-	req, err := a.client.newRequest("GET", "admin/general-settings", nil)
+	req, err := a.client.NewRequest("GET", "admin/general-settings", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	ags := &AdminGeneralSetting{}
-	err = a.client.do(ctx, req, ags)
+	err = req.Do(ctx, ags)
 	if err != nil {
 		return nil, err
 	}
@@ -70,13 +70,13 @@ func (a *adminGeneralSettings) Read(ctx context.Context) (*AdminGeneralSetting, 
 
 // Update updates the general settings.
 func (a *adminGeneralSettings) Update(ctx context.Context, options AdminGeneralSettingsUpdateOptions) (*AdminGeneralSetting, error) {
-	req, err := a.client.newRequest("PATCH", "admin/general-settings", &options)
+	req, err := a.client.NewRequest("PATCH", "admin/general-settings", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ags := &AdminGeneralSetting{}
-	err = a.client.do(ctx, req, ags)
+	err = req.Do(ctx, ags)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_setting_saml.go
+++ b/admin_setting_saml.go
@@ -50,13 +50,13 @@ type AdminSAMLSetting struct {
 
 // Read returns the SAML settings.
 func (a *adminSAMLSettings) Read(ctx context.Context) (*AdminSAMLSetting, error) {
-	req, err := a.client.newRequest("GET", "admin/saml-settings", nil)
+	req, err := a.client.NewRequest("GET", "admin/saml-settings", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	saml := &AdminSAMLSetting{}
-	err = a.client.do(ctx, req, saml)
+	err = req.Do(ctx, saml)
 	if err != nil {
 		return nil, err
 	}
@@ -82,13 +82,13 @@ type AdminSAMLSettingsUpdateOptions struct {
 
 // Update updates the SAML settings.
 func (a *adminSAMLSettings) Update(ctx context.Context, options AdminSAMLSettingsUpdateOptions) (*AdminSAMLSetting, error) {
-	req, err := a.client.newRequest("PATCH", "admin/saml-settings", &options)
+	req, err := a.client.NewRequest("PATCH", "admin/saml-settings", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	saml := &AdminSAMLSetting{}
-	err = a.client.do(ctx, req, saml)
+	err = req.Do(ctx, saml)
 	if err != nil {
 		return nil, err
 	}
@@ -99,13 +99,13 @@ func (a *adminSAMLSettings) Update(ctx context.Context, options AdminSAMLSetting
 // RevokeIdpCert revokes the older IdP certificate when the new IdP
 // certificate is known to be functioning correctly.
 func (a *adminSAMLSettings) RevokeIdpCert(ctx context.Context) (*AdminSAMLSetting, error) {
-	req, err := a.client.newRequest("POST", "admin/saml-settings/actions/revoke-old-certificate", nil)
+	req, err := a.client.NewRequest("POST", "admin/saml-settings/actions/revoke-old-certificate", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	saml := &AdminSAMLSetting{}
-	err = a.client.do(ctx, req, saml)
+	err = req.Do(ctx, saml)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_setting_smtp.go
+++ b/admin_setting_smtp.go
@@ -43,13 +43,13 @@ type AdminSMTPSetting struct {
 
 // Read returns the SMTP settings.
 func (a *adminSMTPSettings) Read(ctx context.Context) (*AdminSMTPSetting, error) {
-	req, err := a.client.newRequest("GET", "admin/smtp-settings", nil)
+	req, err := a.client.NewRequest("GET", "admin/smtp-settings", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	smtp := &AdminSMTPSetting{}
-	err = a.client.do(ctx, req, smtp)
+	err = req.Do(ctx, smtp)
 	if err != nil {
 		return nil, err
 	}
@@ -77,13 +77,13 @@ func (a *adminSMTPSettings) Update(ctx context.Context, options AdminSMTPSetting
 		return nil, err
 	}
 
-	req, err := a.client.newRequest("PATCH", "admin/smtp-settings", &options)
+	req, err := a.client.NewRequest("PATCH", "admin/smtp-settings", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	smtp := &AdminSMTPSetting{}
-	err = a.client.do(ctx, req, smtp)
+	err = req.Do(ctx, smtp)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_setting_twilio.go
+++ b/admin_setting_twilio.go
@@ -34,13 +34,13 @@ type AdminTwilioSetting struct {
 
 // Read returns the Twilio settings.
 func (a *adminTwilioSettings) Read(ctx context.Context) (*AdminTwilioSetting, error) {
-	req, err := a.client.newRequest("GET", "admin/twilio-settings", nil)
+	req, err := a.client.NewRequest("GET", "admin/twilio-settings", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	twilio := &AdminTwilioSetting{}
-	err = a.client.do(ctx, req, twilio)
+	err = req.Do(ctx, twilio)
 	if err != nil {
 		return nil, err
 	}
@@ -66,13 +66,13 @@ type AdminTwilioSettingsVerifyOptions struct {
 
 // Update updates the Twilio settings.
 func (a *adminTwilioSettings) Update(ctx context.Context, options AdminTwilioSettingsUpdateOptions) (*AdminTwilioSetting, error) {
-	req, err := a.client.newRequest("PATCH", "admin/twilio-settings", &options)
+	req, err := a.client.NewRequest("PATCH", "admin/twilio-settings", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	twilio := &AdminTwilioSetting{}
-	err = a.client.do(ctx, req, twilio)
+	err = req.Do(ctx, twilio)
 	if err != nil {
 		return nil, err
 	}
@@ -85,12 +85,12 @@ func (a *adminTwilioSettings) Verify(ctx context.Context, options AdminTwilioSet
 	if err := options.valid(); err != nil {
 		return err
 	}
-	req, err := a.client.newRequest("PATCH", "admin/twilio-settings/verify", &options)
+	req, err := a.client.NewRequest("PATCH", "admin/twilio-settings/verify", &options)
 	if err != nil {
 		return err
 	}
 
-	return a.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o AdminTwilioSettingsVerifyOptions) valid() error {

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -100,13 +100,13 @@ type AdminTerraformVersionsList struct {
 
 // List all the terraform versions.
 func (a *adminTerraformVersions) List(ctx context.Context, options *AdminTerraformVersionsListOptions) (*AdminTerraformVersionsList, error) {
-	req, err := a.client.newRequest("GET", "admin/terraform-versions", options)
+	req, err := a.client.NewRequest("GET", "admin/terraform-versions", options)
 	if err != nil {
 		return nil, err
 	}
 
 	tvl := &AdminTerraformVersionsList{}
-	err = a.client.do(ctx, req, tvl)
+	err = req.Do(ctx, tvl)
 	if err != nil {
 		return nil, err
 	}
@@ -121,13 +121,13 @@ func (a *adminTerraformVersions) Read(ctx context.Context, id string) (*AdminTer
 	}
 
 	u := fmt.Sprintf("admin/terraform-versions/%s", url.QueryEscape(id))
-	req, err := a.client.newRequest("GET", u, nil)
+	req, err := a.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	tfv := &AdminTerraformVersion{}
-	err = a.client.do(ctx, req, tfv)
+	err = req.Do(ctx, tfv)
 	if err != nil {
 		return nil, err
 	}
@@ -140,13 +140,13 @@ func (a *adminTerraformVersions) Create(ctx context.Context, options AdminTerraf
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-	req, err := a.client.newRequest("POST", "admin/terraform-versions", &options)
+	req, err := a.client.NewRequest("POST", "admin/terraform-versions", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	tfv := &AdminTerraformVersion{}
-	err = a.client.do(ctx, req, tfv)
+	err = req.Do(ctx, tfv)
 	if err != nil {
 		return nil, err
 	}
@@ -161,13 +161,13 @@ func (a *adminTerraformVersions) Update(ctx context.Context, id string, options 
 	}
 
 	u := fmt.Sprintf("admin/terraform-versions/%s", url.QueryEscape(id))
-	req, err := a.client.newRequest("PATCH", u, &options)
+	req, err := a.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	tfv := &AdminTerraformVersion{}
-	err = a.client.do(ctx, req, tfv)
+	err = req.Do(ctx, tfv)
 	if err != nil {
 		return nil, err
 	}
@@ -182,12 +182,12 @@ func (a *adminTerraformVersions) Delete(ctx context.Context, id string) error {
 	}
 
 	u := fmt.Sprintf("admin/terraform-versions/%s", url.QueryEscape(id))
-	req, err := a.client.newRequest("DELETE", u, nil)
+	req, err := a.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return a.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o AdminTerraformVersionCreateOptions) valid() error {

--- a/admin_user.go
+++ b/admin_user.go
@@ -96,13 +96,13 @@ func (a *adminUsers) List(ctx context.Context, options *AdminUserListOptions) (*
 	}
 
 	u := "admin/users"
-	req, err := a.client.newRequest("GET", u, options)
+	req, err := a.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	aul := &AdminUserList{}
-	err = a.client.do(ctx, req, aul)
+	err = req.Do(ctx, aul)
 	if err != nil {
 		return nil, err
 	}
@@ -117,12 +117,12 @@ func (a *adminUsers) Delete(ctx context.Context, userID string) error {
 	}
 
 	u := fmt.Sprintf("admin/users/%s", url.QueryEscape(userID))
-	req, err := a.client.newRequest("DELETE", u, nil)
+	req, err := a.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return a.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Suspend a user by its ID.
@@ -132,13 +132,13 @@ func (a *adminUsers) Suspend(ctx context.Context, userID string) (*AdminUser, er
 	}
 
 	u := fmt.Sprintf("admin/users/%s/actions/suspend", url.QueryEscape(userID))
-	req, err := a.client.newRequest("POST", u, nil)
+	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	au := &AdminUser{}
-	err = a.client.do(ctx, req, au)
+	err = req.Do(ctx, au)
 	if err != nil {
 		return nil, err
 	}
@@ -153,13 +153,13 @@ func (a *adminUsers) Unsuspend(ctx context.Context, userID string) (*AdminUser, 
 	}
 
 	u := fmt.Sprintf("admin/users/%s/actions/unsuspend", url.QueryEscape(userID))
-	req, err := a.client.newRequest("POST", u, nil)
+	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	au := &AdminUser{}
-	err = a.client.do(ctx, req, au)
+	err = req.Do(ctx, au)
 	if err != nil {
 		return nil, err
 	}
@@ -174,13 +174,13 @@ func (a *adminUsers) GrantAdmin(ctx context.Context, userID string) (*AdminUser,
 	}
 
 	u := fmt.Sprintf("admin/users/%s/actions/grant_admin", url.QueryEscape(userID))
-	req, err := a.client.newRequest("POST", u, nil)
+	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	au := &AdminUser{}
-	err = a.client.do(ctx, req, au)
+	err = req.Do(ctx, au)
 	if err != nil {
 		return nil, err
 	}
@@ -195,13 +195,13 @@ func (a *adminUsers) RevokeAdmin(ctx context.Context, userID string) (*AdminUser
 	}
 
 	u := fmt.Sprintf("admin/users/%s/actions/revoke_admin", url.QueryEscape(userID))
-	req, err := a.client.newRequest("POST", u, nil)
+	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	au := &AdminUser{}
-	err = a.client.do(ctx, req, au)
+	err = req.Do(ctx, au)
 	if err != nil {
 		return nil, err
 	}
@@ -217,13 +217,13 @@ func (a *adminUsers) Disable2FA(ctx context.Context, userID string) (*AdminUser,
 	}
 
 	u := fmt.Sprintf("admin/users/%s/actions/disable_two_factor", url.QueryEscape(userID))
-	req, err := a.client.newRequest("POST", u, nil)
+	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	au := &AdminUser{}
-	err = a.client.do(ctx, req, au)
+	err = req.Do(ctx, au)
 	if err != nil {
 		return nil, err
 	}

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -81,13 +81,13 @@ func (s *adminWorkspaces) List(ctx context.Context, options *AdminWorkspaceListO
 	}
 
 	u := "admin/workspaces"
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	awl := &AdminWorkspaceList{}
-	err = s.client.do(ctx, req, awl)
+	err = req.Do(ctx, awl)
 	if err != nil {
 		return nil, err
 	}
@@ -102,13 +102,13 @@ func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminW
 	}
 
 	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	aw := &AdminWorkspace{}
-	err = s.client.do(ctx, req, aw)
+	err = req.Do(ctx, aw)
 	if err != nil {
 		return nil, err
 	}
@@ -123,12 +123,12 @@ func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error 
 	}
 
 	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o *AdminWorkspaceListOptions) valid() error {

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -94,13 +94,13 @@ func (s *agentPools) List(ctx context.Context, organization string, options *Age
 	}
 
 	u := fmt.Sprintf("organizations/%s/agent-pools", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	poolList := &AgentPoolList{}
-	err = s.client.do(ctx, req, poolList)
+	err = req.Do(ctx, poolList)
 	if err != nil {
 		return nil, err
 	}
@@ -119,13 +119,13 @@ func (s *agentPools) Create(ctx context.Context, organization string, options Ag
 	}
 
 	u := fmt.Sprintf("organizations/%s/agent-pools", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	pool := &AgentPool{}
-	err = s.client.do(ctx, req, pool)
+	err = req.Do(ctx, pool)
 	if err != nil {
 		return nil, err
 	}
@@ -148,13 +148,13 @@ func (s *agentPools) ReadWithOptions(ctx context.Context, agentpoolID string, op
 	}
 
 	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentpoolID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	pool := &AgentPool{}
-	err = s.client.do(ctx, req, pool)
+	err = req.Do(ctx, pool)
 	if err != nil {
 		return nil, err
 	}
@@ -185,13 +185,13 @@ func (s *agentPools) Update(ctx context.Context, agentPoolID string, options Age
 	}
 
 	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentPoolID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	k := &AgentPool{}
-	err = s.client.do(ctx, req, k)
+	err = req.Do(ctx, k)
 	if err != nil {
 		return nil, err
 	}
@@ -206,12 +206,12 @@ func (s *agentPools) Delete(ctx context.Context, agentPoolID string) error {
 	}
 
 	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentPoolID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o AgentPoolCreateOptions) valid() error {

--- a/agent_token.go
+++ b/agent_token.go
@@ -68,13 +68,13 @@ func (s *agentTokens) List(ctx context.Context, agentPoolID string) (*AgentToken
 	}
 
 	u := fmt.Sprintf("agent-pools/%s/authentication-tokens", url.QueryEscape(agentPoolID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	tokenList := &AgentTokenList{}
-	err = s.client.do(ctx, req, tokenList)
+	err = req.Do(ctx, tokenList)
 	if err != nil {
 		return nil, err
 	}
@@ -93,13 +93,13 @@ func (s *agentTokens) Create(ctx context.Context, agentPoolID string, options Ag
 	}
 
 	u := fmt.Sprintf("agent-pools/%s/authentication-tokens", url.QueryEscape(agentPoolID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	at := &AgentToken{}
-	err = s.client.do(ctx, req, at)
+	err = req.Do(ctx, at)
 	if err != nil {
 		return nil, err
 	}
@@ -114,13 +114,13 @@ func (s *agentTokens) Read(ctx context.Context, agentTokenID string) (*AgentToke
 	}
 
 	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(agentTokenID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	at := &AgentToken{}
-	err = s.client.do(ctx, req, at)
+	err = req.Do(ctx, at)
 	if err != nil {
 		return nil, err
 	}
@@ -135,10 +135,10 @@ func (s *agentTokens) Delete(ctx context.Context, agentTokenID string) error {
 	}
 
 	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(agentTokenID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }

--- a/apply.go
+++ b/apply.go
@@ -72,13 +72,13 @@ func (s *applies) Read(ctx context.Context, applyID string) (*Apply, error) {
 	}
 
 	u := fmt.Sprintf("applies/%s", url.QueryEscape(applyID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	a := &Apply{}
-	err = s.client.do(ctx, req, a)
+	err = req.Do(ctx, a)
 	if err != nil {
 		return nil, err
 	}

--- a/apply_integration_test.go
+++ b/apply_integration_test.go
@@ -22,7 +22,7 @@ func TestAppliesRead(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, nil)
 	defer wTestCleanup()
 
-	rTest, rTestCleanup := createAppliedRun(t, client, wTest)
+	rTest, rTestCleanup := createRunApply(t, client, wTest)
 	defer rTestCleanup()
 
 	t.Run("when the plan exists", func(t *testing.T) {
@@ -50,7 +50,7 @@ func TestAppliesLogs(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	rTest, rTestCleanup := createAppliedRun(t, client, nil)
+	rTest, rTestCleanup := createRunApply(t, client, nil)
 	defer rTestCleanup()
 
 	t.Run("when the log exists", func(t *testing.T) {

--- a/comment.go
+++ b/comment.go
@@ -60,13 +60,13 @@ func (s *comments) List(ctx context.Context, runID string) (*CommentList, error)
 	}
 
 	u := fmt.Sprintf("runs/%s/comments", url.QueryEscape(runID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	cl := &CommentList{}
-	err = s.client.do(ctx, req, cl)
+	err = req.Do(ctx, cl)
 	if err != nil {
 		return nil, err
 	}
@@ -85,13 +85,13 @@ func (s *comments) Create(ctx context.Context, runID string, options CommentCrea
 	}
 
 	u := fmt.Sprintf("runs/%s/comments", url.QueryEscape(runID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	comm := &Comment{}
-	err = s.client.do(ctx, req, comm)
+	err = req.Do(ctx, comm)
 	if err != nil {
 		return nil, err
 	}
@@ -106,13 +106,13 @@ func (s *comments) Read(ctx context.Context, commentID string) (*Comment, error)
 	}
 
 	u := fmt.Sprintf("comments/%s", url.QueryEscape(commentID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	comm := &Comment{}
-	err = s.client.do(ctx, req, comm)
+	err = req.Do(ctx, comm)
 	if err != nil {
 		return nil, err
 	}

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -188,13 +188,13 @@ func (s *configurationVersions) List(ctx context.Context, workspaceID string, op
 	}
 
 	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	cvl := &ConfigurationVersionList{}
-	err = s.client.do(ctx, req, cvl)
+	err = req.Do(ctx, cvl)
 	if err != nil {
 		return nil, err
 	}
@@ -210,13 +210,13 @@ func (s *configurationVersions) Create(ctx context.Context, workspaceID string, 
 	}
 
 	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	cv := &ConfigurationVersion{}
-	err = s.client.do(ctx, req, cv)
+	err = req.Do(ctx, cv)
 	if err != nil {
 		return nil, err
 	}
@@ -239,13 +239,13 @@ func (s *configurationVersions) ReadWithOptions(ctx context.Context, cvID string
 	}
 
 	u := fmt.Sprintf("configuration-versions/%s", url.QueryEscape(cvID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	cv := &ConfigurationVersion{}
-	err = s.client.do(ctx, req, cv)
+	err = req.Do(ctx, cv)
 	if err != nil {
 		return nil, err
 	}
@@ -277,12 +277,12 @@ func (s *configurationVersions) Upload(ctx context.Context, u, path string) erro
 		return err
 	}
 
-	req, err := s.client.newRequest("PUT", u, body)
+	req, err := s.client.NewRequest("PUT", u, body)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Archive a configuration version. This can only be done on configuration versions that
@@ -295,12 +295,12 @@ func (s *configurationVersions) Archive(ctx context.Context, cvID string) error 
 	body := bytes.NewBuffer(nil)
 
 	u := fmt.Sprintf("configuration-versions/%s/actions/archive", url.QueryEscape(cvID))
-	req, err := s.client.newRequest("POST", u, body)
+	req, err := s.client.NewRequest("POST", u, body)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o *ConfigurationVersionReadOptions) valid() error {
@@ -347,13 +347,13 @@ func (s *configurationVersions) Download(ctx context.Context, cvID string) ([]by
 	}
 
 	u := fmt.Sprintf("configuration-versions/%s/download", url.QueryEscape(cvID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var buf bytes.Buffer
-	err = s.client.do(ctx, req, &buf)
+	err = req.Do(ctx, &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/cost_estimate.go
+++ b/cost_estimate.go
@@ -73,13 +73,13 @@ func (s *costEstimates) Read(ctx context.Context, costEstimateID string) (*CostE
 	}
 
 	u := fmt.Sprintf("cost-estimates/%s", url.QueryEscape(costEstimateID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	ce := &CostEstimate{}
-	err = s.client.do(ctx, req, ce)
+	err = req.Do(ctx, ce)
 	if err != nil {
 		return nil, err
 	}
@@ -114,13 +114,13 @@ func (s *costEstimates) Logs(ctx context.Context, costEstimateID string) (io.Rea
 		}
 
 		u := fmt.Sprintf("cost-estimates/%s/output", url.QueryEscape(costEstimateID))
-		req, err := s.client.newRequest("GET", u, nil)
+		req, err := s.client.NewRequest("GET", u, nil)
 		if err != nil {
 			return nil, err
 		}
 
 		logs := bytes.NewBuffer(nil)
-		err = s.client.do(ctx, req, logs)
+		err = req.Do(ctx, logs)
 		if err != nil {
 			return nil, err
 		}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -10,11 +10,11 @@ If you are making relevant changes that is worth communicating to our users, ple
 
 CHANGELOG.md should have the next minor version listed as `# v1.X.0 (Unreleased)` and any changes can go under there. But if you feel that your changes are better suited for a patch version (like a critical bug fix), you may list a new section for this version. You should repeat the same formatting style introduced by previous versions.
 
-### Scoping pull requests that add new resources 
+### Scoping pull requests that add new resources
 
-There are instances where several new resources being added (i.e Workspace Run Tasks and Organization Run Tasks) are coalesced into one PR. In order to keep the review process as efficient and least error prone as possible, we ask that you please scope each PR to an individual resource even if the multiple resources you're adding share similarities. If joining multiple related PRs into one single PR makes more sense logistically, we'd ask that you organize your commit history by resource. A general convention for this repository is one commit for the implementation of the resource's methods, one for the integration test, and one for cleanup and housekeeping (e.g modifying the changelog/docs, generating mocks, etc).   
+There are instances where several new resources being added (i.e Workspace Run Tasks and Organization Run Tasks) are coalesced into one PR. In order to keep the review process as efficient and least error prone as possible, we ask that you please scope each PR to an individual resource even if the multiple resources you're adding share similarities. If joining multiple related PRs into one single PR makes more sense logistically, we'd ask that you organize your commit history by resource. A general convention for this repository is one commit for the implementation of the resource's methods, one for the integration test, and one for cleanup and housekeeping (e.g modifying the changelog/docs, generating mocks, etc).
 
-**Note HashiCorp Employees Only:** When submitting a new set of endpoints please ensure that one of your respective team members approves the changes as well before merging. 
+**Note HashiCorp Employees Only:** When submitting a new set of endpoints please ensure that one of your respective team members approves the changes as well before merging.
 
 ## Running the Linters Locally
 
@@ -198,13 +198,13 @@ func (s *example) Create(ctx context.Context, organization string, options Examp
 	}
 
 	u := fmt.Sprintf("organizations/%s/tasks", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &Example{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -222,13 +222,13 @@ func (s *example) List(ctx context.Context, organization string, options *Exampl
 	}
 
 	u := fmt.Sprintf("organizations/%s/examples", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	el := &ExampleList{}
-	err = s.client.do(ctx, req, el)
+	err = req.Do(ctx, el)
 	if err != nil {
 		return nil, err
 	}
@@ -251,13 +251,13 @@ func (s *example) ReadWithOptions(ctx context.Context, exampleID string, options
 	}
 
 	u := fmt.Sprintf("examples/%s", url.QueryEscape(exampleID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	e := &Example{}
-	err = s.client.do(ctx, req, e)
+	err = req.Do(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -276,13 +276,13 @@ func (s *example) Update(ctx context.Context, exampleID string, options ExampleU
 	}
 
 	u := fmt.Sprintf("examples/%s", url.QueryEscape(exampleID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &Example{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -297,12 +297,12 @@ func (s *example) Delete(ctx context.Context, exampleID string) error {
 	}
 
 	u := fmt.Sprintf("examples/%s", exampleID)
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o *ExampleUpdateOptions) valid() error {

--- a/gpg_key.go
+++ b/gpg_key.go
@@ -76,13 +76,13 @@ func (s *gpgKeys) Create(ctx context.Context, registryName RegistryName, options
 	}
 
 	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys", url.QueryEscape(string(registryName)))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	g := &GPGKey{}
-	err = s.client.do(ctx, req, g)
+	err = req.Do(ctx, g)
 	if err != nil {
 		return nil, err
 	}
@@ -100,13 +100,13 @@ func (s *gpgKeys) Read(ctx context.Context, keyID GPGKeyID) (*GPGKey, error) {
 		url.QueryEscape(keyID.Namespace),
 		url.QueryEscape(keyID.KeyID),
 	)
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	g := &GPGKey{}
-	err = s.client.do(ctx, req, g)
+	err = req.Do(ctx, g)
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func (s *gpgKeys) Update(ctx context.Context, keyID GPGKeyID, options GPGKeyUpda
 		url.QueryEscape(keyID.Namespace),
 		url.QueryEscape(keyID.KeyID),
 	)
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	g := &GPGKey{}
-	err = s.client.do(ctx, req, g)
+	err = req.Do(ctx, g)
 	if err != nil {
 		if strings.Contains(err.Error(), "namespace not authorized") {
 			return nil, ErrNamespaceNotAuthorized
@@ -155,12 +155,12 @@ func (s *gpgKeys) Delete(ctx context.Context, keyID GPGKeyID) error {
 		url.QueryEscape(keyID.Namespace),
 		url.QueryEscape(keyID.KeyID),
 	)
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o GPGKeyID) valid() error {

--- a/helper_test.go
+++ b/helper_test.go
@@ -1437,7 +1437,7 @@ func upgradeOrganizationSubscription(t *testing.T, client *Client, organization 
 		t.Skip("Can not upgrade an organization's subscription when enterprise is enabled. Set ENABLE_TFE=0 to run.")
 	}
 
-	req, err := client.newRequest("GET", "admin/feature-sets", featureSetListOptions{
+	req, err := client.NewRequest("GET", "admin/feature-sets", featureSetListOptions{
 		Q: "Business",
 	})
 	if err != nil {
@@ -1446,7 +1446,7 @@ func upgradeOrganizationSubscription(t *testing.T, client *Client, organization 
 	}
 
 	fsl := &featureSetList{}
-	err = client.do(context.Background(), req, fsl)
+	err = req.Do(context.Background(), fsl)
 	if err != nil {
 		t.Fatalf("failed to enumerate feature sets: %v", err)
 		return
@@ -1464,13 +1464,13 @@ func upgradeOrganizationSubscription(t *testing.T, client *Client, organization 
 	}
 
 	u := fmt.Sprintf("admin/organizations/%s/subscription", url.QueryEscape(organization.Name))
-	req, err = client.newRequest("POST", u, &opts)
+	req, err = client.NewRequest("POST", u, &opts)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)
 		return
 	}
 
-	err = client.do(context.Background(), req, nil)
+	err = req.Do(context.Background(), nil)
 	if err != nil {
 		t.Fatalf("Failed to upgrade subscription: %v", err)
 	}

--- a/ip_ranges.go
+++ b/ip_ranges.go
@@ -37,7 +37,7 @@ type IPRange struct {
 
 // Read an IPRange that was not modified since the specified date.
 func (i *ipRanges) Read(ctx context.Context, modifiedSince string) (*IPRange, error) {
-	req, err := i.client.newRequest("GET", "/api/meta/ip-ranges", nil)
+	req, err := i.client.NewRequest("GET", "/api/meta/ip-ranges", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -47,7 +47,7 @@ func (i *ipRanges) Read(ctx context.Context, modifiedSince string) (*IPRange, er
 	}
 
 	ir := &IPRange{}
-	err = i.customDo(ctx, req, ir)
+	err = req.doIpRanges(ctx, ir)
 	if err != nil {
 		return nil, err
 	}

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -183,13 +183,13 @@ func (s *notificationConfigurations) List(ctx context.Context, workspaceID strin
 	}
 
 	u := fmt.Sprintf("workspaces/%s/notification-configurations", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	ncl := &NotificationConfigurationList{}
-	err = s.client.do(ctx, req, ncl)
+	err = req.Do(ctx, ncl)
 	if err != nil {
 		return nil, err
 	}
@@ -207,13 +207,13 @@ func (s *notificationConfigurations) Create(ctx context.Context, workspaceID str
 	}
 
 	u := fmt.Sprintf("workspaces/%s/notification-configurations", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	nc := &NotificationConfiguration{}
-	err = s.client.do(ctx, req, nc)
+	err = req.Do(ctx, nc)
 	if err != nil {
 		return nil, err
 	}
@@ -228,13 +228,13 @@ func (s *notificationConfigurations) Read(ctx context.Context, notificationConfi
 	}
 
 	u := fmt.Sprintf("notification-configurations/%s", url.QueryEscape(notificationConfigurationID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	nc := &NotificationConfiguration{}
-	err = s.client.do(ctx, req, nc)
+	err = req.Do(ctx, nc)
 	if err != nil {
 		return nil, err
 	}
@@ -253,13 +253,13 @@ func (s *notificationConfigurations) Update(ctx context.Context, notificationCon
 	}
 
 	u := fmt.Sprintf("notification-configurations/%s", url.QueryEscape(notificationConfigurationID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	nc := &NotificationConfiguration{}
-	err = s.client.do(ctx, req, nc)
+	err = req.Do(ctx, nc)
 	if err != nil {
 		return nil, err
 	}
@@ -274,12 +274,12 @@ func (s *notificationConfigurations) Delete(ctx context.Context, notificationCon
 	}
 
 	u := fmt.Sprintf("notification-configurations/%s", url.QueryEscape(notificationConfigurationID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Verify a notification configuration by delivering a verification
@@ -291,13 +291,13 @@ func (s *notificationConfigurations) Verify(ctx context.Context, notificationCon
 
 	u := fmt.Sprintf(
 		"notification-configurations/%s/actions/verify", url.QueryEscape(notificationConfigurationID))
-	req, err := s.client.newRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	nc := &NotificationConfiguration{}
-	err = s.client.do(ctx, req, nc)
+	err = req.Do(ctx, nc)
 	if err != nil {
 		return nil, err
 	}

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -167,13 +167,13 @@ func (s *oAuthClients) List(ctx context.Context, organization string, options *O
 	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	ocl := &OAuthClientList{}
-	err = s.client.do(ctx, req, ocl)
+	err = req.Do(ctx, ocl)
 	if err != nil {
 		return nil, err
 	}
@@ -191,13 +191,13 @@ func (s *oAuthClients) Create(ctx context.Context, organization string, options 
 	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	oc := &OAuthClient{}
-	err = s.client.do(ctx, req, oc)
+	err = req.Do(ctx, oc)
 	if err != nil {
 		return nil, err
 	}
@@ -212,13 +212,13 @@ func (s *oAuthClients) Read(ctx context.Context, oAuthClientID string) (*OAuthCl
 	}
 
 	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	oc := &OAuthClient{}
-	err = s.client.do(ctx, req, oc)
+	err = req.Do(ctx, oc)
 	if err != nil {
 		return nil, err
 	}
@@ -233,13 +233,13 @@ func (s *oAuthClients) Update(ctx context.Context, oAuthClientID string, options
 	}
 
 	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	oc := &OAuthClient{}
-	err = s.client.do(ctx, req, oc)
+	err = req.Do(ctx, oc)
 	if err != nil {
 		return nil, err
 	}
@@ -254,12 +254,12 @@ func (s *oAuthClients) Delete(ctx context.Context, oAuthClientID string) error {
 	}
 
 	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o OAuthClientCreateOptions) valid() error {

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -77,13 +77,13 @@ func (s *oAuthTokens) List(ctx context.Context, organization string, options *OA
 	}
 
 	u := fmt.Sprintf("organizations/%s/oauth-tokens", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	otl := &OAuthTokenList{}
-	err = s.client.do(ctx, req, otl)
+	err = req.Do(ctx, otl)
 	if err != nil {
 		return nil, err
 	}
@@ -98,13 +98,13 @@ func (s *oAuthTokens) Read(ctx context.Context, oAuthTokenID string) (*OAuthToke
 	}
 
 	u := fmt.Sprintf("oauth-tokens/%s", url.QueryEscape(oAuthTokenID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	ot := &OAuthToken{}
-	err = s.client.do(ctx, req, ot)
+	err = req.Do(ctx, ot)
 	if err != nil {
 		return nil, err
 	}
@@ -119,13 +119,13 @@ func (s *oAuthTokens) Update(ctx context.Context, oAuthTokenID string, options O
 	}
 
 	u := fmt.Sprintf("oauth-tokens/%s", url.QueryEscape(oAuthTokenID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ot := &OAuthToken{}
-	err = s.client.do(ctx, req, ot)
+	err = req.Do(ctx, ot)
 	if err != nil {
 		return nil, err
 	}
@@ -140,10 +140,10 @@ func (s *oAuthTokens) Delete(ctx context.Context, oAuthTokenID string) error {
 	}
 
 	u := fmt.Sprintf("oauth-tokens/%s", url.QueryEscape(oAuthTokenID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }

--- a/organization.go
+++ b/organization.go
@@ -200,13 +200,13 @@ type ReadRunQueueOptions struct {
 
 // List all the organizations visible to the current user.
 func (s *organizations) List(ctx context.Context, options *OrganizationListOptions) (*OrganizationList, error) {
-	req, err := s.client.newRequest("GET", "organizations", options)
+	req, err := s.client.NewRequest("GET", "organizations", options)
 	if err != nil {
 		return nil, err
 	}
 
 	orgl := &OrganizationList{}
-	err = s.client.do(ctx, req, orgl)
+	err = req.Do(ctx, orgl)
 	if err != nil {
 		return nil, err
 	}
@@ -220,13 +220,13 @@ func (s *organizations) Create(ctx context.Context, options OrganizationCreateOp
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("POST", "organizations", &options)
+	req, err := s.client.NewRequest("POST", "organizations", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	org := &Organization{}
-	err = s.client.do(ctx, req, org)
+	err = req.Do(ctx, org)
 	if err != nil {
 		return nil, err
 	}
@@ -241,13 +241,13 @@ func (s *organizations) Read(ctx context.Context, organization string) (*Organiz
 	}
 
 	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	org := &Organization{}
-	err = s.client.do(ctx, req, org)
+	err = req.Do(ctx, org)
 	if err != nil {
 		return nil, err
 	}
@@ -262,13 +262,13 @@ func (s *organizations) Update(ctx context.Context, organization string, options
 	}
 
 	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	org := &Organization{}
-	err = s.client.do(ctx, req, org)
+	err = req.Do(ctx, org)
 	if err != nil {
 		return nil, err
 	}
@@ -283,12 +283,12 @@ func (s *organizations) Delete(ctx context.Context, organization string) error {
 	}
 
 	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // ReadCapacity shows the currently used capacity of an organization.
@@ -298,13 +298,13 @@ func (s *organizations) ReadCapacity(ctx context.Context, organization string) (
 	}
 
 	u := fmt.Sprintf("organizations/%s/capacity", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	c := &Capacity{}
-	err = s.client.do(ctx, req, c)
+	err = req.Do(ctx, c)
 	if err != nil {
 		return nil, err
 	}
@@ -319,13 +319,13 @@ func (s *organizations) ReadEntitlements(ctx context.Context, organization strin
 	}
 
 	u := fmt.Sprintf("organizations/%s/entitlement-set", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	e := &Entitlements{}
-	err = s.client.do(ctx, req, e)
+	err = req.Do(ctx, e)
 	if err != nil {
 		return nil, err
 	}
@@ -340,13 +340,13 @@ func (s *organizations) ReadRunQueue(ctx context.Context, organization string, o
 	}
 
 	u := fmt.Sprintf("organizations/%s/runs/queue", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.NewRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	rq := &RunQueue{}
-	err = s.client.do(ctx, req, rq)
+	err = req.Do(ctx, rq)
 	if err != nil {
 		return nil, err
 	}

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -111,13 +111,13 @@ func (s *organizationMemberships) List(ctx context.Context, organization string,
 	}
 
 	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	ml := &OrganizationMembershipList{}
-	err = s.client.do(ctx, req, ml)
+	err = req.Do(ctx, ml)
 	if err != nil {
 		return nil, err
 	}
@@ -135,13 +135,13 @@ func (s *organizationMemberships) Create(ctx context.Context, organization strin
 	}
 
 	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	m := &OrganizationMembership{}
-	err = s.client.do(ctx, req, m)
+	err = req.Do(ctx, m)
 	if err != nil {
 		return nil, err
 	}
@@ -164,13 +164,13 @@ func (s *organizationMemberships) ReadWithOptions(ctx context.Context, organizat
 	}
 
 	u := fmt.Sprintf("organization-memberships/%s", url.QueryEscape(organizationMembershipID))
-	req, err := s.client.newRequest("GET", u, &options)
+	req, err := s.client.NewRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	mem := &OrganizationMembership{}
-	err = s.client.do(ctx, req, mem)
+	err = req.Do(ctx, mem)
 	if err != nil {
 		return nil, err
 	}
@@ -185,12 +185,12 @@ func (s *organizationMemberships) Delete(ctx context.Context, organizationMember
 	}
 
 	u := fmt.Sprintf("organization-memberships/%s", url.QueryEscape(organizationMembershipID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o OrganizationMembershipCreateOptions) valid() error {

--- a/organization_tags.go
+++ b/organization_tags.go
@@ -82,13 +82,13 @@ func (s *organizationTags) List(ctx context.Context, organization string, option
 	}
 
 	u := fmt.Sprintf("organizations/%s/tags", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	tags := &OrganizationTagsList{}
-	err = s.client.do(ctx, req, tags)
+	err = req.Do(ctx, tags)
 	if err != nil {
 		return nil, err
 	}
@@ -112,12 +112,12 @@ func (s *organizationTags) Delete(ctx context.Context, organization string, opti
 		tagsToRemove = append(tagsToRemove, &tagID{ID: id})
 	}
 
-	req, err := s.client.newRequest("DELETE", u, tagsToRemove)
+	req, err := s.client.NewRequest("DELETE", u, tagsToRemove)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Add workspaces to a tag
@@ -136,12 +136,12 @@ func (s *organizationTags) AddWorkspaces(ctx context.Context, tag string, option
 	}
 
 	u := fmt.Sprintf("tags/%s/relationships/workspaces", url.QueryEscape(tag))
-	req, err := s.client.newRequest("POST", u, workspaces)
+	req, err := s.client.NewRequest("POST", u, workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (opts *OrganizationTagsDeleteOptions) valid() error {

--- a/organization_token.go
+++ b/organization_token.go
@@ -47,13 +47,13 @@ func (s *organizationTokens) Create(ctx context.Context, organization string) (*
 	}
 
 	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	ot := &OrganizationToken{}
-	err = s.client.do(ctx, req, ot)
+	err = req.Do(ctx, ot)
 	if err != nil {
 		return nil, err
 	}
@@ -68,13 +68,13 @@ func (s *organizationTokens) Read(ctx context.Context, organization string) (*Or
 	}
 
 	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	ot := &OrganizationToken{}
-	err = s.client.do(ctx, req, ot)
+	err = req.Do(ctx, ot)
 	if err != nil {
 		return nil, err
 	}
@@ -89,10 +89,10 @@ func (s *organizationTokens) Delete(ctx context.Context, organization string) er
 	}
 
 	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }

--- a/plan.go
+++ b/plan.go
@@ -80,13 +80,13 @@ func (s *plans) Read(ctx context.Context, planID string) (*Plan, error) {
 	}
 
 	u := fmt.Sprintf("plans/%s", url.QueryEscape(planID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &Plan{}
-	err = s.client.do(ctx, req, p)
+	err = req.Do(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -145,13 +145,13 @@ func (s *plans) ReadJSONOutput(ctx context.Context, planID string) ([]byte, erro
 	}
 
 	u := fmt.Sprintf("plans/%s/json-output", url.QueryEscape(planID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var buf bytes.Buffer
-	err = s.client.do(ctx, req, &buf)
+	err = req.Do(ctx, &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/plan_export.go
+++ b/plan_export.go
@@ -93,13 +93,13 @@ func (s *planExports) Create(ctx context.Context, options PlanExportCreateOption
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("POST", "plan-exports", &options)
+	req, err := s.client.NewRequest("POST", "plan-exports", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	pe := &PlanExport{}
-	err = s.client.do(ctx, req, pe)
+	err = req.Do(ctx, pe)
 	if err != nil {
 		return nil, err
 	}
@@ -114,13 +114,13 @@ func (s *planExports) Read(ctx context.Context, planExportID string) (*PlanExpor
 	}
 
 	u := fmt.Sprintf("plan-exports/%s", url.QueryEscape(planExportID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	pe := &PlanExport{}
-	err = s.client.do(ctx, req, pe)
+	err = req.Do(ctx, pe)
 	if err != nil {
 		return nil, err
 	}
@@ -135,12 +135,12 @@ func (s *planExports) Delete(ctx context.Context, planExportID string) error {
 	}
 
 	u := fmt.Sprintf("plan-exports/%s", url.QueryEscape(planExportID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Download a plan export's data. Data is exported in a .tar.gz format.
@@ -150,13 +150,13 @@ func (s *planExports) Download(ctx context.Context, planExportID string) ([]byte
 	}
 
 	u := fmt.Sprintf("plan-exports/%s/download", url.QueryEscape(planExportID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var buf bytes.Buffer
-	err = s.client.do(ctx, req, &buf)
+	err = req.Do(ctx, &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/policy.go
+++ b/policy.go
@@ -132,13 +132,13 @@ func (s *policies) List(ctx context.Context, organization string, options *Polic
 	}
 
 	u := fmt.Sprintf("organizations/%s/policies", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	pl := &PolicyList{}
-	err = s.client.do(ctx, req, pl)
+	err = req.Do(ctx, pl)
 	if err != nil {
 		return nil, err
 	}
@@ -156,13 +156,13 @@ func (s *policies) Create(ctx context.Context, organization string, options Poli
 	}
 
 	u := fmt.Sprintf("organizations/%s/policies", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &Policy{}
-	err = s.client.do(ctx, req, p)
+	err = req.Do(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -177,13 +177,13 @@ func (s *policies) Read(ctx context.Context, policyID string) (*Policy, error) {
 	}
 
 	u := fmt.Sprintf("policies/%s", url.QueryEscape(policyID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &Policy{}
-	err = s.client.do(ctx, req, p)
+	err = req.Do(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -198,13 +198,13 @@ func (s *policies) Update(ctx context.Context, policyID string, options PolicyUp
 	}
 
 	u := fmt.Sprintf("policies/%s", url.QueryEscape(policyID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &Policy{}
-	err = s.client.do(ctx, req, p)
+	err = req.Do(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -219,12 +219,12 @@ func (s *policies) Delete(ctx context.Context, policyID string) error {
 	}
 
 	u := fmt.Sprintf("policies/%s", url.QueryEscape(policyID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Upload the policy content of the policy.
@@ -234,12 +234,12 @@ func (s *policies) Upload(ctx context.Context, policyID string, content []byte) 
 	}
 
 	u := fmt.Sprintf("policies/%s/upload", url.QueryEscape(policyID))
-	req, err := s.client.newRequest("PUT", u, content)
+	req, err := s.client.NewRequest("PUT", u, content)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Download the policy content of the policy.
@@ -249,13 +249,13 @@ func (s *policies) Download(ctx context.Context, policyID string) ([]byte, error
 	}
 
 	u := fmt.Sprintf("policies/%s/download", url.QueryEscape(policyID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	var buf bytes.Buffer
-	err = s.client.do(ctx, req, &buf)
+	err = req.Do(ctx, &buf)
 	if err != nil {
 		return nil, err
 	}

--- a/policy_check.go
+++ b/policy_check.go
@@ -138,13 +138,13 @@ func (s *policyChecks) List(ctx context.Context, runID string, options *PolicyCh
 	}
 
 	u := fmt.Sprintf("runs/%s/policy-checks", url.QueryEscape(runID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	pcl := &PolicyCheckList{}
-	err = s.client.do(ctx, req, pcl)
+	err = req.Do(ctx, pcl)
 	if err != nil {
 		return nil, err
 	}
@@ -159,13 +159,13 @@ func (s *policyChecks) Read(ctx context.Context, policyCheckID string) (*PolicyC
 	}
 
 	u := fmt.Sprintf("policy-checks/%s", url.QueryEscape(policyCheckID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	pc := &PolicyCheck{}
-	err = s.client.do(ctx, req, pc)
+	err = req.Do(ctx, pc)
 	if err != nil {
 		return nil, err
 	}
@@ -180,13 +180,13 @@ func (s *policyChecks) Override(ctx context.Context, policyCheckID string) (*Pol
 	}
 
 	u := fmt.Sprintf("policy-checks/%s/actions/override", url.QueryEscape(policyCheckID))
-	req, err := s.client.newRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	pc := &PolicyCheck{}
-	err = s.client.do(ctx, req, pc)
+	err = req.Do(ctx, pc)
 	if err != nil {
 		return nil, err
 	}
@@ -220,13 +220,13 @@ func (s *policyChecks) Logs(ctx context.Context, policyCheckID string) (io.Reade
 		}
 
 		u := fmt.Sprintf("policy-checks/%s/output", url.QueryEscape(policyCheckID))
-		req, err := s.client.newRequest("GET", u, nil)
+		req, err := s.client.NewRequest("GET", u, nil)
 		if err != nil {
 			return nil, err
 		}
 
 		logs := bytes.NewBuffer(nil)
-		err = s.client.do(ctx, req, logs)
+		err = req.Do(ctx, logs)
 		if err != nil {
 			return nil, err
 		}

--- a/policy_set.go
+++ b/policy_set.go
@@ -217,13 +217,13 @@ func (s *policySets) List(ctx context.Context, organization string, options *Pol
 	}
 
 	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	psl := &PolicySetList{}
-	err = s.client.do(ctx, req, psl)
+	err = req.Do(ctx, psl)
 	if err != nil {
 		return nil, err
 	}
@@ -241,13 +241,13 @@ func (s *policySets) Create(ctx context.Context, organization string, options Po
 	}
 
 	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ps := &PolicySet{}
-	err = s.client.do(ctx, req, ps)
+	err = req.Do(ctx, ps)
 	if err != nil {
 		return nil, err
 	}
@@ -270,13 +270,13 @@ func (s *policySets) ReadWithOptions(ctx context.Context, policySetID string, op
 	}
 
 	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	ps := &PolicySet{}
-	err = s.client.do(ctx, req, ps)
+	err = req.Do(ctx, ps)
 	if err != nil {
 		return nil, err
 	}
@@ -294,13 +294,13 @@ func (s *policySets) Update(ctx context.Context, policySetID string, options Pol
 	}
 
 	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ps := &PolicySet{}
-	err = s.client.do(ctx, req, ps)
+	err = req.Do(ctx, ps)
 	if err != nil {
 		return nil, err
 	}
@@ -318,12 +318,12 @@ func (s *policySets) AddPolicies(ctx context.Context, policySetID string, option
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("POST", u, options.Policies)
+	req, err := s.client.NewRequest("POST", u, options.Policies)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // RemovePolicies remove policies from a policy set
@@ -336,12 +336,12 @@ func (s *policySets) RemovePolicies(ctx context.Context, policySetID string, opt
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("DELETE", u, options.Policies)
+	req, err := s.client.NewRequest("DELETE", u, options.Policies)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Addworkspaces adds workspaces to a policy set.
@@ -354,12 +354,12 @@ func (s *policySets) AddWorkspaces(ctx context.Context, policySetID string, opti
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("POST", u, options.Workspaces)
+	req, err := s.client.NewRequest("POST", u, options.Workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // RemoveWorkspaces removes workspaces from a policy set.
@@ -372,12 +372,12 @@ func (s *policySets) RemoveWorkspaces(ctx context.Context, policySetID string, o
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("DELETE", u, options.Workspaces)
+	req, err := s.client.NewRequest("DELETE", u, options.Workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Delete a policy set by its ID.
@@ -387,12 +387,12 @@ func (s *policySets) Delete(ctx context.Context, policySetID string) error {
 	}
 
 	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o PolicySetCreateOptions) valid() error {

--- a/policy_set_parameter.go
+++ b/policy_set_parameter.go
@@ -104,13 +104,13 @@ func (s *policySetParameters) List(ctx context.Context, policySetID string, opti
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/parameters", policySetID)
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	vl := &PolicySetParameterList{}
-	err = s.client.do(ctx, req, vl)
+	err = req.Do(ctx, vl)
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func (s *policySetParameters) Create(ctx context.Context, policySetID string, op
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/parameters", url.QueryEscape(policySetID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &PolicySetParameter{}
-	err = s.client.do(ctx, req, p)
+	err = req.Do(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -152,13 +152,13 @@ func (s *policySetParameters) Read(ctx context.Context, policySetID, parameterID
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &PolicySetParameter{}
-	err = s.client.do(ctx, req, p)
+	err = req.Do(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -176,13 +176,13 @@ func (s *policySetParameters) Update(ctx context.Context, policySetID, parameter
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	p := &PolicySetParameter{}
-	err = s.client.do(ctx, req, p)
+	err = req.Do(ctx, p)
 	if err != nil {
 		return nil, err
 	}
@@ -200,12 +200,12 @@ func (s *policySetParameters) Delete(ctx context.Context, policySetID, parameter
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o PolicySetParameterCreateOptions) valid() error {

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -102,13 +102,13 @@ func (p *policySetVersions) Create(ctx context.Context, policySetID string) (*Po
 	}
 
 	u := fmt.Sprintf("policy-sets/%s/versions", url.QueryEscape(policySetID))
-	req, err := p.client.newRequest("POST", u, nil)
+	req, err := p.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	psv := &PolicySetVersion{}
-	err = p.client.do(ctx, req, psv)
+	err = req.Do(ctx, psv)
 	if err != nil {
 		return nil, err
 	}
@@ -123,13 +123,13 @@ func (p *policySetVersions) Read(ctx context.Context, policySetVersionID string)
 	}
 
 	u := fmt.Sprintf("policy-set-versions/%s", url.QueryEscape(policySetVersionID))
-	req, err := p.client.newRequest("GET", u, nil)
+	req, err := p.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	psv := &PolicySetVersion{}
-	err = p.client.do(ctx, req, psv)
+	err = req.Do(ctx, psv)
 	if err != nil {
 		return nil, err
 	}
@@ -151,10 +151,10 @@ func (p *policySetVersions) Upload(ctx context.Context, psv PolicySetVersion, pa
 		return err
 	}
 
-	req, err := p.client.newRequest("PUT", uploadURL, body)
+	req, err := p.client.NewRequest("PUT", uploadURL, body)
 	if err != nil {
 		return err
 	}
 
-	return p.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }

--- a/registry_module.go
+++ b/registry_module.go
@@ -188,13 +188,13 @@ func (s *registryModules) List(ctx context.Context, organization string, options
 	}
 
 	u := fmt.Sprintf("organizations/%s/registry-modules", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	ml := &RegistryModuleList{}
-	err = s.client.do(ctx, req, ml)
+	err = req.Do(ctx, ml)
 	if err != nil {
 		return nil, err
 	}
@@ -216,12 +216,12 @@ func (r *registryModules) Upload(ctx context.Context, rmv RegistryModuleVersion,
 		return err
 	}
 
-	req, err := r.client.newRequest("PUT", uploadURL, body)
+	req, err := r.client.NewRequest("PUT", uploadURL, body)
 	if err != nil {
 		return err
 	}
 
-	return r.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Create a new registry module without a VCS repo
@@ -237,13 +237,13 @@ func (r *registryModules) Create(ctx context.Context, organization string, optio
 		"organizations/%s/registry-modules",
 		url.QueryEscape(organization),
 	)
-	req, err := r.client.newRequest("POST", u, &options)
+	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	rm := &RegistryModule{}
-	err = r.client.do(ctx, req, rm)
+	err = req.Do(ctx, rm)
 	if err != nil {
 		return nil, err
 	}
@@ -267,13 +267,13 @@ func (r *registryModules) CreateVersion(ctx context.Context, moduleID RegistryMo
 		url.QueryEscape(moduleID.Name),
 		url.QueryEscape(moduleID.Provider),
 	)
-	req, err := r.client.newRequest("POST", u, &options)
+	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	rmv := &RegistryModuleVersion{}
-	err = r.client.do(ctx, req, rmv)
+	err = req.Do(ctx, rmv)
 	if err != nil {
 		return nil, err
 	}
@@ -287,13 +287,13 @@ func (r *registryModules) CreateWithVCSConnection(ctx context.Context, options R
 		return nil, err
 	}
 
-	req, err := r.client.newRequest("POST", "registry-modules", &options)
+	req, err := r.client.NewRequest("POST", "registry-modules", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	rm := &RegistryModule{}
-	err = r.client.do(ctx, req, rm)
+	err = req.Do(ctx, rm)
 	if err != nil {
 		return nil, err
 	}
@@ -313,13 +313,13 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 		url.QueryEscape(moduleID.Name),
 		url.QueryEscape(moduleID.Provider),
 	)
-	req, err := r.client.newRequest("GET", u, nil)
+	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	rm := &RegistryModule{}
-	err = r.client.do(ctx, req, rm)
+	err = req.Do(ctx, rm)
 	if err != nil {
 		return nil, err
 	}
@@ -344,12 +344,12 @@ func (r *registryModules) Delete(ctx context.Context, organization, name string)
 		url.QueryEscape(organization),
 		url.QueryEscape(name),
 	)
-	req, err := r.client.newRequest("POST", u, nil)
+	req, err := r.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return r.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // DeleteProvider is used to delete the specific registry module provider
@@ -364,12 +364,12 @@ func (r *registryModules) DeleteProvider(ctx context.Context, moduleID RegistryM
 		url.QueryEscape(moduleID.Name),
 		url.QueryEscape(moduleID.Provider),
 	)
-	req, err := r.client.newRequest("POST", u, nil)
+	req, err := r.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return r.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // DeleteVersion is used to delete the specific registry module version
@@ -391,12 +391,12 @@ func (r *registryModules) DeleteVersion(ctx context.Context, moduleID RegistryMo
 		url.QueryEscape(moduleID.Provider),
 		url.QueryEscape(version),
 	)
-	req, err := r.client.newRequest("POST", u, nil)
+	req, err := r.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return r.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o RegistryModuleID) valid() error {

--- a/registry_provider.go
+++ b/registry_provider.go
@@ -132,13 +132,13 @@ func (r *registryProviders) List(ctx context.Context, organization string, optio
 	}
 
 	u := fmt.Sprintf("organizations/%s/registry-providers", url.QueryEscape(organization))
-	req, err := r.client.newRequest("GET", u, options)
+	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	pl := &RegistryProviderList{}
-	err = r.client.do(ctx, req, pl)
+	err = req.Do(ctx, pl)
 	if err != nil {
 		return nil, err
 	}
@@ -159,13 +159,13 @@ func (r *registryProviders) Create(ctx context.Context, organization string, opt
 		"organizations/%s/registry-providers",
 		url.QueryEscape(organization),
 	)
-	req, err := r.client.newRequest("POST", u, &options)
+	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	prv := &RegistryProvider{}
-	err = r.client.do(ctx, req, prv)
+	err = req.Do(ctx, prv)
 	if err != nil {
 		return nil, err
 	}
@@ -185,13 +185,13 @@ func (r *registryProviders) Read(ctx context.Context, providerID RegistryProvide
 		url.QueryEscape(providerID.Namespace),
 		url.QueryEscape(providerID.Name),
 	)
-	req, err := r.client.newRequest("GET", u, options)
+	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	prv := &RegistryProvider{}
-	err = r.client.do(ctx, req, prv)
+	err = req.Do(ctx, prv)
 	if err != nil {
 		return nil, err
 	}
@@ -211,12 +211,12 @@ func (r *registryProviders) Delete(ctx context.Context, providerID RegistryProvi
 		url.QueryEscape(providerID.Namespace),
 		url.QueryEscape(providerID.Name),
 	)
-	req, err := r.client.newRequest("DELETE", u, nil)
+	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return r.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o RegistryProviderCreateOptions) valid() error {

--- a/registry_provider_platform.go
+++ b/registry_provider_platform.go
@@ -56,13 +56,13 @@ type RegistryProviderPlatformID struct {
 // RegistryProviderPlatformCreateOptions represents the set of options for creating a registry provider platform
 type RegistryProviderPlatformCreateOptions struct {
 	// Required: A valid operating system string
-	OS       string `jsonapi:"attr,os"`
+	OS string `jsonapi:"attr,os"`
 
 	// Required: A valid architecture string
-	Arch     string `jsonapi:"attr,arch"`
+	Arch string `jsonapi:"attr,arch"`
 
 	// Required: A valid shasum string
-	Shasum   string `jsonapi:"attr,shasum"`
+	Shasum string `jsonapi:"attr,shasum"`
 
 	// Required: A valid filename string
 	Filename string `jsonapi:"attr,filename"`
@@ -96,13 +96,13 @@ func (r *registryProviderPlatforms) Create(ctx context.Context, versionID Regist
 		url.QueryEscape(versionID.Name),
 		url.QueryEscape(versionID.Version),
 	)
-	req, err := r.client.newRequest("POST", u, &options)
+	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	rpp := &RegistryProviderPlatform{}
-	err = r.client.do(ctx, req, rpp)
+	err = req.Do(ctx, rpp)
 	if err != nil {
 		return nil, err
 	}
@@ -128,13 +128,13 @@ func (r *registryProviderPlatforms) List(ctx context.Context, versionID Registry
 		url.QueryEscape(versionID.RegistryProviderID.Name),
 		url.QueryEscape(versionID.Version),
 	)
-	req, err := r.client.newRequest("GET", u, options)
+	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	ppl := &RegistryProviderPlatformList{}
-	err = r.client.do(ctx, req, ppl)
+	err = req.Do(ctx, ppl)
 	if err != nil {
 		return nil, err
 	}
@@ -159,13 +159,13 @@ func (r *registryProviderPlatforms) Read(ctx context.Context, platformID Registr
 		url.QueryEscape(platformID.OS),
 		url.QueryEscape(platformID.Arch),
 	)
-	req, err := r.client.newRequest("GET", u, nil)
+	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	rpp := &RegistryProviderPlatform{}
-	err = r.client.do(ctx, req, rpp)
+	err = req.Do(ctx, rpp)
 
 	if err != nil {
 		return nil, err
@@ -191,12 +191,12 @@ func (r *registryProviderPlatforms) Delete(ctx context.Context, platformID Regis
 		url.QueryEscape(platformID.OS),
 		url.QueryEscape(platformID.Arch),
 	)
-	req, err := r.client.newRequest("DELETE", u, nil)
+	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return r.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (id RegistryProviderPlatformID) valid() error {

--- a/registry_provider_version.go
+++ b/registry_provider_version.go
@@ -74,10 +74,10 @@ type RegistryProviderVersionListOptions struct {
 
 type RegistryProviderVersionCreateOptions struct {
 	// Required: A valid semver version string.
-	Version   string   `jsonapi:"attr,version"`
+	Version string `jsonapi:"attr,version"`
 
 	// Required: A valid gpg-key string.
-	KeyID     string   `jsonapi:"attr,key-id"`
+	KeyID string `jsonapi:"attr,key-id"`
 
 	// Required: An array of Terraform provider API versions that this version supports.
 	Protocols []string `jsonapi:"attr,protocols"`
@@ -99,13 +99,13 @@ func (r *registryProviderVersions) List(ctx context.Context, providerID Registry
 		url.QueryEscape(providerID.Namespace),
 		url.QueryEscape(providerID.Name),
 	)
-	req, err := r.client.newRequest("GET", u, options)
+	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	pvl := &RegistryProviderVersionList{}
-	err = r.client.do(ctx, req, pvl)
+	err = req.Do(ctx, pvl)
 	if err != nil {
 		return nil, err
 	}
@@ -134,13 +134,13 @@ func (r *registryProviderVersions) Create(ctx context.Context, providerID Regist
 		url.QueryEscape(providerID.Namespace),
 		url.QueryEscape(providerID.Name),
 	)
-	req, err := r.client.newRequest("POST", u, &options)
+	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	prvv := &RegistryProviderVersion{}
-	err = r.client.do(ctx, req, prvv)
+	err = req.Do(ctx, prvv)
 	if err != nil {
 		return nil, err
 	}
@@ -162,13 +162,13 @@ func (r *registryProviderVersions) Read(ctx context.Context, versionID RegistryP
 		url.QueryEscape(versionID.Name),
 		url.QueryEscape(versionID.Version),
 	)
-	req, err := r.client.newRequest("GET", u, nil)
+	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	prvv := &RegistryProviderVersion{}
-	err = r.client.do(ctx, req, prvv)
+	err = req.Do(ctx, prvv)
 	if err != nil {
 		return nil, err
 	}
@@ -190,12 +190,12 @@ func (r *registryProviderVersions) Delete(ctx context.Context, versionID Registr
 		url.QueryEscape(versionID.Name),
 		url.QueryEscape(versionID.Version),
 	)
-	req, err := r.client.newRequest("DELETE", u, nil)
+	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return r.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // ShasumsUploadURL returns the upload URL to upload shasums if one is available

--- a/request.go
+++ b/request.go
@@ -1,0 +1,104 @@
+package tfe
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
+	"golang.org/x/time/rate"
+)
+
+// ClientRequest encapsulates a request sent by the Client
+type ClientRequest struct {
+	retryableRequest *retryablehttp.Request
+	http             *retryablehttp.Client
+	limiter          *rate.Limiter
+
+	// Header are the headers that will be sent in this request
+	Header http.Header
+}
+
+func (r ClientRequest) Do(ctx context.Context, model interface{}) error {
+	// Wait will block until the limiter can obtain a new token
+	// or returns an error if the given context is canceled.
+	if err := r.limiter.Wait(ctx); err != nil {
+		return err
+	}
+
+	// Add the context to the request.
+	reqWithCxt := r.retryableRequest.WithContext(ctx)
+
+	// Execute the request and check the response.
+	resp, err := r.http.Do(reqWithCxt)
+	if err != nil {
+		// If we got an error, and the context has been canceled,
+		// the context's error is probably more useful.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return err
+		}
+	}
+	defer resp.Body.Close()
+
+	// Basic response checking.
+	if err := checkResponseCode(resp); err != nil {
+		return err
+	}
+
+	// Return here if decoding the response isn't needed.
+	if model == nil {
+		return nil
+	}
+
+	// If v implements io.Writer, write the raw response body.
+	if w, ok := model.(io.Writer); ok {
+		_, err := io.Copy(w, resp.Body)
+		return err
+	}
+
+	return unmarshalResponse(resp.Body, model)
+}
+
+// doIpRanges is similar to Do except that The IP ranges API is not returning jsonapi
+// like every other endpoint which means we need to handle it differently.
+func (r *ClientRequest) doIpRanges(ctx context.Context, ir *IPRange) error {
+	// Wait will block until the limiter can obtain a new token
+	// or returns an error if the given context is canceled.
+	if err := r.limiter.Wait(ctx); err != nil {
+		return err
+	}
+
+	// Add the context to the request.
+	contextReq := r.retryableRequest.WithContext(ctx)
+
+	// Execute the request and check the response.
+	resp, err := r.http.Do(contextReq)
+	if err != nil {
+		// If we got an error, and the context has been canceled,
+		// the context's error is probably more useful.
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		default:
+			return err
+		}
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 && resp.StatusCode >= 400 {
+		return fmt.Errorf("error HTTP response while retrieving IP ranges: %d", resp.StatusCode)
+	} else if resp.StatusCode == 304 {
+		return nil
+	}
+
+	err = json.NewDecoder(resp.Body).Decode(ir)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/run.go
+++ b/run.go
@@ -325,13 +325,13 @@ func (s *runs) List(ctx context.Context, workspaceID string, options *RunListOpt
 	}
 
 	u := fmt.Sprintf("workspaces/%s/runs", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	rl := &RunList{}
-	err = s.client.do(ctx, req, rl)
+	err = req.Do(ctx, rl)
 	if err != nil {
 		return nil, err
 	}
@@ -345,13 +345,13 @@ func (s *runs) Create(ctx context.Context, options RunCreateOptions) (*Run, erro
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("POST", "runs", &options)
+	req, err := s.client.NewRequest("POST", "runs", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &Run{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -374,13 +374,13 @@ func (s *runs) ReadWithOptions(ctx context.Context, runID string, options *RunRe
 	}
 
 	u := fmt.Sprintf("runs/%s", url.QueryEscape(runID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &Run{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -395,12 +395,12 @@ func (s *runs) Apply(ctx context.Context, runID string, options RunApplyOptions)
 	}
 
 	u := fmt.Sprintf("runs/%s/actions/apply", url.QueryEscape(runID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Cancel a run by its ID.
@@ -410,12 +410,12 @@ func (s *runs) Cancel(ctx context.Context, runID string, options RunCancelOption
 	}
 
 	u := fmt.Sprintf("runs/%s/actions/cancel", url.QueryEscape(runID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // ForceCancel is used to forcefully cancel a run by its ID.
@@ -425,12 +425,12 @@ func (s *runs) ForceCancel(ctx context.Context, runID string, options RunForceCa
 	}
 
 	u := fmt.Sprintf("runs/%s/actions/force-cancel", url.QueryEscape(runID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Discard a run by its ID.
@@ -440,12 +440,12 @@ func (s *runs) Discard(ctx context.Context, runID string, options RunDiscardOpti
 	}
 
 	u := fmt.Sprintf("runs/%s/actions/discard", url.QueryEscape(runID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o RunCreateOptions) valid() error {

--- a/run_task.go
+++ b/run_task.go
@@ -143,13 +143,13 @@ func (s *runTasks) Create(ctx context.Context, organization string, options RunT
 	}
 
 	u := fmt.Sprintf("organizations/%s/tasks", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &RunTask{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -167,13 +167,13 @@ func (s *runTasks) List(ctx context.Context, organization string, options *RunTa
 	}
 
 	u := fmt.Sprintf("organizations/%s/tasks", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	rl := &RunTaskList{}
-	err = s.client.do(ctx, req, rl)
+	err = req.Do(ctx, rl)
 	if err != nil {
 		return nil, err
 	}
@@ -196,13 +196,13 @@ func (s *runTasks) ReadWithOptions(ctx context.Context, runTaskID string, option
 	}
 
 	u := fmt.Sprintf("tasks/%s", url.QueryEscape(runTaskID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &RunTask{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -221,13 +221,13 @@ func (s *runTasks) Update(ctx context.Context, runTaskID string, options RunTask
 	}
 
 	u := fmt.Sprintf("tasks/%s", url.QueryEscape(runTaskID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &RunTask{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -242,12 +242,12 @@ func (s *runTasks) Delete(ctx context.Context, runTaskID string) error {
 	}
 
 	u := fmt.Sprintf("tasks/%s", runTaskID)
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // AttachToWorkspace is a convenient method to attach a run task to a workspace. See: WorkspaceRunTasks.Create()

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -101,13 +101,13 @@ func (s *runTriggers) List(ctx context.Context, workspaceID string, options *Run
 	}
 
 	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	rtl := &RunTriggerList{}
-	err = s.client.do(ctx, req, rtl)
+	err = req.Do(ctx, rtl)
 	if err != nil {
 		return nil, err
 	}
@@ -125,13 +125,13 @@ func (s *runTriggers) Create(ctx context.Context, workspaceID string, options Ru
 	}
 
 	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	rt := &RunTrigger{}
-	err = s.client.do(ctx, req, rt)
+	err = req.Do(ctx, rt)
 	if err != nil {
 		return nil, err
 	}
@@ -146,13 +146,13 @@ func (s *runTriggers) Read(ctx context.Context, runTriggerID string) (*RunTrigge
 	}
 
 	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	rt := &RunTrigger{}
-	err = s.client.do(ctx, req, rt)
+	err = req.Do(ctx, rt)
 	if err != nil {
 		return nil, err
 	}
@@ -167,12 +167,12 @@ func (s *runTriggers) Delete(ctx context.Context, runTriggerID string) error {
 	}
 
 	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o RunTriggerCreateOptions) valid() error {

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -84,13 +84,13 @@ func (s *sshKeys) List(ctx context.Context, organization string, options *SSHKey
 	}
 
 	u := fmt.Sprintf("organizations/%s/ssh-keys", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	kl := &SSHKeyList{}
-	err = s.client.do(ctx, req, kl)
+	err = req.Do(ctx, kl)
 	if err != nil {
 		return nil, err
 	}
@@ -109,13 +109,13 @@ func (s *sshKeys) Create(ctx context.Context, organization string, options SSHKe
 	}
 
 	u := fmt.Sprintf("organizations/%s/ssh-keys", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	k := &SSHKey{}
-	err = s.client.do(ctx, req, k)
+	err = req.Do(ctx, k)
 	if err != nil {
 		return nil, err
 	}
@@ -130,13 +130,13 @@ func (s *sshKeys) Read(ctx context.Context, sshKeyID string) (*SSHKey, error) {
 	}
 
 	u := fmt.Sprintf("ssh-keys/%s", url.QueryEscape(sshKeyID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	k := &SSHKey{}
-	err = s.client.do(ctx, req, k)
+	err = req.Do(ctx, k)
 	if err != nil {
 		return nil, err
 	}
@@ -151,13 +151,13 @@ func (s *sshKeys) Update(ctx context.Context, sshKeyID string, options SSHKeyUpd
 	}
 
 	u := fmt.Sprintf("ssh-keys/%s", url.QueryEscape(sshKeyID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	k := &SSHKey{}
-	err = s.client.do(ctx, req, k)
+	err = req.Do(ctx, k)
 	if err != nil {
 		return nil, err
 	}
@@ -172,12 +172,12 @@ func (s *sshKeys) Delete(ctx context.Context, sshKeyID string) error {
 	}
 
 	u := fmt.Sprintf("ssh-keys/%s", url.QueryEscape(sshKeyID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o SSHKeyCreateOptions) valid() error {

--- a/state_version.go
+++ b/state_version.go
@@ -154,13 +154,13 @@ func (s *stateVersions) List(ctx context.Context, options *StateVersionListOptio
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("GET", "state-versions", options)
+	req, err := s.client.NewRequest("GET", "state-versions", options)
 	if err != nil {
 		return nil, err
 	}
 
 	svl := &StateVersionList{}
-	err = s.client.do(ctx, req, svl)
+	err = req.Do(ctx, svl)
 	if err != nil {
 		return nil, err
 	}
@@ -178,13 +178,13 @@ func (s *stateVersions) Create(ctx context.Context, workspaceID string, options 
 	}
 
 	u := fmt.Sprintf("workspaces/%s/state-versions", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	sv := &StateVersion{}
-	err = s.client.do(ctx, req, sv)
+	err = req.Do(ctx, sv)
 	if err != nil {
 		return nil, err
 	}
@@ -202,13 +202,13 @@ func (s *stateVersions) ReadWithOptions(ctx context.Context, svID string, option
 	}
 
 	u := fmt.Sprintf("state-versions/%s", url.QueryEscape(svID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	sv := &StateVersion{}
-	err = s.client.do(ctx, req, sv)
+	err = req.Do(ctx, sv)
 	if err != nil {
 		return nil, err
 	}
@@ -231,13 +231,13 @@ func (s *stateVersions) ReadCurrentWithOptions(ctx context.Context, workspaceID 
 	}
 
 	u := fmt.Sprintf("workspaces/%s/current-state-version", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	sv := &StateVersion{}
-	err = s.client.do(ctx, req, sv)
+	err = req.Do(ctx, sv)
 	if err != nil {
 		return nil, err
 	}
@@ -252,14 +252,14 @@ func (s *stateVersions) ReadCurrent(ctx context.Context, workspaceID string) (*S
 
 // Download retrieves the actual stored state of a state version
 func (s *stateVersions) Download(ctx context.Context, u string) ([]byte, error) {
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 	req.Header.Set("Accept", "application/json")
 
 	var buf bytes.Buffer
-	err = s.client.do(ctx, req, &buf)
+	err = req.Do(ctx, &buf)
 	if err != nil {
 		return nil, err
 	}
@@ -274,13 +274,13 @@ func (s *stateVersions) ListOutputs(ctx context.Context, svID string, options *S
 	}
 
 	u := fmt.Sprintf("state-versions/%s/outputs", url.QueryEscape(svID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	sv := &StateVersionOutputsList{}
-	err = s.client.do(ctx, req, sv)
+	err = req.Do(ctx, sv)
 	if err != nil {
 		return nil, err
 	}

--- a/state_version_output.go
+++ b/state_version_output.go
@@ -40,13 +40,13 @@ func (s *stateVersionOutputs) ReadCurrent(ctx context.Context, workspaceID strin
 	}
 
 	u := fmt.Sprintf("workspaces/%s/current-state-version-outputs", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	so := &StateVersionOutputsList{}
-	err = s.client.do(ctx, req, so)
+	err = req.Do(ctx, so)
 	if err != nil {
 		return nil, err
 	}
@@ -61,13 +61,13 @@ func (s *stateVersionOutputs) Read(ctx context.Context, outputID string) (*State
 	}
 
 	u := fmt.Sprintf("state-version-outputs/%s", url.QueryEscape(outputID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	so := &StateVersionOutput{}
-	err = s.client.do(ctx, req, so)
+	err = req.Do(ctx, so)
 	if err != nil {
 		return nil, err
 	}

--- a/task_result.go
+++ b/task_result.go
@@ -75,13 +75,13 @@ func (t *taskResults) Read(ctx context.Context, taskResultID string) (*TaskResul
 	}
 
 	u := fmt.Sprintf("task-results/%s", taskResultID)
-	req, err := t.client.newRequest("GET", u, nil)
+	req, err := t.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &TaskResult{}
-	err = t.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}

--- a/task_stages.go
+++ b/task_stages.go
@@ -85,13 +85,13 @@ func (s *taskStages) Read(ctx context.Context, taskStageID string, options *Task
 	}
 
 	u := fmt.Sprintf("task-stages/%s", taskStageID)
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	t := &TaskStage{}
-	err = s.client.do(ctx, req, t)
+	err = req.Do(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -106,14 +106,14 @@ func (s *taskStages) List(ctx context.Context, runID string, options *TaskStageL
 	}
 
 	u := fmt.Sprintf("runs/%s/task-stages", runID)
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	tlist := &TaskStageList{}
 
-	err = s.client.do(ctx, req, tlist)
+	err = req.Do(ctx, tlist)
 	if err != nil {
 		return nil, err
 	}

--- a/team.go
+++ b/team.go
@@ -155,13 +155,13 @@ func (s *teams) List(ctx context.Context, organization string, options *TeamList
 		return nil, err
 	}
 	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	tl := &TeamList{}
-	err = s.client.do(ctx, req, tl)
+	err = req.Do(ctx, tl)
 	if err != nil {
 		return nil, err
 	}
@@ -179,13 +179,13 @@ func (s *teams) Create(ctx context.Context, organization string, options TeamCre
 	}
 
 	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	t := &Team{}
-	err = s.client.do(ctx, req, t)
+	err = req.Do(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -200,13 +200,13 @@ func (s *teams) Read(ctx context.Context, teamID string) (*Team, error) {
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	t := &Team{}
-	err = s.client.do(ctx, req, t)
+	err = req.Do(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -221,13 +221,13 @@ func (s *teams) Update(ctx context.Context, teamID string, options TeamUpdateOpt
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	t := &Team{}
-	err = s.client.do(ctx, req, t)
+	err = req.Do(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -242,12 +242,12 @@ func (s *teams) Delete(ctx context.Context, teamID string) error {
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o TeamCreateOptions) valid() error {

--- a/team_access.go
+++ b/team_access.go
@@ -165,13 +165,13 @@ func (s *teamAccesses) List(ctx context.Context, options *TeamAccessListOptions)
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("GET", "team-workspaces", options)
+	req, err := s.client.NewRequest("GET", "team-workspaces", options)
 	if err != nil {
 		return nil, err
 	}
 
 	tal := &TeamAccessList{}
-	err = s.client.do(ctx, req, tal)
+	err = req.Do(ctx, tal)
 	if err != nil {
 		return nil, err
 	}
@@ -185,13 +185,13 @@ func (s *teamAccesses) Add(ctx context.Context, options TeamAccessAddOptions) (*
 		return nil, err
 	}
 
-	req, err := s.client.newRequest("POST", "team-workspaces", &options)
+	req, err := s.client.NewRequest("POST", "team-workspaces", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ta := &TeamAccess{}
-	err = s.client.do(ctx, req, ta)
+	err = req.Do(ctx, ta)
 	if err != nil {
 		return nil, err
 	}
@@ -206,13 +206,13 @@ func (s *teamAccesses) Read(ctx context.Context, teamAccessID string) (*TeamAcce
 	}
 
 	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	ta := &TeamAccess{}
-	err = s.client.do(ctx, req, ta)
+	err = req.Do(ctx, ta)
 	if err != nil {
 		return nil, err
 	}
@@ -227,13 +227,13 @@ func (s *teamAccesses) Update(ctx context.Context, teamAccessID string, options 
 	}
 
 	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ta := &TeamAccess{}
-	err = s.client.do(ctx, req, ta)
+	err = req.Do(ctx, ta)
 	if err != nil {
 		return nil, err
 	}
@@ -248,12 +248,12 @@ func (s *teamAccesses) Remove(ctx context.Context, teamAccessID string) error {
 	}
 
 	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o *TeamAccessListOptions) valid() error {

--- a/team_member.go
+++ b/team_member.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"fmt"
 	"net/url"
-
-	retryablehttp "github.com/hashicorp/go-retryablehttp"
 )
 
 // Compile-time proof of interface implementation.
@@ -80,13 +78,13 @@ func (s *teamMembers) ListUsers(ctx context.Context, teamID string) ([]*User, er
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	t := &Team{}
-	err = s.client.do(ctx, req, t)
+	err = req.Do(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -107,13 +105,13 @@ func (s *teamMembers) ListOrganizationMemberships(ctx context.Context, teamID st
 	}
 
 	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	t := &Team{}
-	err = s.client.do(ctx, req, t)
+	err = req.Do(ctx, t)
 	if err != nil {
 		return nil, err
 	}
@@ -133,7 +131,7 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 	usersOrMemberships := options.kind()
 	u := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
 
-	var req *retryablehttp.Request
+	var req *ClientRequest
 
 	if usersOrMemberships == "users" {
 		var err error
@@ -141,7 +139,7 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 		for _, name := range options.Usernames {
 			members = append(members, &teamMemberUser{Username: name})
 		}
-		req, err = s.client.newRequest("POST", u, members)
+		req, err = s.client.NewRequest("POST", u, members)
 		if err != nil {
 			return err
 		}
@@ -151,13 +149,13 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 		for _, ID := range options.OrganizationMembershipIDs {
 			members = append(members, &teamMemberOrgMembership{ID: ID})
 		}
-		req, err = s.client.newRequest("POST", u, members)
+		req, err = s.client.NewRequest("POST", u, members)
 		if err != nil {
 			return err
 		}
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Remove multiple users from a team.
@@ -172,7 +170,7 @@ func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMem
 	usersOrMemberships := options.kind()
 	u := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
 
-	var req *retryablehttp.Request
+	var req *ClientRequest
 
 	if usersOrMemberships == "users" {
 		var err error
@@ -180,7 +178,7 @@ func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMem
 		for _, name := range options.Usernames {
 			members = append(members, &teamMemberUser{Username: name})
 		}
-		req, err = s.client.newRequest("DELETE", u, members)
+		req, err = s.client.NewRequest("DELETE", u, members)
 		if err != nil {
 			return err
 		}
@@ -190,13 +188,13 @@ func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMem
 		for _, ID := range options.OrganizationMembershipIDs {
 			members = append(members, &teamMemberOrgMembership{ID: ID})
 		}
-		req, err = s.client.newRequest("DELETE", u, members)
+		req, err = s.client.NewRequest("DELETE", u, members)
 		if err != nil {
 			return err
 		}
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // kind returns "users" or "organization-memberships"

--- a/team_token.go
+++ b/team_token.go
@@ -47,13 +47,13 @@ func (s *teamTokens) Create(ctx context.Context, teamID string) (*TeamToken, err
 	}
 
 	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	tt := &TeamToken{}
-	err = s.client.do(ctx, req, tt)
+	err = req.Do(ctx, tt)
 	if err != nil {
 		return nil, err
 	}
@@ -68,13 +68,13 @@ func (s *teamTokens) Read(ctx context.Context, teamID string) (*TeamToken, error
 	}
 
 	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	tt := &TeamToken{}
-	err = s.client.do(ctx, req, tt)
+	err = req.Do(ctx, tt)
 	if err != nil {
 		return nil, err
 	}
@@ -89,10 +89,10 @@ func (s *teamTokens) Delete(ctx context.Context, teamID string) error {
 	}
 
 	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }

--- a/testing.go
+++ b/testing.go
@@ -28,7 +28,7 @@ func FetchTestAccountDetails(t *testing.T, client *Client) *TestAccountDetails {
 	}
 
 	ctx := context.Background()
-	err = client.do(ctx, req, tad)
+	err = req.Do(ctx, tad)
 	if err != nil {
 		t.Fatalf("could not fetch test user details: %v", err)
 	}

--- a/testing.go
+++ b/testing.go
@@ -22,7 +22,7 @@ type TestAccountDetails struct {
 // address associated with the token used to run the tests.
 func FetchTestAccountDetails(t *testing.T, client *Client) *TestAccountDetails {
 	tad := &TestAccountDetails{}
-	req, err := client.newRequest("GET", "account/details", nil)
+	req, err := client.NewRequest("GET", "account/details", nil)
 	if err != nil {
 		t.Fatalf("could not create account details request: %v", err)
 	}

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -379,15 +379,15 @@ func createRequest(v interface{}) (*retryablehttp.Request, []byte, error) {
 		return nil, nil, err
 	}
 
-	request, err := client.newRequest("POST", "/bar", v)
+	request, err := client.NewRequest("POST", "/bar", v)
 	if err != nil {
 		return nil, nil, err
 	}
-	body, err := request.BodyBytes()
+	body, err := request.retryableRequest.BodyBytes()
 	if err != nil {
-		return request, nil, err
+		return request.retryableRequest, nil, err
 	}
-	return request, body, nil
+	return request.retryableRequest, body, nil
 }
 
 func TestClient_configureLimiter(t *testing.T) {

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -141,10 +141,10 @@ func Test_RegistryBasePath(t *testing.T) {
 
 	t.Run("ensures client creates a request with registry base path", func(t *testing.T) {
 		path := "/api/registry/some/path/to/resource"
-		req, err := client.newRequest("GET", path, nil)
+		req, err := client.NewRequest("GET", path, nil)
 		require.NoError(t, err)
 
 		expected := os.Getenv("TFE_ADDRESS") + path
-		assert.Equal(t, req.URL.String(), expected)
+		assert.Equal(t, req.retryableRequest.URL.String(), expected)
 	})
 }

--- a/user.go
+++ b/user.go
@@ -62,13 +62,13 @@ type UserUpdateOptions struct {
 
 // ReadCurrent reads the details of the currently authenticated user.
 func (s *users) ReadCurrent(ctx context.Context) (*User, error) {
-	req, err := s.client.newRequest("GET", "account/details", nil)
+	req, err := s.client.NewRequest("GET", "account/details", nil)
 	if err != nil {
 		return nil, err
 	}
 
 	u := &User{}
-	err = s.client.do(ctx, req, u)
+	err = req.Do(ctx, u)
 	if err != nil {
 		return nil, err
 	}
@@ -78,13 +78,13 @@ func (s *users) ReadCurrent(ctx context.Context) (*User, error) {
 
 // UpdateCurrent updates attributes of the currently authenticated user.
 func (s *users) UpdateCurrent(ctx context.Context, options UserUpdateOptions) (*User, error) {
-	req, err := s.client.newRequest("PATCH", "account/update", &options)
+	req, err := s.client.NewRequest("PATCH", "account/update", &options)
 	if err != nil {
 		return nil, err
 	}
 
 	u := &User{}
-	err = s.client.do(ctx, req, u)
+	err = req.Do(ctx, u)
 	if err != nil {
 		return nil, err
 	}

--- a/user_token.go
+++ b/user_token.go
@@ -62,13 +62,13 @@ func (s *userTokens) Create(ctx context.Context, userID string, options UserToke
 	}
 
 	u := fmt.Sprintf("users/%s/authentication-tokens", url.QueryEscape(userID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	ut := &UserToken{}
-	err = s.client.do(ctx, req, ut)
+	err = req.Do(ctx, ut)
 	if err != nil {
 		return nil, err
 	}
@@ -83,13 +83,13 @@ func (s *userTokens) List(ctx context.Context, userID string) (*UserTokenList, e
 	}
 
 	u := fmt.Sprintf("users/%s/authentication-tokens", url.QueryEscape(userID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	tl := &UserTokenList{}
-	err = s.client.do(ctx, req, tl)
+	err = req.Do(ctx, tl)
 	if err != nil {
 		return nil, err
 	}
@@ -104,13 +104,13 @@ func (s *userTokens) Read(ctx context.Context, tokenID string) (*UserToken, erro
 	}
 
 	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	tt := &UserToken{}
-	err = s.client.do(ctx, req, tt)
+	err = req.Do(ctx, tt)
 	if err != nil {
 		return nil, err
 	}
@@ -125,10 +125,10 @@ func (s *userTokens) Delete(ctx context.Context, tokenID string) error {
 	}
 
 	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }

--- a/variable.go
+++ b/variable.go
@@ -131,13 +131,13 @@ func (s *variables) List(ctx context.Context, workspaceID string, options *Varia
 	}
 
 	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	vl := &VariableList{}
-	err = s.client.do(ctx, req, vl)
+	err = req.Do(ctx, vl)
 	if err != nil {
 		return nil, err
 	}
@@ -155,13 +155,13 @@ func (s *variables) Create(ctx context.Context, workspaceID string, options Vari
 	}
 
 	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := &Variable{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -179,13 +179,13 @@ func (s *variables) Read(ctx context.Context, workspaceID, variableID string) (*
 	}
 
 	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	v := &Variable{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -203,13 +203,13 @@ func (s *variables) Update(ctx context.Context, workspaceID, variableID string, 
 	}
 
 	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := &Variable{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -227,12 +227,12 @@ func (s *variables) Delete(ctx context.Context, workspaceID, variableID string) 
 	}
 
 	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o VariableCreateOptions) valid() error {

--- a/variable_set.go
+++ b/variable_set.go
@@ -165,13 +165,13 @@ func (s *variableSets) List(ctx context.Context, organization string, options *V
 	}
 
 	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	vl := &VariableSetList{}
-	err = s.client.do(ctx, req, vl)
+	err = req.Do(ctx, vl)
 	if err != nil {
 		return nil, err
 	}
@@ -189,13 +189,13 @@ func (s *variableSets) Create(ctx context.Context, organization string, options 
 	}
 
 	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, options)
+	req, err := s.client.NewRequest("POST", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	vl := &VariableSet{}
-	err = s.client.do(ctx, req, vl)
+	err = req.Do(ctx, vl)
 	if err != nil {
 		return nil, err
 	}
@@ -210,13 +210,13 @@ func (s *variableSets) Read(ctx context.Context, variableSetID string, options *
 	}
 
 	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	vs := &VariableSet{}
-	err = s.client.do(ctx, req, vs)
+	err = req.Do(ctx, vs)
 	if err != nil {
 		return nil, err
 	}
@@ -231,13 +231,13 @@ func (s *variableSets) Update(ctx context.Context, variableSetID string, options
 	}
 
 	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("PATCH", u, options)
+	req, err := s.client.NewRequest("PATCH", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := &VariableSet{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -252,12 +252,12 @@ func (s *variableSets) Delete(ctx context.Context, variableSetID string) error {
 	}
 
 	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Apply variable set to workspaces in the supplied list.
@@ -271,12 +271,12 @@ func (s *variableSets) ApplyToWorkspaces(ctx context.Context, variableSetID stri
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/workspaces", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("POST", u, options.Workspaces)
+	req, err := s.client.NewRequest("POST", u, options.Workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Remove variable set from workspaces in the supplied list.
@@ -290,12 +290,12 @@ func (s *variableSets) RemoveFromWorkspaces(ctx context.Context, variableSetID s
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/workspaces", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("DELETE", u, options.Workspaces)
+	req, err := s.client.NewRequest("DELETE", u, options.Workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // Update variable set to be applied to only the workspaces in the supplied list.
@@ -312,13 +312,13 @@ func (s *variableSets) UpdateWorkspaces(ctx context.Context, variableSetID strin
 
 	// We force inclusion of workspaces as that is the primary data for which we are concerned with confirming changes.
 	u := fmt.Sprintf("varsets/%s?include=%s", url.QueryEscape(variableSetID), VariableSetWorkspaces)
-	req, err := s.client.newRequest("PATCH", u, &o)
+	req, err := s.client.NewRequest("PATCH", u, &o)
 	if err != nil {
 		return nil, err
 	}
 
 	v := &VariableSet{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -72,13 +72,13 @@ func (s *variableSetVariables) List(ctx context.Context, variableSetID string, o
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	vl := &VariableSetVariableList{}
-	err = s.client.do(ctx, req, vl)
+	err = req.Do(ctx, vl)
 	if err != nil {
 		return nil, err
 	}
@@ -135,13 +135,13 @@ func (s *variableSetVariables) Create(ctx context.Context, variableSetID string,
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
-	req, err := s.client.newRequest("POST", u, options)
+	req, err := s.client.NewRequest("POST", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := &VariableSetVariable{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -159,14 +159,14 @@ func (s *variableSetVariables) Read(ctx context.Context, variableSetID, variable
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 
 	if err != nil {
 		return nil, err
 	}
 
 	v := &VariableSetVariable{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -208,13 +208,13 @@ func (s *variableSetVariables) Update(ctx context.Context, variableSetID, variab
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
-	req, err := s.client.newRequest("PATCH", u, options)
+	req, err := s.client.NewRequest("PATCH", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	v := &VariableSetVariable{}
-	err = s.client.do(ctx, req, v)
+	err = req.Do(ctx, v)
 	if err != nil {
 		return nil, err
 	}
@@ -232,10 +232,10 @@ func (s *variableSetVariables) Delete(ctx context.Context, variableSetID, variab
 	}
 
 	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }

--- a/workspace.go
+++ b/workspace.go
@@ -536,13 +536,13 @@ func (s *workspaces) List(ctx context.Context, organization string, options *Wor
 	}
 
 	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	wl := &WorkspaceList{}
-	err = s.client.do(ctx, req, wl)
+	err = req.Do(ctx, wl)
 	if err != nil {
 		return nil, err
 	}
@@ -560,13 +560,13 @@ func (s *workspaces) Create(ctx context.Context, organization string, options Wo
 	}
 
 	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -596,13 +596,13 @@ func (s *workspaces) ReadWithOptions(ctx context.Context, organization, workspac
 		url.QueryEscape(organization),
 		url.QueryEscape(workspace),
 	)
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -626,13 +626,13 @@ func (s *workspaces) ReadByIDWithOptions(ctx context.Context, workspaceID string
 	}
 
 	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -651,13 +651,13 @@ func (s *workspaces) Readme(ctx context.Context, workspaceID string) (io.Reader,
 	}
 
 	u := fmt.Sprintf("workspaces/%s?include=readme", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	r := &workspaceWithReadme{}
-	err = s.client.do(ctx, req, r)
+	err = req.Do(ctx, r)
 	if err != nil {
 		return nil, err
 	}
@@ -685,13 +685,13 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 		url.QueryEscape(organization),
 		url.QueryEscape(workspace),
 	)
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -706,13 +706,13 @@ func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options
 	}
 
 	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -734,12 +734,12 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 		url.QueryEscape(organization),
 		url.QueryEscape(workspace),
 	)
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // DeleteByID deletes a workspace by its ID.
@@ -749,12 +749,12 @@ func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
 	}
 
 	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // RemoveVCSConnection from a workspace.
@@ -772,13 +772,13 @@ func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, work
 		url.QueryEscape(workspace),
 	)
 
-	req, err := s.client.newRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
+	req, err := s.client.NewRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -794,13 +794,13 @@ func (s *workspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceID st
 
 	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
 
-	req, err := s.client.newRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
+	req, err := s.client.NewRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -815,13 +815,13 @@ func (s *workspaces) Lock(ctx context.Context, workspaceID string, options Works
 	}
 
 	u := fmt.Sprintf("workspaces/%s/actions/lock", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -836,13 +836,13 @@ func (s *workspaces) Unlock(ctx context.Context, workspaceID string) (*Workspace
 	}
 
 	u := fmt.Sprintf("workspaces/%s/actions/unlock", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -857,13 +857,13 @@ func (s *workspaces) ForceUnlock(ctx context.Context, workspaceID string) (*Work
 	}
 
 	u := fmt.Sprintf("workspaces/%s/actions/force-unlock", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -881,13 +881,13 @@ func (s *workspaces) AssignSSHKey(ctx context.Context, workspaceID string, optio
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/ssh-key", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -902,13 +902,13 @@ func (s *workspaces) UnassignSSHKey(ctx context.Context, workspaceID string) (*W
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/ssh-key", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("PATCH", u, &workspaceUnassignSSHKeyOptions{})
+	req, err := s.client.NewRequest("PATCH", u, &workspaceUnassignSSHKeyOptions{})
 	if err != nil {
 		return nil, err
 	}
 
 	w := &Workspace{}
-	err = s.client.do(ctx, req, w)
+	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
 	}
@@ -924,13 +924,13 @@ func (s *workspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID s
 
 	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
 
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	wl := &WorkspaceList{}
-	err = s.client.do(ctx, req, wl)
+	err = req.Do(ctx, wl)
 	if err != nil {
 		return nil, err
 	}
@@ -948,12 +948,12 @@ func (s *workspaces) AddRemoteStateConsumers(ctx context.Context, workspaceID st
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, options.Workspaces)
+	req, err := s.client.NewRequest("POST", u, options.Workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // RemoveRemoteStateConsumers removes the remote state consumers for a given workspace.
@@ -966,12 +966,12 @@ func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("DELETE", u, options.Workspaces)
+	req, err := s.client.NewRequest("DELETE", u, options.Workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // UpdateRemoteStateConsumers removes the remote state consumers for a given workspace.
@@ -984,12 +984,12 @@ func (s *workspaces) UpdateRemoteStateConsumers(ctx context.Context, workspaceID
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("PATCH", u, options.Workspaces)
+	req, err := s.client.NewRequest("PATCH", u, options.Workspaces)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // ListTags returns the tags for a given workspace.
@@ -1000,13 +1000,13 @@ func (s *workspaces) ListTags(ctx context.Context, workspaceID string, options *
 
 	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.QueryEscape(workspaceID))
 
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	tl := &TagList{}
-	err = s.client.do(ctx, req, tl)
+	err = req.Do(ctx, tl)
 	if err != nil {
 		return nil, err
 	}
@@ -1024,12 +1024,12 @@ func (s *workspaces) AddTags(ctx context.Context, workspaceID string, options Wo
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("POST", u, options.Tags)
+	req, err := s.client.NewRequest("POST", u, options.Tags)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 // RemoveTags removes a list of tags from a workspace.
@@ -1042,12 +1042,12 @@ func (s *workspaces) RemoveTags(ctx context.Context, workspaceID string, options
 	}
 
 	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("DELETE", u, options.Tags)
+	req, err := s.client.NewRequest("DELETE", u, options.Tags)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o WorkspaceCreateOptions) valid() error {

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -147,7 +147,7 @@ func TestWorkspacesList(t *testing.T) {
 	})
 
 	t.Run("with current-state-version,current-run included", func(t *testing.T) {
-		_, rCleanup := createAppliedRun(t, client, wTest1)
+		_, rCleanup := createRunApply(t, client, wTest1)
 		t.Cleanup(rCleanup)
 
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
@@ -469,7 +469,7 @@ func TestWorkspacesReadWithHistory(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 	defer wTestCleanup()
 
-	_, rCleanup := createAppliedRun(t, client, wTest)
+	_, rCleanup := createRunApply(t, client, wTest)
 	defer rCleanup()
 
 	w, err := client.Workspaces.Read(context.Background(), orgTest.Name, wTest.Name)
@@ -489,7 +489,7 @@ func TestWorkspacesReadReadme(t *testing.T) {
 	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{})
 	defer wTestCleanup()
 
-	_, rCleanup := createAppliedRun(t, client, wTest)
+	_, rCleanup := createRunApply(t, client, wTest)
 	defer rCleanup()
 
 	t.Run("when the readme exists", func(t *testing.T) {

--- a/workspace_run_task.go
+++ b/workspace_run_task.go
@@ -75,13 +75,13 @@ func (s *workspaceRunTasks) List(ctx context.Context, workspaceID string, option
 	}
 
 	u := fmt.Sprintf("workspaces/%s/tasks", url.QueryEscape(workspaceID))
-	req, err := s.client.newRequest("GET", u, options)
+	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
 
 	rl := &WorkspaceRunTaskList{}
-	err = s.client.do(ctx, req, rl)
+	err = req.Do(ctx, rl)
 	if err != nil {
 		return nil, err
 	}
@@ -104,13 +104,13 @@ func (s *workspaceRunTasks) Read(ctx context.Context, workspaceID, workspaceTask
 		url.QueryEscape(workspaceID),
 		url.QueryEscape(workspaceTaskID),
 	)
-	req, err := s.client.newRequest("GET", u, nil)
+	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
 	}
 
 	wr := &WorkspaceRunTask{}
-	err = s.client.do(ctx, req, wr)
+	err = req.Do(ctx, wr)
 	if err != nil {
 		return nil, err
 	}
@@ -129,13 +129,13 @@ func (s *workspaceRunTasks) Create(ctx context.Context, workspaceID string, opti
 	}
 
 	u := fmt.Sprintf("workspaces/%s/tasks", workspaceID)
-	req, err := s.client.newRequest("POST", u, &options)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	wr := &WorkspaceRunTask{}
-	err = s.client.do(ctx, req, wr)
+	err = req.Do(ctx, wr)
 	if err != nil {
 		return nil, err
 	}
@@ -158,13 +158,13 @@ func (s *workspaceRunTasks) Update(ctx context.Context, workspaceID, workspaceTa
 		url.QueryEscape(workspaceID),
 		url.QueryEscape(workspaceTaskID),
 	)
-	req, err := s.client.newRequest("PATCH", u, &options)
+	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
 	}
 
 	wr := &WorkspaceRunTask{}
-	err = s.client.do(ctx, req, wr)
+	err = req.Do(ctx, wr)
 	if err != nil {
 		return nil, err
 	}
@@ -187,12 +187,12 @@ func (s *workspaceRunTasks) Delete(ctx context.Context, workspaceID, workspaceTa
 		url.QueryEscape(workspaceID),
 		url.QueryEscape(workspaceTaskID),
 	)
-	req, err := s.client.newRequest("DELETE", u, nil)
+	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
 	}
 
-	return s.client.do(ctx, req, nil)
+	return req.Do(ctx, nil)
 }
 
 func (o *WorkspaceRunTaskCreateOptions) valid() error {


### PR DESCRIPTION
## Description

Due to the overwhelmingly bad state of the CI in this repository, this change borrows some code from our internal integration-tests-api package to do more reliable and transparent run creation test setup. Here are the points:

1. Waits longer and polls less often for runs to reach a desired state, but...
2. When runs error, the plan log is read from the API and written to the log so the test environment can be diagnosed
3. Logs are printed while tests wait on run status so that test developers can easily figure out why their run didn't enter the expected state
4. As a bonus I encapsulated the client request so that it could have a more convenient external interface if we want to take this a step further and encapsulate the test helper itself.

## Testing plan

1. CI only

