### PR TITLE
Enable workspace and organization Health Assessment (drift detection) setting management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -47,7 +47,7 @@
 * [beta] Add support for triggering Workspace runs through matching Git tags [#434](https://github.com/hashicorp/go-tfe/pull/434)
 * Add `Query` param field to `AgentPoolListOptions` to allow searching based on agent pool name, by @JarrettSpiker [#417](https://github.com/hashicorp/go-tfe/pull/417)
 * Add organization scope and allowed workspaces field for scope agents by @Netra2104 [#453](https://github.com/hashicorp/go-tfe/pull/453)
-* Adds `Namespace` and `RegistryName` fields to `RegistryModuleID` to allow reading of Public Registry Modules by @Uk1288 [#464](https://github.com/hashicorp/go-tfe/pull/464)
+* Add support for managing workspace drift detection setting [#462](https://github.com/hashicorp/go-tfe/pull/462)
 
 ## Bug fixes
 * Fixed JSON mapping for Configuration Versions failing to properly set the `speculative` property [#459](https://github.com/hashicorp/go-tfe/pull/459)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 * Add `Query` param field to `OrganizationListOptions` to allow searching based on name or email by @laurenolivia [#529](https://github.com/hashicorp/go-tfe/pull/529)
 
+* Add support for managing workspace and organization health assessment (drift detection) setting [#462](https://github.com/hashicorp/go-tfe/pull/462)
+
 ## Bug Fixes
 * Fixes null value returned in variable set relationship in `VariableSetVariable` by @sebasslash [#521](https://github.com/hashicorp/go-tfe/pull/521)
 
@@ -47,7 +49,7 @@
 * [beta] Add support for triggering Workspace runs through matching Git tags [#434](https://github.com/hashicorp/go-tfe/pull/434)
 * Add `Query` param field to `AgentPoolListOptions` to allow searching based on agent pool name, by @JarrettSpiker [#417](https://github.com/hashicorp/go-tfe/pull/417)
 * Add organization scope and allowed workspaces field for scope agents by @Netra2104 [#453](https://github.com/hashicorp/go-tfe/pull/453)
-* Add support for managing workspace drift detection setting [#462](https://github.com/hashicorp/go-tfe/pull/462)
+* Adds `Namespace` and `RegistryName` fields to `RegistryModuleID` to allow reading of Public Registry Modules by @Uk1288 [#464](https://github.com/hashicorp/go-tfe/pull/464)
 
 ## Bug fixes
 * Fixed JSON mapping for Configuration Versions failing to properly set the `speculative` property [#459](https://github.com/hashicorp/go-tfe/pull/459)

--- a/organization.go
+++ b/organization.go
@@ -64,11 +64,11 @@ type OrganizationList struct {
 // Organization represents a Terraform Enterprise organization.
 type Organization struct {
 	Name                                              string                   `jsonapi:"primary,organizations"`
+	AssessmentsEnforced                               bool                     `jsonapi:"attr,assessments-enforced"`
 	CollaboratorAuthPolicy                            AuthPolicyType           `jsonapi:"attr,collaborator-auth-policy"`
 	CostEstimationEnabled                             bool                     `jsonapi:"attr,cost-estimation-enabled"`
 	CreatedAt                                         time.Time                `jsonapi:"attr,created-at,iso8601"`
 	Email                                             string                   `jsonapi:"attr,email"`
-	AssessmentsEnforced                               bool                     `jsonapi:"attr,assessments-enforced"`
 	ExternalID                                        string                   `jsonapi:"attr,external-id"`
 	OwnersTeamSAMLRoleID                              string                   `jsonapi:"attr,owners-team-saml-role-id"`
 	Permissions                                       *OrganizationPermissions `jsonapi:"attr,permissions"`
@@ -143,6 +143,9 @@ type OrganizationCreateOptions struct {
 	// Required: Name of the organization.
 	Name *string `jsonapi:"attr,name"`
 
+	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
+	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
+
 	// Required: Admin email address.
 	Email *string `jsonapi:"attr,email"`
 
@@ -163,9 +166,6 @@ type OrganizationCreateOptions struct {
 
 	// Optional: SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
-
-	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
-	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
 }
 
 // OrganizationUpdateOptions represents the options for updating an organization.
@@ -178,6 +178,9 @@ type OrganizationUpdateOptions struct {
 
 	// New name for the organization.
 	Name *string `jsonapi:"attr,name,omitempty"`
+
+	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
+	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
 
 	// New admin email address.
 	Email *string `jsonapi:"attr,email,omitempty"`
@@ -199,9 +202,6 @@ type OrganizationUpdateOptions struct {
 
 	// SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
-
-	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
-	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
 }
 
 // ReadRunQueueOptions represents the options for showing the queue.

--- a/organization.go
+++ b/organization.go
@@ -68,6 +68,7 @@ type Organization struct {
 	CostEstimationEnabled                             bool                     `jsonapi:"attr,cost-estimation-enabled"`
 	CreatedAt                                         time.Time                `jsonapi:"attr,created-at,iso8601"`
 	Email                                             string                   `jsonapi:"attr,email"`
+	AssessmentsEnforced                               bool                     `jsonapi:"attr,assessments-enforced"`
 	ExternalID                                        string                   `jsonapi:"attr,external-id"`
 	OwnersTeamSAMLRoleID                              string                   `jsonapi:"attr,owners-team-saml-role-id"`
 	Permissions                                       *OrganizationPermissions `jsonapi:"attr,permissions"`
@@ -162,6 +163,9 @@ type OrganizationCreateOptions struct {
 
 	// Optional: SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
+
+	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces or if the decission to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
+	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
 }
 
 // OrganizationUpdateOptions represents the options for updating an organization.
@@ -195,6 +199,9 @@ type OrganizationUpdateOptions struct {
 
 	// SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
+
+	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces or if the decission to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
+	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
 }
 
 // ReadRunQueueOptions represents the options for showing the queue.

--- a/organization.go
+++ b/organization.go
@@ -144,7 +144,7 @@ type OrganizationCreateOptions struct {
 	Name *string `jsonapi:"attr,name"`
 
 	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
-	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
+	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced,omitempty"`
 
 	// Required: Admin email address.
 	Email *string `jsonapi:"attr,email"`
@@ -180,7 +180,7 @@ type OrganizationUpdateOptions struct {
 	Name *string `jsonapi:"attr,name,omitempty"`
 
 	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
-	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
+	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced,omitempty"`
 
 	// New admin email address.
 	Email *string `jsonapi:"attr,email,omitempty"`

--- a/organization.go
+++ b/organization.go
@@ -164,7 +164,7 @@ type OrganizationCreateOptions struct {
 	// Optional: SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
-	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces or if the decission to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
+	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
 	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
 }
 
@@ -200,7 +200,7 @@ type OrganizationUpdateOptions struct {
 	// SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
-	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces or if the decission to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
+	// Optional: AssessmentsEnforced toggles whether health assessment enablement is enforced across all assessable workspaces (those with a minimum terraform versio of 0.15.4 and not running in local execution mode) or if the decision to enabled health assessments is delegated to the workspace setting AssessmentsEnabled.
 	AssessmentsEnforced *bool `jsonapi:"attr,assessments-enforced"`
 }
 

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -478,6 +478,7 @@ func TestOrganization_Unmarshal(t *testing.T) {
 			"type": "organizations",
 			"id":   "org-name",
 			"attributes": map[string]interface{}{
+				"assessments-enforced":     true,
 				"collaborator-auth-policy": AuthPolicyPassword,
 				"cost-estimation-enabled":  true,
 				"created-at":               "2018-03-02T23:42:06.651Z",
@@ -500,6 +501,7 @@ func TestOrganization_Unmarshal(t *testing.T) {
 	parsedTime, err := time.Parse(iso8601TimeFormat, "2018-03-02T23:42:06.651Z")
 	require.NoError(t, err)
 	assert.Equal(t, org.Name, "org-name")
+	assert.Equal(t, org.AssessmentsEnforced, true)
 	assert.Equal(t, org.CreatedAt, parsedTime)
 	assert.Equal(t, org.CollaboratorAuthPolicy, AuthPolicyPassword)
 	assert.Equal(t, org.CostEstimationEnabled, true)

--- a/workspace.go
+++ b/workspace.go
@@ -115,7 +115,7 @@ type Workspace struct {
 	CanQueueDestroyPlan        bool                  `jsonapi:"attr,can-queue-destroy-plan"`
 	CreatedAt                  time.Time             `jsonapi:"attr,created-at,iso8601"`
 	Description                string                `jsonapi:"attr,description"`
-	DriftDetection             bool                  `jsonapi:"attr,drift-detection"`
+	AssessmentsEnabled         bool                  `jsonapi:"attr,assessments-enabled"`
 	Environment                string                `jsonapi:"attr,environment"`
 	ExecutionMode              string                `jsonapi:"attr,execution-mode"`
 	FileTriggersEnabled        bool                  `jsonapi:"attr,file-triggers-enabled"`
@@ -271,10 +271,10 @@ type WorkspaceCreateOptions struct {
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
-	// Optional: Whether to enable drift detection for the workspace.
+	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
 	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#create-a-workspace
 	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
-	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
+	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
 
 	// Optional: Which execution mode to use. Valid values are remote, local, and agent.
 	// When set to local, the workspace will be used for state storage only.
@@ -395,10 +395,10 @@ type WorkspaceUpdateOptions struct {
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
-	// Optional: Whether to enable drift detection for the workspace.
+	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
 	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#update-a-workspace
 	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
-	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
+	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
 
 	// Optional: Which execution mode to use. Valid values are remote, local, and agent.
 	// When set to local, the workspace will be used for state storage only.

--- a/workspace.go
+++ b/workspace.go
@@ -351,7 +351,7 @@ type WorkspaceCreateOptions struct {
 	// exist, it is created and added to the workspace.
 	Tags []*Tag `jsonapi:"relation,tags,omitempty"`
 
-	// Optional: Whether to enabled drift detection for the workspace.
+	// Optional: Whether to enable drift detection for the workspace.
 	// Requires remote execution mode, TFCB entitlement, and a valid agent pool to work
 	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
 }
@@ -453,7 +453,7 @@ type WorkspaceUpdateOptions struct {
 	// repository.
 	WorkingDirectory *string `jsonapi:"attr,working-directory,omitempty"`
 
-	// Optional: Whether to enabled drift detection for the workspace.
+	// Optional: Whether to enable drift detection for the workspace.
 	// Requires remote execution mode, TFCB entitlement, and a valid agent pool to work
 	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
 }

--- a/workspace.go
+++ b/workspace.go
@@ -271,6 +271,11 @@ type WorkspaceCreateOptions struct {
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
+	// Optional: Whether to enable drift detection for the workspace.
+	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#create-a-workspace
+	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
+	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
+
 	// Optional: Which execution mode to use. Valid values are remote, local, and agent.
 	// When set to local, the workspace will be used for state storage only.
 	// This value must not be specified if operations is specified.
@@ -350,10 +355,6 @@ type WorkspaceCreateOptions struct {
 	// A list of tags to attach to the workspace. If the tag does not already
 	// exist, it is created and added to the workspace.
 	Tags []*Tag `jsonapi:"relation,tags,omitempty"`
-
-	// Optional: Whether to enable drift detection for the workspace.
-	// Requires remote execution mode, TFCB entitlement, and a valid agent pool to work
-	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
 }
 
 // TODO: move this struct out. VCSRepoOptions is used by workspaces, policy sets, and registry modules
@@ -393,6 +394,11 @@ type WorkspaceUpdateOptions struct {
 
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
+
+	// Optional: Whether to enable drift detection for the workspace.
+	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#update-a-workspace
+	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
+	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
 
 	// Optional: Which execution mode to use. Valid values are remote, local, and agent.
 	// When set to local, the workspace will be used for state storage only.
@@ -452,10 +458,6 @@ type WorkspaceUpdateOptions struct {
 	// the environment when multiple environments exist within the same
 	// repository.
 	WorkingDirectory *string `jsonapi:"attr,working-directory,omitempty"`
-
-	// Optional: Whether to enable drift detection for the workspace.
-	// Requires remote execution mode, TFCB entitlement, and a valid agent pool to work
-	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
 }
 
 // WorkspaceLockOptions represents the options for locking a workspace.

--- a/workspace.go
+++ b/workspace.go
@@ -115,6 +115,7 @@ type Workspace struct {
 	CanQueueDestroyPlan        bool                  `jsonapi:"attr,can-queue-destroy-plan"`
 	CreatedAt                  time.Time             `jsonapi:"attr,created-at,iso8601"`
 	Description                string                `jsonapi:"attr,description"`
+	DriftDetection             bool                  `jsonapi:"attr,drift-detection"`
 	Environment                string                `jsonapi:"attr,environment"`
 	ExecutionMode              string                `jsonapi:"attr,execution-mode"`
 	FileTriggersEnabled        bool                  `jsonapi:"attr,file-triggers-enabled"`
@@ -349,6 +350,10 @@ type WorkspaceCreateOptions struct {
 	// A list of tags to attach to the workspace. If the tag does not already
 	// exist, it is created and added to the workspace.
 	Tags []*Tag `jsonapi:"relation,tags,omitempty"`
+
+	// Optional: Whether to enabled drift detection for the workspace.
+	// Requires remote execution mode, TFCB entitlement, and a valid agent pool to work
+	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
 }
 
 // TODO: move this struct out. VCSRepoOptions is used by workspaces, policy sets, and registry modules
@@ -447,6 +452,10 @@ type WorkspaceUpdateOptions struct {
 	// the environment when multiple environments exist within the same
 	// repository.
 	WorkingDirectory *string `jsonapi:"attr,working-directory,omitempty"`
+
+	// Optional: Whether to enabled drift detection for the workspace.
+	// Requires remote execution mode, TFCB entitlement, and a valid agent pool to work
+	DriftDetection *bool `jsonapi:"attr,drift-detection,omitempty"`
 }
 
 // WorkspaceLockOptions represents the options for locking a workspace.

--- a/workspace.go
+++ b/workspace.go
@@ -111,11 +111,11 @@ type Workspace struct {
 	Actions                    *WorkspaceActions     `jsonapi:"attr,actions"`
 	AgentPoolID                string                `jsonapi:"attr,agent-pool-id"`
 	AllowDestroyPlan           bool                  `jsonapi:"attr,allow-destroy-plan"`
+	AssessmentsEnabled         bool                  `jsonapi:"attr,assessments-enabled"`
 	AutoApply                  bool                  `jsonapi:"attr,auto-apply"`
 	CanQueueDestroyPlan        bool                  `jsonapi:"attr,can-queue-destroy-plan"`
 	CreatedAt                  time.Time             `jsonapi:"attr,created-at,iso8601"`
 	Description                string                `jsonapi:"attr,description"`
-	AssessmentsEnabled         bool                  `jsonapi:"attr,assessments-enabled"`
 	Environment                string                `jsonapi:"attr,environment"`
 	ExecutionMode              string                `jsonapi:"attr,execution-mode"`
 	FileTriggersEnabled        bool                  `jsonapi:"attr,file-triggers-enabled"`
@@ -265,16 +265,16 @@ type WorkspaceCreateOptions struct {
 	// Optional: Whether destroy plans can be queued on the workspace.
 	AllowDestroyPlan *bool `jsonapi:"attr,allow-destroy-plan,omitempty"`
 
+	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
+	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#create-a-workspace
+	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
+	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
+
 	// Optional: Whether to automatically apply changes when a Terraform plan is successful.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
 
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
-
-	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
-	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#create-a-workspace
-	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
-	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
 
 	// Optional: Which execution mode to use. Valid values are remote, local, and agent.
 	// When set to local, the workspace will be used for state storage only.
@@ -383,6 +383,11 @@ type WorkspaceUpdateOptions struct {
 	// Optional: Whether destroy plans can be queued on the workspace.
 	AllowDestroyPlan *bool `jsonapi:"attr,allow-destroy-plan,omitempty"`
 
+	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
+	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#update-a-workspace
+	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
+	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
+
 	// Optional: Whether to automatically apply changes when a Terraform plan is successful.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
 
@@ -394,11 +399,6 @@ type WorkspaceUpdateOptions struct {
 
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
-
-	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
-	// Reference: https://www.terraform.io/cloud-docs/api-docs/workspaces#update-a-workspace
-	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
-	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
 
 	// Optional: Which execution mode to use. Valid values are remote, local, and agent.
 	// When set to local, the workspace will be used for state storage only.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -327,7 +327,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			AllowDestroyPlan:           Bool(false),
 			AutoApply:                  Bool(true),
 			Description:                String("qux"),
-			DriftDetection:             Bool(false),
+			AssessmentsEnabled:         Bool(false),
 			FileTriggersEnabled:        Bool(true),
 			Operations:                 Bool(true),
 			QueueAllRuns:               Bool(true),
@@ -364,7 +364,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			assert.Equal(t, *options.Description, item.Description)
 			assert.Equal(t, *options.AllowDestroyPlan, item.AllowDestroyPlan)
 			assert.Equal(t, *options.AutoApply, item.AutoApply)
-			assert.Equal(t, *options.DriftDetection, item.DriftDetection)
+			assert.Equal(t, *options.AssessmentsEnabled, item.AssessmentsEnabled)
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
@@ -721,13 +721,13 @@ func TestWorkspacesUpdate(t *testing.T) {
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
-			Name:             String(wTest.Name),
-			AllowDestroyPlan: Bool(false),
-			AutoApply:        Bool(true),
-			Operations:       Bool(true),
-			QueueAllRuns:     Bool(true),
-			DriftDetection:   Bool(true),
-			TerraformVersion: String("0.15.4"),
+			Name:               String(wTest.Name),
+			AllowDestroyPlan:   Bool(false),
+			AutoApply:          Bool(true),
+			Operations:         Bool(true),
+			QueueAllRuns:       Bool(true),
+			AssessmentsEnabled: Bool(true),
+			TerraformVersion:   String("0.15.4"),
 		}
 
 		wAfter, err := client.Workspaces.Update(ctx, orgTest.Name, wTest.Name, options)
@@ -737,7 +737,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 		assert.NotEqual(t, wTest.AllowDestroyPlan, wAfter.AllowDestroyPlan)
 		assert.NotEqual(t, wTest.AutoApply, wAfter.AutoApply)
 		assert.NotEqual(t, wTest.QueueAllRuns, wAfter.QueueAllRuns)
-		assert.NotEqual(t, wTest.DriftDetection, wAfter.DriftDetection)
+		assert.NotEqual(t, wTest.AssessmentsEnabled, wAfter.AssessmentsEnabled)
 		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
 		assert.Equal(t, wTest.WorkingDirectory, wAfter.WorkingDirectory)
 	})

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -327,6 +327,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			AllowDestroyPlan:           Bool(false),
 			AutoApply:                  Bool(true),
 			Description:                String("qux"),
+			DriftDetection:             Bool(false),
 			FileTriggersEnabled:        Bool(true),
 			Operations:                 Bool(true),
 			QueueAllRuns:               Bool(true),
@@ -363,6 +364,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			assert.Equal(t, *options.Description, item.Description)
 			assert.Equal(t, *options.AllowDestroyPlan, item.AllowDestroyPlan)
 			assert.Equal(t, *options.AutoApply, item.AutoApply)
+			assert.Equal(t, *options.DriftDetection, item.DriftDetection)
 			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
 			assert.Equal(t, *options.Operations, item.Operations)
 			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
@@ -724,7 +726,8 @@ func TestWorkspacesUpdate(t *testing.T) {
 			AutoApply:        Bool(true),
 			Operations:       Bool(true),
 			QueueAllRuns:     Bool(true),
-			TerraformVersion: String("0.10.0"),
+			DriftDetection:   Bool(true),
+			TerraformVersion: String("0.15.4"),
 		}
 
 		wAfter, err := client.Workspaces.Update(ctx, orgTest.Name, wTest.Name, options)
@@ -734,6 +737,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 		assert.NotEqual(t, wTest.AllowDestroyPlan, wAfter.AllowDestroyPlan)
 		assert.NotEqual(t, wTest.AutoApply, wAfter.AutoApply)
 		assert.NotEqual(t, wTest.QueueAllRuns, wAfter.QueueAllRuns)
+		assert.NotEqual(t, wTest.DriftDetection, wAfter.DriftDetection)
 		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
 		assert.Equal(t, wTest.WorkingDirectory, wAfter.WorkingDirectory)
 	})

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -717,6 +717,8 @@ func TestWorkspacesUpdate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("when updating a subset of values", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

🚨 This has been updated to support and test against the settings changes described [here](https://github.com/hashicorp/atlas/pull/13300) 🚨

## Description

Allow go-tfe to access and manage drift detection setting for workspaces in TFC.

## Testing plan

## External links

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/workspaces#request-body)
-[ tfe provider PR ](https://github.com/hashicorp/terraform-provider-tfe/pull/550)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ go test -run TestWorkspacesUpdate -v ./... -tags=integration
=== RUN   TestWorkspacesUpdate
=== RUN   TestWorkspacesUpdate/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdate/with_valid_options
=== RUN   TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value
=== RUN   TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID
=== RUN   TestWorkspacesUpdate/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_name
=== RUN   TestWorkspacesUpdate/when_options_has_an_invalid_organization
=== RUN   TestWorkspacesUpdate/when_options_include_trigger-patterns_(behind_a_feature_flag)
=== RUN   TestWorkspacesUpdate/when_options_include_both_trigger-patterns_and_trigger-paths_error_is_returned
=== RUN   TestWorkspacesUpdate/when_options_include_trigger-patterns_populated_and_empty_trigger-paths_workspace_is_updated
=== RUN   TestWorkspacesUpdate/when_options_include_VCSRepo_tags-regex
    helper_test.go:633: Export a valid OAUTH_CLIENT_GITHUB_TOKEN before running this test!
=== RUN   TestWorkspacesUpdate/when_options_include_tags-regex_and_file-triggers-enabled_is_true_an_error_is_returned
=== RUN   TestWorkspacesUpdate/when_options_include_both_non-empty_tags-regex_and_file-triggers-enabled_an_error_is_returned
=== RUN   TestWorkspacesUpdate/when_options_include_both_tags-regex_and_trigger-prefixes_an_error_is_returned
=== RUN   TestWorkspacesUpdate/when_options_include_both_tags-regex_and_trigger-patterns_error_is_returned
--- PASS: TestWorkspacesUpdate (49.53s)
    --- PASS: TestWorkspacesUpdate/when_updating_a_subset_of_values (2.25s)
    --- PASS: TestWorkspacesUpdate/with_valid_options (4.49s)
    --- PASS: TestWorkspacesUpdate/when_options_includes_both_an_operations_value_and_an_enforcement_mode_value (0.00s)
    --- PASS: TestWorkspacesUpdate/when_'agent'_execution_mode_is_specified_without_an_an_agent_pool_ID (0.00s)
    --- PASS: TestWorkspacesUpdate/when_an_error_is_returned_from_the_api (2.27s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_name (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_has_an_invalid_organization (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_include_trigger-patterns_(behind_a_feature_flag) (13.19s)
    --- PASS: TestWorkspacesUpdate/when_options_include_both_trigger-patterns_and_trigger-paths_error_is_returned (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_include_trigger-patterns_populated_and_empty_trigger-paths_workspace_is_updated (12.40s)
    --- SKIP: TestWorkspacesUpdate/when_options_include_VCSRepo_tags-regex (5.24s)
    --- PASS: TestWorkspacesUpdate/when_options_include_tags-regex_and_file-triggers-enabled_is_true_an_error_is_returned (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_include_both_non-empty_tags-regex_and_file-triggers-enabled_an_error_is_returned (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_include_both_tags-regex_and_trigger-prefixes_an_error_is_returned (0.00s)
    --- PASS: TestWorkspacesUpdate/when_options_include_both_tags-regex_and_trigger-patterns_error_is_returned (0.00s)
=== RUN   TestWorkspacesUpdateByID
=== RUN   TestWorkspacesUpdateByID/when_updating_a_subset_of_values
=== RUN   TestWorkspacesUpdateByID/with_valid_options
=== RUN   TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api
=== RUN   TestWorkspacesUpdateByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUpdateByID (19.45s)
    --- PASS: TestWorkspacesUpdateByID/when_updating_a_subset_of_values (2.46s)
    --- PASS: TestWorkspacesUpdateByID/with_valid_options (4.15s)
    --- PASS: TestWorkspacesUpdateByID/when_an_error_is_returned_from_the_api (2.22s)
    --- PASS: TestWorkspacesUpdateByID/without_a_valid_workspace_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	69.204s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```

```
$ go test -run TestWorkspacesRead -v ./... -tags=integration
=== RUN   TestWorkspacesRead
=== RUN   TestWorkspacesRead/when_the_workspace_exists
=== RUN   TestWorkspacesRead/when_the_workspace_does_not_exist
=== RUN   TestWorkspacesRead/when_the_organization_does_not_exist
=== RUN   TestWorkspacesRead/without_a_valid_organization
=== RUN   TestWorkspacesRead/without_a_valid_workspace
--- PASS: TestWorkspacesRead (1.35s)
    --- PASS: TestWorkspacesRead/when_the_workspace_exists (0.13s)
    --- PASS: TestWorkspacesRead/when_the_workspace_does_not_exist (0.08s)
    --- PASS: TestWorkspacesRead/when_the_organization_does_not_exist (0.08s)
    --- PASS: TestWorkspacesRead/without_a_valid_organization (0.00s)
    --- PASS: TestWorkspacesRead/without_a_valid_workspace (0.00s)
=== RUN   TestWorkspacesReadWithOptions
=== RUN   TestWorkspacesReadWithOptions/when_options_to_include_resource
--- PASS: TestWorkspacesReadWithOptions (4.62s)
    --- PASS: TestWorkspacesReadWithOptions/when_options_to_include_resource (0.65s)
PASS
ok  	github.com/hashicorp/go-tfe	5.974s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```

```
$ go test -run TestWorkspacesCreate/with_valid_options -v ./... -tags=integration
=== RUN   TestWorkspacesCreate
=== RUN   TestWorkspacesCreate/with_valid_options
--- PASS: TestWorkspacesCreate (11.94s)
    --- PASS: TestWorkspacesCreate/with_valid_options (4.28s)
PASS
ok  	github.com/hashicorp/go-tfe	12.250s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```

```
$ go test -run TestOrganizationsCreate -v ./... -tags=integration
=== RUN   TestOrganizationsCreate
=== RUN   TestOrganizationsCreate/with_valid_options
=== RUN   TestOrganizationsCreate/when_no_email_is_provided
=== RUN   TestOrganizationsCreate/when_no_name_is_provided
=== RUN   TestOrganizationsCreate/with_invalid_name
--- PASS: TestOrganizationsCreate (6.67s)
    --- PASS: TestOrganizationsCreate/with_valid_options (4.48s)
    --- PASS: TestOrganizationsCreate/when_no_email_is_provided (0.00s)
    --- PASS: TestOrganizationsCreate/when_no_name_is_provided (0.00s)
    --- PASS: TestOrganizationsCreate/with_invalid_name (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	6.888s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```

```
go test -run TestOrganization_Unmarshall -v ./... -tags=integration
testing: warning: no tests to run
PASS
ok  	github.com/hashicorp/go-tfe	0.209s [no tests to run]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```