### PR TITLE
Replace deprecated GET api for registry modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * [beta] Add support for triggering Workspace runs through matching Git tags [#434](https://github.com/hashicorp/go-tfe/pull/434)
 * Add `Query` param field to `AgentPoolListOptions` to allow searching based on agent pool name, by @JarrettSpiker [#417](https://github.com/hashicorp/go-tfe/pull/417)
 * Add organization scope and allowed workspaces field for scope agents by @Netra2104 [#453](https://github.com/hashicorp/go-tfe/pull/453)
-* Adds `Namespace` and `RegistryName` fields to `RegistryModuleID` to allow reading of Public Registry Modules by @Uk1288 [#438](https://github.com/hashicorp/go-tfe/pull/438)
+* Adds `Namespace` and `RegistryName` fields to `RegistryModuleID` to allow reading of Public Registry Modules by @Uk1288 [#464](https://github.com/hashicorp/go-tfe/pull/464)
 
 ## Bug fixes
 * Fixed JSON mapping for Configuration Versions failing to properly set the `speculative` property [#459](https://github.com/hashicorp/go-tfe/pull/459)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,10 @@
 # Unreleased
 
+## Enhancements
 * [beta] Add support for triggering Workspace runs through matching Git tags [#434](https://github.com/hashicorp/go-tfe/pull/434)
 * Add `Query` param field to `AgentPoolListOptions` to allow searching based on agent pool name, by @JarrettSpiker [#417](https://github.com/hashicorp/go-tfe/pull/417)
 * Add organization scope and allowed workspaces field for scope agents by @Netra2104 [#453](https://github.com/hashicorp/go-tfe/pull/453)
+* Adds `Namespace` and `RegistryName` fields to `RegistryModuleID` to allow reading of Public Registry Modules by @Uk1288 [#438](https://github.com/hashicorp/go-tfe/pull/438)
 
 ## Bug fixes
 * Fixed JSON mapping for Configuration Versions failing to properly set the `speculative` property [#459](https://github.com/hashicorp/go-tfe/pull/459)

--- a/errors.go
+++ b/errors.go
@@ -174,7 +174,7 @@ var (
 
 	ErrInvalidArch = errors.New("invalid value for arch")
 
-	ErrInvalidRegistryName = errors.New("invalid value for registry-name")
+	ErrInvalidRegistryName = errors.New(`invalid value for registry-name. It must be either "private" or "public"`)
 )
 
 // Missing values for required field/option
@@ -300,4 +300,6 @@ var (
 	ErrRequiredFilename = errors.New("filename is required")
 
 	ErrInvalidAsciiArmor = errors.New("ascii armor is invalid")
+
+	ErrRequiredNamespace = errors.New("namespace is required for public registry")
 )

--- a/registry_module.go
+++ b/registry_module.go
@@ -441,16 +441,18 @@ func (o RegistryModuleID) valid() error {
 	if !validStringID(&o.Provider) {
 		return ErrInvalidProvider
 	}
-	// RegistryName is optional, only validate if specified
-	if validString((*string)(&o.RegistryName)) {
-		registryNamesMap := map[RegistryName]RegistryName{PublicRegistry: PublicRegistry, PrivateRegistry: PrivateRegistry}
-		if _, ok := registryNamesMap[o.RegistryName]; !ok {
-			return ErrInvalidRegistryName
-		}
-	}
 
-	if o.RegistryName == PublicRegistry && !validString(&o.Namespace) {
-		return ErrRequiredNamespace
+	switch o.RegistryName {
+	case PublicRegistry:
+		if !validString(&o.Namespace) {
+			return ErrRequiredNamespace
+		}
+	case PrivateRegistry:
+	case "":
+		// no-op:  RegistryName is optional
+	// for all other string
+	default:
+		return ErrInvalidRegistryName
 	}
 
 	return nil

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -417,6 +417,29 @@ func TestRegistryModulesRead(t *testing.T) {
 		})
 	})
 
+	t.Run("with complete registry module ID fields", func(t *testing.T) {
+		rm, err := client.RegistryModules.Read(ctx, RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         registryModuleTest.Name,
+			Provider:     registryModuleTest.Provider,
+			Namespace:    orgTest.Name,
+			RegistryName: PrivateRegistry,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, registryModuleTest.ID, rm.ID)
+
+		t.Run("permissions are properly decoded", func(t *testing.T) {
+			assert.True(t, rm.Permissions.CanDelete)
+			assert.True(t, rm.Permissions.CanResync)
+			assert.True(t, rm.Permissions.CanRetry)
+		})
+
+		t.Run("timestamps are properly decoded", func(t *testing.T) {
+			assert.NotEmpty(t, rm.CreatedAt)
+			assert.NotEmpty(t, rm.UpdatedAt)
+		})
+	})
+
 	t.Run("without a name", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, RegistryModuleID{
 			Organization: orgTest.Name,
@@ -455,6 +478,18 @@ func TestRegistryModulesRead(t *testing.T) {
 		})
 		assert.Nil(t, rm)
 		assert.Equal(t, err, ErrInvalidProvider)
+	})
+
+	t.Run("with an invalid registry name", func(t *testing.T) {
+		rm, err := client.RegistryModules.Read(ctx, RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         registryModuleTest.Name,
+			Provider:     registryModuleTest.Provider,
+			Namespace:    orgTest.Name,
+			RegistryName: "PRIVATE",
+		})
+		assert.Nil(t, rm)
+		assert.Equal(t, err, ErrInvalidRegistryName)
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {
@@ -775,8 +810,10 @@ func TestRegistryModule_Unmarshal(t *testing.T) {
 			"type": "registry-modules",
 			"id":   "1",
 			"attributes": map[string]interface{}{
-				"name":     "module",
-				"provider": "tfe",
+				"name":          "module",
+				"provider":      "tfe",
+				"namespace":     "org-abc",
+				"registry-name": "private",
 				"permissions": map[string]interface{}{
 					"can-delete": true,
 					"can-resync": true,
@@ -815,6 +852,8 @@ func TestRegistryModule_Unmarshal(t *testing.T) {
 	assert.Equal(t, rm.ID, "1")
 	assert.Equal(t, rm.Name, "module")
 	assert.Equal(t, rm.Provider, "tfe")
+	assert.Equal(t, rm.Namespace, "org-abc")
+	assert.Equal(t, rm.RegistryName, "private")
 	assert.Equal(t, rm.Permissions.CanDelete, true)
 	assert.Equal(t, rm.Permissions.CanRetry, true)
 	assert.Equal(t, rm.Status, RegistryModuleStatusPending)

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -853,7 +853,7 @@ func TestRegistryModule_Unmarshal(t *testing.T) {
 	assert.Equal(t, rm.Name, "module")
 	assert.Equal(t, rm.Provider, "tfe")
 	assert.Equal(t, rm.Namespace, "org-abc")
-	assert.Equal(t, rm.RegistryName, "private")
+	assert.Equal(t, rm.RegistryName, PrivateRegistry)
 	assert.Equal(t, rm.Permissions.CanDelete, true)
 	assert.Equal(t, rm.Permissions.CanRetry, true)
 	assert.Equal(t, rm.Status, RegistryModuleStatusPending)

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -426,9 +426,11 @@ func TestRegistryModulesRead(t *testing.T) {
 			RegistryName: PrivateRegistry,
 		})
 		require.NoError(t, err)
+		require.NotEmpty(t, rm)
 		assert.Equal(t, registryModuleTest.ID, rm.ID)
 
 		t.Run("permissions are properly decoded", func(t *testing.T) {
+			require.NotEmpty(t, rm.Permissions)
 			assert.True(t, rm.Permissions.CanDelete)
 			assert.True(t, rm.Permissions.CanResync)
 			assert.True(t, rm.Permissions.CanRetry)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
The go-client employs the deprecated API (GET /registry-modules/show/:organization_name/:name/:provider) to GET published modules. The API works only for private modules.

This PR replaces the deprecated API with the newer API: GET /organizations/:organization_name/registry-modules/:registry_name/:namespace/:name/:provider which works for both public and private modules.

My initial thought was to replace the `RegistryModuleID` in `Read(ctx context.Context, moduleID RegistryModuleID) (*RegistryModule, error)` with:
```
type RegistryModuleReadOptions struct {
 // Required: The organization the module belongs to
 Organization string
 // Required: The name of the module
 Name string
 // Required: The module provider
 Provider string
 // The namespace of the module. For private modules this is the name of the organization that owns the module
 // Required for public modules
 Namespace string
 // Either public or private. If not provided, defaults to private
 RegistryName RegistryName
}
```
but this would lead to a breaking change.

To allow for backward compatibility I went with the current solution which just extends the `RegistryModuleID`.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
1.  _Create both private and public registry modules_
1.  _Before the changes, use the `Read` method to get modules. Private module is returned successfully while public module returns not found_
1.  _With code changes, Read should return both private and public modules._
1.  _It should work with previous RegistryModuleID attributes as well._
## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestRegistryModules

=== RUN   TestRegistryModulesRead
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider
2022/07/14 08:36:19 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2022/07/14 08:36:19 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/without_a_name
=== RUN   TestRegistryModulesRead/with_an_invalid_name
=== RUN   TestRegistryModulesRead/without_a_provider
=== RUN   TestRegistryModulesRead/with_an_invalid_provider
=== RUN   TestRegistryModulesRead/with_an_invalid_registry_name
=== RUN   TestRegistryModulesRead/without_a_valid_organization
=== RUN   TestRegistryModulesRead/when_the_registry_module_does_not_exist
2022/07/14 08:36:19 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2022/07/14 08:36:19 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
--- PASS: TestRegistryModulesRead (1.56s)
    --- PASS: TestRegistryModulesRead/with_valid_name_and_provider (0.12s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields (0.13s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_name (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_registry_name (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesRead/when_the_registry_module_does_not_exist (0.11s)
=== RUN   TestRegistryModulesDelete

```

## Dependent PR
https://github.com/hashicorp/go-tfe/pull/460 **is blocked by this PR**