### PR TITLE
Speculative Flag inaccurate on Configuration Version List 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 * [beta] Add support for triggering Workspace runs through matching Git tags [#434](https://github.com/hashicorp/go-tfe/pull/434)
 
+## Bug fixes
+* Fixed JSON mapping for Configuration Versions failing to properly set the `speculative` property [#459](https://github.com/hashicorp/go-tfe/pull/459)
+
 # v1.4.0
 
 ## Enhancements

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -92,7 +92,7 @@ type ConfigurationVersion struct {
 	Error            string              `jsonapi:"attr,error"`
 	ErrorMessage     string              `jsonapi:"attr,error-message"`
 	Source           ConfigurationSource `jsonapi:"attr,source"`
-	Speculative      bool                `jsonapi:"attr,speculative "`
+	Speculative      bool                `jsonapi:"attr,speculative"`
 	Status           ConfigurationStatus `jsonapi:"attr,status"`
 	StatusTimestamps *CVStatusTimestamps `jsonapi:"attr,status-timestamps"`
 	UploadURL        string              `jsonapi:"attr,upload-url"`


### PR DESCRIPTION
## Description

When Listing Configuration Versions, the Speculative flag was always returning false.
It appears this was due to a trailing space in the struct.

`go-tfe` version 1.3.0

This change removes that space and allows the function call to return accurately if the CV is speculative.

## Testing plan

To replicate, create a CV that is marked as speculative, then list CV's for that workspace.

```go
	cv, err := client.ConfigurationVersions.List(ctx, w.ID, &tfe.ConfigurationVersionListOptions{
		ListOptions: tfe.ListOptions{PageSize: 100},
		Include:     []tfe.ConfigVerIncludeOpt{},
	})
```

The resulting `cv` variable will not be marked as Speculative.

