### PR TITLE
Initial tflocal configuration for CI

### DIFF
--- a/tflocal/main.tf
+++ b/tflocal/main.tf
@@ -15,8 +15,6 @@ module "tflocal" {
   ejson_file_content           = var.ejson_file_content
   quay_username                = var.quay_username
   quay_password                = var.quay_password
-  circleci_token               = var.circleci_token
-  update_circleci              = var.update_circleci
   run_cleanup_script           = var.run_cleanup_script
   env                          = var.env
 

--- a/tflocal/main.tf
+++ b/tflocal/main.tf
@@ -1,0 +1,28 @@
+module "tflocal" {
+  source                       = "app.terraform.io/hashicorp-v2/tflocal-cloud/aws"
+  version                      = "0.3.0"
+  tflocal_cloud                = "true"
+  tflocal_cloud_admin_password = var.tflocal_cloud_admin_password
+  tflocal_cloud_admin_token    = var.tflocal_cloud_admin_token
+  git_branch                   = var.git_branch
+  tfe_ref                      = var.tfe_ref
+  ngrok_domain                 = var.ngrok_domain
+  ngrok_tunnel_token           = var.ngrok_tunnel_token
+  private_github_token         = var.private_github_token
+  private_github_user          = var.private_github_user
+  gem_contribsys_key           = var.gem_contribsys_key
+  ejson_file_name              = var.ejson_file_name
+  ejson_file_content           = var.ejson_file_content
+  quay_username                = var.quay_username
+  quay_password                = var.quay_password
+  circleci_token               = var.circleci_token
+  update_circleci              = var.update_circleci
+  run_cleanup_script           = var.run_cleanup_script
+  env                          = var.env
+
+  tags = {
+    Codebase  = "hashicorp/go-tfe"
+    Purpose   = "go-tfe integration tests"
+    Workspace = terraform.workspace
+  }
+}

--- a/tflocal/outputs.tf
+++ b/tflocal/outputs.tf
@@ -1,0 +1,26 @@
+output "aws_instance_id" {
+  value       = module.tflocal.aws_instance_id
+  description = "The AWS identifier for the setup's EC2 instance"
+}
+
+output "ngrok_domain" {
+  value       = module.tflocal.ngrok_domain
+  description = "The ngrok domain name reserved for this instance"
+}
+
+output "tfe_address" {
+  value       = module.tflocal.tfe_address
+  description = "The full URL including scheme for the ngrok domain reserved for this instance"
+}
+
+output "tfe_password" {
+  value       = module.tflocal.tfe_password
+  sensitive   = true
+  description = "The seeded site-admin password for this instance that can be used to log into the UI"
+}
+
+output "tfe_token" {
+  value       = module.tflocal.tfe_token
+  sensitive   = true
+  description = "The seeded site-admin token for this instance that can be used to authenticate API actions"
+}

--- a/tflocal/providers.tf
+++ b/tflocal/providers.tf
@@ -1,0 +1,40 @@
+
+variable "TFC_WORKSPACE_NAME" {
+  type        = string
+  description = "Current TFE(C) workspace name. Used as part of the AWS provider's assume role session name argument. Set to a placeholder default to allow for non-TFE runs to occur when needed."
+  default     = "TFC_WORKSPACE_NAME_DEFAULT"
+}
+
+variable "TFC_RUN_ID" {
+  type        = string
+  description = "Current TFE(C) run ID. Used as part of the AWS provider's assume role session name argument. Set to a placeholder default to allow for non-TFE runs to occur when needed."
+  default     = "TFC_RUN_ID_DEFAULT"
+}
+
+variable "aws_assume_role_arn" {
+  type        = string
+  description = "AWS arn of the role the provider should assume role into."
+}
+
+variable "aws_assume_role_external_id" {
+  type        = string
+  description = "External ID of the role the provider should assume role into, prevents collisions."
+}
+
+provider "aws" {
+  region = var.aws_region
+
+  assume_role {
+    # [Session name] is a string of characters consisting of upper- and lower-case alphanumeric characters
+    # with no spaces. You can also include underscores or any of the following characters: =,.@-
+    session_name = "${replace(var.TFC_WORKSPACE_NAME, "/", "-")}-${var.TFC_RUN_ID}"
+    role_arn     = var.aws_assume_role_arn
+    external_id  = var.aws_assume_role_external_id
+  }
+}
+
+provider "random" {}
+
+provider "cloudinit" {}
+
+provider "ngrok" {}

--- a/tflocal/terraform.tf
+++ b/tflocal/terraform.tf
@@ -1,0 +1,27 @@
+terraform {
+  required_version = "~> 1.2"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.46"
+    }
+
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.2"
+    }
+
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 3.1"
+    }
+
+    ngrok = {
+      source  = "ngrok/ngrok"
+      version = "~> 0.1"
+    }
+  }
+
+  cloud {}
+}

--- a/tflocal/variables.tf
+++ b/tflocal/variables.tf
@@ -80,18 +80,6 @@ variable "quay_password" {
   sensitive   = true
 }
 
-variable "circleci_token" {
-  description = "Token to hit the CircleCI API and update the go-tfe and terraform-provider-tfe projects with their respective dynamic variables"
-  type        = string
-  sensitive   = true
-}
-
-variable "update_circleci" {
-  description = "If true, will update downstream CircleCI projects with environment variables matching the outputs"
-  type        = bool
-  default     = false
-}
-
 variable "run_cleanup_script" {
   description = "On/off toggle for running the delete script to allow for easier troubleshooting from TFE UI for this job; set to 'true' or 'false'"
   type        = bool

--- a/tflocal/variables.tf
+++ b/tflocal/variables.tf
@@ -1,0 +1,99 @@
+variable "aws_region" {
+  type = string
+}
+
+variable "tflocal_cloud_admin_password" {
+  description = "The password for logging into this tfe:local's TFC instance; stored in 1Password under Engineering Service's 'TFLOCAL_CLOUD tfe instance login and ngrok'"
+  type        = string
+}
+
+variable "tflocal_cloud_admin_token" {
+  description = "The token for accessing this instance's API as admin"
+  type        = string
+  sensitive   = true
+}
+
+variable "env" {
+  description = "Environment variables that will be present during startup. These may be propagated into services through the Docker Compose definitions"
+  type        = map(string)
+  default     = {}
+}
+
+variable "git_branch" {
+  description = "Git branch of the `atlas` repo to build tfe:local from"
+  type        = string
+}
+
+variable "tfe_ref" {
+  description = "Git ref for the TFE tags to use for the stack's Docker images. If left blank will use the most recently published ref"
+  type        = string
+  default     = ""
+}
+
+variable "ngrok_domain" {
+  description = "Public-facing ngrok url; stored in 1Password under Engineering Service's 'TFLOCAL_CLOUD tfe instance login and ngrok'"
+  type        = string
+}
+
+variable "ngrok_tunnel_token" {
+  description = "The NGROK Tunnel token"
+  type        = string
+  sensitive   = true
+}
+
+variable "private_github_token" {
+  description = "Private token to give access to `atlas` repo via GitHub API"
+  type        = string
+  sensitive   = true
+}
+
+variable "private_github_user" {
+  description = "User to give access to `atlas` repo via remote git calls"
+  type        = string
+}
+
+variable "gem_contribsys_key" {
+  description = "Sidekiq license key necessary for tfe:local's bundle install"
+  type        = string
+  sensitive   = true
+}
+
+variable "ejson_file_name" {
+  description = "Name for EJSON secrets file"
+  type        = string
+}
+
+variable "ejson_file_content" {
+  description = "EJSON secrets key that is the sole content of EJSON secrets file"
+  type        = string
+  sensitive   = true
+}
+
+variable "quay_username" {
+  description = "Username for Quay.io Docker container access"
+  type        = string
+}
+
+variable "quay_password" {
+  description = "Password for Quay.io Docker container access"
+  type        = string
+  sensitive   = true
+}
+
+variable "circleci_token" {
+  description = "Token to hit the CircleCI API and update the go-tfe and terraform-provider-tfe projects with their respective dynamic variables"
+  type        = string
+  sensitive   = true
+}
+
+variable "update_circleci" {
+  description = "If true, will update downstream CircleCI projects with environment variables matching the outputs"
+  type        = bool
+  default     = false
+}
+
+variable "run_cleanup_script" {
+  description = "On/off toggle for running the delete script to allow for easier troubleshooting from TFE UI for this job; set to 'true' or 'false'"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
This configuration makes use of the tflocal module that provisions the necessary TFE installation and AWS resources to run CI.

Once merged, I can connect the go-tfe repo to our TFC workspace where this configuration will live. 