### PR TITLE
Add Include param to Policy set list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,8 @@
 * Adds new run creation attributes: `allow-empty-apply`, `terraform-version`, `plan-only` by @sebasslash [#482](https://github.com/hashicorp/go-tfe/pull/447)
 * Adds additional Task Stage and Run Statuses for Pre-plan run tasks by @glennsarti [#469](https://github.com/hashicorp/go-tfe/pull/469)
 * Adds `stage` field to the create and update methods for Workspace Run Tasks by @glennsarti [#469](https://github.com/hashicorp/go-tfe/pull/469)
-<<<<<<< HEAD
 * Adds `ResourcesProcessed`, `StateVersion`, `TerraformVersion`, `Modules`, `Providers`, and `Resources` fields to the State Version struct by @laurenolivia [#484](https://github.com/hashicorp/go-tfe/pull/484)
-
 * Add `Include` param field to `PolicySetListOptions` to allow policy list to include related resource data such as workspaces, policies, newest_version, or current_version by @Uk1288 [#471](https://github.com/hashicorp/go-tfe/pull/471)
-=======
-* Add `Include` param field to `PolicySetListOptions` to allow policy list to include related resource data such as workspaces, policies, newest_version, or current_version by @Uk1288 [#494](https://github.com/hashicorp/go-tfe/pull/494)
->>>>>>> 65d8fda (Update changelog)
 # v1.6.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,13 @@
 * Adds new run creation attributes: `allow-empty-apply`, `terraform-version`, `plan-only` by @sebasslash [#482](https://github.com/hashicorp/go-tfe/pull/447)
 * Adds additional Task Stage and Run Statuses for Pre-plan run tasks by @glennsarti [#469](https://github.com/hashicorp/go-tfe/pull/469)
 * Adds `stage` field to the create and update methods for Workspace Run Tasks by @glennsarti [#469](https://github.com/hashicorp/go-tfe/pull/469)
+<<<<<<< HEAD
+* Adds `ResourcesProcessed`, `StateVersion`, `TerraformVersion`, `Modules`, `Providers`, and `Resources` fields to the State Version struct by @laurenolivia [#484](https://github.com/hashicorp/go-tfe/pull/484)
 
+* Add `Include` param field to `PolicySetListOptions` to allow policy list to include related resource data such as workspaces, policies, newest_version, or current_version by @Uk1288 [#471](https://github.com/hashicorp/go-tfe/pull/471)
+=======
+* Add `Include` param field to `PolicySetListOptions` to allow policy list to include related resource data such as workspaces, policies, newest_version, or current_version by @Uk1288 [#494](https://github.com/hashicorp/go-tfe/pull/494)
+>>>>>>> 65d8fda (Update changelog)
 # v1.6.0
 
 ## Enhancements

--- a/policy_set.go
+++ b/policy_set.go
@@ -104,6 +104,10 @@ type PolicySetListOptions struct {
 
 	// Optional: A search string (partial policy set name) used to filter the results.
 	Search string `url:"search[name],omitempty"`
+
+	// Optional: A list of relations to include. See available resources
+	// https://www.terraform.io/cloud-docs/api-docs/policy-sets#available-related-resources
+	Include []PolicySetIncludeOpt `url:"include,omitempty"`
 }
 
 // PolicySetReadOptions are read options.

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -23,9 +23,14 @@ func TestPolicySetsList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	psTest1, psTestCleanup1 := createPolicySet(t, client, orgTest, nil, nil)
+	upgradeOrganizationSubscription(t, client, orgTest)
+
+	workspace, workspaceCleanup := createWorkspace(t, client, orgTest)
+	defer workspaceCleanup()
+
+	psTest1, psTestCleanup1 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace})
 	defer psTestCleanup1()
-	psTest2, psTestCleanup2 := createPolicySet(t, client, orgTest, nil, nil)
+	psTest2, psTestCleanup2 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace})
 	defer psTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
@@ -69,6 +74,19 @@ func TestPolicySetsList(t *testing.T) {
 		assert.Equal(t, 1, psl.TotalCount)
 	})
 
+	t.Run("with include param", func(t *testing.T) {
+		psl, err := client.PolicySets.List(ctx, orgTest.Name, &PolicySetListOptions{
+			Include: []PolicySetIncludeOpt{PolicySetWorkspaces},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, 2, len(psl.Items))
+
+		assert.NotNil(t, psl.Items[0].Workspaces)
+		assert.Equal(t, 1, len(psl.Items[0].Workspaces))
+		assert.Equal(t, workspace.ID, psl.Items[0].Workspaces[0].ID)
+	})
+
 	t.Run("without a valid organization", func(t *testing.T) {
 		ps, err := client.PolicySets.List(ctx, badIdentifier, nil)
 		assert.Nil(t, ps)
@@ -84,6 +102,9 @@ func TestPolicySetsCreate(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	var vcsPolicyID string
 
 	t.Run("with valid attributes", func(t *testing.T) {
@@ -245,6 +266,8 @@ func TestPolicySetsRead(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil)
 	defer psTestCleanup()
 
@@ -311,6 +334,8 @@ func TestPolicySetsUpdate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil)
 	defer psTestCleanup()
 
@@ -354,6 +379,8 @@ func TestPolicySetsAddPolicies(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
 
 	pTest1, pTestCleanup1 := createPolicy(t, client, orgTest)
 	defer pTestCleanup1()
@@ -410,6 +437,8 @@ func TestPolicySetsRemovePolicies(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	pTest1, pTestCleanup1 := createPolicy(t, client, orgTest)
 	defer pTestCleanup1()
 	pTest2, pTestCleanup2 := createPolicy(t, client, orgTest)
@@ -458,6 +487,8 @@ func TestPolicySetsAddWorkspaces(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
 
 	wTest1, wTestCleanup1 := createWorkspace(t, client, orgTest)
 	defer wTestCleanup1()
@@ -528,6 +559,8 @@ func TestPolicySetsRemoveWorkspaces(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	wTest1, wTestCleanup1 := createWorkspace(t, client, orgTest)
 	defer wTestCleanup1()
 	wTest2, wTestCleanup2 := createWorkspace(t, client, orgTest)
@@ -590,6 +623,8 @@ func TestPolicySetsDelete(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
 
 	psTest, _ := createPolicySet(t, client, orgTest, nil, nil)
 

--- a/state_version.go
+++ b/state_version.go
@@ -161,11 +161,11 @@ type StateVersionNullResource int
 type StateVersionTerraformRemoteState int
 
 type StateVersionResources struct {
-	Name     string `jsonapi:"attr,name"`
-	Count    string `jsonapi:"attr,count"`
-	Type     int    `jsonapi:"attr,type"`
-	Module   string `jsonapi:"attr,module"`
-	Provider string `jsonapi:"attr,name"`
+	Name     string
+	Count    string
+	Type     int
+	Module   string
+	Provider string
 }
 
 // List all the state versions for a given workspace.

--- a/state_version.go
+++ b/state_version.go
@@ -163,7 +163,9 @@ type StateVersionModuleRoot struct {
 	TerraformRemoteState int `jsonapi:"attr,data.terraform-remote-state"`
 }
 
-type StateVersionProviders map[string]ProviderData
+type StateVersionProviders struct {
+	Data ProviderData `jsonapi:"attr,provider[map]string"`
+}
 
 type ProviderData struct {
 	NullResource         int `json:"null-resource"`

--- a/state_version.go
+++ b/state_version.go
@@ -55,12 +55,18 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID           string    `jsonapi:"primary,state-versions"`
-	CreatedAt    time.Time `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL  string    `jsonapi:"attr,hosted-state-download-url"`
-	Serial       int64     `jsonapi:"attr,serial"`
-	VCSCommitSHA string    `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL string    `jsonapi:"attr,vcs-commit-url"`
+	ID                 string                  `jsonapi:"primary,state-versions"`
+	CreatedAt          time.Time               `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL        string                  `jsonapi:"attr,hosted-state-download-url"`
+	Serial             int64                   `jsonapi:"attr,serial"`
+	VCSCommitSHA       string                  `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL       string                  `jsonapi:"attr,vcs-commit-url"`
+	ResourcesProcessed bool                    `jsonapi:"attr,resources-processed"`
+	StateVersion       int                     `jsonapi:"attr,state-version"`
+	TerraformVersion   string                  `jsonapi:"attr,terraform-version"`
+	Modules            *StateVersionModules    `jsonapi:"attr,modules"`
+	Providers          *StateVersionProviders  `jsonapi:"attr,providers"`
+	Resources          []StateVersionResources `jsonapi:"attr,resources"`
 
 	// Relations
 	Run     *Run                  `jsonapi:"relation,run"`
@@ -139,13 +145,30 @@ type StateVersionCreateOptions struct {
 	// Optional: Specifies the run to associate the state with.
 	Run *Run `jsonapi:"relation,run,omitempty"`
 
-	// Optional: The external, json representation of state outputs, base64 encoded. Supplying this field 
+	// Optional: The external, json representation of state outputs, base64 encoded. Supplying this field
 	// will provide more detailed output type information to TFE.
 	// For more information on the contents of this field: https://www.terraform.io/internals/json-format#values-representation
 	// about the current terraform state.
 	//
 	// **Note**: This field is in BETA, subject to change and not widely available yet.
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
+}
+
+type StateVersionNullResrouce int
+type StateVersionTerraformRemoteState int
+
+type StateVersionModules struct{}
+
+type StateVersionProviders struct {
+	Provider StateVersionTerraformRemoteState `jsonapi:"attr,providers"`
+}
+
+type StateVersionResources struct {
+	Name     string `jsonapi:"attr,name"`
+	Count    string `jsonapi:"attr,count"`
+	Type     int    `jsonapi:"attr,type"`
+	Module   string `jsonapi:"attr,module"`
+	Provider string `jsonapi:"attr,name"`
 }
 
 // List all the state versions for a given workspace.

--- a/state_version.go
+++ b/state_version.go
@@ -55,18 +55,18 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID                 string                   `jsonapi:"primary,state-versions"`
-	CreatedAt          time.Time                `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL        string                   `jsonapi:"attr,hosted-state-download-url"`
-	Serial             int64                    `jsonapi:"attr,serial"`
-	VCSCommitSHA       string                   `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL       string                   `jsonapi:"attr,vcs-commit-url"`
-	ResourcesProcessed bool                     `jsonapi:"attr,resources-processed"`
-	StateVersion       int                      `jsonapi:"attr,state-version"`
-	TerraformVersion   string                   `jsonapi:"attr,terraform-version"`
-	Modules            *StateVersionModules     `jsonapi:"attr,modules"`
-	Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
-	Resources          []*StateVersionResources `jsonapi:"attr,resources"`
+	ID                 string    `jsonapi:"primary,state-versions"`
+	CreatedAt          time.Time `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL        string    `jsonapi:"attr,hosted-state-download-url"`
+	Serial             int64     `jsonapi:"attr,serial"`
+	VCSCommitSHA       string    `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL       string    `jsonapi:"attr,vcs-commit-url"`
+	ResourcesProcessed bool      `jsonapi:"attr,resources-processed"`
+	StateVersion       int       `jsonapi:"attr,state-version"`
+	TerraformVersion   string    `jsonapi:"attr,terraform-version"`
+	// Modules            *StateVersionModules     `jsonapi:"attr,modules"`
+	// Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
+	// Resources []*StateVersionResources `jsonapi:"attr,resources"`
 
 	// Relations
 	Run     *Run                  `jsonapi:"relation,run"`
@@ -154,24 +154,29 @@ type StateVersionCreateOptions struct {
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
 }
 
-type StateVersionModules struct {
-	Root *StateVersionModuleRoot `jsonapi:"attr,root"`
-}
+// type StateVersionModules struct {
+// 	Root *StateVersionModuleRoot `jsonapi:"attr,root"`
+// }
 
-type StateVersionModuleRoot struct {
-	NullResource         int `jsonapi:"attr,null-resource"`
-	TerraformRemoteState int `jsonapi:"attr,data.terraform-remote-state"`
-}
+// type StateVersionModuleRoot struct {
+// 	NullResource         int `jsonapi:"attr,null-resource"`
+// 	TerraformRemoteState int `jsonapi:"attr,data.terraform-remote-state"`
+// }
 
-type StateVersionProviders map[string]struct{}
+// type StateVersionProviders map[string]ProviderData
 
-type StateVersionResources struct {
-	Name     string `jsonapi:"attr,name"`
-	Count    string `jsonapi:"attr,count"`
-	Type     int    `jsonapi:"attr,type"`
-	Module   string `jsonapi:"attr,module"`
-	Provider string `jsonapi:"attr,provider"`
-}
+// type ProviderData struct {
+// 	NullResource         int `json:"null-resource"`
+// 	TerraformRemoteState int `json:"data.terraform-remote-state"`
+// }
+
+// type StateVersionResources struct {
+// 	Name     string `jsonapi:"attr,name"`
+// 	Count    string `jsonapi:"attr,count"`
+// 	Type     int    `jsonapi:"attr,type"`
+// 	Module   string `jsonapi:"attr,module"`
+// 	Provider string `jsonapi:"attr,provider"`
+// }
 
 // List all the state versions for a given workspace.
 func (s *stateVersions) List(ctx context.Context, options *StateVersionListOptions) (*StateVersionList, error) {

--- a/state_version.go
+++ b/state_version.go
@@ -55,18 +55,18 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID                 string    `jsonapi:"primary,state-versions"`
-	CreatedAt          time.Time `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL        string    `jsonapi:"attr,hosted-state-download-url"`
-	Serial             int64     `jsonapi:"attr,serial"`
-	VCSCommitSHA       string    `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL       string    `jsonapi:"attr,vcs-commit-url"`
-	ResourcesProcessed bool      `jsonapi:"attr,resources-processed"`
-	StateVersion       int       `jsonapi:"attr,state-version"`
-	TerraformVersion   string    `jsonapi:"attr,terraform-version"`
-	// Modules            *StateVersionModules     `jsonapi:"attr,modules"`
-	// Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
-	// Resources          []*StateVersionResources `jsonapi:"attr,resources"`
+	ID                 string                   `jsonapi:"primary,state-versions"`
+	CreatedAt          time.Time                `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL        string                   `jsonapi:"attr,hosted-state-download-url"`
+	Serial             int64                    `jsonapi:"attr,serial"`
+	VCSCommitSHA       string                   `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL       string                   `jsonapi:"attr,vcs-commit-url"`
+	ResourcesProcessed bool                     `jsonapi:"attr,resources-processed"`
+	StateVersion       int                      `jsonapi:"attr,state-version"`
+	TerraformVersion   string                   `jsonapi:"attr,terraform-version"`
+	Modules            *StateVersionModules     `jsonapi:"attr,modules"`
+	Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
+	Resources          []*StateVersionResources `jsonapi:"attr,resources"`
 
 	// Relations
 	Run     *Run                  `jsonapi:"relation,run"`
@@ -154,29 +154,29 @@ type StateVersionCreateOptions struct {
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
 }
 
-// type StateVersionModules struct {
-// 	Root StateVersionModuleRoot `jsonapi:"attr,root"`
-// }
+type StateVersionModules struct {
+	Root StateVersionModuleRoot `jsonapi:"attr,root"`
+}
 
-// type StateVersionModuleRoot struct {
-// 	NullResource         int `jsonapi:"attr,null-resource"`
-// 	TerraformRemoteState int `jsonapi:"attr,data.terraform-remote-state"`
-// }
+type StateVersionModuleRoot struct {
+	NullResource         int `jsonapi:"attr,null-resource"`
+	TerraformRemoteState int `jsonapi:"attr,data.terraform-remote-state"`
+}
 
-// type StateVersionProviders map[string]ProviderData
+type StateVersionProviders map[string]ProviderData
 
-// type ProviderData struct {
-// 	NullResource         int `json:"null-resource"`
-// 	TerraformRemoteState int `json:"data.terraform-remote-state"`
-// }
+type ProviderData struct {
+	NullResource         int `json:"null-resource"`
+	TerraformRemoteState int `json:"data.terraform-remote-state"`
+}
 
-// type StateVersionResources struct {
-// 	Name     string `jsonapi:"attr,name"`
-// 	Count    string `jsonapi:"attr,count"`
-// 	Type     int    `jsonapi:"attr,type"`
-// 	Module   string `jsonapi:"attr,module"`
-// 	Provider string `jsonapi:"attr,provider"`
-// }
+type StateVersionResources struct {
+	Name     string `jsonapi:"attr,name"`
+	Count    string `jsonapi:"attr,count"`
+	Type     int    `jsonapi:"attr,type"`
+	Module   string `jsonapi:"attr,module"`
+	Provider string `jsonapi:"attr,provider"`
+}
 
 // List all the state versions for a given workspace.
 func (s *stateVersions) List(ctx context.Context, options *StateVersionListOptions) (*StateVersionList, error) {

--- a/state_version.go
+++ b/state_version.go
@@ -55,18 +55,18 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID                 string                  `jsonapi:"primary,state-versions"`
-	CreatedAt          time.Time               `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL        string                  `jsonapi:"attr,hosted-state-download-url"`
-	Serial             int64                   `jsonapi:"attr,serial"`
-	VCSCommitSHA       string                  `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL       string                  `jsonapi:"attr,vcs-commit-url"`
-	ResourcesProcessed bool                    `jsonapi:"attr,resources-processed"`
-	StateVersion       int                     `jsonapi:"attr,state-version"`
-	TerraformVersion   string                  `jsonapi:"attr,terraform-version"`
-	Modules            *StateVersionModules    `jsonapi:"attr,modules"`
-	Providers          *StateVersionProviders  `jsonapi:"attr,providers"`
-	Resources          []StateVersionResources `jsonapi:"attr,resources"`
+	ID                 string                   `jsonapi:"primary,state-versions"`
+	CreatedAt          time.Time                `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL        string                   `jsonapi:"attr,hosted-state-download-url"`
+	Serial             int64                    `jsonapi:"attr,serial"`
+	VCSCommitSHA       string                   `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL       string                   `jsonapi:"attr,vcs-commit-url"`
+	ResourcesProcessed bool                     `jsonapi:"attr,resources-processed"`
+	StateVersion       int                      `jsonapi:"attr,state-version"`
+	TerraformVersion   string                   `jsonapi:"attr,terraform-version"`
+	Modules            *StateVersionModules     `jsonapi:"attr,modules"`
+	Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
+	Resources          []*StateVersionResources `jsonapi:"attr,resources"`
 
 	// Relations
 	Run     *Run                  `jsonapi:"relation,run"`
@@ -154,18 +154,23 @@ type StateVersionCreateOptions struct {
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
 }
 
-type StateVersionModules struct{}
-type StateVersionProviders struct{}
+type StateVersionModules struct {
+	Root *StateVersionModuleRoot `jsonapi:"attr,root"`
+}
 
-type StateVersionNullResource int
-type StateVersionTerraformRemoteState int
+type StateVersionModuleRoot struct {
+	NullResource         int `jsonapi:"attr,null-resource"`
+	TerraformRemoteState int `jsonapi:"attr,data.terraform-remote-state"`
+}
+
+type StateVersionProviders map[string]struct{}
 
 type StateVersionResources struct {
-	Name     string
-	Count    string
-	Type     int
-	Module   string
-	Provider string
+	Name     string `jsonapi:"attr,name"`
+	Count    string `jsonapi:"attr,count"`
+	Type     int    `jsonapi:"attr,type"`
+	Module   string `jsonapi:"attr,module"`
+	Provider string `jsonapi:"attr,provider"`
 }
 
 // List all the state versions for a given workspace.

--- a/state_version.go
+++ b/state_version.go
@@ -154,8 +154,8 @@ type StateVersionCreateOptions struct {
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
 }
 
-type StateVersionModules map[string]interface{}
-type StateVersionProviders map[string]interface{}
+type StateVersionModules map[string]map[string]interface{}
+type StateVersionProviders map[string]map[string]interface{}
 
 type StateVersionNullResource int
 type StateVersionTerraformRemoteState int

--- a/state_version.go
+++ b/state_version.go
@@ -55,18 +55,18 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID           string    `jsonapi:"primary,state-versions"`
-	CreatedAt    time.Time `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL  string    `jsonapi:"attr,hosted-state-download-url"`
-	Serial       int64     `jsonapi:"attr,serial"`
-	VCSCommitSHA string    `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL string    `jsonapi:"attr,vcs-commit-url"`
-	// ResourcesProcessed bool      `jsonapi:"attr,resources-processed"`
-	// StateVersion       int       `jsonapi:"attr,state-version"`
-	// TerraformVersion   string    `jsonapi:"attr,terraform-version"`
+	ID                 string    `jsonapi:"primary,state-versions"`
+	CreatedAt          time.Time `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL        string    `jsonapi:"attr,hosted-state-download-url"`
+	Serial             int64     `jsonapi:"attr,serial"`
+	VCSCommitSHA       string    `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL       string    `jsonapi:"attr,vcs-commit-url"`
+	ResourcesProcessed bool      `jsonapi:"attr,resources-processed"`
+	StateVersion       int       `jsonapi:"attr,state-version"`
+	TerraformVersion   string    `jsonapi:"attr,terraform-version"`
 	// Modules            *StateVersionModules     `jsonapi:"attr,modules"`
 	// Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
-	// Resources []*StateVersionResources `jsonapi:"attr,resources"`
+	// Resources          []*StateVersionResources `jsonapi:"attr,resources"`
 
 	// Relations
 	Run     *Run                  `jsonapi:"relation,run"`
@@ -155,7 +155,7 @@ type StateVersionCreateOptions struct {
 }
 
 // type StateVersionModules struct {
-// 	Root *StateVersionModuleRoot `jsonapi:"attr,root"`
+// 	Root StateVersionModuleRoot `jsonapi:"attr,root"`
 // }
 
 // type StateVersionModuleRoot struct {

--- a/state_version.go
+++ b/state_version.go
@@ -154,8 +154,8 @@ type StateVersionCreateOptions struct {
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
 }
 
-type StateVersionModules map[string]map[string]interface{}
-type StateVersionProviders map[string]map[string]interface{}
+type StateVersionModules struct{}
+type StateVersionProviders struct{}
 
 type StateVersionNullResource int
 type StateVersionTerraformRemoteState int

--- a/state_version.go
+++ b/state_version.go
@@ -55,15 +55,15 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID                 string    `jsonapi:"primary,state-versions"`
-	CreatedAt          time.Time `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL        string    `jsonapi:"attr,hosted-state-download-url"`
-	Serial             int64     `jsonapi:"attr,serial"`
-	VCSCommitSHA       string    `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL       string    `jsonapi:"attr,vcs-commit-url"`
-	ResourcesProcessed bool      `jsonapi:"attr,resources-processed"`
-	StateVersion       int       `jsonapi:"attr,state-version"`
-	TerraformVersion   string    `jsonapi:"attr,terraform-version"`
+	ID           string    `jsonapi:"primary,state-versions"`
+	CreatedAt    time.Time `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL  string    `jsonapi:"attr,hosted-state-download-url"`
+	Serial       int64     `jsonapi:"attr,serial"`
+	VCSCommitSHA string    `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL string    `jsonapi:"attr,vcs-commit-url"`
+	// ResourcesProcessed bool      `jsonapi:"attr,resources-processed"`
+	// StateVersion       int       `jsonapi:"attr,state-version"`
+	// TerraformVersion   string    `jsonapi:"attr,terraform-version"`
 	// Modules            *StateVersionModules     `jsonapi:"attr,modules"`
 	// Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
 	// Resources []*StateVersionResources `jsonapi:"attr,resources"`

--- a/state_version.go
+++ b/state_version.go
@@ -154,14 +154,11 @@ type StateVersionCreateOptions struct {
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
 }
 
-type StateVersionNullResrouce int
+type StateVersionModules map[string]interface{}
+type StateVersionProviders map[string]interface{}
+
+type StateVersionNullResource int
 type StateVersionTerraformRemoteState int
-
-type StateVersionModules struct{}
-
-type StateVersionProviders struct {
-	Provider StateVersionTerraformRemoteState `jsonapi:"attr,providers"`
-}
 
 type StateVersionResources struct {
 	Name     string `jsonapi:"attr,name"`

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -333,6 +333,12 @@ func TestStateVersionsRead(t *testing.T) {
 		sv.Outputs = nil
 
 		assert.Equal(t, svTest, sv)
+		assert.NotEmpty(t, svTest, svTest.ResourcesProcessed)
+		assert.NotEmpty(t, svTest, svTest.StateVersion)
+		assert.NotEmpty(t, svTest, svTest.TerraformVersion)
+		assert.NotEmpty(t, svTest, svTest.Modules)
+		assert.NotEmpty(t, svTest, svTest.Providers)
+		assert.NotEmpty(t, svTest, svTest.Resources)
 	})
 
 	t.Run("when the state version does not exist", func(t *testing.T) {

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -20,15 +20,15 @@ func TestStateVersionsList(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	svTest1, svTestCleanup1 := createStateVersion(t, client, 0, wTest)
-	defer svTestCleanup1()
+	t.Cleanup(svTestCleanup1)
 	svTest2, svTestCleanup2 := createStateVersion(t, client, 1, wTest)
-	defer svTestCleanup2()
+	t.Cleanup(svTestCleanup2)
 
 	t.Run("without StateVersionListOptions", func(t *testing.T) {
 		svl, err := client.StateVersions.List(ctx, nil)
@@ -115,7 +115,7 @@ func TestStateVersionsCreate(t *testing.T) {
 	ctx := context.Background()
 
 	wTest, wTestCleanup := createWorkspace(t, client, nil)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	state, err := ioutil.ReadFile("test-fixtures/state-version/terraform.tfstate")
 	if err != nil {
@@ -248,7 +248,7 @@ func TestStateVersionsCreate(t *testing.T) {
 		t.Skip("This can only be tested with the run specific token")
 
 		rTest, rTestCleanup := createRun(t, client, wTest)
-		defer rTestCleanup()
+		t.Cleanup(rTestCleanup)
 
 		ctx := context.Background()
 		sv, err := client.StateVersions.Create(ctx, wTest.ID, StateVersionCreateOptions{
@@ -316,7 +316,7 @@ func TestStateVersionsRead(t *testing.T) {
 	ctx := context.Background()
 
 	svTest, svTestCleanup := createStateVersion(t, client, 0, nil)
-	defer svTestCleanup()
+	t.Cleanup(svTestCleanup)
 
 	t.Run("when the state version exists", func(t *testing.T) {
 		sv, err := client.StateVersions.Read(ctx, svTest.ID)
@@ -353,7 +353,7 @@ func TestStateVersionsReadWithOptions(t *testing.T) {
 	ctx := context.Background()
 
 	svTest, svTestCleanup := createStateVersion(t, client, 0, nil)
-	defer svTestCleanup()
+	t.Cleanup(svTestCleanup)
 
 	// give TFC some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
@@ -375,13 +375,13 @@ func TestStateVersionsCurrent(t *testing.T) {
 	ctx := context.Background()
 
 	wTest1, wTest1Cleanup := createWorkspace(t, client, nil)
-	defer wTest1Cleanup()
+	t.Cleanup(wTest1Cleanup)
 
 	wTest2, wTest2Cleanup := createWorkspace(t, client, nil)
-	defer wTest2Cleanup()
+	t.Cleanup(wTest2Cleanup)
 
 	svTest, svTestCleanup := createStateVersion(t, client, 0, wTest1)
-	defer svTestCleanup()
+	t.Cleanup(svTestCleanup)
 
 	t.Run("when a state version exists", func(t *testing.T) {
 		sv, err := client.StateVersions.ReadCurrent(ctx, wTest1.ID)
@@ -418,10 +418,10 @@ func TestStateVersionsCurrentWithOptions(t *testing.T) {
 	ctx := context.Background()
 
 	wTest1, wTest1Cleanup := createWorkspace(t, client, nil)
-	defer wTest1Cleanup()
+	t.Cleanup(wTest1Cleanup)
 
 	svTest, svTestCleanup := createStateVersion(t, client, 0, wTest1)
-	defer svTestCleanup()
+	t.Cleanup(svTestCleanup)
 
 	// give TFC some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
@@ -443,7 +443,7 @@ func TestStateVersionsDownload(t *testing.T) {
 	ctx := context.Background()
 
 	svTest, svTestCleanup := createStateVersion(t, client, 0, nil)
-	defer svTestCleanup()
+	t.Cleanup(svTestCleanup)
 
 	stateTest, err := ioutil.ReadFile("test-fixtures/state-version/terraform.tfstate")
 	require.NoError(t, err)
@@ -475,10 +475,10 @@ func TestStateVersionOutputs(t *testing.T) {
 	ctx := context.Background()
 
 	wTest1, wTest1Cleanup := createWorkspace(t, client, nil)
-	defer wTest1Cleanup()
+	t.Cleanup(wTest1Cleanup)
 
 	sv, svTestCleanup := createStateVersion(t, client, 0, wTest1)
-	defer svTestCleanup()
+	t.Cleanup(svTestCleanup)
 
 	// give TFC some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, sv.ID)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (CircleCI) will not test your fork unless you are an authorized employee, so a HashiCorp maintainer will initiate the tests for you and report any missing tests or simple problems. In order to speed up this process, it's not uncommon for your commits to be incorporated into another PR that we can commit test changes to.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description
!!! Moved to: https://github.com/hashicorp/go-tfe/pull/497

This PR adds the `Include` param field to `PolicySetListOptions` to allow policy list to include related resource data such as workspaces, policies, newest_version, or current_version.


## Testing plan

1.  _Fetch list of policy sets with Include param set to workspace should return list items with attached workspace object_

## External links
[API doc](https://www.terraform.io/cloud-docs/api-docs/policy-sets#list-policy-sets)

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/cloud-docs/api-docs/policy-sets#list-policy-sets)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/591)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestPolicySets

=== RUN   TestPolicySetsList
=== RUN   TestPolicySetsList/without_list_options
=== RUN   TestPolicySetsList/with_pagination
=== RUN   TestPolicySetsList/with_search
=== RUN   TestPolicySetsList/with_include_param
=== RUN   TestPolicySetsList/without_a_valid_organization
--- PASS: TestPolicySetsList (2.62s)
    --- PASS: TestPolicySetsList/without_list_options (0.16s)
    --- PASS: TestPolicySetsList/with_pagination (0.14s)
    --- PASS: TestPolicySetsList/with_search (0.17s)
    --- PASS: TestPolicySetsList/with_include_param (0.18s)
    --- PASS: TestPolicySetsList/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsCreate
=== RUN   TestPolicySetsCreate/with_valid_attributes
=== RUN   TestPolicySetsCreate/with_all_attributes_provided
=== RUN   TestPolicySetsCreate/with_policies_and_workspaces_provided
=== RUN   TestPolicySetsCreate/with_vcs_policy_set
    helper_test.go:445: Export a valid OAUTH_CLIENT_GITHUB_TOKEN before running this test!
=== RUN   TestPolicySetsCreate/with_vcs_policy_updated
    helper_test.go:445: Export a valid OAUTH_CLIENT_GITHUB_TOKEN before running this test!
=== RUN   TestPolicySetsCreate/without_a_name_provided
=== RUN   TestPolicySetsCreate/with_an_invalid_name_provided
=== RUN   TestPolicySetsCreate/without_a_valid_organization
--- PASS: TestPolicySetsCreate (2.15s)
    --- PASS: TestPolicySetsCreate/with_valid_attributes (0.14s)
    --- PASS: TestPolicySetsCreate/with_all_attributes_provided (0.15s)
    --- PASS: TestPolicySetsCreate/with_policies_and_workspaces_provided (0.78s)
    --- SKIP: TestPolicySetsCreate/with_vcs_policy_set (0.00s)
    --- SKIP: TestPolicySetsCreate/with_vcs_policy_updated (0.00s)
    --- PASS: TestPolicySetsCreate/without_a_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/with_an_invalid_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsRead
=== RUN   TestPolicySetsRead/with_a_valid_ID
=== RUN   TestPolicySetsRead/without_a_valid_ID
=== RUN   TestPolicySetsRead/with_policy_set_version
--- PASS: TestPolicySetsRead (2.33s)
    --- PASS: TestPolicySetsRead/with_a_valid_ID (0.11s)
    --- PASS: TestPolicySetsRead/without_a_valid_ID (0.00s)
    --- PASS: TestPolicySetsRead/with_policy_set_version (0.93s)
=== RUN   TestPolicySetsUpdate
=== RUN   TestPolicySetsUpdate/with_valid_attributes
=== RUN   TestPolicySetsUpdate/with_invalid_attributes
=== RUN   TestPolicySetsUpdate/without_a_valid_ID
--- PASS: TestPolicySetsUpdate (1.42s)
    --- PASS: TestPolicySetsUpdate/with_valid_attributes (0.14s)
    --- PASS: TestPolicySetsUpdate/with_invalid_attributes (0.00s)
    --- PASS: TestPolicySetsUpdate/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsAddPolicies
=== RUN   TestPolicySetsAddPolicies/with_policies_provided
=== RUN   TestPolicySetsAddPolicies/without_policies_provided
=== RUN   TestPolicySetsAddPolicies/with_empty_policies_slice
=== RUN   TestPolicySetsAddPolicies/without_a_valid_ID
--- PASS: TestPolicySetsAddPolicies (2.29s)
    --- PASS: TestPolicySetsAddPolicies/with_policies_provided (0.24s)
    --- PASS: TestPolicySetsAddPolicies/without_policies_provided (0.00s)
    --- PASS: TestPolicySetsAddPolicies/with_empty_policies_slice (0.00s)
    --- PASS: TestPolicySetsAddPolicies/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsRemovePolicies
=== RUN   TestPolicySetsRemovePolicies/with_policies_provided
=== RUN   TestPolicySetsRemovePolicies/without_policies_provided
=== RUN   TestPolicySetsRemovePolicies/with_empty_policies_slice
=== RUN   TestPolicySetsRemovePolicies/without_a_valid_ID
--- PASS: TestPolicySetsRemovePolicies (2.03s)
    --- PASS: TestPolicySetsRemovePolicies/with_policies_provided (0.24s)
    --- PASS: TestPolicySetsRemovePolicies/without_policies_provided (0.00s)
    --- PASS: TestPolicySetsRemovePolicies/with_empty_policies_slice (0.00s)
    --- PASS: TestPolicySetsRemovePolicies/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsAddWorkspaces
=== RUN   TestPolicySetsAddWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsAddWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsAddWorkspaces (2.16s)
    --- PASS: TestPolicySetsAddWorkspaces/with_workspaces_provided (0.31s)
    --- PASS: TestPolicySetsAddWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsRemoveWorkspaces
=== RUN   TestPolicySetsRemoveWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsRemoveWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsRemoveWorkspaces (2.13s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_workspaces_provided (0.24s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsDelete
=== RUN   TestPolicySetsDelete/with_valid_options
=== RUN   TestPolicySetsDelete/when_the_policy_does_not_exist
=== RUN   TestPolicySetsDelete/when_the_policy_ID_is_invalid
--- PASS: TestPolicySetsDelete (1.72s)
    --- PASS: TestPolicySetsDelete/with_valid_options (0.21s)
    --- PASS: TestPolicySetsDelete/when_the_policy_does_not_exist (0.10s)
    --- PASS: TestPolicySetsDelete/when_the_policy_ID_is_invalid (0.00s)
PASS
```
