### PR TITLE
Rename TF_CLOUD_WORKSPACE to TF_WORKSPACE

### DIFF
--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -20,7 +20,7 @@ jobs:
           TFE_TOKEN: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           TF_CLOUD_ORGANIZATION: "hashicorp-v2"
           TF_CLOUD_HOSTNAME: "app.terraform.io"
-          TF_CLOUD_WORKSPACE: "tflocal-go-tfe-nightly"
+          TF_WORKSPACE: "tflocal-go-tfe-nightly"
         run: |
           cd tflocal/
           terraform init


### PR DESCRIPTION
## Description

Wrong env var name, see [Terraform Cloud Environment variables](https://www.terraform.io/cli/cloud/settings#environment-variables). 

