### PR TITLE
[Beta] Add detailed-type field to state_version_output.go

### DIFF
--- a/state_version_output.go
+++ b/state_version_output.go
@@ -31,6 +31,8 @@ type StateVersionOutput struct {
 	Sensitive bool        `jsonapi:"attr,sensitive"`
 	Type      string      `jsonapi:"attr,type"`
 	Value     interface{} `jsonapi:"attr,value"`
+	// BETA: This field is experimental and not universally present in all versions of TFE/Terraform
+	DetailedType interface{} `jsonapi:"attr,detailed-type"`
 }
 
 // ReadCurrent reads the current state version outputs for the specified workspace


### PR DESCRIPTION
## Description

This beta field is conditionally provided by the API depending on feature flags. It is needed for an upcoming release of terraform, so I believe it should be released as beta.

## Testing plan

See https://github.com/hashicorp/terraform/pull/31507 to test this
