### PR TITLE
Set tflocal build script to trigger a run with auto apply

### DIFF
--- a/.github/scripts/build-tflocal/main.go
+++ b/.github/scripts/build-tflocal/main.go
@@ -48,6 +48,7 @@ func triggerRun(ctx context.Context, organizationName, workspaceName string) err
 		IsDestroy:    tfe.Bool(false),
 		Message:      tfe.String("Queued nightly from tflocal-cloud GH Actions via go-tfe"),
 		Workspace:    wk,
+		AutoApply:    tfe.Bool(true),
 		ReplaceAddrs: []string{instanceAddr, tokenAddr},
 	})
 	if err != nil {


### PR DESCRIPTION
Last night, `instance` workflow triggered a run that ended up stuck in the waiting confirmation state. Given any runs triggered by this workflow won't capture any new configuration changes, we can safely set it to auto-apply, eliminating the need for someone to intervene manually. 