### PR TITLE
Add new run creation attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Unreleased
-# v1.7.0
 
 ## Enhancements
+
+* Adds new run creation attributes: `allow-empty-apply`, `terraform-version`, `plan-only` by @sebasslash [#482](https://github.com/hashicorp/go-tfe/pull/447)
 
 # v1.6.0
 

--- a/errors.go
+++ b/errors.go
@@ -304,4 +304,6 @@ var (
 	ErrInvalidAsciiArmor = errors.New("ascii armor is invalid")
 
 	ErrRequiredNamespace = errors.New("namespace is required for public registry")
+
+	ErrTerraformVersionValidForPlanOnly = errors.New("setting terraform-version is only valid when plan-only is set to true")
 )

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -201,7 +201,35 @@ func TestRunsCreate(t *testing.T) {
 
 		r, err := client.Runs.Create(ctx, options)
 		require.NoError(t, err)
+		require.NotNil(t, r.ConfigurationVersion)
 		assert.Equal(t, cvTest.ID, r.ConfigurationVersion.ID)
+	})
+
+	t.Run("with allow empty apply", func(t *testing.T) {
+		options := RunCreateOptions{
+			Workspace:       wTest,
+			AllowEmptyApply: Bool(true),
+		}
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, true, r.AllowEmptyApply)
+	})
+
+	t.Run("with terraform version and plan only", func(t *testing.T) {
+		options := RunCreateOptions{
+			Workspace:        wTest,
+			TerraformVersion: String("1.0.0"),
+		}
+		_, err := client.Runs.Create(ctx, options)
+		require.ErrorIs(t, err, ErrTerraformVersionValidForPlanOnly)
+
+		options.PlanOnly = Bool(true)
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, true, r.PlanOnly)
+		assert.Equal(t, "1.0.0", r.TerraformVersion)
 	})
 
 	t.Run("refresh defaults to true if not set as a create option", func(t *testing.T) {


### PR DESCRIPTION
This PR adds three new fields to the `RunCreateOptions` struct:
* `allow-empty-apply`
* `terraform-version`
* `plan-only`

Reviewer Notes:
- Error validation is performed by the client when a run-specific terraform version is set and the run is not configured with `PlanOnly: true`. It will return `ErrVersionValidForPlanOnly` (personally not a huge fan of this name, so hopefully there may be some other naming options here) 
- The version itself is not validated by the client to follow semver... I decided to offload this to the API which also checks if the desired version is available to the organization. If however, we have strong opinions that the client should validate the version, we can always use the [go-version](https://github.com/hashicorp/go-version) package. 