### PR TITLE
io/ioutil is deprecated, removed

### DIFF
--- a/apply_integration_test.go
+++ b/apply_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -60,7 +60,7 @@ func TestAppliesLogs(t *testing.T) {
 		logReader, err := client.Applies.Logs(ctx, a.ID)
 		require.NoError(t, err)
 
-		logs, err := ioutil.ReadAll(logReader)
+		logs, err := io.ReadAll(logReader)
 		require.NoError(t, err)
 
 		assert.Contains(t, string(logs), "1 added, 0 changed, 0 destroyed")

--- a/audit_trail.go
+++ b/audit_trail.go
@@ -3,7 +3,7 @@ package tfe
 import (
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"time"
 
@@ -128,7 +128,7 @@ func (s *auditTrails) List(ctx context.Context, options *AuditTrailListOptions) 
 		return nil, err
 	}
 
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -11,7 +11,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"math/rand"
 	"net/http"
 	"net/url"
@@ -1384,7 +1383,7 @@ func createStateVersion(t *testing.T, client *Client, serial int64, w *Workspace
 		w, wCleanup = createWorkspace(t, client, nil)
 	}
 
-	state, err := ioutil.ReadFile("test-fixtures/state-version/terraform.tfstate")
+	state, err := os.ReadFile("test-fixtures/state-version/terraform.tfstate")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/logreader_integration_test.go
+++ b/logreader_integration_test.go
@@ -6,7 +6,6 @@ package tfe
 import (
 	"context"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -71,7 +70,7 @@ func TestLogReader_withMarkersSingle(t *testing.T) {
 		return false, nil
 	}
 
-	logs, err := ioutil.ReadAll(lr)
+	logs, err := io.ReadAll(lr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +111,7 @@ func TestLogReader_withMarkersDouble(t *testing.T) {
 		return false, nil
 	}
 
-	logs, err := ioutil.ReadAll(lr)
+	logs, err := io.ReadAll(lr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -159,7 +158,7 @@ func TestLogReader_withMarkersMulti(t *testing.T) {
 		return false, nil
 	}
 
-	logs, err := ioutil.ReadAll(lr)
+	logs, err := io.ReadAll(lr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -202,7 +201,7 @@ func TestLogReader_withoutMarkers(t *testing.T) {
 		return false, nil
 	}
 
-	logs, err := ioutil.ReadAll(lr)
+	logs, err := io.ReadAll(lr)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -247,7 +246,7 @@ func TestLogReader_withoutEndOfTextMarker(t *testing.T) {
 		return false, nil
 	}
 
-	logs, err := ioutil.ReadAll(lr)
+	logs, err := io.ReadAll(lr)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -59,7 +59,7 @@ func TestPlansLogs(t *testing.T) {
 		logReader, err := client.Plans.Logs(ctx, p.ID)
 		require.NoError(t, err)
 
-		logs, err := ioutil.ReadAll(logReader)
+		logs, err := io.ReadAll(logReader)
 		require.NoError(t, err)
 
 		assert.Contains(t, string(logs), "1 to add, 0 to change, 0 to destroy")

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -7,7 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"testing"
 	"time"
 
@@ -210,7 +210,7 @@ func TestPolicyChecksLogs(t *testing.T) {
 		logReader, err := client.PolicyChecks.Logs(ctx, pc.ID)
 		require.NoError(t, err)
 
-		logs, err := ioutil.ReadAll(logReader)
+		logs, err := io.ReadAll(logReader)
 		require.NoError(t, err)
 
 		assert.Contains(t, string(logs), "1 policies evaluated")

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"crypto/md5"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -110,17 +110,17 @@ func TestStateVersionsCreate(t *testing.T) {
 	wTest, wTestCleanup := createWorkspace(t, client, nil)
 	t.Cleanup(wTestCleanup)
 
-	state, err := ioutil.ReadFile("test-fixtures/state-version/terraform.tfstate")
+	state, err := os.ReadFile("test-fixtures/state-version/terraform.tfstate")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	jsonState, err := ioutil.ReadFile("test-fixtures/json-state/state.json")
+	jsonState, err := os.ReadFile("test-fixtures/json-state/state.json")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	jsonStateOutputs, err := ioutil.ReadFile("test-fixtures/json-state-outputs/everything.json")
+	jsonStateOutputs, err := os.ReadFile("test-fixtures/json-state-outputs/everything.json")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -459,7 +459,7 @@ func TestStateVersionsDownload(t *testing.T) {
 	svTest, svTestCleanup := createStateVersion(t, client, 0, nil)
 	t.Cleanup(svTestCleanup)
 
-	stateTest, err := ioutil.ReadFile("test-fixtures/state-version/terraform.tfstate")
+	stateTest, err := os.ReadFile("test-fixtures/state-version/terraform.tfstate")
 	require.NoError(t, err)
 
 	t.Run("when the state version exists", func(t *testing.T) {

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"sort"
 	"strings"
 	"testing"
@@ -654,7 +654,7 @@ func TestWorkspacesReadReadme(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, w)
 
-		readme, err := ioutil.ReadAll(w)
+		readme, err := io.ReadAll(w)
 		require.NoError(t, err)
 		require.True(
 			t,


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

"io/ioutil" has been [deprecated](https://pkg.go.dev/io/ioutil) since Go 1.16.

## Testing plan

1. See referenced documentation

## External links

N/A

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange

...
```
