### PR TITLE
Remove duplicate cloud block

### DIFF
--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -23,12 +23,6 @@ jobs:
           TF_CLOUD_WORKSPACE: "tflocal-go-tfe-nightly"
         run: |
           cd tflocal/
-          cat <<EOT >> backend.tf
-          terraform {
-            cloud {}
-          }
-          EOT
-
           terraform init
           terraform apply -auto-approve -input=false
 


### PR DESCRIPTION
I completely missed that we already have the `cloud` block defined in [tflocal/terraform.tf](https://github.com/hashicorp/go-tfe/blob/2f3fd5b9fe528649bb46c53aacc236f1536f0c16/tflocal/terraform.tf#L26). 

This PR removes the duplicate `backend.tf` file created for the workflow. 
