### PR TITLE
Add Name to the Oauth Client Payload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# v1.6.0
+* Add `Name` field to `OAuthClient` by @barrettclark [#466](https://github.com/hashicorp/go-tfe/pull/466)
+
 # v1.5.0
 
 ## Enhancements

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -73,6 +73,7 @@ type OAuthClient struct {
 	HTTPURL             string              `jsonapi:"attr,http-url"`
 	Key                 string              `jsonapi:"attr,key"`
 	RSAPublicKey        string              `jsonapi:"attr,rsa-public-key"`
+	Name                *string             `jsonapi:"attr,name"`
 	Secret              string              `jsonapi:"attr,secret"`
 	ServiceProvider     ServiceProviderType `jsonapi:"attr,service-provider"`
 	ServiceProviderName string              `jsonapi:"attr,service-provider-display-name"`

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -109,6 +109,7 @@ func TestOAuthClientsCreate(t *testing.T) {
 		oc, err := client.OAuthClients.Create(ctx, orgTest.Name, options)
 		require.NoError(t, err)
 		assert.NotEmpty(t, oc.ID)
+		assert.Nil(t, oc.Name)
 		assert.Equal(t, "https://api.github.com", oc.APIURL)
 		assert.Equal(t, "https://github.com", oc.HTTPURL)
 		assert.Equal(t, 1, len(oc.OAuthTokens))


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe!

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description
The [oauth-clients endpoint](https://www.terraform.io/cloud-docs/api-docs/oauth-clients#sample-response) returns the name attribute of each OAuth Client, but the [OAuthClient struct](https://github.com/hashicorp/go-tfe/blob/main/oauth_client.go#L67-L83) doesn't expose this attribute. This pull request adds the Name field to the OAuthClient struct.

Fixes #461

<!-- Describe why you're making this change. -->

## Testing plan

This is how you see the name in the Oauth Client payload:
1.  Make sure you have a GitHub [personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token)
1.  Make sure you have a TF API token that has admin access
1.  Configure a [GitHub Oauth linkage](https://www.terraform.io/cloud-docs/vcs/github). If you give the Oauth linkage a name, you will see that name in the API response in the next step.
2. Now you can fetch the [list of OAuth Clients from the API](https://www.terraform.io/cloud-docs/api-docs/oauth-clients#sample-response)

In order to run the integration test you also need to do the first two steps from above.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ GITHUB_TOKEN=$GITHUB_TOKEN TF_ACC=1 TFE_TOKEN=$TFE_TOKEN TFE_ADDRESS=$TFE_ADDRESS go test -v -run TestOAuthClientsCreate ./... --tags=integration
```


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1202588229476830