### PR TITLE
Add `Query` and `Status` query param fields to `OrganizationMembershipListOptions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# (Unreleased)
+
+## Enhancements
+* Adds `Query` and `Status` fields to `OrganizationMembershipListOptions` to allow filtering memberships by status or username by @sebasslash [#550](https://github.com/hashicorp/go-tfe/pull/550)
+
 # v1.10.0
 
 ## Enhancements

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -80,6 +80,13 @@ type OrganizationMembershipListOptions struct {
 
 	// Optional: A list of organization member emails to filter by.
 	Emails []string `url:"filter[email],omitempty"`
+
+	// Optional: If specified, restricts results to those matching status value.
+	Status OrganizationMembershipStatus `url:"filter[status],omitempty"`
+
+	// Optional: A query string to search organization memberships by user name
+	// and email.
+	Query string `url:"q,omitempty"`
 }
 
 // OrganizationMembershipCreateOptions represents the options for creating an organization membership.

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -103,6 +103,46 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		})
 	})
 
+	t.Run("with status filter option", func(t *testing.T) {
+		_, memTest1Cleanup := createOrganizationMembership(t, client, orgTest)
+		t.Cleanup(memTest1Cleanup)
+		_, memTest2Cleanup := createOrganizationMembership(t, client, orgTest)
+		t.Cleanup(memTest2Cleanup)
+
+		ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, &OrganizationMembershipListOptions{
+			Status: OrganizationMembershipInvited,
+		})
+		require.NoError(t, err)
+
+		require.Len(t, ml.Items, 2)
+		for _, member := range ml.Items {
+			assert.Equal(t, member.Status, OrganizationMembershipInvited)
+		}
+	})
+
+	t.Run("with search query string", func(t *testing.T) {
+		memTest1, memTest1Cleanup := createOrganizationMembership(t, client, orgTest)
+		t.Cleanup(memTest1Cleanup)
+		_, memTest2Cleanup := createOrganizationMembership(t, client, orgTest)
+		t.Cleanup(memTest2Cleanup)
+		_, memTest3Cleanup := createOrganizationMembership(t, client, orgTest)
+		t.Cleanup(memTest3Cleanup)
+
+		t.Run("using an email", func(t *testing.T) {
+			ml, err := client.OrganizationMemberships.List(ctx, orgTest.Name, &OrganizationMembershipListOptions{
+				Query: memTest1.Email,
+			})
+			require.NoError(t, err)
+
+			require.Len(t, ml.Items, 1)
+			assert.Equal(t, ml.Items[0].Email, memTest1.Email)
+		})
+
+		t.Run("using a user name", func(t *testing.T) {
+			t.Skip("Skipping, missing Account API support in order to set usernames")
+		})
+	})
+
 	t.Run("without a valid organization", func(t *testing.T) {
 		ml, err := client.OrganizationMemberships.List(ctx, badIdentifier, nil)
 		assert.Nil(t, ml)


### PR DESCRIPTION
## Description

Adds two missing fields supported by our [List Organization Memberships API](https://www.terraform.io/cloud-docs/api-docs/organization-memberships#list-memberships-for-an-organization):
* `q`: A search query string. Organization memberships are searchable by user name and email.
* `filter[status]`:  If specified, restricts results to those with the matching status value. Valid values are `invited` and `active`

One thing to note is that we skip one of the query string tests because it depends on being able to assign a username to the user of an organization membership. A test like this requires [Account API support](https://www.terraform.io/cloud-docs/api-docs/account#update-your-account-info), which go-tfe currently does not support. Once supported, we can update the skipped test to be able to dynamically assign usernames and thus make them query-able.  

## Testing plan

`go test -v ./... -run TestOrganizationMembershipsList -tags=integration`

## External links

- [Query params supported by List Organization Memberships endpoint. ](https://www.terraform.io/cloud-docs/api-docs/organization-memberships#query-parameters)
