### PR TITLE
Resource scaffolding script

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -64,11 +64,28 @@ t.Run("with nested changes trigger", func (t *testing.T) {
 
 **Note**: After your PR has been merged, and the feature either reaches general availability, you should remove the `skipIfBeta()` flag.
 
-## Best Practices for Adding a New Endpoint
+## Adding New Endpoints
 
-Here you will find a scaffold to get you started when building a json:api RESTful endpoint. The comments are meant to guide you but should be replaced with endpoint-specific and type-specific documentation. Additionally, you'll need to add an integration test that covers each method of the main interface.
+### Scaffolding a Resource
 
-In general, an interface should cover one RESTful resource, which sometimes involves two or more endpoints. Add all new modules to the tfe package.
+When creating a new resource you can use the helper script `generate_resource.sh` to quickly setup boilerplate code for adding a new set of endpoints related to that resource:
+
+```sh
+./generate_resource.sh organization
+```
+
+### Guidelines for Adding New Endpoints
+
+* An interface should cover one RESTful resource, which sometimes involves two or more endpoints.
+* We require that each resource interface provides compile-time proof that it has been implemented.
+* You'll need to add an integration test that covers each method of the resource's interface.
+* Option structs serve as a proxy for either passing query params or request bodies:
+    - `ListOptions` and `ReadOptions` are values passed as query parameters.
+    - `CreateOptions` and `UpdateOptions` represent the request body.
+* URL parameters should be defined as method parameters.
+* Any resource specific errors must be defined in `errors.go`
+
+Here is a more comprehensive example of how a resource will look like when implemented. The helper script `generate_resource.sh` will generate a subset of this example, focusing only on the core details that are required across all resources in go-tfe.
 
 ```go
 package tfe

--- a/scripts/generate_resource.sh
+++ b/scripts/generate_resource.sh
@@ -1,0 +1,238 @@
+#!/bin/bash
+
+set -euo pipefail
+
+info() {
+  printf "\r\033[00;35m$1\033[0m\n"
+}
+
+success() {
+  printf "\r\033[00;32m$1\033[0m\n"
+}
+
+fail() {
+  printf "\r\033[0;31m$1\033[0m\n"
+}
+
+__help="This script is used to quickly scaffold a resource in go-tfe. Simply provide a resource name as the first argument and it will generate standard boilerplate.
+\n- The resource name cannot be plural.
+\n- The resource name cannot contain numbers or special characters.
+\nNote: This script cannot generate appropriate camelcasing for resource names.\n
+Example usage: ./generate_resource.sh Organization
+"
+
+# Ensure a resource name is passed as an argument
+if [[ "$#" -ne 1 ]]; then
+    fail "Invalid number of arguments passed. Must specify a single resource name."
+    exit 1
+fi
+
+arg="$1"
+if [[ $arg = "-h" ]]; then
+    echo -e $__help
+    exit 1
+fi
+
+
+# Ensure the resource name isn't plural
+if [[ "${arg: -1}" = "s" ]]; then
+    fail "Error: Resource name cannot be plural."
+    exit 1
+fi
+
+if [[ "${arg}" =~ [^a-zA-Z] ]]; then
+    fail "Error: Resource name can only contain letters."
+    exit 1
+fi
+
+resource=$(echo "$arg" | tr '[:upper:]' '[:lower:]')
+plural_resource="${resource}s"
+
+# Capitalized names
+c_resource="$(tr '[:lower:]' '[:upper:]' <<< ${resource:0:1})${resource:1}"
+c_plural_resource="$(tr '[:lower:]' '[:upper:]' <<< ${plural_resource:0:1})${plural_resource:1}"
+
+# Option struct names
+list_opts="${c_resource}ListOptions"
+read_opts="${c_resource}ReadOptions"
+create_opts="${c_resource}CreateOptions"
+update_opts="${c_resource}UpdateOptions"
+
+resource_list="${c_resource}List"
+resource_id="${resource}ID"
+
+info "Creating $resource.go"
+
+cat <<EOF > $resource.go
+package tfe
+
+import (
+  "context"
+)
+
+var _ $c_plural_resource = (*$plural_resource)(nil)
+
+// $c_plural_resource describes all the $resource related methods that the Terraform
+// Enterprise API supports
+//
+// TFE API docs: (TODO: ADD DOCS URL)
+type $c_plural_resource interface {
+  // List all $plural_resource.
+  List(ctx context.Context, options *$list_opts) (*${resource_list}, error)
+
+  // Create a $resource.
+  Create(ctx context.Context, options $create_opts) (*${c_resource}, error)
+
+  // Read a $resource by its ID.
+  Read(ctx context.Context, $resource_id string) (*${c_resource}, error)
+
+  // Read a $resource by its ID with options.
+  ReadWithOptions(ctx context.Context, $resource_id string, options *$read_opts) (*${c_resource}, error)
+
+  // Update a $resource.
+  Update(ctx context.Context, $resource_id string, options $update_opts) (*${c_resource}, error)
+
+  // Delete a $resource.
+  Delete(ctx context.Context, $resource_id string) error
+}
+
+// $plural_resource implements $c_plural_resource
+type $plural_resource struct {
+  client *Client
+}
+
+// $resource_list represents a list of $plural_resource
+type $resource_list struct {
+  *Pagination
+  Items []*${c_resource}
+}
+
+// $c_resource represents a Terraform Enterprise $resource
+type $c_resource struct {
+  ID string \`jsonapi:"primary,$plural_resource"\`
+  // Add more fields here
+}
+
+// $list_opts represents the options for listing $plural_resource
+type $list_opts struct {
+  ListOptions
+
+  // Add more list options here
+}
+
+// $create_opts represents the options for creating $plural_resource
+type $create_opts struct {
+  Type string \`jsonapi:"primary,$plural_resource"\`
+  // Add more create options here
+}
+
+// $read_opts represents the options for reading a $resource
+type $read_opts struct {
+  // Add more read options here
+}
+
+// $update_opts represents the options for updating a $resource
+type $update_opts struct {
+  ID string \`jsonapi:"primary,$plural_resource"\`
+
+  // Add more update options here
+}
+
+// List all $plural_resource
+func (s *${plural_resource}) List(ctx context.Context, options *$list_opts) (*${resource_list}, error) {
+  panic("not implemented")
+}
+
+// Create a new $resource with the given options.
+func (s *${plural_resource}) Create(ctx context.Context, options $create_opts) (*${c_resource}, error) {
+  panic("not implemented")
+}
+
+// Read a $resource by its ID.
+func (s *${plural_resource}) Read(ctx context.Context, $resource_id string) (*${c_resource}, error) {
+  panic("not implemented")
+}
+
+
+// Read a $resource by its ID with the given options.
+func (s *${plural_resource}) ReadWithOptions(ctx context.Context, $resource_id string, options *$read_opts) (*${c_resource}, error) {
+  panic("not implemented")
+}
+
+// Update a $resource by its ID.
+func (s *${plural_resource}) Update(ctx context.Context, $resource_id string, options $update_opts) (*${c_resource}, error) {
+  panic("not implemented")
+}
+
+// Delete a $resource by its ID.
+func (s *${plural_resource}) Delete(ctx context.Context, $resource_id string) error {
+  panic("not implemented")
+}
+EOF
+
+
+info "Creating ${resource}_integration_test.go"
+
+cat <<EOF > ${resource}_integration_test.go
+//go:build integration
+// +build integration
+
+package tfe
+
+import (
+  "context"
+  "testing"
+
+  "github.com/stretchr/testify/assert"
+  "github.com/stretchr/testify/require"
+)
+
+func Test${c_plural_resource}List(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}
+
+func Test${c_plural_resource}Read(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}
+
+func Test${c_plural_resource}Create(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}
+
+func Test${c_plural_resource}Update(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}
+EOF
+
+
+# Ensure the file is properly formatted and our code is A-OK.
+info "Formatting $resource.go and ${resource}_integration_test.go"
+gofmt -w $resource.go ${resource}_integration_test.go
+info "Vetting newly created files"
+go vet ./...
+
+success "✅ Created new resource: $c_resource"


### PR DESCRIPTION
This script introduces a quick way for contributors to generate boilerplate when adding an entirely new set of endpoints to go-tfe. 

Usage:

```sh
./generate_resource.sh <resource name>
```

Example:
```sh
./generate_resource.sh Foobar
```

It will create a file, `foobar.go` and `foobar_integration_test.go` that look as follows:

`foobar.go`
```go
package tfe

import (
        "context"
)

var _ Foobars = (*foobars)(nil)

// Foobars describes all the foobar related methods that the Terraform
// Enterprise API supports
//
// TFE API docs: (TODO: ADD DOCS URL)
type Foobars interface {
        // List all foobars.
        List(ctx context.Context, options *FoobarListOptions) (*FoobarList, error)

        // Create a foobar.
        Create(ctx context.Context, options FoobarCreateOptions) (*Foobar, error)

        // Read a foobar by its ID.
        Read(ctx context.Context, foobarID string) (*Foobar, error)

        // Read a foobar by its ID with options.
        ReadWithOptions(ctx context.Context, foobarID string, options *FoobarReadOptions) (*Foobar, error)

        // Update a foobar.
        Update(ctx context.Context, foobarID string, options FoobarUpdateOptions) (*Foobar, error)

        // Delete a foobar.
        Delete(ctx context.Context, foobarID string) error
}

// foobars implements Foobars
type foobars struct {
        client *Client
}

// FoobarList represents a list of foobars
type FoobarList struct {
        *Pagination
        Items []*Foobar
}

// Foobar represents a Terraform Enterprise foobar
type Foobar struct {
        ID string `jsonapi:"primary,foobars"`
        // Add more fields here
}

// FoobarListOptions represents the options for listing foobars
type FoobarListOptions struct {
        ListOptions

        // Add more list options here
}

// FoobarCreateOptions represents the options for creating foobars
type FoobarCreateOptions struct {
        Type string `jsonapi:"primary,foobars"`
        // Add more create options here
}

// FoobarReadOptions represents the options for reading a foobar
type FoobarReadOptions struct {
        // Add more read options here
}

// FoobarUpdateOptions represents the options for updating a foobar
type FoobarUpdateOptions struct {
        ID string `jsonapi:"primary,foobars"`

        // Add more update options here
}

// List all foobars
func (s *foobars) List(ctx context.Context, options *FoobarListOptions) (*FoobarList, error) {
        panic("not implemented")
}

// Create a new foobar with the given options.
func (s *foobars) Create(ctx context.Context, options FoobarCreateOptions) (*Foobar, error) {
        panic("not implemented")
}

// Read a foobar by its ID.
func (s *foobars) Read(ctx context.Context, foobarID string) (*Foobar, error) {
        panic("not implemented")
}

// Read a foobar by its ID with the given options.
func (s *foobars) ReadWithOptions(ctx context.Context, foobarID string, options *FoobarReadOptions) (*Foobar, error) {
        panic("not implemented")
}

// Update a foobar by its ID.
func (s *foobars) Update(ctx context.Context, foobarID string, options FoobarUpdateOptions) (*Foobar, error) {
        panic("not implemented")
}

// Delete a foobar by its ID.
func (s *foobars) Delete(ctx context.Context, foobarID string) error {
        panic("not implemented")
}
```

`foobar_integration_test.go`
```go
//go:build integration
// +build integration

package tfe

import (
        "context"
        "testing"

        "github.com/stretchr/testify/assert"
        "github.com/stretchr/testify/require"
)

func TestFoobarsList(t *testing.T) {
        client := testClient(t)
        ctx := context.Background()

        // Create your test helper resources here
        t.Run("test not yet implemented", func(t *testing.T) {
                require.NotNil(t, nil)
        })
}

func TestFoobarsRead(t *testing.T) {
        client := testClient(t)
        ctx := context.Background()

        // Create your test helper resources here
        t.Run("test not yet implemented", func(t *testing.T) {
                require.NotNil(t, nil)
        })
}

func TestFoobarsCreate(t *testing.T) {
        client := testClient(t)
        ctx := context.Background()

        // Create your test helper resources here
        t.Run("test not yet implemented", func(t *testing.T) {
                require.NotNil(t, nil)
        })
}

func TestFoobarsUpdate(t *testing.T) {
        client := testClient(t)
        ctx := context.Background()

        // Create your test helper resources here
        t.Run("test not yet implemented", func(t *testing.T) {
                require.NotNil(t, nil)
        })
}
```

I've also included a very basic help flag `-h` which describes the requirements for the resource name as well as the limitation of casing when generating the boilerplate. 