### PR TITLE
Use `require` to prevent a panic when dereferencing a nil pointer

### DIFF
--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -39,7 +39,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
 			Query: org.Name,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, true, adminOrgItemsContainsName(adminOrgList.Items, org.Name))
 		assert.Equal(t, 1, adminOrgList.CurrentPage)
 		assert.Equal(t, 1, adminOrgList.TotalCount)
@@ -51,7 +51,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
 			Query: randomName,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, false, adminOrgItemsContainsName(adminOrgList.Items, org.Name))
 		assert.Equal(t, 1, adminOrgList.CurrentPage)
 		assert.Equal(t, 0, adminOrgList.TotalCount)
@@ -61,9 +61,9 @@ func TestAdminOrganizations_List(t *testing.T) {
 		adminOrgList, err := client.Admin.Organizations.List(ctx, &AdminOrganizationListOptions{
 			Include: []AdminOrgIncludeOpt{AdminOrgOwners},
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.NotEmpty(t, adminOrgList.Items)
+		require.NotEmpty(t, adminOrgList.Items)
 		assert.NotNil(t, adminOrgList.Items[0].Owners)
 		assert.NotEmpty(t, adminOrgList.Items[0].Owners[0].Email)
 	})
@@ -95,8 +95,8 @@ func TestAdminOrganizations_Read(t *testing.T) {
 		defer orgTestCleanup()
 
 		adminOrg, err := client.Admin.Organizations.Read(ctx, org.Name)
-		assert.NoError(t, err)
-		assert.NotNilf(t, adminOrg, "Organization is not nil")
+		require.NoError(t, err)
+		require.NotNilf(t, adminOrg, "Organization is not nil")
 		assert.Equal(t, adminOrg.Name, org.Name)
 
 		// attributes part of an AdminOrganization response that are not null
@@ -133,12 +133,12 @@ func TestAdminOrganizations_Delete(t *testing.T) {
 		originalOrg, _ := createOrganization(t, client)
 
 		adminOrg, err := client.Admin.Organizations.Read(ctx, originalOrg.Name)
-		assert.NoError(t, err)
-		assert.NotNilf(t, adminOrg, "Organization is not nil")
+		require.NoError(t, err)
+		require.NotNil(t, adminOrg)
 		assert.Equal(t, adminOrg.Name, originalOrg.Name)
 
 		err = client.Admin.Organizations.Delete(ctx, adminOrg.Name)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Cannot find deleted org
 		_, err = client.Admin.Organizations.Read(ctx, originalOrg.Name)
@@ -169,7 +169,7 @@ func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
 		defer org2TestCleanup()
 
 		err := client.Admin.Organizations.UpdateModuleConsumers(ctx, org1.Name, []string{org2.Name})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		adminModuleConsumerList, err := client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, nil)
 		require.NoError(t, err)
@@ -181,7 +181,7 @@ func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
 		defer org3TestCleanup()
 
 		err = client.Admin.Organizations.UpdateModuleConsumers(ctx, org1.Name, []string{org3.Name})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		adminModuleConsumerList, err = client.Admin.Organizations.ListModuleConsumers(ctx, org1.Name, nil)
 		require.NoError(t, err)
@@ -215,8 +215,8 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		defer orgTestCleanup()
 
 		adminOrg, err := client.Admin.Organizations.Read(ctx, org.Name)
-		assert.NoError(t, err)
-		assert.NotNilf(t, adminOrg, "Org returned as nil")
+		require.NoError(t, err)
+		require.NotNilf(t, adminOrg, "Org returned as nil")
 
 		accessBetaTools := true
 		globalModuleSharing := false
@@ -235,8 +235,8 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
-		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
-		assert.NoError(t, err)
+		require.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
+		require.NoError(t, err)
 
 		assert.Equal(t, accessBetaTools, adminOrg.AccessBetaTools)
 		assert.Equal(t, adminOrg.GlobalModuleSharing, &globalModuleSharing)
@@ -256,8 +256,8 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
-		assert.NoError(t, err)
-		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
+		require.NoError(t, err)
+		require.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
 
 		assert.Equal(t, adminOrg.GlobalModuleSharing, &globalModuleSharing)
 		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
@@ -273,8 +273,8 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
-		assert.NoError(t, err)
-		assert.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
+		require.NoError(t, err)
+		require.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
 
 		assert.Equal(t, &globalModuleSharing, adminOrg.GlobalModuleSharing)
 		assert.Equal(t, adminOrg.IsDisabled, isDisabled)

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -37,7 +37,7 @@ func TestAdminRuns_List(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, nil)
 		require.NoError(t, err)
 
-		assert.NotEmpty(t, rl.Items)
+		require.NotEmpty(t, rl.Items)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), true)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), true)
 	})
@@ -61,7 +61,7 @@ func TestAdminRuns_List(t *testing.T) {
 			},
 		})
 		require.NoError(t, err)
-		assert.NotEmpty(t, rl.Items)
+		require.NotEmpty(t, rl.Items)
 		assert.Equal(t, 1, rl.CurrentPage)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), true)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), true)
@@ -71,11 +71,10 @@ func TestAdminRuns_List(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			Include: []AdminRunIncludeOpt{AdminRunWorkspace},
 		})
+		require.NoError(t, err)
 
-		assert.NoError(t, err)
-
-		assert.NotEmpty(t, rl.Items)
-		assert.NotNil(t, rl.Items[0].Workspace)
+		require.NotEmpty(t, rl.Items)
+		require.NotNil(t, rl.Items[0].Workspace)
 		assert.NotEmpty(t, rl.Items[0].Workspace.Name)
 	})
 
@@ -84,11 +83,11 @@ func TestAdminRuns_List(t *testing.T) {
 			Include: []AdminRunIncludeOpt{AdminRunWorkspaceOrg},
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		require.NotEmpty(t, rl.Items)
 
-		assert.NotEmpty(t, rl.Items)
-		assert.NotNil(t, rl.Items[0].Workspace)
-		assert.NotNil(t, rl.Items[0].Workspace.Organization)
+		require.NotNil(t, rl.Items[0].Workspace)
+		require.NotNil(t, rl.Items[0].Workspace.Organization)
 		assert.NotEmpty(t, rl.Items[0].Workspace.Organization.Name)
 	})
 
@@ -102,16 +101,16 @@ func TestAdminRuns_List(t *testing.T) {
 
 	t.Run("with RunStatus.pending filter", func(t *testing.T) {
 		r1, err := client.Runs.Read(ctx, rTest1.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		r2, err := client.Runs.Read(ctx, rTest2.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// There should be pending Runs
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			RunStatus: string(RunPending),
 		})
-		assert.NoError(t, err)
-		assert.NotEmpty(t, rl.Items)
+		require.NoError(t, err)
+		require.NotEmpty(t, rl.Items)
 
 		assert.Equal(t, r1.Status, RunPlanning)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, r1.ID), false)
@@ -124,7 +123,7 @@ func TestAdminRuns_List(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			RunStatus: string(RunApplied),
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Empty(t, rl.Items)
 	})
 
@@ -132,18 +131,18 @@ func TestAdminRuns_List(t *testing.T) {
 		rl, err := client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			Query: rTest1.ID,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.NotEmpty(t, rl.Items)
+		require.NotEmpty(t, rl.Items)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), true)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), false)
 
 		rl, err = client.Admin.Runs.List(ctx, &AdminRunsListOptions{
 			Query: rTest2.ID,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.NotEmpty(t, rl.Items)
+		require.NotEmpty(t, rl.Items)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest1.ID), false)
 		assert.Equal(t, adminRunItemsContainsID(rl.Items, rTest2.ID), true)
 	})
@@ -191,12 +190,18 @@ func TestAdminRuns_ForceCancel(t *testing.T) {
 		rTestPlanning, err := client.Runs.Read(ctx, rTest1.ID)
 		require.NoError(t, err)
 		assert.Equal(t, RunPlanning, rTestPlanning.Status)
+
+		require.NotNil(t, rTestPlanning.Actions)
+		require.NotNil(t, rTestPlanning.Permissions)
 		assert.Equal(t, true, rTestPlanning.Actions.IsCancelable)
 		assert.Equal(t, true, rTestPlanning.Permissions.CanForceCancel)
 
 		rTestPending, err := client.Runs.Read(ctx, rTest2.ID)
 		require.NoError(t, err)
 		assert.Equal(t, RunPending, rTestPending.Status)
+
+		require.NotNil(t, rTestPlanning.Actions)
+		require.NotNil(t, rTestPlanning.Permissions)
 		assert.Equal(t, true, rTestPending.Actions.IsCancelable)
 		assert.Equal(t, true, rTestPending.Permissions.CanForceCancel)
 
@@ -231,7 +236,7 @@ func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
 		}
 
 		err := opts.valid()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("has invalid status", func(t *testing.T) {
@@ -259,7 +264,7 @@ func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
 		}
 
 		err := opts.valid()
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -18,7 +18,7 @@ func TestAdminUsers_List(t *testing.T) {
 	ctx := context.Background()
 
 	currentUser, err := client.Users.ReadCurrent(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	org, orgCleanup := createOrganization(t, client)
 	defer orgCleanup()
@@ -79,10 +79,10 @@ func TestAdminUsers_List(t *testing.T) {
 			Include: []AdminUserIncludeOpt{AdminUserOrgs},
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		require.NotEmpty(t, ul.Items)
+		require.NotEmpty(t, ul.Items[0].Organizations)
 
-		assert.NotEmpty(t, ul.Items)
-		assert.NotNil(t, ul.Items[0].Organizations)
 		assert.NotEmpty(t, ul.Items[0].Organizations[0].Name)
 	})
 
@@ -91,9 +91,9 @@ func TestAdminUsers_List(t *testing.T) {
 			Administrators: "true",
 		})
 
-		assert.NoError(t, err)
-		assert.NotEmpty(t, ul.Items)
-		assert.NotNil(t, ul.Items[0])
+		require.NoError(t, err)
+		require.NotEmpty(t, ul.Items)
+		require.NotNil(t, ul.Items[0])
 		// We use this `includesEmail` helper function because throughout
 		// the tests, there could be multiple admins, depending on the
 		// ordering of the test runs.

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -91,9 +91,9 @@ func TestAdminWorkspaces_List(t *testing.T) {
 			Include: []AdminWorkspaceIncludeOpt{AdminWorkspaceOrg},
 		})
 
-		assert.NoError(t, err)
-		assert.NotEmpty(t, wl.Items)
-		assert.NotNil(t, wl.Items[0].Organization)
+		require.NoError(t, err)
+		require.NotEmpty(t, wl.Items)
+		require.NotNil(t, wl.Items[0].Organization)
 		assert.NotEmpty(t, wl.Items[0].Organization.Name)
 	})
 
@@ -106,16 +106,16 @@ func TestAdminWorkspaces_List(t *testing.T) {
 			Workspace:            wTest1,
 		}
 		run, err := client.Runs.Create(ctx, runOpts)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
 			Include: []AdminWorkspaceIncludeOpt{AdminWorkspaceCurrentRun},
 		})
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
-		assert.NotEmpty(t, wl.Items)
-		assert.NotNil(t, wl.Items[0].CurrentRun)
+		require.NotEmpty(t, wl.Items)
+		require.NotNil(t, wl.Items[0].CurrentRun)
 		assert.Equal(t, wl.Items[0].CurrentRun.ID, run.ID)
 	})
 }
@@ -149,8 +149,8 @@ func TestAdminWorkspaces_Read(t *testing.T) {
 		defer workspaceCleanup()
 
 		adminWorkspace, err := client.Admin.Workspaces.Read(ctx, workspace.ID)
-		assert.NoError(t, err)
-		assert.NotNilf(t, adminWorkspace, "Admin Workspace is not nil")
+		require.NoError(t, err)
+		require.NotNilf(t, adminWorkspace, "Admin Workspace is not nil")
 		assert.Equal(t, adminWorkspace.ID, workspace.ID)
 		assert.Equal(t, adminWorkspace.Name, workspace.Name)
 		assert.Equal(t, adminWorkspace.Locked, workspace.Locked)
@@ -183,12 +183,12 @@ func TestAdminWorkspaces_Delete(t *testing.T) {
 		workspace, _ := createWorkspace(t, client, org)
 
 		adminWorkspace, err := client.Admin.Workspaces.Read(ctx, workspace.ID)
-		assert.NoError(t, err)
-		assert.NotNilf(t, adminWorkspace, "Admin Workspace is not nil")
+		require.NoError(t, err)
+		require.NotNilf(t, adminWorkspace, "Admin Workspace is not nil")
 		assert.Equal(t, adminWorkspace.ID, workspace.ID)
 
 		err = client.Admin.Workspaces.Delete(ctx, adminWorkspace.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		// Cannot find deleted workspace
 		_, err = client.Admin.Workspaces.Read(ctx, workspace.ID)

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -44,7 +44,9 @@ func TestAgentPoolsList(t *testing.T) {
 			Include: []AgentPoolIncludeOpt{AgentPoolWorkspaces},
 		})
 		require.NoError(t, err)
-		assert.NotEmpty(t, k.Items[0].Workspaces[0])
+		require.NotEmpty(t, k.Items)
+		require.NotEmpty(t, k.Items[0].Workspaces)
+		assert.NotNil(t, k.Items[0].Workspaces[0])
 	})
 
 	t.Run("with list options", func(t *testing.T) {

--- a/agent_token_integration_test.go
+++ b/agent_token_integration_test.go
@@ -98,7 +98,7 @@ func TestAgentTokensRead(t *testing.T) {
 
 	t.Run("read token with valid token ID", func(t *testing.T) {
 		at, err := client.AgentTokens.Read(ctx, token.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		// The initial API call to create a token will return a value in the token
 		// object. Empty that out for comparison
 		token.Token = ""
@@ -125,7 +125,7 @@ func TestAgentTokensDelete(t *testing.T) {
 
 	t.Run("with valid token ID", func(t *testing.T) {
 		err := client.AgentTokens.Delete(ctx, token.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("without valid token ID", func(t *testing.T) {

--- a/audit_trail_integration_test.go
+++ b/audit_trail_integration_test.go
@@ -33,16 +33,16 @@ func TestAuditTrailsList(t *testing.T) {
 	t.Run("with no specified timeframe", func(t *testing.T) {
 		atl, err := auditTrailClient.AuditTrails.List(ctx, nil)
 		require.NoError(t, err)
-		require.Greater(t, len(atl.Items), 0)
+		require.NotEmpty(t, atl.Items)
 
 		log := atl.Items[0]
 		assert.NotEmpty(t, log.ID)
 		assert.NotEmpty(t, log.Timestamp)
 		assert.NotEmpty(t, log.Type)
 		assert.NotEmpty(t, log.Version)
-		assert.NotNil(t, log.Resource)
-		assert.NotNil(t, log.Auth)
-		assert.NotNil(t, log.Request)
+		require.NotNil(t, log.Resource)
+		require.NotNil(t, log.Auth)
+		require.NotNil(t, log.Request)
 
 		t.Run("with resource deserialized correctly", func(t *testing.T) {
 			assert.NotEmpty(t, log.Resource.ID)
@@ -85,8 +85,8 @@ func TestAuditTrailsList(t *testing.T) {
 		})
 		require.NoError(t, err)
 
+		require.Greater(t, len(atl.Items), 0)
 		assert.LessOrEqual(t, len(atl.Items), 20)
-		assert.Greater(t, len(atl.Items), 0)
 
 		for _, log := range atl.Items {
 			assert.True(t, log.Timestamp.After(since))

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -185,7 +185,7 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 		cv, err := client.ConfigurationVersions.ReadWithOptions(ctx, cv.ID, options)
 		require.NoError(t, err)
 
-		assert.NotZero(t, cv.IngressAttributes)
+		require.NotNil(t, cv.IngressAttributes)
 		assert.NotZero(t, cv.IngressAttributes.CommitURL)
 		assert.NotZero(t, cv.IngressAttributes.CommitSHA)
 	})
@@ -298,7 +298,7 @@ func TestConfigurationVersionsDownload(t *testing.T) {
 		cvFile, err := client.ConfigurationVersions.Download(ctx, uploadedCv.ID)
 
 		assert.NotNil(t, cvFile)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, bytes.Equal(cvFile, expectedCvFile.Bytes()), "Configuration version should match")
 	})
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -876,8 +876,6 @@ func createPlanExport(t *testing.T, client *Client, r *Run) (*PlanExport, func()
 			}
 		}
 	}
-
-	return nil, rCleanup
 }
 
 func createRegistryModule(t *testing.T, client *Client, org *Organization) (*RegistryModule, func()) {

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -73,6 +73,9 @@ func TestOAuthClientsList(t *testing.T) {
 			Include: []OAuthClientIncludeOpt{OauthClientOauthTokens},
 		})
 		require.NoError(t, err)
+		require.NotEmpty(t, ocl.Items)
+		require.NotNil(t, ocl.Items[0])
+		require.NotEmpty(t, ocl.Items[0].OAuthTokens)
 		assert.NotEmpty(t, ocl.Items[0].OAuthTokens[0].ID)
 	})
 
@@ -104,7 +107,7 @@ func TestOAuthClientsCreate(t *testing.T) {
 		}
 
 		oc, err := client.OAuthClients.Create(ctx, orgTest.Name, options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, oc.ID)
 		assert.Equal(t, "https://api.github.com", oc.APIURL)
 		assert.Equal(t, "https://github.com", oc.HTTPURL)
@@ -192,7 +195,7 @@ func TestOAuthClientsCreate_rsaKeyPair(t *testing.T) {
 		}
 
 		oc, err := client.OAuthClients.Create(ctx, orgTest.Name, options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, oc.ID)
 		assert.Equal(t, "https://bbs.com", oc.APIURL)
 		assert.Equal(t, "https://bbs.com", oc.HTTPURL)
@@ -410,7 +413,7 @@ func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
 		}
 
 		origOC, err := client.OAuthClients.Create(ctx, orgTest.Name, options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, origOC.ID)
 
 		newKey := randomString(t)
@@ -418,7 +421,7 @@ func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
 			Key: String(newKey),
 		}
 		oc, err := client.OAuthClients.Update(ctx, origOC.ID, updateOpts)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, oc.ID)
 		assert.Equal(t, ServiceProviderBitbucketServer, oc.ServiceProvider)
 		assert.Equal(t, oc.RSAPublicKey, origOC.RSAPublicKey)
@@ -437,7 +440,7 @@ func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
 		}
 
 		origOC, err := client.OAuthClients.Create(ctx, orgTest.Name, options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, origOC.ID)
 
 		updateOpts := OAuthClientUpdateOptions{

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -51,7 +51,7 @@ func TestOrganizationTokensRead(t *testing.T) {
 		_, otTestCleanup := createOrganizationToken(t, client, orgTest)
 
 		ot, err := client.OrganizationTokens.Read(ctx, orgTest.Name)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, ot)
 
 		otTestCleanup()
@@ -81,7 +81,7 @@ func TestOrganizationTokensDelete(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.OrganizationTokens.Delete(ctx, orgTest.Name)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("when a token does not exist", func(t *testing.T) {

--- a/plan_export_integration_test.go
+++ b/plan_export_integration_test.go
@@ -22,7 +22,7 @@ func TestPlanExportsCreate(t *testing.T) {
 	defer rTestCleanup()
 
 	pTest, err := client.Plans.Read(ctx, rTest.Plan.ID)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := PlanExportCreateOptions{
@@ -91,7 +91,7 @@ func TestPlanExportsDelete(t *testing.T) {
 
 	t.Run("with a valid ID", func(t *testing.T) {
 		err := client.PlanExports.Delete(ctx, peTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("when the export does not exist", func(t *testing.T) {
@@ -115,7 +115,7 @@ func TestPlanExportsDownload(t *testing.T) {
 	t.Run("with a valid ID", func(t *testing.T) {
 		pe, err := client.PlanExports.Download(ctx, peTest.ID)
 		assert.NotNil(t, pe)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("without a valid ID", func(t *testing.T) {

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -68,6 +68,9 @@ func TestPolicyChecksList(t *testing.T) {
 			Include: []PolicyCheckIncludeOpt{PolicyCheckRun},
 		})
 		require.NoError(t, err)
+		require.NotEmpty(t, pcl.Items)
+		require.NotNil(t, pcl.Items[0])
+		require.NotNil(t, pcl.Items[0].Run)
 		assert.NotEmpty(t, pcl.Items[0].Run.Status)
 	})
 

--- a/policy_integration_test.go
+++ b/policy_integration_test.go
@@ -372,17 +372,17 @@ func TestPoliciesUpload(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Policies.Upload(ctx, pTest.ID, []byte(`main = rule { true }`))
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with empty content", func(t *testing.T) {
 		err := client.Policies.Upload(ctx, pTest.ID, []byte{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("without any content", func(t *testing.T) {
 		err := client.Policies.Upload(ctx, pTest.ID, nil)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("without a valid policy ID", func(t *testing.T) {
@@ -413,7 +413,7 @@ func TestPoliciesDownload(t *testing.T) {
 		require.NoError(t, err)
 
 		content, err := client.Policies.Download(ctx, pTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, testContent, content)
 	})
 

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -290,11 +290,13 @@ func TestPolicySetsRead(t *testing.T) {
 
 		// The newest policy set version is changed to the most recent one
 		// that was created.
+		require.NotNil(t, psWithOptions.NewestVersion)
 		assert.Equal(t, psWithOptions.NewestVersion.ID, psvNew.ID)
 		assert.Equal(t, psWithOptions.NewestVersion.Status, PolicySetVersionPending)
 		// The current one is now set because policies were uploaded to the
 		// policy set version. Notice how it is set to the one that was uplaoded,
 		// not the newest policy set version.
+		require.NotNil(t, psWithOptions.CurrentVersion)
 		assert.Equal(t, psWithOptions.CurrentVersion.ID, psv.ID)
 		assert.Equal(t, psWithOptions.CurrentVersion.Status, PolicySetVersionReady)
 	})

--- a/policy_set_parameter_integration_test.go
+++ b/policy_set_parameter_integration_test.go
@@ -283,7 +283,7 @@ func TestPolicySetParametersDelete(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.PolicySetParameters.Delete(ctx, psTest.ID, pTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with non existing parameter ID", func(t *testing.T) {

--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -136,7 +136,9 @@ func TestRegistryProvidersList(t *testing.T) {
 		}
 
 		providersRead, err := client.RegistryProviders.List(ctx, provider.Organization.Name, &options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
+		require.NotEmpty(t, providersRead.Items)
 		providerRead := providersRead.Items[0]
 		assert.Equal(t, providerRead.ID, provider.ID)
 		assert.Equal(t, len(versions), len(providerRead.RegistryProviderVersions))
@@ -316,7 +318,8 @@ func TestRegistryProvidersRead(t *testing.T) {
 				}
 
 				prv, err := client.RegistryProviders.Read(ctx, id, nil)
-				assert.NoError(t, err)
+				require.NoError(t, err)
+
 				assert.NotEmpty(t, prv.ID)
 				assert.Equal(t, registryProviderTest.Name, prv.Name)
 				assert.Equal(t, registryProviderTest.Namespace, prv.Namespace)
@@ -377,7 +380,9 @@ func TestRegistryProvidersRead(t *testing.T) {
 		}
 
 		providerRead, err := client.RegistryProviders.Read(ctx, id, &options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+		require.NotEmpty(t, providerRead.RegistryProviderVersions)
+
 		assert.Equal(t, providerRead.ID, provider.ID)
 		assert.Equal(t, len(versions), len(providerRead.RegistryProviderVersions))
 		foundVersion := &RegistryProviderVersion{}
@@ -463,7 +468,7 @@ func TestRegistryProvidersIDValidation(t *testing.T) {
 			Namespace:        "namespace",
 			Name:             "name",
 		}
-		assert.NoError(t, id.valid())
+		require.NoError(t, id.valid())
 	})
 
 	t.Run("without a name", func(t *testing.T) {

--- a/registry_provider_platform_integration_test.go
+++ b/registry_provider_platform_integration_test.go
@@ -195,7 +195,7 @@ func TestRegistryProviderPlatformsDelete(t *testing.T) {
 		}
 
 		err := client.RegistryProviderPlatforms.Delete(ctx, platformID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with a non-existant version", func(t *testing.T) {
@@ -243,7 +243,8 @@ func TestRegistryProviderPlatformsRead(t *testing.T) {
 		}
 
 		readPlatform, err := client.RegistryProviderPlatforms.Read(ctx, platformID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
+
 		assert.Equal(t, platformID.OS, readPlatform.OS)
 		assert.Equal(t, platformID.Arch, readPlatform.Arch)
 		assert.Equal(t, platform.Filename, readPlatform.Filename)

--- a/registry_provider_version_integration_test.go
+++ b/registry_provider_version_integration_test.go
@@ -38,7 +38,7 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 			Version:            version,
 			RegistryProviderID: validRegistryProviderId,
 		}
-		assert.NoError(t, id.valid())
+		require.NoError(t, id.valid())
 	})
 
 	t.Run("without a version", func(t *testing.T) {
@@ -121,9 +121,9 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 
 		t.Run("includes upload links", func(t *testing.T) {
 			_, err := prvv.ShasumsUploadURL()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			_, err = prvv.ShasumsSigUploadURL()
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			expectedLinks := []string{
 				"shasums-upload",
 				"shasums-sig-upload",
@@ -229,7 +229,7 @@ func TestRegistryProviderVersionsList(t *testing.T) {
 				},
 			})
 			require.NoError(t, err)
-			assert.NotEmpty(t, returnedVersions.Items)
+			require.NotEmpty(t, returnedVersions.Items)
 			assert.Equal(t, versionN, returnedVersions.TotalCount)
 			assert.Equal(t, 1, returnedVersions.TotalPages)
 			for _, rv := range returnedVersions.Items {
@@ -258,7 +258,8 @@ func TestRegistryProviderVersionsList(t *testing.T) {
 						},
 					})
 					require.NoError(t, err)
-					assert.NotEmpty(t, returnedVersions.Items)
+					require.NotEmpty(t, returnedVersions.Items)
+
 					assert.Equal(t, versionN, returnedVersions.TotalCount)
 					assert.Equal(t, pageN, returnedVersions.TotalPages)
 					assert.Equal(t, pageSize, len(returnedVersions.Items))
@@ -321,7 +322,7 @@ func TestRegistryProviderVersionsDelete(t *testing.T) {
 		}
 
 		err := client.RegistryProviderVersions.Delete(ctx, versionID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with non existing version", func(t *testing.T) {
@@ -359,7 +360,7 @@ func TestRegistryProviderVersionsRead(t *testing.T) {
 		}
 
 		readVersion, err := client.RegistryProviderVersions.Read(ctx, versionID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, version.ID, readVersion.ID)
 		assert.Equal(t, version.Version, readVersion.Version)
 		assert.Equal(t, version.KeyID, readVersion.KeyID)

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -45,6 +45,7 @@ func TestRunsList(t *testing.T) {
 			Include: []RunIncludeOpt{},
 		})
 		require.NoError(t, err)
+		require.NotEmpty(t, rl.Items)
 
 		found := []string{}
 		for _, r := range rl.Items {
@@ -79,11 +80,10 @@ func TestRunsList(t *testing.T) {
 		rl, err := client.Runs.List(ctx, wTest.ID, &RunListOptions{
 			Include: []RunIncludeOpt{RunWorkspace},
 		})
+		require.NoError(t, err)
 
-		assert.NoError(t, err)
-
-		assert.NotEmpty(t, rl.Items)
-		assert.NotNil(t, rl.Items[0].Workspace)
+		require.NotEmpty(t, rl.Items)
+		require.NotNil(t, rl.Items[0].Workspace)
 		assert.NotEmpty(t, rl.Items[0].Workspace.Name)
 	})
 
@@ -118,7 +118,7 @@ func TestRunsListQueryParams(t *testing.T) {
 			description: "with status query parameter",
 			options:     &RunListOptions{Status: string(RunPending), Include: []RunIncludeOpt{RunWorkspace}},
 			assertion: func(tc testCase, rl *RunList, err error) {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, 1, len(rl.Items))
 			},
 		},
@@ -126,7 +126,7 @@ func TestRunsListQueryParams(t *testing.T) {
 			description: "with source query parameter",
 			options:     &RunListOptions{Source: string(RunSourceAPI), Include: []RunIncludeOpt{RunWorkspace}},
 			assertion: func(tc testCase, rl *RunList, err error) {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, 2, len(rl.Items))
 				assert.Equal(t, rl.Items[0].Source, RunSourceAPI)
 			},
@@ -135,7 +135,7 @@ func TestRunsListQueryParams(t *testing.T) {
 			description: "with operation of plan_only parameter",
 			options:     &RunListOptions{Operation: string(RunOperationPlanOnly), Include: []RunIncludeOpt{RunWorkspace}},
 			assertion: func(tc testCase, rl *RunList, err error) {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, 0, len(rl.Items))
 			},
 		},
@@ -155,7 +155,7 @@ func TestRunsListQueryParams(t *testing.T) {
 			description: "with name & commit parameter",
 			options:     &RunListOptions{Name: randomString(t), Commit: randomString(t), Include: []RunIncludeOpt{RunWorkspace}},
 			assertion: func(tc testCase, rl *RunList, err error) {
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, 0, len(rl.Items))
 			},
 		},
@@ -185,11 +185,11 @@ func TestRunsCreate(t *testing.T) {
 		}
 
 		r, err := client.Runs.Create(ctx, options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotNil(t, r.ID)
 		assert.NotNil(t, r.CreatedAt)
 		assert.NotNil(t, r.Source)
-		assert.NotEmpty(t, r.StatusTimestamps)
+		require.NotNil(t, r.StatusTimestamps)
 		assert.NotZero(t, r.StatusTimestamps.PlanQueueableAt)
 	})
 
@@ -323,7 +323,7 @@ func TestRunsRead_CostEstimate(t *testing.T) {
 
 	t.Run("when the run exists", func(t *testing.T) {
 		r, err := client.Runs.Read(ctx, rTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, rTest, r)
 	})
 
@@ -355,7 +355,7 @@ func TestRunsReadWithOptions(t *testing.T) {
 		r, err := client.Runs.ReadWithOptions(ctx, rTest.ID, curOpts)
 		require.NoError(t, err)
 
-		assert.NotEmpty(t, r.CreatedBy)
+		require.NotEmpty(t, r.CreatedBy)
 		assert.NotEmpty(t, r.CreatedBy.Username)
 	})
 }
@@ -374,15 +374,15 @@ func TestRunsApply(t *testing.T) {
 		err := client.Runs.Apply(ctx, rTest.ID, RunApplyOptions{
 			Comment: String("Hello, Earl"),
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		r, err := client.Runs.Read(ctx, rTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 
 		assert.Len(t, r.Comments, 1)
 
 		c, err := client.Comments.Read(ctx, r.Comments[0].ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "Hello, Earl", c.Body)
 	})
 
@@ -414,7 +414,7 @@ func TestRunsCancel(t *testing.T) {
 
 	t.Run("when the run exists", func(t *testing.T) {
 		err := client.Runs.Cancel(ctx, rTest.ID, RunCancelOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("when the run does not exist", func(t *testing.T) {
@@ -507,7 +507,7 @@ func TestRunsDiscard(t *testing.T) {
 
 	t.Run("when the run exists", func(t *testing.T) {
 		err := client.Runs.Discard(ctx, rTest.ID, RunDiscardOptions{})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("when the run does not exist", func(t *testing.T) {

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -116,7 +116,7 @@ func TestRunTasksRead(t *testing.T) {
 
 		require.NoError(t, err)
 
-		assert.NotEmpty(t, r.WorkspaceRunTasks)
+		require.NotEmpty(t, r.WorkspaceRunTasks)
 		assert.NotEmpty(t, r.WorkspaceRunTasks[0].ID)
 		assert.NotEmpty(t, r.WorkspaceRunTasks[0].EnforcementLevel)
 		assert.NotEmpty(t, r.WorkspaceRunTasks[1].ID)

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -127,7 +127,8 @@ func TestRunTriggerList(t *testing.T) {
 			},
 		)
 		require.NoError(t, err)
-		assert.NotEmpty(t, rtl.Items)
+		require.NotEmpty(t, rtl.Items)
+		require.NotNil(t, rtl.Items[0].Sourceable)
 		assert.NotEmpty(t, rtl.Items[0].Sourceable.Name)
 	})
 

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -44,6 +44,7 @@ func TestStateVersionsList(t *testing.T) {
 
 		svl, err := client.StateVersions.List(ctx, options)
 		require.NoError(t, err)
+		require.NotEmpty(t, svl.Items)
 
 		// We need to strip the upload URL as that is a dynamic link.
 		svTest1.DownloadURL = ""

--- a/state_version_output_integration_test.go
+++ b/state_version_output_integration_test.go
@@ -33,6 +33,9 @@ func TestStateVersionOutputsRead(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	require.NotEmpty(t, sv.Outputs)
+	require.NotNil(t, sv.Outputs[0])
+
 	output := sv.Outputs[0]
 
 	t.Run("Read by ID", func(t *testing.T) {
@@ -54,17 +57,14 @@ func TestStateVersionOutputsRead(t *testing.T) {
 
 	t.Run("Read current workspace outputs", func(t *testing.T) {
 		so, err := client.StateVersionOutputs.ReadCurrent(ctx, wTest1.ID)
-
-		assert.Nil(t, err)
-		assert.NotNil(t, so)
-
-		assert.Greater(t, len(so.Items), 0, "workspace state version outputs were empty")
+		require.NoError(t, err)
+		assert.NotEmpty(t, so.Items)
 	})
 
 	t.Run("Sensitive secrets are null", func(t *testing.T) {
 		so, err := client.StateVersionOutputs.ReadCurrent(ctx, wTest1.ID)
-		assert.Nil(t, err)
-		assert.NotNil(t, so)
+		require.NoError(t, err)
+		require.NotEmpty(t, so.Items)
 
 		var found *StateVersionOutput = nil
 		for _, s := range so.Items {

--- a/task_stages_integration_test.go
+++ b/task_stages_integration_test.go
@@ -36,6 +36,8 @@ func TestTaskStagesRead(t *testing.T) {
 		Include: []RunIncludeOpt{RunTaskStages},
 	})
 	require.NoError(t, err)
+	require.NotEmpty(t, r.TaskStages)
+	require.NotNil(t, r.TaskStages[0])
 
 	t.Run("without read options", func(t *testing.T) {
 		taskStage, err := client.TaskStages.Read(ctx, r.TaskStages[0].ID, nil)
@@ -62,6 +64,8 @@ func TestTaskStagesRead(t *testing.T) {
 			Include: []TaskStageIncludeOpt{TaskStageTaskResults},
 		})
 		require.NoError(t, err)
+		require.NotEmpty(t, taskStage.TaskResults)
+		require.NotNil(t, taskStage.TaskResults[0])
 
 		t.Run("task results are properly decoded", func(t *testing.T) {
 			assert.NotEmpty(t, taskStage.TaskResults[0].ID)
@@ -104,7 +108,7 @@ func TestTaskStagesList(t *testing.T) {
 		taskStageList, err := client.TaskStages.List(ctx, rTest.ID, nil)
 		require.NoError(t, err)
 
-		assert.NotNil(t, taskStageList.Items)
+		require.NotEmpty(t, taskStageList.Items)
 		assert.NotEmpty(t, taskStageList.Items[0].ID)
 		assert.Equal(t, 2, len(taskStageList.Items[0].TaskResults))
 	})

--- a/team_member_integration_test.go
+++ b/team_member_integration_test.go
@@ -240,7 +240,7 @@ func TestTeamMembersRemoveByUsernames(t *testing.T) {
 		}
 
 		err := client.TeamMembers.Remove(ctx, tmTest.ID, options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }
 
@@ -271,6 +271,6 @@ func TestTeamMembersRemoveByOrganizationMemberships(t *testing.T) {
 		}
 
 		err := client.TeamMembers.Remove(ctx, tmTest.ID, options)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 }

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -54,7 +54,7 @@ func TestTeamTokensRead(t *testing.T) {
 		_, ttTestCleanup := createTeamToken(t, client, tmTest)
 
 		tt, err := client.TeamTokens.Read(ctx, tmTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.NotEmpty(t, tt)
 
 		ttTestCleanup()
@@ -86,7 +86,7 @@ func TestTeamTokensDelete(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.TeamTokens.Delete(ctx, tmTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("when a token does not exist", func(t *testing.T) {

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -16,7 +16,8 @@ func TestUsersReadCurrent(t *testing.T) {
 	ctx := context.Background()
 
 	u, err := client.Users.ReadCurrent(ctx)
-	assert.NoError(t, err)
+	require.NoError(t, err)
+
 	assert.NotEmpty(t, u.ID)
 	assert.NotEmpty(t, u.AvatarURL)
 	assert.NotEmpty(t, u.Username)
@@ -49,7 +50,7 @@ func TestUsersUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		u, err := client.Users.ReadCurrent(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, u, uTest)
 	})
 
@@ -60,7 +61,7 @@ func TestUsersUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		u, err := client.Users.ReadCurrent(ctx)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "NewTestUsername", u.Username)
 	})
 
@@ -81,7 +82,7 @@ func TestUsersUpdate(t *testing.T) {
 			t.Fatalf("cannot test with user %q because both email and unconfirmed email are empty", u.ID)
 		}
 
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, "newtestemail@hashicorp.com", email)
 	})
 

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -322,7 +322,7 @@ func TestVariablesDelete(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Variables.Delete(ctx, wTest.ID, vTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with non existing variable ID", func(t *testing.T) {

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -23,6 +23,7 @@ func TestVariableSetsList(t *testing.T) {
 	t.Run("without list options", func(t *testing.T) {
 		vsl, err := client.VariableSets.List(ctx, orgTest.Name, nil)
 		require.NoError(t, err)
+		require.NotEmpty(t, vsl.Items)
 		assert.Contains(t, vsl.Items, vsTest1)
 		assert.Contains(t, vsl.Items, vsTest2)
 

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -2,9 +2,10 @@ package tfe
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestVariableSetVariablesList(t *testing.T) {
@@ -334,7 +335,7 @@ func TestVariableSetVariablesDelete(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.VariableSetVariables.Delete(ctx, vsTest.ID, vTest.ID)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 	})
 
 	t.Run("with non existing variable ID", func(t *testing.T) {

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -139,10 +139,9 @@ func TestWorkspacesList(t *testing.T) {
 			Include: []WSIncludeOpt{WSOrganization},
 		})
 
-		assert.NoError(t, err)
-
-		assert.NotEmpty(t, wl.Items)
-		assert.NotNil(t, wl.Items[0].Organization)
+		require.NoError(t, err)
+		require.NotEmpty(t, wl.Items)
+		require.NotNil(t, wl.Items[0].Organization)
 		assert.NotEmpty(t, wl.Items[0].Organization.Email)
 	})
 
@@ -154,16 +153,17 @@ func TestWorkspacesList(t *testing.T) {
 			Include: []WSIncludeOpt{WSCurrentStateVer, WSCurrentRun},
 		})
 
-		assert.NoError(t, err)
-		assert.NotEmpty(t, wl.Items)
+		require.NoError(t, err)
+		require.NotEmpty(t, wl.Items)
 
 		foundWTest1 := false
 		for _, ws := range wl.Items {
 			if ws.ID == wTest1.ID {
 				foundWTest1 = true
-				assert.NotNil(t, wl.Items[0].CurrentStateVersion)
+				require.NotNil(t, wl.Items[0].CurrentStateVersion)
 				assert.NotEmpty(t, wl.Items[0].CurrentStateVersion.DownloadURL)
-				assert.NotNil(t, wl.Items[0].CurrentRun)
+
+				require.NotNil(t, wl.Items[0].CurrentRun)
 				assert.NotEmpty(t, wl.Items[0].CurrentRun.Message)
 			}
 		}


### PR DESCRIPTION
# Description

This PR stemmed from a panic from occurring during the execution of `TestPolicySetsRead/with_policy_set_version`. 

```
Failed
=== RUN   TestPolicySetsRead/with_policy_set_version
    --- FAIL: TestPolicySetsRead/with_policy_set_version (0.40s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0x73cf25]

goroutine 2388 [running]:
testing.tRunner.func1.2({0x807ca0, 0xb8e330})
	/usr/local/go/src/testing/testing.go:1209 +0x24e
testing.tRunner.func1()
	/usr/local/go/src/testing/testing.go:1212 +0x218
panic({0x807ca0, 0xb8e330})
	/usr/local/go/src/runtime/panic.go:1038 +0x215
github.com/hashicorp/go-tfe.TestPolicySetsRead.func3(0x91c5b0)
	/home/circleci/project/policy_set_integration_test.go:298 +0x445
testing.tRunner(0xc0005069c0, 0xc00059f9e0)
	/usr/local/go/src/testing/testing.go:1259 +0x102
created by testing.(*T).Run
	/usr/local/go/src/testing/testing.go:1306 +0x35a
exit status 2
```


What's happening here is the test is expecting two relationships to be included in the response, `CurrentVersion` and `NewestVersion`, but was subject to the overall flakiness of our CI environment. This PR does not fix nor prevent the flakiness. 

**Note**: Why `require` and not `assert`? `require` makes the same calls as `assert` but it will terminate the execution of a test upon failure. Using `assert` would still continue the test's execution, dereference a nil pointer, and boom **panic**!

Therefore this PR attempts to go through each integration test and swap `assert` for `require` in instances where:

* We check for the existence of nested fields (we require the parent object to be present)
* We use the include query param in a test
* When "assertion" order matters; pretty much ties into the first point