### PR TITLE
[CI] Fix: remove inline terraform block 

### DIFF
--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -23,7 +23,12 @@ jobs:
           TF_CLOUD_WORKSPACE: "tflocal-go-tfe-nightly"
         run: |
           cd tflocal/
-          echo "terraform { cloud {} }" > backend.tf
+          cat <<EOT >> backend.tf
+          terraform {
+            cloud {}
+          }
+          EOT
+
           terraform init
           terraform apply -auto-approve -input=false
 


### PR DESCRIPTION
Terraform expects the `cloud` block to be defined in its own line:
```
A single-line block definition can contain only a
single argument. If you meant to define argument "cloud", use an equals
sign to assign it a value. To define a nested block, place it on a line of
its own within its parent block.
```

Also remove the logic to await a run's completion since we are now using Terraform to initiate the run. 