### PR TITLE
Modify CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,0 @@
-
-# This whitelists the whole repo
-* @hashicorp/tf-practitioner

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-*.go @hashicorp/tf-cli
-*.md @hashicorp/tf-cli
+* @hashicorp/tf-cli


### PR DESCRIPTION
* Removes the duplicate `CODEOWNERS` file in `.github/` pointing to a non-existing team. 
* Give wildcard access to owners instead of by file extension. 