### PR TITLE
Resource scaffolding script v2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,39 @@
+# This rule runs the resource scaffolding script
+# $1 is the name of the resource to generate
+check_defined = \
+    $(strip $(foreach 1,$1, \
+        $(call __check_defined,$1,$(strip $(value 2)))))
+__check_defined = \
+    $(if $(value $1),, \
+      $(error Undefined $1$(if $2, ($2))))
+
+.PHONY: vet fmt lint test mocks envvars generate
+
+generate:
+	$(call check_defined, RESOURCE)
+	@cd ./scripts/generate_resource; \
+	go mod tidy; \
+	go run . $(RESOURCE) ;
+
+fmt:
+
+vet:
+	go vet
+
+fmt:
+	go fmt ./...
+
+lint:
+	golangci-lint run .
+
+test:
+	go test ./... $(TESTARGS) -tags=integration -timeout=30m
+
+mocks:
+	$(call check_defined, FILENAME)
+	@echo "mockgen -source=$(FILENAME) -destination=mocks/$(FILENAME) -package=mocks" >> generate_mocks.sh
+	./generate_mocks.sh
+
+envvars:
+	./scripts/setup-test-envvars.sh
+

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -19,7 +19,7 @@ There are instances where several new resources being added (i.e Workspace Run T
 ## Running the Linters Locally
 
 1. Ensure you have [installed golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
-2. From the CLI, run `golangci-lint run`
+2. From the CLI, run `make lint`
 
 ## Writing Tests
 
@@ -36,6 +36,12 @@ You'll need to generate mocks if an existing endpoint method is modified or a ne
 
 ```
 mockgen -source=example_resource.go -destination=mocks/example_resource_mocks.go -package=mocks
+```
+
+Alternatively, you can use the Makefile target `mocks` to automate the steps:
+
+```
+FILENAME=example_resource.go make mocks
 ```
 
 ## Adding API changes that are not generally available
@@ -64,11 +70,35 @@ t.Run("with nested changes trigger", func (t *testing.T) {
 
 **Note**: After your PR has been merged, and the feature either reaches general availability, you should remove the `skipIfBeta()` flag.
 
-## Best Practices for Adding a New Endpoint
+## Adding New Endpoints
 
-Here you will find a scaffold to get you started when building a json:api RESTful endpoint. The comments are meant to guide you but should be replaced with endpoint-specific and type-specific documentation. Additionally, you'll need to add an integration test that covers each method of the main interface.
+### Scaffolding a Resource
 
-In general, an interface should cover one RESTful resource, which sometimes involves two or more endpoints. Add all new modules to the tfe package.
+When creating a new resource you can use the helper script `generate_resource` to quickly setup boilerplate code for adding a new set of endpoints related to that resource:
+
+#### Running the script directly
+```sh
+cd ./scripts/generate_resource
+go run . example_resource
+```
+
+#### Running the Makefile target `generate`
+```sh
+RESOURCE=example_resource make generate
+```
+
+### Guidelines for Adding New Endpoints
+
+* An interface should cover one RESTful resource, which sometimes involves two or more endpoints.
+* We require that each resource interface provides compile-time proof that it has been implemented.
+* You'll need to add an integration test that covers each method of the resource's interface.
+* Option structs serve as a proxy for either passing query params or request bodies:
+    - `ListOptions` and `ReadOptions` are values passed as query parameters.
+    - `CreateOptions` and `UpdateOptions` represent the request body.
+* URL parameters should be defined as method parameters.
+* Any resource specific errors must be defined in `errors.go`
+
+Here is a more comprehensive example of what a resource looks like when implemented. The helper script `generate_resource` generates a subset of this example, focusing only on the core details that are required across all resources in go-tfe.
 
 ```go
 package tfe

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -72,6 +72,11 @@ $ envchain YOUR_NAMESPACE_HERE go test -run TestNotificationConfiguration -v ./.
 $ TFE_TOKEN=xyz TFE_ADDRESS=xyz ENABLE_TFE=1 go test -run TestNotificationConfiguration -v ./... -tags=integration
 ```
 
+#### Using Makefile target `test`
+```sh
+TFE_TOKEN=xyz TFE_ADDRESS=xyz TESTARGS="-run TestNotificationConfiguration" make test
+```
+
 ### Running all tests
 It takes about 20 minutes to run all of the tests, so specify a larger timeout when you run the tests (_the default timeout is 10 minutes_):
 

--- a/scripts/generate_resource/go.mod
+++ b/scripts/generate_resource/go.mod
@@ -1,0 +1,7 @@
+module generate_resource
+
+go 1.17
+
+require github.com/iancoleman/strcase v0.2.0
+
+require github.com/gertd/go-pluralize v0.2.1

--- a/scripts/generate_resource/go.sum
+++ b/scripts/generate_resource/go.sum
@@ -1,0 +1,4 @@
+github.com/gertd/go-pluralize v0.2.1 h1:M3uASbVjMnTsPb0PNqg+E/24Vwigyo/tvyMTtAlLgiA=
+github.com/gertd/go-pluralize v0.2.1/go.mod h1:rbYaKDbsXxmRfr8uygAEKhOWsjyrrqrkHVpZvoOp8zk=
+github.com/iancoleman/strcase v0.2.0 h1:05I4QRnGpI0m37iZQRuskXh+w77mr6Z41lwQzuHLwW0=
+github.com/iancoleman/strcase v0.2.0/go.mod h1:iwCmte+B7n89clKwxIoIXy/HfoL7AsD47ZCWhYzw7ho=

--- a/scripts/generate_resource/main.go
+++ b/scripts/generate_resource/main.go
@@ -1,0 +1,102 @@
+package main
+
+import (
+	"fmt"
+	"log"
+	"os"
+	"regexp"
+	"strings"
+	"text/template"
+
+	"github.com/gertd/go-pluralize"
+	"github.com/iancoleman/strcase"
+)
+
+var validResourceName = regexp.MustCompile(`^[a-zA-Z_]+$`).MatchString
+
+func generateResourceTemplate(name string) ResourceTemplate {
+	var pluralName string
+	pluralize := pluralize.NewClient()
+
+	if pluralize.IsPlural(name) {
+		pluralName = name
+		name = pluralize.Singular(name)
+	} else {
+		pluralName = pluralize.Plural(name)
+	}
+
+	camelName := strcase.ToCamel(name)
+
+	return ResourceTemplate{
+		PrimaryTag:        strings.ReplaceAll(name, "_", "-"),
+		Name:              strings.ReplaceAll(name, "_", " "),
+		PluralName:        strings.ReplaceAll(pluralName, "_", " "),
+		Resource:          camelName,
+		ResourceInterface: strcase.ToCamel(pluralName),
+		ResourceStruct:    strcase.ToLowerCamel(pluralName),
+		ResourceID:        fmt.Sprintf("%sID", camelName),
+		ListOptions:       fmt.Sprintf("%sListOptions", camelName),
+		ReadOptions:       fmt.Sprintf("%sReadOptions", camelName),
+		CreateOptions:     fmt.Sprintf("%sCreateOptions", camelName),
+		UpdateOptions:     fmt.Sprintf("%sUpdateOptions", camelName),
+	}
+}
+
+func main() {
+	var resourceName string
+
+	if len(os.Args) < 2 {
+		log.Fatal("usage: <resource name>")
+	}
+
+	if os.Args[1] == "-h" {
+		fmt.Println(helpTemplate)
+		return
+	} else {
+		resourceName = strings.ToLower(os.Args[1])
+	}
+
+	if !validResourceName(resourceName) {
+		log.Fatal("resource name can only contain letters or underscores.")
+	}
+
+	resourceTmpl := generateResourceTemplate(resourceName)
+
+	tmp, err := template.New("source").Parse(sourceTemplate)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	sourceFile, err := os.Create("../../" + resourceName + ".go")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer sourceFile.Close()
+
+	fmt.Printf("Generating %s.go\n", resourceName)
+	err = tmp.Execute(sourceFile, resourceTmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	tmp, err = template.New("source").Parse(testTemplate)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	testFile, err := os.Create("../../" + resourceName + "_integration_test.go")
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer testFile.Close()
+
+	fmt.Printf("Generating %s_integration_test.go\n", resourceName)
+	err = tmp.Execute(testFile, resourceTmpl)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("Done generating files for new resource: %s\n", resourceTmpl.Resource)
+}

--- a/scripts/generate_resource/templates.go
+++ b/scripts/generate_resource/templates.go
@@ -1,0 +1,203 @@
+package main
+
+type ResourceTemplate struct {
+	// Lower cased name of a resource, not plural
+	Name string
+
+	// Lower cased name of a resource, plural
+	PluralName string
+
+	// Name of resource model
+	Resource string
+
+	// Name of resource interface
+	ResourceInterface string
+
+	// Name of resource struct that implements resource interface
+	ResourceStruct string
+
+	// The resource ID
+	ResourceID string
+
+	// Struct tag name for (un)marshalling the JSON+API resource.
+	PrimaryTag string
+
+	ListOptions   string
+	ReadOptions   string
+	CreateOptions string
+	UpdateOptions string
+}
+
+const helpTemplate = `
+This script is used to quickly scaffold a resource in go-tfe. Simply provide a
+resource name as the first argument and it will generate standard boilerplate.
+
+Note: A resource name can only contain letters and underscores.
+
+Allowed: policy_set, Run_task, orGanizatIon
+Not Allowed: policy123, #user, my cool resource
+
+If your resource contains multiple terms, e.g policy set, you must use an
+underscore delimiter for each term in order to generate proper casing in your
+code. For example, if you wanted to generate the policy set resource as
+PolicySet you would pass policy_set as your argument.
+
+Example usage: go run ./scripts/generate_resource/main.go policy_set`
+
+const sourceTemplate = `
+package tfe
+
+import (
+  "context"
+)
+
+var _ {{ .ResourceInterface }} = (*{{ .ResourceStruct }})(nil)
+
+// {{ .ResourceInterface }} describes all the {{ .Name }} related methods that the Terraform
+// Enterprise API supports
+//
+// TFE API docs: (TODO: ADD DOCS URL)
+type {{ .ResourceInterface }} interface {
+  // List all {{ .PluralName }}.
+  List(ctx context.Context, options *{{ .ListOptions }}) (*{{ .Resource }}List, error)
+
+  // Create a {{ .Name }}.
+  Create(ctx context.Context, options {{ .CreateOptions }}) (*{{ .Resource }}, error)
+
+  // Read a {{ .Name }} by its ID.
+  Read(ctx context.Context, {{ .ResourceID }} string) (*{{ .Resource }}, error)
+
+  // Read a {{ .Name }} by its ID with options.
+  ReadWithOptions(ctx context.Context, {{ .ResourceID }} string, options *{{ .ReadOptions }}) (*{{ .Resource }}, error)
+
+  // Update a {{ .Name }}.
+  Update(ctx context.Context, {{ .ResourceID }} string, options {{ .UpdateOptions }}) (*{{ .Resource }}, error)
+
+  // Delete a {{ .Name }}.
+  Delete(ctx context.Context, {{ .ResourceID }} string) error
+}
+
+// {{ .ResourceStruct }} implements {{ .ResourceInterface }}
+type {{ .ResourceStruct }} struct {
+  client *Client
+}
+
+// {{ .Resource }}List represents a list of {{ .PluralName }}
+type {{ .Resource }}List struct {
+  *Pagination
+  Items []*{{ .Resource }}
+}
+
+// {{ .Resource }} represents a Terraform Enterprise $resource
+type {{ .Resource }} struct {
+  ID string ` + "`jsonapi:\"primary," + `{{ .PrimaryTag }}` + "\"`" + `
+  // Add more fields here
+}
+
+// {{ .ListOptions }} represents the options for listing {{ .PluralName }}
+type {{ .ListOptions }} struct {
+  ListOptions
+
+  // Add more list options here
+}
+
+// {{ .CreateOptions }} represents the options for creating a {{ .Name }}
+type {{ .CreateOptions }} struct {
+  Type string ` + "`jsonapi:\"primary," + `{{ .PrimaryTag }}` + "\"`" + `
+  // Add more create options here
+}
+
+// {{ .ReadOptions }} represents the options for reading a {{ .Name }}
+type {{ .ReadOptions }} struct {
+  // Add more read options here
+}
+
+// {{ .UpdateOptions }} represents the options for updating a {{ .Name }}
+type {{ .UpdateOptions }} struct {
+  ID string ` + "`jsonapi:\"primary," + `{{ .PrimaryTag }}` + "\"`" + `
+
+  // Add more update options here
+}
+
+// List all {{ .PluralName }}.
+func List(ctx context.Context, options *{{ .ListOptions }}) (*{{ .Resource }}List, error) {
+    panic("not yet implemented")
+}
+
+// Create a {{ .Name }}.
+func Create(ctx context.Context, options {{ .CreateOptions }}) (*{{ .Resource }}, error) {
+    panic("not yet implemented")
+}
+
+// Read a {{ .Name }} by its ID.
+func Read(ctx context.Context, {{ .ResourceID }} string) (*{{ .Resource }}, error) {
+    panic("not yet implemented")
+}
+
+// Read a {{ .Name }} by its ID with options.
+func ReadWithOptions(ctx context.Context, {{ .ResourceID }} string, options *{{ .ReadOptions }}) (*{{ .Resource }}, error) {
+    panic("not yet implemented")
+}
+
+// Update a {{ .Name }}.
+func Update(ctx context.Context, {{ .ResourceID }} string, options {{ .UpdateOptions }}) (*{{ .Resource }}, error) {
+    panic("not yet implemented")
+}
+
+// Delete a {{ .Name }}.
+func Delete(ctx context.Context, {{ .ResourceID }} string) error {
+    panic("not yet implemented")
+}`
+
+const testTemplate = `//go:build integration
+// +build integration
+
+package tfe
+
+import (
+  "context"
+  "testing"
+
+  "github.com/stretchr/testify/assert"
+  "github.com/stretchr/testify/require"
+)
+
+func Test{{ .ResourceInterface }}List(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}
+
+func Test{{ .ResourceInterface }}Read(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}
+
+func Test{{ .ResourceInterface }}Create(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}
+
+func Test{{ .ResourceInterface }}Update(t *testing.T) {
+  client := testClient(t)
+  ctx := context.Background()
+
+  // Create your test helper resources here
+  t.Run("test not yet implemented", func(t *testing.T) {
+    require.NotNil(t, nil)
+  })
+}`


### PR DESCRIPTION
An extension of #525, where I've ported the script `generate_resource` over to Go, giving us greater flexibility in code generation. Namely, the biggest benefit (aside from writing it in Go) is that we can properly case the resource name without having to write a complex bash script. 

I've also introduced a `Makefile` since we've been writing a few scripts to help improve the workflow for contributors. 

You can run `generate_resource`:
```sh
RESOURCE=example_resource make generate
```

Will create `ExampleResource`, stub out the interface and struct methods, and generate an integration test file. 

Other Makefile targets include:
* `make vet`: runs `go vet`
* `make lint`: runs `golangci-lint run .`
* `make test`: runs `go test`, e.g

```sh
TESTARGS="-run TestRunsList" make test
```

* `make mocks`: automates mock creation by appending a `mockgen` command to `generate_mocks.sh` and then running that script, e.g

```sh
FILENAME=example_resource.go make mocks
```

* `make envvars`: runs our `./script/setup-test-envvars.sh` script
