### PR TITLE
Fix struct tag for varset relationship

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Bug Fixes
+* Fixes null value returned in variable set relationship in `VariableSetVariable` by @sebasslash [#521](https://github.com/hashicorp/go-tfe/pull/521)
+
 # v1.9.0
 
 ## Enhancements

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -49,7 +49,7 @@ type VariableSetVariable struct {
 	Sensitive   bool         `jsonapi:"attr,sensitive"`
 
 	// Relations
-	VariableSet *VariableSet `jsonapi:"relation,configurable"`
+	VariableSet *VariableSet `jsonapi:"relation,varset"`
 }
 
 type VariableSetVariableListOptions struct {

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -34,12 +34,14 @@ func TestVariableSetVariablesList(t *testing.T) {
 	t.Run("without list options", func(t *testing.T) {
 		vl, err := client.VariableSetVariables.List(ctx, vsTest.ID, nil)
 		require.NoError(t, err)
+		require.NotEmpty(t, vl.Items)
 		assert.Contains(t, vl.Items, vTest1)
 		assert.Contains(t, vl.Items, vTest2)
 
-		t.Skip("paging not supported yet in API")
-		assert.Equal(t, 1, vl.CurrentPage)
-		assert.Equal(t, 2, vl.TotalCount)
+		t.Run("variable set relationship is deserialized", func(t *testing.T) {
+			require.NotNil(t, vl.Items[0].VariableSet)
+			assert.Equal(t, vsTest.ID, vl.Items[0].VariableSet.ID)
+		})
 	})
 
 	t.Run("with list options", func(t *testing.T) {


### PR DESCRIPTION
This PR fixes #491, where the struct tag definition for the variable set relationship was incorrectly named thus resulting in a null value. 

