### PR TITLE
Improve test execution time with test splitting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: test
 on:
   pull_request:
-    branches: [ main ]
+    branches:
+      - main
 jobs:
   codegen:
     name: Codegen
@@ -42,6 +43,12 @@ jobs:
   tests:
     name: Integration Tests
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        ci_node_total: [2]
+        ci_node_index: [0, 1]
+
     timeout-minutes: 30
     steps:
       - name: Checkout code
@@ -74,6 +81,8 @@ jobs:
           GITHUB_REGISTRY_MODULE_IDENTIFIER: "hashicorp/terraform-random-module"
           OAUTH_CLIENT_GITHUB_TOKEN: "${{ secrets.OAUTH_CLIENT_GITHUB_TOKEN }}"
           GO111MODULE: "on"
+          CI_NODE_TOTAL: ${{ matrix.ci_node_total }}
+          CI_NODE_INDEX: ${{ matrix.ci_node_index }}
         run: |
           source $HOME/.env
           gotestsum --format short-verbose -- -timeout=40m -tags=integration

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAdminOrganizations_List(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -70,6 +71,7 @@ func TestAdminOrganizations_List(t *testing.T) {
 }
 
 func TestAdminOrganizations_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -111,6 +113,7 @@ func TestAdminOrganizations_Read(t *testing.T) {
 }
 
 func TestAdminOrganizations_Delete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -148,6 +151,7 @@ func TestAdminOrganizations_Delete(t *testing.T) {
 }
 
 func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -192,6 +196,7 @@ func TestAdminOrganizations_ModuleConsumers(t *testing.T) {
 }
 
 func TestAdminOrganizations_Update(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -17,6 +17,7 @@ import (
 )
 
 func TestAdminRuns_List(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -149,6 +150,7 @@ func TestAdminRuns_List(t *testing.T) {
 }
 
 func TestAdminRuns_ForceCancel(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -228,6 +230,7 @@ func TestAdminRuns_ForceCancel(t *testing.T) {
 }
 
 func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	t.Run("has valid status", func(t *testing.T) {
@@ -269,6 +272,8 @@ func TestAdminRuns_AdminRunsListOptions_valid(t *testing.T) {
 }
 
 func TestAdminRun_ForceCancel_Marshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	opts := AdminRunForceCancelOptions{
 		Comment: String("cancel comment"),
 	}
@@ -285,6 +290,8 @@ func TestAdminRun_ForceCancel_Marshal(t *testing.T) {
 }
 
 func TestAdminRun_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "runs",

--- a/admin_setting_cost_estimation_integration_test.go
+++ b/admin_setting_cost_estimation_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdminSettings_CostEstimation_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -24,6 +25,7 @@ func TestAdminSettings_CostEstimation_Read(t *testing.T) {
 }
 
 func TestAdminSettings_CostEstimation_Update(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_setting_customization_integration_test.go
+++ b/admin_setting_customization_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdminSettings_Customization_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -29,6 +30,7 @@ func TestAdminSettings_Customization_Read(t *testing.T) {
 }
 
 func TestAdminSettings_Customization_Update(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_setting_general_integration_test.go
+++ b/admin_setting_general_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdminSettings_General_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -38,6 +39,7 @@ func TestAdminSettings_General_Read(t *testing.T) {
 }
 
 func TestAdminSettings_General_Update(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdminSettings_SAML_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -40,6 +41,7 @@ func TestAdminSettings_SAML_Read(t *testing.T) {
 }
 
 func TestAdminSettings_SAML_Update(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -61,6 +63,7 @@ func TestAdminSettings_SAML_Update(t *testing.T) {
 }
 
 func TestAdminSettings_SAML_RevokeIdpCert(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_setting_smtp_integration_test.go
+++ b/admin_setting_smtp_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdminSettings_SMTP_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -30,6 +31,7 @@ func TestAdminSettings_SMTP_Read(t *testing.T) {
 }
 
 func TestAdminSettings_SMTP_Update(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_setting_twilio_integration_test.go
+++ b/admin_setting_twilio_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdminSettings_Twilio_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -27,6 +28,7 @@ func TestAdminSettings_Twilio_Read(t *testing.T) {
 }
 
 func TestAdminSettings_Twilio_Update(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -41,6 +43,7 @@ func TestAdminSettings_Twilio_Update(t *testing.T) {
 }
 
 func TestAdminSettings_Twilio_Verify(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAdminTerraformVersions_List(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -96,6 +97,7 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 }
 
 func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -163,6 +165,7 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 }
 
 func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAdminUsers_List(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -102,6 +103,7 @@ func TestAdminUsers_List(t *testing.T) {
 }
 
 func TestAdminUsers_Delete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -143,6 +145,7 @@ func TestAdminUsers_Delete(t *testing.T) {
 }
 
 func TestAdminUsers_Disable2FA(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAdminWorkspaces_List(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -121,6 +122,7 @@ func TestAdminWorkspaces_List(t *testing.T) {
 }
 
 func TestAdminWorkspaces_Read(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -158,6 +160,7 @@ func TestAdminWorkspaces_Read(t *testing.T) {
 }
 
 func TestAdminWorkspaces_Delete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfCloud(t)
 
 	client := testClient(t)
@@ -210,6 +213,8 @@ func adminWorkspaceItemsContainsID(items []*AdminWorkspace, id string) bool {
 }
 
 func TestAdminWorkspace_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "workspaces",

--- a/agent_integration_test.go
+++ b/agent_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAgentsRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfNotLinuxAmd64(t)
 
 	client := testClient(t)
@@ -46,6 +47,7 @@ func TestAgentsRead(t *testing.T) {
 }
 
 func TestAgentsList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfNotLinuxAmd64(t)
 
 	client := testClient(t)

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestAgentPoolsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -88,6 +90,8 @@ func TestAgentPoolsList(t *testing.T) {
 }
 
 func TestAgentPoolsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -132,6 +136,8 @@ func TestAgentPoolsCreate(t *testing.T) {
 }
 
 func TestAgentPoolsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -178,6 +184,8 @@ func TestAgentPoolsRead(t *testing.T) {
 }
 
 func TestAgentPoolsUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -255,6 +263,8 @@ func TestAgentPoolsUpdate(t *testing.T) {
 }
 
 func TestAgentPoolsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/agent_token_integration_test.go
+++ b/agent_token_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestAgentTokensList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -52,6 +53,7 @@ func TestAgentTokensList(t *testing.T) {
 }
 
 func TestAgentTokensCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -84,6 +86,7 @@ func TestAgentTokensCreate(t *testing.T) {
 	})
 }
 func TestAgentTokensRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -112,6 +115,7 @@ func TestAgentTokensRead(t *testing.T) {
 }
 
 func TestAgentTokensDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 

--- a/apply_integration_test.go
+++ b/apply_integration_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestAppliesRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -47,6 +49,8 @@ func TestAppliesRead(t *testing.T) {
 }
 
 func TestAppliesLogs(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -74,6 +78,8 @@ func TestAppliesLogs(t *testing.T) {
 }
 
 func TestApplies_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "applies",

--- a/audit_trail_integration_test.go
+++ b/audit_trail_integration_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAuditTrailsList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 
 	userClient := testClient(t)

--- a/comment_integration_test.go
+++ b/comment_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestCommentsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -18,6 +18,8 @@ import (
 )
 
 func TestConfigurationVersionsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -74,6 +76,8 @@ func TestConfigurationVersionsList(t *testing.T) {
 }
 
 func TestConfigurationVersionsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -116,6 +120,8 @@ func TestConfigurationVersionsCreate(t *testing.T) {
 }
 
 func TestConfigurationVersionsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -148,6 +154,8 @@ func TestConfigurationVersionsRead(t *testing.T) {
 }
 
 func TestConfigurationVersionsReadWithOptions(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -192,6 +200,8 @@ func TestConfigurationVersionsReadWithOptions(t *testing.T) {
 }
 
 func TestConfigurationVersionsUpload(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -229,6 +239,8 @@ func TestConfigurationVersionsUpload(t *testing.T) {
 }
 
 func TestConfigurationVersionsArchive(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -282,6 +294,8 @@ func TestConfigurationVersionsArchive(t *testing.T) {
 }
 
 func TestConfigurationVersionsDownload(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -320,6 +334,8 @@ func TestConfigurationVersionsDownload(t *testing.T) {
 }
 
 func TestConfigurationVersions_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "configuration-versions",

--- a/cost_estimate_integration_test.go
+++ b/cost_estimate_integration_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestCostEstimatesRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -60,6 +61,8 @@ func TestCostEstimatesRead(t *testing.T) {
 }
 
 func TestCostEsimate_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "cost-estimates",

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,6 +25,13 @@ There are instances where several new resources being added (i.e Workspace Run T
 
 The test suite contains many acceptance tests that are run against the latest version of Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in [TESTS.md](TESTS.md). Our CI system (Github Actions) will not test your fork until a one-time approval takes place.
 
+<<<<<<< HEAD
+=======
+## Test Splitting
+
+Our CI workflow makes use of multiple nodes to run our tests in a more efficient manner. To prevent your test from running across all nodes, you **must** add `skipIfNotCINode(t)` to your top level test before any other helper or test logic.
+
+>>>>>>> e307d93 (rename from checktestnode to skipIfNotCINode)
 ## Editor Settings
 
 We've included VSCode settings to assist with configuring the go extension. For other editors that integrate with the [Go Language Server](https://github.com/golang/tools/tree/master/gopls), the main thing to do is to add the `integration` build tags so that the test files are found by the language server. See `.vscode/settings.json` for more details.
@@ -59,6 +66,7 @@ When adding test cases, you can temporarily use the skipIfBeta() test helper to 
 
 ```
 t.Run("with nested changes trigger", func (t *testing.T) {
+  skipIfNotCINode(t)
   skipIfBeta(t)
   options := WorkspaceCreateOptions {
      // rest of required fields here

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -26,12 +26,19 @@ There are instances where several new resources being added (i.e Workspace Run T
 The test suite contains many acceptance tests that are run against the latest version of Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in [TESTS.md](TESTS.md). Our CI system (Github Actions) will not test your fork until a one-time approval takes place.
 
 <<<<<<< HEAD
+<<<<<<< HEAD
 =======
 ## Test Splitting
 
 Our CI workflow makes use of multiple nodes to run our tests in a more efficient manner. To prevent your test from running across all nodes, you **must** add `skipIfNotCINode(t)` to your top level test before any other helper or test logic.
 
 >>>>>>> e307d93 (rename from checktestnode to skipIfNotCINode)
+=======
+## Test Splitting
+
+Our CI workflow makes use of multiple nodes to run our tests in a more efficient manner. To prevent your test from running across all nodes, you **must** add `checkTestNodeEnv(t)` to your top level test before any other helper or test logic.
+
+>>>>>>> d0e4157 (Update contributing docs to mention test splitting)
 ## Editor Settings
 
 We've included VSCode settings to assist with configuring the go extension. For other editors that integrate with the [Go Language Server](https://github.com/golang/tools/tree/master/gopls), the main thing to do is to add the `integration` build tags so that the test files are found by the language server. See `.vscode/settings.json` for more details.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/hashicorp/go-tfe
 
-go 1.17
+go 1.19
 
 require (
 	github.com/golang/mock v1.6.0

--- a/gpg_key_integration_test.go
+++ b/gpg_key_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestGPGKeyCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -71,6 +73,8 @@ func TestGPGKeyCreate(t *testing.T) {
 }
 
 func TestGPGKeyRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -110,6 +114,8 @@ func TestGPGKeyRead(t *testing.T) {
 }
 
 func TestGPGKeyUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -173,6 +179,8 @@ func TestGPGKeyUpdate(t *testing.T) {
 }
 
 func TestGPGKeyDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/ip_ranges_integration_test.go
+++ b/ip_ranges_integration_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestIPRangesRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 
 	client := testClient(t)

--- a/logreader_integration_test.go
+++ b/logreader_integration_test.go
@@ -21,6 +21,8 @@ func checkedWrite(t *testing.T, w io.Writer, message []byte) {
 }
 
 func testLogReader(t *testing.T, h http.HandlerFunc) (*httptest.Server, *LogReader) {
+	skipIfNotCINode(t)
+
 	ts := httptest.NewServer(h)
 
 	cfg := &Config{
@@ -49,6 +51,7 @@ func testLogReader(t *testing.T, h http.HandlerFunc) (*httptest.Server, *LogRead
 }
 
 func TestLogReader_withMarkersSingle(t *testing.T) {
+	skipIfNotCINode(t)
 	t.Parallel()
 
 	logReads := 0
@@ -88,6 +91,7 @@ func TestLogReader_withMarkersSingle(t *testing.T) {
 }
 
 func TestLogReader_withMarkersDouble(t *testing.T) {
+	skipIfNotCINode(t)
 	t.Parallel()
 
 	logReads := 0
@@ -129,6 +133,7 @@ func TestLogReader_withMarkersDouble(t *testing.T) {
 }
 
 func TestLogReader_withMarkersMulti(t *testing.T) {
+	skipIfNotCINode(t)
 	t.Parallel()
 
 	logReads := 0
@@ -176,6 +181,7 @@ func TestLogReader_withMarkersMulti(t *testing.T) {
 }
 
 func TestLogReader_withoutMarkers(t *testing.T) {
+	skipIfNotCINode(t)
 	t.Parallel()
 
 	logReads := 0
@@ -219,6 +225,7 @@ func TestLogReader_withoutMarkers(t *testing.T) {
 }
 
 func TestLogReader_withoutEndOfTextMarker(t *testing.T) {
+	skipIfNotCINode(t)
 	t.Parallel()
 
 	logReads := 0

--- a/notification_configuration_integration_test.go
+++ b/notification_configuration_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestNotificationConfigurationList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -71,6 +73,8 @@ func TestNotificationConfigurationList(t *testing.T) {
 }
 
 func TestNotificationConfigurationCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -200,6 +204,8 @@ func TestNotificationConfigurationCreate(t *testing.T) {
 }
 
 func TestNotificationConfigurationRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -224,6 +230,8 @@ func TestNotificationConfigurationRead(t *testing.T) {
 }
 
 func TestNotificationConfigurationUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -321,6 +329,8 @@ func TestNotificationConfigurationUpdate(t *testing.T) {
 }
 
 func TestNotificationConfigurationDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -349,6 +359,8 @@ func TestNotificationConfigurationDelete(t *testing.T) {
 }
 
 func TestNotificationConfigurationVerify(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -14,6 +14,8 @@ import (
 )
 
 func TestOAuthClientsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -87,6 +89,8 @@ func TestOAuthClientsList(t *testing.T) {
 }
 
 func TestOAuthClientsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -178,6 +182,8 @@ func TestOAuthClientsCreate(t *testing.T) {
 }
 
 func TestOAuthClientsCreate_rsaKeyPair(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -207,6 +213,8 @@ func TestOAuthClientsCreate_rsaKeyPair(t *testing.T) {
 }
 
 func TestOAuthClientsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -240,6 +248,8 @@ func TestOAuthClientsRead(t *testing.T) {
 }
 
 func TestOAuthClientsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -275,6 +285,8 @@ func TestOAuthClientsDelete(t *testing.T) {
 }
 
 func TestOAuthClientsCreateOptionsValid(t *testing.T) {
+	skipIfNotCINode(t)
+
 	t.Run("with valid options", func(t *testing.T) {
 		options := OAuthClientCreateOptions{
 			APIURL:          String("https://api.github.com"),
@@ -396,6 +408,8 @@ MIIEpAIBAAKCAQEAoKizy4xbN6qZFAwIJV24liz/vYBSvR3SjEiUzhpp0uMAmICN
 `
 
 func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/oauth_token_integration_test.go
+++ b/oauth_token_integration_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestOAuthTokensList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -76,6 +78,8 @@ func TestOAuthTokensList(t *testing.T) {
 }
 
 func TestOAuthTokensRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -103,6 +107,8 @@ func TestOAuthTokensRead(t *testing.T) {
 }
 
 func TestOAuthTokensUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -161,6 +167,8 @@ dpIe8YOINN27XaojJvVpT5uBVCcZLF+G7kaMjSwCTlDx3Q==
 }
 
 func TestOAuthTokensDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestOrganizationsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -101,6 +103,8 @@ func TestOrganizationsList(t *testing.T) {
 }
 
 func TestOrganizationsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -150,6 +154,8 @@ func TestOrganizationsCreate(t *testing.T) {
 }
 
 func TestOrganizationsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -186,6 +192,8 @@ func TestOrganizationsRead(t *testing.T) {
 }
 
 func TestOrganizationsUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -263,6 +271,8 @@ func TestOrganizationsUpdate(t *testing.T) {
 }
 
 func TestOrganizationsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -284,6 +294,7 @@ func TestOrganizationsDelete(t *testing.T) {
 }
 
 func TestOrganizationsReadCapacity(t *testing.T) {
+	skipIfNotCINode(t)
 	t.Skip("Capacity queues are not available in the API")
 	client := testClient(t)
 	ctx := context.Background()
@@ -338,6 +349,7 @@ func TestOrganizationsReadCapacity(t *testing.T) {
 }
 
 func TestOrganizationsReadEntitlements(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -473,6 +485,7 @@ func TestOrganizationsReadRunQueue(t *testing.T) {
 }
 
 func TestOrganization_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "organizations",
@@ -511,6 +524,7 @@ func TestOrganization_Unmarshal(t *testing.T) {
 }
 
 func TestOrganizationsReadRunTasksPermission(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 	skipIfBeta(t)
 
@@ -533,6 +547,7 @@ func TestOrganizationsReadRunTasksPermission(t *testing.T) {
 }
 
 func TestOrganizationsReadRunTasksEntitlement(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 	skipIfBeta(t)

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestOrganizationMembershipsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -109,6 +111,8 @@ func TestOrganizationMembershipsList(t *testing.T) {
 }
 
 func TestOrganizationMembershipsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -158,6 +162,8 @@ func TestOrganizationMembershipsCreate(t *testing.T) {
 }
 
 func TestOrganizationMembershipsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -191,6 +197,8 @@ func TestOrganizationMembershipsRead(t *testing.T) {
 }
 
 func TestOrganizationMembershipsReadWithOptions(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -234,6 +242,8 @@ func TestOrganizationMembershipsReadWithOptions(t *testing.T) {
 }
 
 func TestOrganizationMembershipsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/organization_tags_integration_test.go
+++ b/organization_tags_integration_test.go
@@ -10,6 +10,8 @@ import (
 )
 
 func TestOrganizationTagsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -81,6 +83,8 @@ func TestOrganizationTagsList(t *testing.T) {
 }
 
 func TestOrganizationTagsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -131,6 +135,8 @@ func TestOrganizationTagsDelete(t *testing.T) {
 }
 
 func TestOrganizationTagsAddWorkspace(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestOrganizationTokensCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -41,6 +43,8 @@ func TestOrganizationTokensCreate(t *testing.T) {
 }
 
 func TestOrganizationTokensRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -71,6 +75,8 @@ func TestOrganizationTokensRead(t *testing.T) {
 }
 
 func TestOrganizationTokensDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/plan_export_integration_test.go
+++ b/plan_export_integration_test.go
@@ -15,6 +15,8 @@ import (
 )
 
 func TestPlanExportsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -60,6 +62,8 @@ func TestPlanExportsCreate(t *testing.T) {
 }
 
 func TestPlanExportsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -83,6 +87,8 @@ func TestPlanExportsRead(t *testing.T) {
 }
 
 func TestPlanExportsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -106,6 +112,8 @@ func TestPlanExportsDelete(t *testing.T) {
 }
 
 func TestPlanExportsDownload(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -126,6 +134,8 @@ func TestPlanExportsDownload(t *testing.T) {
 }
 
 func TestPlanExport_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "plan-exports",

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -16,6 +16,8 @@ import (
 )
 
 func TestPlansRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -46,6 +48,8 @@ func TestPlansRead(t *testing.T) {
 }
 
 func TestPlansLogs(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -73,6 +77,8 @@ func TestPlansLogs(t *testing.T) {
 }
 
 func TestPlan_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "plans",
@@ -117,6 +123,8 @@ func TestPlan_Unmarshal(t *testing.T) {
 }
 
 func TestPlansJSONOutput(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 	rTest, rTestCleanup := createPlannedRun(t, client, nil)

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestPolicyChecksList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -82,6 +83,7 @@ func TestPolicyChecksList(t *testing.T) {
 }
 
 func TestPolicyChecksRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -125,6 +127,7 @@ func TestPolicyChecksRead(t *testing.T) {
 }
 
 func TestPolicyChecksOverride(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -185,6 +188,7 @@ func TestPolicyChecksOverride(t *testing.T) {
 }
 
 func TestPolicyChecksLogs(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -224,6 +228,8 @@ func TestPolicyChecksLogs(t *testing.T) {
 }
 
 func TestPolicyCheck_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "policy-checks",

--- a/policy_integration_test.go
+++ b/policy_integration_test.go
@@ -16,6 +16,7 @@ import (
 )
 
 func TestPoliciesList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -78,6 +79,7 @@ func TestPoliciesList(t *testing.T) {
 }
 
 func TestPoliciesCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -194,6 +196,7 @@ func TestPoliciesCreate(t *testing.T) {
 }
 
 func TestPoliciesRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -247,6 +250,7 @@ func TestPoliciesRead(t *testing.T) {
 }
 
 func TestPoliciesUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -331,6 +335,7 @@ func TestPoliciesUpdate(t *testing.T) {
 }
 
 func TestPoliciesDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -362,6 +367,7 @@ func TestPoliciesDelete(t *testing.T) {
 }
 
 func TestPoliciesUpload(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -392,6 +398,7 @@ func TestPoliciesUpload(t *testing.T) {
 }
 
 func TestPoliciesDownload(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -425,6 +432,8 @@ func TestPoliciesDownload(t *testing.T) {
 }
 
 func TestPolicy_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "policies",
@@ -465,6 +474,8 @@ func TestPolicy_Unmarshal(t *testing.T) {
 }
 
 func TestPolicyCreateOptions_Marshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	opts := PolicyCreateOptions{
 		Name:        String("my-policy"),
 		Description: String("details"),
@@ -493,6 +504,8 @@ func TestPolicyCreateOptions_Marshal(t *testing.T) {
 }
 
 func TestPolicyUpdateOptions_Marshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	opts := PolicyUpdateOptions{
 		Description: String("details"),
 		Enforce: []*EnforcementOptions{

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestPolicySetsList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -95,6 +96,7 @@ func TestPolicySetsList(t *testing.T) {
 }
 
 func TestPolicySetsCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -258,6 +260,7 @@ func TestPolicySetsCreate(t *testing.T) {
 }
 
 func TestPolicySetsRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -326,6 +329,7 @@ func TestPolicySetsRead(t *testing.T) {
 }
 
 func TestPolicySetsUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -372,6 +376,7 @@ func TestPolicySetsUpdate(t *testing.T) {
 }
 
 func TestPolicySetsAddPolicies(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -429,6 +434,7 @@ func TestPolicySetsAddPolicies(t *testing.T) {
 }
 
 func TestPolicySetsRemovePolicies(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -480,6 +486,7 @@ func TestPolicySetsRemovePolicies(t *testing.T) {
 }
 
 func TestPolicySetsAddWorkspaces(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -551,6 +558,7 @@ func TestPolicySetsAddWorkspaces(t *testing.T) {
 }
 
 func TestPolicySetsRemoveWorkspaces(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -616,6 +624,7 @@ func TestPolicySetsRemoveWorkspaces(t *testing.T) {
 }
 
 func TestPolicySetsDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)

--- a/policy_set_parameter_integration_test.go
+++ b/policy_set_parameter_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestPolicySetParametersList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -64,6 +65,7 @@ func TestPolicySetParametersList(t *testing.T) {
 }
 
 func TestPolicySetParametersCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -166,6 +168,7 @@ func TestPolicySetParametersCreate(t *testing.T) {
 }
 
 func TestPolicySetParametersRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -205,6 +208,7 @@ func TestPolicySetParametersRead(t *testing.T) {
 }
 
 func TestPolicySetParametersUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -271,6 +275,7 @@ func TestPolicySetParametersUpdate(t *testing.T) {
 }
 
 func TestPolicySetParametersDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -15,6 +15,7 @@ import (
 const waitForPolicySetVersionUpload = 500 * time.Millisecond
 
 func TestPolicySetVersionsCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -39,6 +40,7 @@ func TestPolicySetVersionsCreate(t *testing.T) {
 }
 
 func TestPolicySetVersionsRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -65,6 +67,7 @@ func TestPolicySetVersionsRead(t *testing.T) {
 }
 
 func TestPolicySetVersionsUpload(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -107,6 +110,8 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 }
 
 func TestPolicySetVersionsUploadURL(t *testing.T) {
+	skipIfNotCINode(t)
+
 	t.Run("successfully returns upload link", func(t *testing.T) {
 		links := map[string]interface{}{
 			"upload": "example.com",

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -19,6 +19,8 @@ import (
 )
 
 func TestRegistryModulesList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -64,6 +66,8 @@ func TestRegistryModulesList(t *testing.T) {
 }
 
 func TestRegistryModulesCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -228,6 +232,8 @@ func TestRegistryModulesCreate(t *testing.T) {
 }
 
 func TestRegistryModulesCreateVersion(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -360,6 +366,8 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 }
 
 func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
+	skipIfNotCINode(t)
+
 	githubIdentifier := os.Getenv("GITHUB_REGISTRY_MODULE_IDENTIFIER")
 	if githubIdentifier == "" {
 		t.Skip("Export a valid GITHUB_REGISTRY_MODULE_IDENTIFIER before running this test")
@@ -466,6 +474,8 @@ func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 }
 
 func TestRegistryModulesRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -634,6 +644,8 @@ func TestRegistryModulesRead(t *testing.T) {
 }
 
 func TestRegistryModulesDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -678,6 +690,8 @@ func TestRegistryModulesDelete(t *testing.T) {
 }
 
 func TestRegistryModulesDeleteProvider(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -760,6 +774,8 @@ func TestRegistryModulesDeleteProvider(t *testing.T) {
 }
 
 func TestRegistryModulesDeleteVersion(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -883,6 +899,8 @@ func TestRegistryModulesDeleteVersion(t *testing.T) {
 }
 
 func TestRegistryModulesUpload(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -925,6 +943,8 @@ func TestRegistryModulesUpload(t *testing.T) {
 }
 
 func TestRegistryModule_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "registry-modules",
@@ -992,6 +1012,8 @@ func TestRegistryModule_Unmarshal(t *testing.T) {
 }
 
 func TestRegistryCreateWithVCSOptions_Marshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	// https://www.terraform.io/docs/cloud/api/modules.html#sample-payload
 	opts := RegistryModuleCreateWithVCSConnectionOptions{
 		VCSRepo: &RegistryModuleVCSRepoOptions{

--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRegistryProvidersList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -157,6 +159,8 @@ func TestRegistryProvidersList(t *testing.T) {
 }
 
 func TestRegistryProvidersCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -284,6 +288,8 @@ func TestRegistryProvidersCreate(t *testing.T) {
 }
 
 func TestRegistryProvidersRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -400,6 +406,8 @@ func TestRegistryProvidersRead(t *testing.T) {
 }
 
 func TestRegistryProvidersDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -458,6 +466,8 @@ func TestRegistryProvidersDelete(t *testing.T) {
 }
 
 func TestRegistryProvidersIDValidation(t *testing.T) {
+	skipIfNotCINode(t)
+
 	orgName := "orgName"
 	registryName := PublicRegistry
 

--- a/registry_provider_platform_integration_test.go
+++ b/registry_provider_platform_integration_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRegistryProviderPlatformsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -166,6 +168,8 @@ func TestRegistryProviderPlatformsCreate(t *testing.T) {
 }
 
 func TestRegistryProviderPlatformsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -211,6 +215,8 @@ func TestRegistryProviderPlatformsDelete(t *testing.T) {
 }
 
 func TestRegistryProviderPlatformsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -289,6 +295,8 @@ func TestRegistryProviderPlatformsRead(t *testing.T) {
 }
 
 func TestRegistryProviderPlatformsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/registry_provider_version_integration_test.go
+++ b/registry_provider_version_integration_test.go
@@ -13,6 +13,8 @@ import (
 )
 
 func TestRegistryProviderVersionsIDValidation(t *testing.T) {
+	skipIfNotCINode(t)
+
 	version := "1.0.0"
 	validRegistryProviderId := RegistryProviderID{
 		OrganizationName: "orgName",
@@ -86,6 +88,8 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 }
 
 func TestRegistryProviderVersionsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -198,6 +202,8 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 }
 
 func TestRegistryProviderVersionsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -302,6 +308,8 @@ func TestRegistryProviderVersionsList(t *testing.T) {
 }
 
 func TestRegistryProviderVersionsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -342,6 +350,8 @@ func TestRegistryProviderVersionsDelete(t *testing.T) {
 }
 
 func TestRegistryProviderVersionsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -17,6 +17,8 @@ import (
 )
 
 func TestRunsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -97,6 +99,8 @@ func TestRunsList(t *testing.T) {
 }
 
 func TestRunsListQueryParams(t *testing.T) {
+	skipIfNotCINode(t)
+
 	type testCase struct {
 		options     *RunListOptions
 		description string
@@ -158,6 +162,8 @@ func TestRunsListQueryParams(t *testing.T) {
 }
 
 func TestRunsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -327,6 +333,7 @@ func TestRunsCreate(t *testing.T) {
 }
 
 func TestRunsRead_CostEstimate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfEnterprise(t)
 	skipIfFreeOnly(t)
 
@@ -356,6 +363,8 @@ func TestRunsRead_CostEstimate(t *testing.T) {
 }
 
 func TestRunsReadWithOptions(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -376,6 +385,8 @@ func TestRunsReadWithOptions(t *testing.T) {
 }
 
 func TestRunsApply(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -413,6 +424,8 @@ func TestRunsApply(t *testing.T) {
 }
 
 func TestRunsCancel(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 
 	ctx := context.Background()
@@ -444,6 +457,8 @@ func TestRunsCancel(t *testing.T) {
 }
 
 func TestRunsForceCancel(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -512,6 +527,8 @@ func TestRunsForceCancel(t *testing.T) {
 }
 
 func TestRunsDiscard(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -537,6 +554,8 @@ func TestRunsDiscard(t *testing.T) {
 }
 
 func TestRun_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "runs",

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestRunTasksCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -52,6 +53,7 @@ func TestRunTasksCreate(t *testing.T) {
 }
 
 func TestRunTasksList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -78,6 +80,7 @@ func TestRunTasksList(t *testing.T) {
 }
 
 func TestRunTasksRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -129,6 +132,7 @@ func TestRunTasksRead(t *testing.T) {
 }
 
 func TestRunTasksUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -181,6 +185,7 @@ func TestRunTasksUpdate(t *testing.T) {
 }
 
 func TestRunTasksDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -211,6 +216,7 @@ func TestRunTasksDelete(t *testing.T) {
 }
 
 func TestRunTasksAttachToWorkspace(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestRunTriggerList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -146,6 +148,8 @@ func TestRunTriggerList(t *testing.T) {
 }
 
 func TestRunTriggerCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -196,6 +200,8 @@ func TestRunTriggerCreate(t *testing.T) {
 }
 
 func TestRunTriggerRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -229,6 +235,8 @@ func TestRunTriggerRead(t *testing.T) {
 }
 
 func TestRunTriggerDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/scripts/generate_resource/templates.go
+++ b/scripts/generate_resource/templates.go
@@ -163,6 +163,8 @@ import (
 )
 
 func Test{{ .ResourceInterface }}List(t *testing.T) {
+  skipIfNotCINode(t)
+
   client := testClient(t)
   ctx := context.Background()
 
@@ -173,6 +175,8 @@ func Test{{ .ResourceInterface }}List(t *testing.T) {
 }
 
 func Test{{ .ResourceInterface }}Read(t *testing.T) {
+  skipIfNotCINode(t)
+
   client := testClient(t)
   ctx := context.Background()
 
@@ -183,6 +187,8 @@ func Test{{ .ResourceInterface }}Read(t *testing.T) {
 }
 
 func Test{{ .ResourceInterface }}Create(t *testing.T) {
+  skipIfNotCINode(t)
+
   client := testClient(t)
   ctx := context.Background()
 
@@ -193,6 +199,8 @@ func Test{{ .ResourceInterface }}Create(t *testing.T) {
 }
 
 func Test{{ .ResourceInterface }}Update(t *testing.T) {
+  skipIfNotCINode(t)
+
   client := testClient(t)
   ctx := context.Background()
 

--- a/ssh_key_integration_test.go
+++ b/ssh_key_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestSSHKeysList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -59,6 +61,8 @@ func TestSSHKeysList(t *testing.T) {
 }
 
 func TestSSHKeysCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -113,6 +117,8 @@ func TestSSHKeysCreate(t *testing.T) {
 }
 
 func TestSSHKeysRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -142,6 +148,8 @@ func TestSSHKeysRead(t *testing.T) {
 }
 
 func TestSSHKeysUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -182,6 +190,8 @@ func TestSSHKeysUpdate(t *testing.T) {
 }
 
 func TestSSHKeysDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -25,6 +25,8 @@ func containsStateVersion(versions []*StateVersion, item *StateVersion) bool {
 }
 
 func TestStateVersionsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -104,6 +106,8 @@ func TestStateVersionsList(t *testing.T) {
 }
 
 func TestStateVersionsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -311,6 +315,8 @@ func TestStateVersionsCreate(t *testing.T) {
 }
 
 func TestStateVersionsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -361,6 +367,8 @@ func TestStateVersionsRead(t *testing.T) {
 }
 
 func TestStateVersionsReadWithOptions(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -383,6 +391,8 @@ func TestStateVersionsReadWithOptions(t *testing.T) {
 }
 
 func TestStateVersionsCurrent(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -428,6 +438,8 @@ func TestStateVersionsCurrent(t *testing.T) {
 }
 
 func TestStateVersionsCurrentWithOptions(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -453,6 +465,8 @@ func TestStateVersionsCurrentWithOptions(t *testing.T) {
 }
 
 func TestStateVersionsDownload(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -468,15 +482,6 @@ func TestStateVersionsDownload(t *testing.T) {
 		assert.Equal(t, stateTest, state)
 	})
 
-	t.Run("when the state version does not exist", func(t *testing.T) {
-		state, err := client.StateVersions.Download(
-			ctx,
-			svTest.DownloadURL[:len(svTest.DownloadURL)-10]+"nonexisting",
-		)
-		assert.Nil(t, state)
-		assert.Error(t, err)
-	})
-
 	t.Run("with an invalid url", func(t *testing.T) {
 		state, err := client.StateVersions.Download(ctx, badIdentifier)
 		assert.Nil(t, state)
@@ -485,6 +490,8 @@ func TestStateVersionsDownload(t *testing.T) {
 }
 
 func TestStateVersionOutputs(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/state_version_output_integration_test.go
+++ b/state_version_output_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestStateVersionOutputsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/task_stages_integration_test.go
+++ b/task_stages_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTaskStagesRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -78,6 +79,7 @@ func TestTaskStagesRead(t *testing.T) {
 }
 
 func TestTaskStagesList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)

--- a/team_access_integration_test.go
+++ b/team_access_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTeamAccessesList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -90,6 +91,7 @@ func TestTeamAccessesList(t *testing.T) {
 }
 
 func TestTeamAccessesAdd(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -222,6 +224,7 @@ func TestTeamAccessesAdd(t *testing.T) {
 }
 
 func TestTeamAccessesRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -274,6 +277,7 @@ func TestTeamAccessesRead(t *testing.T) {
 }
 
 func TestTeamAccessesUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -306,6 +310,7 @@ func TestTeamAccessesUpdate(t *testing.T) {
 }
 
 func TestTeamAccessesRemove(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -340,6 +345,7 @@ func TestTeamAccessesRemove(t *testing.T) {
 }
 
 func TestTeamAccessesReadRunTasks(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 	skipIfBeta(t)
 	skipIfEnterprise(t)
@@ -370,6 +376,7 @@ func TestTeamAccessesReadRunTasks(t *testing.T) {
 }
 
 func TestTeamAccessesUpdateRunTasks(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 	skipIfBeta(t)
 

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestTeamsList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -82,6 +83,7 @@ func TestTeamsList(t *testing.T) {
 }
 
 func TestTeamsCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -141,6 +143,7 @@ func TestTeamsCreate(t *testing.T) {
 }
 
 func TestTeamsRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -203,6 +206,7 @@ func TestTeamsRead(t *testing.T) {
 }
 
 func TestTeamsUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -281,6 +285,7 @@ func TestTeamsUpdate(t *testing.T) {
 }
 
 func TestTeamsDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -366,6 +371,7 @@ func TestTeamCreateOptions_Marshal(t *testing.T) {
 }
 
 func TestTeamsUpdateRunTasks(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 	skipIfBeta(t)
 	skipIfEnterprise(t)

--- a/team_member_integration_test.go
+++ b/team_member_integration_test.go
@@ -16,8 +16,9 @@ func TestTeamMembersList(t *testing.T) {
 	// but this test uses extra functionality that is only available
 	// to paid accounts. Organizations under a free account can
 	// create team tokens, but they only have access to one team: the
-	// owners team. This teste creates new teams, and that feature is
+	// owners team. This test creates new teams, and that feature is
 	// unavaiable to paid accounts.
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -58,6 +59,7 @@ func TestTeamMembersList(t *testing.T) {
 }
 
 func TestTeamMembersAddWithInvalidOptions(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -102,6 +104,7 @@ func TestTeamMembersAddWithInvalidOptions(t *testing.T) {
 }
 
 func TestTeamMembersAddByUsername(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -136,6 +139,7 @@ func TestTeamMembersAddByUsername(t *testing.T) {
 }
 
 func TestTeamMembersAddByOrganizationMembers(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -174,6 +178,7 @@ func TestTeamMembersAddByOrganizationMembers(t *testing.T) {
 }
 
 func TestTeamMembersRemoveWithInvalidOptions(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -218,6 +223,7 @@ func TestTeamMembersRemoveWithInvalidOptions(t *testing.T) {
 }
 
 func TestTeamMembersRemoveByUsernames(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -245,6 +251,7 @@ func TestTeamMembersRemoveByUsernames(t *testing.T) {
 }
 
 func TestTeamMembersRemoveByOrganizationMemberships(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestTeamTokensCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -42,6 +43,7 @@ func TestTeamTokensCreate(t *testing.T) {
 	})
 }
 func TestTeamTokensRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -74,6 +76,7 @@ func TestTeamTokensRead(t *testing.T) {
 }
 
 func TestTeamTokensDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -21,6 +21,8 @@ import (
 )
 
 func TestClient_newClient(t *testing.T) {
+	skipIfNotCINode(t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
 		w.Header().Set("X-RateLimit-Limit", "30")
@@ -91,6 +93,8 @@ func TestClient_newClient(t *testing.T) {
 }
 
 func TestClient_defaultConfig(t *testing.T) {
+	skipIfNotCINode(t)
+
 	t.Run("with no environment variables", func(t *testing.T) {
 		defer setupEnvVars("", "")()
 		os.Unsetenv("TFE_HOSTNAME")
@@ -123,6 +127,8 @@ func TestClient_defaultConfig(t *testing.T) {
 }
 
 func TestClient_headers(t *testing.T) {
+	skipIfNotCINode(t)
+
 	testedCalls := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testedCalls++
@@ -186,6 +192,8 @@ func TestClient_headers(t *testing.T) {
 }
 
 func TestClient_userAgent(t *testing.T) {
+	skipIfNotCINode(t)
+
 	testedCalls := 0
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		testedCalls++
@@ -246,6 +254,8 @@ type InvalidBody struct {
 }
 
 func TestClient_requestBodySerialization(t *testing.T) {
+	skipIfNotCINode(t)
+
 	t.Run("jsonapi request", func(t *testing.T) {
 		body := JSONAPIBody{StrAttr: "foo"}
 		_, requestBody, err := createRequest(&body)
@@ -391,6 +401,8 @@ func createRequest(v interface{}) (*retryablehttp.Request, []byte, error) {
 }
 
 func TestClient_configureLimiter(t *testing.T) {
+	skipIfNotCINode(t)
+
 	rateLimit := ""
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
@@ -452,6 +464,8 @@ func TestClient_configureLimiter(t *testing.T) {
 }
 
 func TestClient_retryHTTPCheck(t *testing.T) {
+	skipIfNotCINode(t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
 		w.Header().Set("X-RateLimit-Limit", "30")
@@ -534,6 +548,8 @@ func TestClient_retryHTTPCheck(t *testing.T) {
 }
 
 func TestClient_retryHTTPBackoff(t *testing.T) {
+	skipIfNotCINode(t)
+
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
 		w.Header().Set("X-RateLimit-Limit", "30")

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -39,6 +39,8 @@ const (
 )
 
 func Test_unmarshalResponse(t *testing.T) {
+	skipIfNotCINode(t)
+
 	t.Run("unmarshal properly formatted json", func(t *testing.T) {
 		// This structure is intended to include multiple possible fields and
 		// formats that are valid for JSON:API
@@ -117,6 +119,8 @@ func Test_unmarshalResponse(t *testing.T) {
 }
 
 func Test_EncodeQueryParams(t *testing.T) {
+	skipIfNotCINode(t)
+
 	t.Run("with no listOptions and therefore no include field defined", func(t *testing.T) {
 		urlVals := map[string][]string{
 			"include": []string{},
@@ -134,6 +138,8 @@ func Test_EncodeQueryParams(t *testing.T) {
 }
 
 func Test_RegistryBasePath(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client, err := NewClient(&Config{
 		Token: "foo",
 	})

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestUsersReadCurrent(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -28,6 +30,8 @@ func TestUsersReadCurrent(t *testing.T) {
 }
 
 func TestUsersUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -14,6 +14,8 @@ import (
 
 // TestUserTokens_List tests listing user tokens
 func TestUserTokens_List(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 	user, err := client.Users.ReadCurrent(ctx)
@@ -43,6 +45,8 @@ func TestUserTokens_List(t *testing.T) {
 
 // TestUserTokens_Create tests basic creation of user tokens
 func TestUserTokens_Create(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 	user, err := client.Users.ReadCurrent(ctx)
@@ -82,6 +86,8 @@ func TestUserTokens_Create(t *testing.T) {
 
 // TestUserTokens_Read tests basic creation of user tokens
 func TestUserTokens_Read(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 	user, err := client.Users.ReadCurrent(ctx)

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -12,6 +12,8 @@ import (
 )
 
 func TestVariablesList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -62,6 +64,8 @@ func TestVariablesList(t *testing.T) {
 }
 
 func TestVariablesCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -195,6 +199,8 @@ func TestVariablesCreate(t *testing.T) {
 }
 
 func TestVariablesRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -232,6 +238,8 @@ func TestVariablesRead(t *testing.T) {
 }
 
 func TestVariablesUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -312,6 +320,8 @@ func TestVariablesUpdate(t *testing.T) {
 }
 
 func TestVariablesDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestVariableSetsList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -57,6 +59,8 @@ func TestVariableSetsList(t *testing.T) {
 }
 
 func TestVariableSetsCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -106,6 +110,8 @@ func TestVariableSetsCreate(t *testing.T) {
 }
 
 func TestVariableSetsRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -129,6 +135,8 @@ func TestVariableSetsRead(t *testing.T) {
 }
 
 func TestVariableSetsUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -168,6 +176,8 @@ func TestVariableSetsUpdate(t *testing.T) {
 }
 
 func TestVariableSetsDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -193,6 +203,8 @@ func TestVariableSetsDelete(t *testing.T) {
 }
 
 func TestVariableSetsApplyToAndRemoveFromWorkspaces(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -293,6 +305,8 @@ func TestVariableSetsApplyToAndRemoveFromWorkspaces(t *testing.T) {
 }
 
 func TestVariableSetsUpdateWorkspaces(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestVariableSetVariablesList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -69,6 +71,8 @@ func TestVariableSetVariablesList(t *testing.T) {
 }
 
 func TestVariableSetVariablesCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -205,6 +209,8 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 }
 
 func TestVariableSetVariablesRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -248,6 +254,8 @@ func TestVariableSetVariablesRead(t *testing.T) {
 }
 
 func TestVariableSetVariablesUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -327,6 +335,8 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 }
 
 func TestVariableSetVariablesDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -33,6 +33,8 @@ type WorkspaceTableTest struct {
 }
 
 func TestWorkspacesList(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -185,6 +187,8 @@ func TestWorkspacesList(t *testing.T) {
 }
 
 func TestWorkspacesCreateTableDriven(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -315,6 +319,8 @@ func TestWorkspacesCreateTableDriven(t *testing.T) {
 }
 
 func TestWorkspacesCreate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -510,6 +516,8 @@ func TestWorkspacesCreate(t *testing.T) {
 }
 
 func TestWorkspacesRead(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -556,6 +564,8 @@ func TestWorkspacesRead(t *testing.T) {
 }
 
 func TestWorkspacesReadWithOptions(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -605,6 +615,8 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 }
 
 func TestWorkspacesReadWithHistory(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
@@ -637,6 +649,8 @@ func TestWorkspacesReadWithHistory(t *testing.T) {
 }
 
 func TestWorkspacesReadReadme(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -677,6 +691,8 @@ func TestWorkspacesReadReadme(t *testing.T) {
 }
 
 func TestWorkspacesReadByID(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -711,6 +727,8 @@ func TestWorkspacesReadByID(t *testing.T) {
 }
 
 func TestWorkspacesUpdate(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -913,6 +931,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 }
 
 func TestWorkspacesUpdateTableDriven(t *testing.T) {
+	skipIfNotCINode(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -1049,6 +1068,8 @@ func TestWorkspacesUpdateTableDriven(t *testing.T) {
 }
 
 func TestWorkspacesUpdateByID(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1134,6 +1155,8 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 }
 
 func TestWorkspacesDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1163,6 +1186,8 @@ func TestWorkspacesDelete(t *testing.T) {
 }
 
 func TestWorkspacesDeleteByID(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1187,6 +1212,8 @@ func TestWorkspacesDeleteByID(t *testing.T) {
 }
 
 func TestWorkspacesRemoveVCSConnection(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1204,6 +1231,8 @@ func TestWorkspacesRemoveVCSConnection(t *testing.T) {
 }
 
 func TestWorkspacesRemoveVCSConnectionByID(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1221,6 +1250,8 @@ func TestWorkspacesRemoveVCSConnectionByID(t *testing.T) {
 }
 
 func TestWorkspacesLock(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1249,6 +1280,8 @@ func TestWorkspacesLock(t *testing.T) {
 }
 
 func TestWorkspacesUnlock(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1298,6 +1331,8 @@ func TestWorkspacesUnlock(t *testing.T) {
 }
 
 func TestWorkspacesForceUnlock(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1333,6 +1368,8 @@ func TestWorkspacesForceUnlock(t *testing.T) {
 }
 
 func TestWorkspacesAssignSSHKey(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1378,6 +1415,8 @@ func TestWorkspacesAssignSSHKey(t *testing.T) {
 }
 
 func TestWorkspacesUnassignSSHKey(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1414,6 +1453,8 @@ func TestWorkspacesUnassignSSHKey(t *testing.T) {
 }
 
 func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1471,6 +1512,8 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 }
 
 func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1547,6 +1590,8 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 }
 
 func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1611,6 +1656,8 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 }
 
 func TestWorkspaces_AddTags(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1723,6 +1770,8 @@ func TestWorkspaces_AddTags(t *testing.T) {
 }
 
 func TestWorkspaces_RemoveTags(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1800,6 +1849,8 @@ func TestWorkspaces_RemoveTags(t *testing.T) {
 }
 
 func TestWorkspace_Unmarshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	data := map[string]interface{}{
 		"data": map[string]interface{}{
 			"type": "workspaces",
@@ -1864,6 +1915,8 @@ func TestWorkspace_Unmarshal(t *testing.T) {
 }
 
 func TestWorkspaceCreateOptions_Marshal(t *testing.T) {
+	skipIfNotCINode(t)
+
 	opts := WorkspaceCreateOptions{
 		AllowDestroyPlan: Bool(true),
 		Name:             String("my-workspace"),
@@ -1888,6 +1941,7 @@ func TestWorkspaceCreateOptions_Marshal(t *testing.T) {
 }
 
 func TestWorkspacesRunTasksPermission(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 	skipIfBeta(t)
 

--- a/workspace_run_task_integration_test.go
+++ b/workspace_run_task_integration_test.go
@@ -12,6 +12,7 @@ import (
 )
 
 func TestWorkspaceRunTasksCreate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -48,6 +49,7 @@ func TestWorkspaceRunTasksCreate(t *testing.T) {
 
 func TestWorkspaceRunTasksCreateBeta(t *testing.T) {
 	// Once Pre-Plan Tasks are generally available, this can replace the above TestWorkspaceRunTasksCreate
+	skipIfNotCINode(t)
 	skipIfBeta(t)
 	skipIfFreeOnly(t)
 
@@ -88,6 +90,7 @@ func TestWorkspaceRunTasksCreateBeta(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksList(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -122,6 +125,7 @@ func TestWorkspaceRunTasksList(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksRead(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -157,6 +161,7 @@ func TestWorkspaceRunTasksRead(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksUpdate(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)
@@ -189,6 +194,7 @@ func TestWorkspaceRunTasksUpdate(t *testing.T) {
 
 func TestWorkspaceRunTasksUpdateBeta(t *testing.T) {
 	// Once Pre-Plan Tasks are generally available, this can replace the above TestWorkspaceRunTasksUpdate
+	skipIfNotCINode(t)
 	skipIfBeta(t)
 	skipIfFreeOnly(t)
 
@@ -224,6 +230,7 @@ func TestWorkspaceRunTasksUpdateBeta(t *testing.T) {
 }
 
 func TestWorkspaceRunTasksDelete(t *testing.T) {
+	skipIfNotCINode(t)
 	skipIfFreeOnly(t)
 
 	client := testClient(t)


### PR DESCRIPTION
## Description

Currently, our CI workflow completes after about ~22 minutes which introduces unnecessary friction for community and internal pull requests. This PR introduces test splitting into our CI workflow in an effort to reduce our test execution time. While Github Actions does not support test splitting directly like other services such as CircleCI, it does support running [multiple nodes for a job](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix). Therefore we had to introduce our own bespoke strategy to split tests across these nodes. From these changes we were able to reduce our workflow execution time to ~11 minutes, or roughly a **50% reduction**. 

### Node Index Modulo Strategy
In order to evenly balance the number of tests across X number of CI nodes (currently 2), we decided to use a modulo strategy where we count each test parsing the output from `go test -v ./... -list=. -tags=integration`, assigning an index to each test prior to executing the tests. We then take that index and calculate the value of the node index it should execute on by computing the modulo of the total number of nodes. If the following is true, the test will execute on the given node. 

```go
CURRENT_TEST_INDEX % CI_NODE_TOTAL == CI_NODE_INDEX
```
`CURRENT_TEST_INDEX`: the index assigned to a particular test, from [0, X total number of tests]
`CI_NODE_TOTAL`: value is assigned in `ci.yml`, currently 2
`CI_NODE_INDEX`: the index of the node that's currently executing the tests, [0, CI_NODE_TOTAL - 1]

## Impact for Maintainers
Each top level test **must** call ` skipIfNotCINode(t)` before any other `skipIfX()` flag or test logic. If this is omitted from a test, the test will run across all nodes. Ideally, we shouldn't have this be manually called and should be part of a test harness, but we currently don't provide one for our integration tests. 

## Next Steps
We noticed some tests were unusually slow:
```
TestStateVersionsDownload (379.52s)
TestRunsCreate (8.50s)
TestRunsRead_CostEstimate (28.35s)
TestRunsApply (17.92s)
TestRunsDiscard (29.96s)
TestPlanExportsCreate (79.04s)
TestPlanExportsRead (55.31s)
TestPlanExportsDelete (85.68s)
TestPlanExportsDownload (42.42s)
TestPolicyChecksRead (15.95s)
TestPolicyChecksOverride/when_the_policy_failed (16.80s)
TestPolicyChecksOverride/when_the_policy_passed (16.33s)
TestLogReader_withoutMarkers (37.19s)
TestLogReader_withoutEndOfTextMarker (47.36s)
TestLogReader_withMarkersMulti (33.77s)
```
Future investigation will be needed to improve these long running tests. 