### PR TITLE
List workspace variable sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # (Unreleased)
 
 ## Enhancements
+
 * Adds `Query` and `Status` fields to `OrganizationMembershipListOptions` to allow filtering memberships by status or username by @sebasslash [#550](https://github.com/hashicorp/go-tfe/pull/550)
+*  Add `ListForWorkspace` method to `VariableSets` interface to enable fetching variable sets associated with a workspace. [#551](https://github.com/hashicorp/go-tfe/pull/551)
 
 # v1.10.0
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -1742,6 +1742,34 @@ func createVariableSet(t *testing.T, client *Client, org *Organization, options 
 	}
 }
 
+func applyVariableSetToWorkspace(t *testing.T, client *Client, vsID string, wsID string) {
+	if vsID == "" {
+		t.Fatal("variable set ID must not be empty")
+	}
+
+	if wsID == "" {
+		t.Fatal("workspace ID must not be empty")
+	}
+
+	opts := &VariableSetApplyToWorkspacesOptions{}
+	opts.Workspaces = append(opts.Workspaces, &Workspace{ID: wsID})
+
+	ctx := context.Background()
+	if err := client.VariableSets.ApplyToWorkspaces(ctx, vsID, opts); err != nil {
+		t.Fatalf("Error applying variable set %s to workspace %s: %v", vsID, wsID, err)
+	}
+
+	t.Cleanup(func() {
+		removeOpts := &VariableSetRemoveFromWorkspacesOptions{}
+		removeOpts.Workspaces = append(removeOpts.Workspaces, &Workspace{ID: wsID})
+		if err := client.VariableSets.RemoveFromWorkspaces(ctx, vsID, removeOpts); err != nil {
+			t.Errorf("Error removing variable set from workspace! WARNING: Dangling resources\n"+
+				"may exist! The full error is shown below.\n\n"+
+				"VariableSet ID: %s\nError: %s", vsID, err)
+		}
+	})
+}
+
 func createVariableSetVariable(t *testing.T, client *Client, vs *VariableSet, options VariableSetVariableCreateOptions) (*VariableSetVariable, func()) {
 	var vsCleanup func()
 

--- a/mocks/variable_set_mocks.go
+++ b/mocks/variable_set_mocks.go
@@ -93,6 +93,21 @@ func (mr *MockVariableSetsMockRecorder) List(ctx, organization, options interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockVariableSets)(nil).List), ctx, organization, options)
 }
 
+// ListForWorkspace mocks base method.
+func (m *MockVariableSets) ListForWorkspace(ctx context.Context, workspaceID string, options *tfe.VariableSetListOptions) (*tfe.VariableSetList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListForWorkspace", ctx, workspaceID, options)
+	ret0, _ := ret[0].(*tfe.VariableSetList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListForWorkspace indicates an expected call of ListForWorkspace.
+func (mr *MockVariableSetsMockRecorder) ListForWorkspace(ctx, workspaceID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListForWorkspace", reflect.TypeOf((*MockVariableSets)(nil).ListForWorkspace), ctx, workspaceID, options)
+}
+
 // Read mocks base method.
 func (m *MockVariableSets) Read(ctx context.Context, variableSetID string, options *tfe.VariableSetReadOptions) (*tfe.VariableSet, error) {
 	m.ctrl.T.Helper()

--- a/variable_set.go
+++ b/variable_set.go
@@ -17,6 +17,9 @@ type VariableSets interface {
 	// List all the variable sets within an organization.
 	List(ctx context.Context, organization string, options *VariableSetListOptions) (*VariableSetList, error)
 
+	// ListForWorkspace gets the associated variable sets for a workspace.
+	ListForWorkspace(ctx context.Context, workspaceID string, options *VariableSetListOptions) (*VariableSetList, error)
+
 	// Create is used to create a new variable set.
 	Create(ctx context.Context, organization string, options *VariableSetCreateOptions) (*VariableSet, error)
 
@@ -165,6 +168,32 @@ func (s *variableSets) List(ctx context.Context, organization string, options *V
 	}
 
 	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
+	req, err := s.client.NewRequest("GET", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	vl := &VariableSetList{}
+	err = req.Do(ctx, vl)
+	if err != nil {
+		return nil, err
+	}
+
+	return vl, nil
+}
+
+// ListForWorkspace gets the associated variable sets for a workspace.
+func (s *variableSets) ListForWorkspace(ctx context.Context, workspaceID string, options *VariableSetListOptions) (*VariableSetList, error) {
+	if !validStringID(&workspaceID) {
+		return nil, ErrInvalidWorkspaceID
+	}
+	if options != nil {
+		if err := options.valid(); err != nil {
+			return nil, err
+		}
+	}
+
+	u := fmt.Sprintf("workspaces/%s/varsets", url.QueryEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -51,10 +51,64 @@ func TestVariableSetsList(t *testing.T) {
 		assert.Equal(t, 2, vsl.TotalCount)
 	})
 
-	t.Run("when Organization name is invalid ID", func(t *testing.T) {
+	t.Run("when Organization name is an invalid ID", func(t *testing.T) {
 		vsl, err := client.VariableSets.List(ctx, badIdentifier, nil)
 		assert.Nil(t, vsl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
+	})
+}
+
+func TestVariableSetsListForWorkspace(t *testing.T) {
+	skipIfNotCINode(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+	workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(workspaceTestCleanup)
+
+	vsTest1, vsTestCleanup1 := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+	t.Cleanup(vsTestCleanup1)
+	vsTest2, vsTestCleanup2 := createVariableSet(t, client, orgTest, VariableSetCreateOptions{})
+	t.Cleanup(vsTestCleanup2)
+
+	applyVariableSetToWorkspace(t, client, vsTest1.ID, workspaceTest.ID)
+	applyVariableSetToWorkspace(t, client, vsTest2.ID, workspaceTest.ID)
+
+	t.Run("without list options", func(t *testing.T) {
+		vsl, err := client.VariableSets.ListForWorkspace(ctx, workspaceTest.ID, nil)
+		require.NoError(t, err)
+		require.Len(t, vsl.Items, 2)
+
+		ids := []string{vsTest1.ID, vsTest2.ID}
+		for _, varset := range vsl.Items {
+			assert.Contains(t, ids, varset.ID)
+		}
+	})
+
+	t.Run("with list options", func(t *testing.T) {
+		t.Skip("paging not supported yet in API")
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		vsl, err := client.VariableSets.ListForWorkspace(ctx, workspaceTest.ID, &VariableSetListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+		require.NoError(t, err)
+		assert.Empty(t, vsl.Items)
+		assert.Equal(t, 999, vsl.CurrentPage)
+		assert.Equal(t, 2, vsl.TotalCount)
+	})
+
+	t.Run("when Workspace ID is an invalid ID", func(t *testing.T) {
+		vsl, err := client.VariableSets.ListForWorkspace(ctx, badIdentifier, nil)
+		assert.Nil(t, vsl)
+		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})
 }
 


### PR DESCRIPTION
## Description

Build off of #520 and #551, maintaining the original interface but adding missing test helper to apply a variable set to a workspace (otherwise test fails). 

This also fixes the assertion that a given variable set is contained within the list fetched from workspace. `assert.Contains()` is a tricky call because it performs deep equality. A resource may or may not have relationships defined depending on the endpoint you're calling, in this case:
```go
// when we create a Variable Set
vsTest := client.VariableSets.Create() //omit params
vsTest.Workspaces == [] // true

// after applying vsTest to a workspace
vsList := client.VariableSets.ListForWorkspace()
vsTest.Items[0].Workspaces == [] // false

// therefore
assert.Contains(t, vsList.Items, vsTest) // false
```