### PR TITLE
Add PullRequestOutputsEnabled to Workspace settings

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -37,6 +37,8 @@ var (
 	ErrUnsupportedBothTriggerPatternsAndPrefixes = errors.New(`"TriggerPatterns" and "TriggerPrefixes" cannot be populated at the same time`)
 
 	ErrUnsupportedBothNamespaceAndPrivateRegistryName = errors.New(`"Namespace" cannot be populated when "RegistryName" is "private"`)
+
+	ErrUnsupportedPullRequestOutputsEnabled = errors.New(`"PullRequestOutputsEnabled" can be true only when "SpeculativeEnabled" is set to true`)
 )
 
 // Library errors that usually indicate a bug in the implementation of go-tfe

--- a/workspace.go
+++ b/workspace.go
@@ -124,6 +124,7 @@ type Workspace struct {
 	Name                       string                `jsonapi:"attr,name"`
 	Operations                 bool                  `jsonapi:"attr,operations"`
 	Permissions                *WorkspacePermissions `jsonapi:"attr,permissions"`
+	PullRequestOutputsEnabled  bool                  `jsonapi:"attr,pull-request-outputs-enabled"`
 	QueueAllRuns               bool                  `jsonapi:"attr,queue-all-runs"`
 	SpeculativeEnabled         bool                  `jsonapi:"attr,speculative-enabled"`
 	SourceName                 string                `jsonapi:"attr,source-name"`
@@ -298,6 +299,9 @@ type WorkspaceCreateOptions struct {
 	// Use ExecutionMode instead.
 	Operations *bool `jsonapi:"attr,operations,omitempty"`
 
+	// Optional: Whether the workspace shows Terraform output in pull request comments.
+	PullRequestOutputsEnabled *bool `jsonapi:"attr,pull-request-outputs-enabled,omitempty"`
+
 	// Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
@@ -407,6 +411,9 @@ type WorkspaceUpdateOptions struct {
 	// DEPRECATED. Whether the workspace will use remote or local execution mode.
 	// Use ExecutionMode instead.
 	Operations *bool `jsonapi:"attr,operations,omitempty"`
+
+	// Optional: Whether the workspace shows Terraform output in pull request comments.
+	PullRequestOutputsEnabled *bool `jsonapi:"attr,pull-request-outputs-enabled,omitempty"`
 
 	// Optional: Whether to queue all runs. Unless this is set to true, runs triggered by
 	// a webhook will not be queued until at least one run is manually queued.
@@ -1084,6 +1091,10 @@ func (o WorkspaceCreateOptions) valid() error {
 		o.FileTriggersEnabled != nil && *o.FileTriggersEnabled {
 		return ErrUnsupportedBothTagsRegexAndFileTriggersEnabled
 	}
+	if o.PullRequestOutputsEnabled != nil && *o.PullRequestOutputsEnabled &&
+		(o.SpeculativeEnabled == nil || !*o.SpeculativeEnabled) {
+		return ErrUnsupportedPullRequestOutputsEnabled
+	}
 
 	return nil
 }
@@ -1114,6 +1125,10 @@ func (o WorkspaceUpdateOptions) valid() error {
 	if o.VCSRepo != nil && o.VCSRepo.TagsRegex != nil &&
 		o.FileTriggersEnabled != nil && *o.FileTriggersEnabled {
 		return ErrUnsupportedBothTagsRegexAndFileTriggersEnabled
+	}
+	if o.PullRequestOutputsEnabled != nil && *o.PullRequestOutputsEnabled &&
+		(o.SpeculativeEnabled == nil || !*o.SpeculativeEnabled) {
+		return ErrUnsupportedPullRequestOutputsEnabled
 	}
 
 	return nil

--- a/workspace.go
+++ b/workspace.go
@@ -299,6 +299,7 @@ type WorkspaceCreateOptions struct {
 	// Use ExecutionMode instead.
 	Operations *bool `jsonapi:"attr,operations,omitempty"`
 
+	// **Note: This field is still in BETA and subject to change.**
 	// Optional: Whether the workspace shows Terraform output in pull request comments.
 	PullRequestOutputsEnabled *bool `jsonapi:"attr,pull-request-outputs-enabled,omitempty"`
 
@@ -412,6 +413,7 @@ type WorkspaceUpdateOptions struct {
 	// Use ExecutionMode instead.
 	Operations *bool `jsonapi:"attr,operations,omitempty"`
 
+	// **Note: This field is still in BETA and subject to change.**
 	// Optional: Whether the workspace shows Terraform output in pull request comments.
 	PullRequestOutputsEnabled *bool `jsonapi:"attr,pull-request-outputs-enabled,omitempty"`
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -434,9 +434,8 @@ func TestWorkspacesCreate(t *testing.T) {
 	})
 
 	t.Run("when both speculative-enabled and pull-request-outputs-enabled are true (behind a feature flag)", func(t *testing.T) {
-		skipIfBeta(t)
 		options := WorkspaceCreateOptions{
-			Name:                      String("foobar"),
+			Name:                      String("tst-foobar"),
 			SpeculativeEnabled:        Bool(true),
 			PullRequestOutputsEnabled: Bool(true),
 		}
@@ -459,11 +458,11 @@ func TestWorkspacesCreate(t *testing.T) {
 	t.Run("when speculative-enabled is falsy and pull-request-outputs-enabled is true", func(t *testing.T) {
 		optionsList := []WorkspaceCreateOptions{
 			WorkspaceCreateOptions{
-				Name:                      String("foobar"),
+				Name:                      String("tst-foobar"),
 				PullRequestOutputsEnabled: Bool(true),
 			},
 			WorkspaceCreateOptions{
-				Name:                      String("foobar"),
+				Name:                      String("tst-foobar"),
 				SpeculativeEnabled:        Bool(false),
 				PullRequestOutputsEnabled: Bool(true),
 			},
@@ -960,9 +959,8 @@ func TestWorkspacesUpdate(t *testing.T) {
 	})
 
 	t.Run("when both speculative-enabled and pull-request-outputs-enabled are true (behind a feature flag)", func(t *testing.T) {
-		skipIfBeta(t)
 		options := WorkspaceUpdateOptions{
-			Name:                      String("foobar"),
+			Name:                      String("tst-foobar"),
 			SpeculativeEnabled:        Bool(true),
 			PullRequestOutputsEnabled: Bool(true),
 		}
@@ -985,11 +983,11 @@ func TestWorkspacesUpdate(t *testing.T) {
 	t.Run("when speculative-enabled is falsy and pull-request-outputs-enabled is true", func(t *testing.T) {
 		optionsList := []WorkspaceUpdateOptions{
 			WorkspaceUpdateOptions{
-				Name:                      String("foobar"),
+				Name:                      String("tst-foobar"),
 				PullRequestOutputsEnabled: Bool(true),
 			},
 			WorkspaceUpdateOptions{
-				Name:                      String("foobar"),
+				Name:                      String("tst-foobar"),
 				SpeculativeEnabled:        Bool(false),
 				PullRequestOutputsEnabled: Bool(true),
 			},


### PR DESCRIPTION
## Description

Add `PullRequestOutputsEnabled` to Workspace settings.

The PR is not ready to be released yet due to other dependencies. Will unmark its draft status when it's ready to be reviewed.

## External links
- [Asana](https://app.asana.com/0/1201287664926243/1202307454909375/f)
- [RFC](https://docs.google.com/document/d/1EtPNCPfiPQfSEwe3ZoAGS5tk6PahmTROD20OtgmUYwc/edit#)