### PR TITLE
fix stateversion flaky test

### DIFF
--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -318,26 +318,39 @@ func TestStateVersionsRead(t *testing.T) {
 	t.Cleanup(svTestCleanup)
 
 	t.Run("when the state version exists", func(t *testing.T) {
-		sv, err := client.StateVersions.Read(ctx, svTest.ID)
-		require.NoError(t, err)
+		if !svTest.ResourcesProcessed {
+			_, err := retry(func() (interface{}, error) {
+				svTest, err := client.StateVersions.Read(ctx, svTest.ID)
+				require.NoError(t, err)
 
-		// Don't compare the DownloadURL because it will be generated twice
-		// in this test - once at creation of the configuration version, and
-		// again during the GET.
-		svTest.DownloadURL, sv.DownloadURL = "", ""
+				if !svTest.ResourcesProcessed {
+					return nil, fmt.Errorf("resources not processed %s", err)
+				} else {
+					sv, err := client.StateVersions.Read(ctx, svTest.ID)
+					require.NoError(t, err)
+					// Don't compare the DownloadURL because it will be generated twice
+					// in this test - once at creation of the configuration version, and
+					// again during the GET.
+					svTest.DownloadURL, sv.DownloadURL = "", ""
+					// outputs are populated only once the state has been parsed by TFC
+					// which can cause the tests to fail if it doesn't happen fast enough.
+					svTest.Outputs = nil
+					sv.Outputs = nil
 
-		// outputs are populated only once the state has been parsed by TFC
-		// which can cause the tests to fail if it doesn't happen fast enough.
-		svTest.Outputs = nil
-		sv.Outputs = nil
-
-		assert.Equal(t, svTest, sv)
-		assert.NotEmpty(t, svTest, svTest.ResourcesProcessed)
-		assert.NotEmpty(t, svTest, svTest.StateVersion)
-		assert.NotEmpty(t, svTest, svTest.TerraformVersion)
-		assert.NotEmpty(t, svTest, svTest.Modules)
-		assert.NotEmpty(t, svTest, svTest.Providers)
-		assert.NotEmpty(t, svTest, svTest.Resources)
+					assert.Equal(t, svTest, sv)
+					assert.NotEmpty(t, svTest, svTest.ResourcesProcessed)
+					assert.NotEmpty(t, svTest, svTest.StateVersion)
+					assert.NotEmpty(t, svTest, svTest.TerraformVersion)
+					assert.NotEmpty(t, svTest, svTest.Modules)
+					assert.NotEmpty(t, svTest, svTest.Providers)
+					assert.NotEmpty(t, svTest, svTest.Resources)
+					return svTest, nil
+				}
+			})
+			if err != nil {
+				t.Fatalf("error retrying state version read, err=%s", err)
+			}
+		}
 	})
 
 	t.Run("when the state version does not exist", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR fixes a flaky test.

## Testing plan

1. `svTest.ResourcesProcessed` and `sv.ResourcesProcessed` should both either return true, or fail the test.
2. Running tests locally should suffice.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://www.terraform.io/docs/cloud/api/xxxx.html)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
