### PR TITLE
Update Run and Workspace Run Tasks for Pre-plan Run Tasks 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Enhancements
 
 * Adds new run creation attributes: `allow-empty-apply`, `terraform-version`, `plan-only` by @sebasslash [#482](https://github.com/hashicorp/go-tfe/pull/447)
+* Adds additional Task Stage and Run Statuses for Pre-plan run tasks by @glennsarti [#469](https://github.com/hashicorp/go-tfe/pull/469)
+* Adds `stage` field to the create and update methods for Workspace Run Tasks by @glennsarti [#469](https://github.com/hashicorp/go-tfe/pull/469)
 
 # v1.6.0
 

--- a/run.go
+++ b/run.go
@@ -51,8 +51,8 @@ type RunStatus string
 // List all available run statuses.
 const (
 	RunApplied            RunStatus = "applied"
-	RunApplyQueued        RunStatus = "apply_queued"
 	RunApplying           RunStatus = "applying"
+	RunApplyQueued        RunStatus = "apply_queued"
 	RunCanceled           RunStatus = "canceled"
 	RunConfirmed          RunStatus = "confirmed"
 	RunCostEstimated      RunStatus = "cost_estimated"
@@ -60,17 +60,21 @@ const (
 	RunDiscarded          RunStatus = "discarded"
 	RunErrored            RunStatus = "errored"
 	RunFetching           RunStatus = "fetching"
+	RunFetchingCompleted  RunStatus = "fetching_completed"
 	RunPending            RunStatus = "pending"
-	RunPlanQueued         RunStatus = "plan_queued"
 	RunPlanned            RunStatus = "planned"
 	RunPlannedAndFinished RunStatus = "planned_and_finished"
 	RunPlanning           RunStatus = "planning"
+	RunPlanQueued         RunStatus = "plan_queued"
 	RunPolicyChecked      RunStatus = "policy_checked"
 	RunPolicyChecking     RunStatus = "policy_checking"
 	RunPolicyOverride     RunStatus = "policy_override"
 	RunPolicySoftFailed   RunStatus = "policy_soft_failed"
-	RunPostPlanRunning    RunStatus = "post_plan_running"
 	RunPostPlanCompleted  RunStatus = "post_plan_completed"
+	RunPostPlanRunning    RunStatus = "post_plan_running"
+	RunPrePlanCompleted   RunStatus = "pre_plan_completed"
+	RunPrePlanRunning     RunStatus = "pre_plan_running"
+	RunQueuing            RunStatus = "queuing"
 )
 
 // RunSource represents a source type of a run.
@@ -157,8 +161,8 @@ type RunPermissions struct {
 // RunStatusTimestamps holds the timestamps for individual run statuses.
 type RunStatusTimestamps struct {
 	AppliedAt            time.Time `jsonapi:"attr,applied-at,rfc3339"`
-	ApplyQueuedAt        time.Time `jsonapi:"attr,apply-queued-at,rfc3339"`
 	ApplyingAt           time.Time `jsonapi:"attr,applying-at,rfc3339"`
+	ApplyQueuedAt        time.Time `jsonapi:"attr,apply-queued-at,rfc3339"`
 	CanceledAt           time.Time `jsonapi:"attr,canceled-at,rfc3339"`
 	ConfirmedAt          time.Time `jsonapi:"attr,confirmed-at,rfc3339"`
 	CostEstimatedAt      time.Time `jsonapi:"attr,cost-estimated-at,rfc3339"`
@@ -168,13 +172,18 @@ type RunStatusTimestamps struct {
 	FetchedAt            time.Time `jsonapi:"attr,fetched-at,rfc3339"`
 	FetchingAt           time.Time `jsonapi:"attr,fetching-at,rfc3339"`
 	ForceCanceledAt      time.Time `jsonapi:"attr,force-canceled-at,rfc3339"`
-	PlanQueueableAt      time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
-	PlanQueuedAt         time.Time `jsonapi:"attr,plan-queued-at,rfc3339"`
 	PlannedAndFinishedAt time.Time `jsonapi:"attr,planned-and-finished-at,rfc3339"`
 	PlannedAt            time.Time `jsonapi:"attr,planned-at,rfc3339"`
 	PlanningAt           time.Time `jsonapi:"attr,planning-at,rfc3339"`
+	PlanQueueableAt      time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
+	PlanQueuedAt         time.Time `jsonapi:"attr,plan-queued-at,rfc3339"`
 	PolicyCheckedAt      time.Time `jsonapi:"attr,policy-checked-at,rfc3339"`
 	PolicySoftFailedAt   time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
+	PostPlanCompletedAt  time.Time `jsonapi:"attr,post-plan-completed-at,rfc3339"`
+	PostPlanRunningAt    time.Time `jsonapi:"attr,post-plan-running-at,rfc3339"`
+	PrePlanCompletedAt   time.Time `jsonapi:"attr,pre-plan-completed-at,rfc3339"`
+	PrePlanRunningAt     time.Time `jsonapi:"attr,pre-plan-running-at,rfc3339"`
+	QueuingAt            time.Time `jsonapi:"attr,queuing-at,rfc3339"`
 }
 
 // RunIncludeOpt represents the available options for include query params.

--- a/task_stages.go
+++ b/task_stages.go
@@ -29,6 +29,7 @@ type taskStages struct {
 type Stage string
 
 const (
+	PrePlan  Stage = "pre_plan"
 	PostPlan Stage = "post_plan"
 )
 

--- a/workspace_run_task.go
+++ b/workspace_run_task.go
@@ -37,6 +37,7 @@ type workspaceRunTasks struct {
 type WorkspaceRunTask struct {
 	ID               string               `jsonapi:"primary,workspace-tasks"`
 	EnforcementLevel TaskEnforcementLevel `jsonapi:"attr,enforcement-level"`
+	Stage            Stage                `jsonapi:"attr,stage"`
 
 	RunTask   *RunTask   `jsonapi:"relation,task"`
 	Workspace *Workspace `jsonapi:"relation,workspace"`
@@ -60,12 +61,15 @@ type WorkspaceRunTaskCreateOptions struct {
 	EnforcementLevel TaskEnforcementLevel `jsonapi:"attr,enforcement-level"`
 	// Required: The run task to attach to the workspace
 	RunTask *RunTask `jsonapi:"relation,task"`
+	// Optional: The stage to run the task in. This is currently in BETA
+	Stage *Stage `jsonapi:"attr,stage,omitempty"`
 }
 
 // WorkspaceRunTaskUpdateOptions represent the set of options for updating a workspace run task.
 type WorkspaceRunTaskUpdateOptions struct {
 	Type             string               `jsonapi:"primary,workspace-tasks"`
 	EnforcementLevel TaskEnforcementLevel `jsonapi:"attr,enforcement-level,omitempty"`
+	Stage            *Stage               `jsonapi:"attr,stage,omitempty"` // The stage to run the task in. This is currently in BETA
 }
 
 // List all run tasks attached to a workspace


### PR DESCRIPTION
## Description

This commit updates the client for the new Pre-plan Run tasks:
* New run statuses; FetchingCompleted, Queuing which are ephemeral and will rarely be seen.
  PrePlanRunning and PrePlanCompleted are for the pre-plan tasks
* Add missing Run Status Time Stamps
* New Task stage; PrePlan
* Ability to set/update the stage for a Workspace Run Task. This is a beta feature and must
  be opted into. However it is optional and is not a breaking API change.
* Adds additional Workspace Run Tasks tests which are gated behind the BETA flag. Note that
  the original tests still remain to affirm that this commit does not change any existing
  behaviour.

## Testing plan

Run the acceptance tests against a TFC/TFE instance with the pre-plan feature flag enabled

## External links

- [API documentation](https://github.com/hashicorp/terraform-docs-common/pull/72)
- RFC - TF515

## Output from tests

With `go test -v ./... -tags=integration -run TestWorkspaceRunTasks -count=1`

```
=== RUN   TestWorkspaceRunTasksCreate
=== RUN   TestWorkspaceRunTasksCreate/attach_run_task_to_workspace
=== RUN   TestWorkspaceRunTasksCreate/attach_run_task_to_workspace/ensure_run_task_is_deserialized_properly
--- PASS: TestWorkspaceRunTasksCreate (3.39s)
    --- PASS: TestWorkspaceRunTasksCreate/attach_run_task_to_workspace (0.64s)
        --- PASS: TestWorkspaceRunTasksCreate/attach_run_task_to_workspace/ensure_run_task_is_deserialized_properly (0.00s)
=== RUN   TestWorkspaceRunTasksCreateBeta
=== RUN   TestWorkspaceRunTasksCreateBeta/attach_run_task_to_workspace
=== RUN   TestWorkspaceRunTasksCreateBeta/attach_run_task_to_workspace/ensure_run_task_is_deserialized_properly
--- PASS: TestWorkspaceRunTasksCreateBeta (3.28s)
    --- PASS: TestWorkspaceRunTasksCreateBeta/attach_run_task_to_workspace (0.60s)
        --- PASS: TestWorkspaceRunTasksCreateBeta/attach_run_task_to_workspace/ensure_run_task_is_deserialized_properly (0.00s)
=== RUN   TestWorkspaceRunTasksList
=== RUN   TestWorkspaceRunTasksList/with_no_params
--- PASS: TestWorkspaceRunTasksList (5.18s)
    --- PASS: TestWorkspaceRunTasksList/with_no_params (0.36s)
=== RUN   TestWorkspaceRunTasksRead
=== RUN   TestWorkspaceRunTasksRead/by_ID
=== RUN   TestWorkspaceRunTasksRead/by_ID/ensure_run_task_is_deserialized
=== RUN   TestWorkspaceRunTasksRead/by_ID/ensure_workspace_is_deserialized
--- PASS: TestWorkspaceRunTasksRead (3.48s)
    --- PASS: TestWorkspaceRunTasksRead/by_ID (0.25s)
        --- PASS: TestWorkspaceRunTasksRead/by_ID/ensure_run_task_is_deserialized (0.00s)
        --- PASS: TestWorkspaceRunTasksRead/by_ID/ensure_workspace_is_deserialized (0.00s)
=== RUN   TestWorkspaceRunTasksUpdate
=== RUN   TestWorkspaceRunTasksUpdate/rename_task
--- PASS: TestWorkspaceRunTasksUpdate (3.79s)
    --- PASS: TestWorkspaceRunTasksUpdate/rename_task (0.56s)
=== RUN   TestWorkspaceRunTasksUpdateBeta
=== RUN   TestWorkspaceRunTasksUpdateBeta/update_task
--- PASS: TestWorkspaceRunTasksUpdateBeta (3.90s)
    --- PASS: TestWorkspaceRunTasksUpdateBeta/update_task (0.51s)
=== RUN   TestWorkspaceRunTasksDelete
=== RUN   TestWorkspaceRunTasksDelete/with_valid_options
=== RUN   TestWorkspaceRunTasksDelete/when_the_workspace_run_task_does_not_exist
=== RUN   TestWorkspaceRunTasksDelete/when_the_workspace_does_not_exist
--- PASS: TestWorkspaceRunTasksDelete (4.10s)
    --- PASS: TestWorkspaceRunTasksDelete/with_valid_options (0.52s)
    --- PASS: TestWorkspaceRunTasksDelete/when_the_workspace_run_task_does_not_exist (0.24s)
    --- PASS: TestWorkspaceRunTasksDelete/when_the_workspace_does_not_exist (0.25s)
PASS
ok      github.com/hashicorp/go-tfe     27.384s
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```