### PR TITLE
Fix ignored json meta tags for run variables in RunCreateOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Bug Fixes
 * Fixes null value returned in variable set relationship in `VariableSetVariable` by @sebasslash [#521](https://github.com/hashicorp/go-tfe/pull/521)
+* Fix marshalling of run variables in `RunCreateOptions`. The `Variables` field type in `Run` struct has changed from `[]*RunVariable` to `[]*RunVariableAttr` by @Uk1288 [#531](https://github.com/hashicorp/go-tfe/pull/531)
 
 # v1.9.0
 

--- a/run.go
+++ b/run.go
@@ -127,7 +127,7 @@ type Run struct {
 	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
 	TargetAddrs            []string             `jsonapi:"attr,target-addrs,omitempty"`
 	TerraformVersion       string               `jsonapi:"attr,terraform-version"`
-	Variables              []*RunVariable       `jsonapi:"attr,variables"`
+	Variables              []*RunVariableAttr   `jsonapi:"attr,variables"`
 
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
@@ -304,7 +304,7 @@ type RunCreateOptions struct {
 	// user confirmation. It defaults to the Workspace.AutoApply setting.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
 
-	// RunVariables allows you to specify terraform input variables for
+	// Variables allows you to specify terraform input variables for
 	// a particular run, prioritized over variables defined on the workspace.
 	Variables []*RunVariable `jsonapi:"attr,variables,omitempty"`
 }
@@ -321,12 +321,17 @@ type RunCancelOptions struct {
 	Comment *string `json:"comment,omitempty"`
 }
 
-// RunVariable represents a variable that can be applied to a run. All values must be expressed as an HCL literal
+type RunVariableAttr struct {
+	Key   string `jsonapi:"attr,key"`
+	Value string `jsonapi:"attr,value"`
+}
+
+// RunVariableAttr represents a variable that can be applied to a run. All values must be expressed as an HCL literal
 // in the same syntax you would use when writing terraform code. See https://www.terraform.io/docs/language/expressions/types.html#types
 // for more details.
 type RunVariable struct {
-	Key   string `jsonapi:"attr,key"`
-	Value string `jsonapi:"attr,value"`
+	Key   string `json:"key"`
+	Value string `json:"value"`
 }
 
 // RunForceCancelOptions represents the options for force-canceling a run.


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description: 

**NOTE: The`Variables` field in `Run` has been changed from type `[]*RunVariable` to `[]*RunVariableAttr` **

Ref PR: https://github.com/hashicorp/go-tfe/pull/204

Run variables in RunCreateOptions are not marshalled in line with the API (https://www.terraform.io/cloud-docs/api-docs/run#request-body). The variables are currently marshalled as:

```
"variables": [
        {
          "Key": "aKey",
          "Value": "\"aValue\""
        }
]
```

instead of 

```
"variables": [
        {
          "key": "aKey",
          "value": "\"aValue\""
        }
]
```

This PR adds changes that marshals and un-marshals the run variables correctly.

<!-- Describe why you're making this change. -->

## Testing plan

1.  _Create a run with options_
```
	newRun, err := client.Runs.Create(context.Background(), tfe.RunCreateOptions{
		Workspace: &tfe.Workspace{
			ID: "ws-ID",
		},
		Variables: []*tfe.RunVariableOption{
			{
				Key:   "name",
				Value: "\"aName\"",
			},
		},
	})
```
1.  _`Run` should be created with correct variable key, name attributes,_
1.  _`Run` value in go client should have Key, Value fields populated as well._


## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
-->
- [API documentation](https://www.terraform.io/cloud-docs/api-docs/run#request-body)
- [Issue](https://github.com/hashicorp/go-tfe/issues/380)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestRunCreateOptions_Marshal

=== RUN   TestRunCreateOptions_Marshal
--- PASS: TestRunCreateOptions_Marshal (1.47s)
PASS
ok 
```
