### PR TITLE
A workflow script for maintainers to rebase fork PRs to local for CI

### DIFF
--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -25,20 +25,10 @@ There are instances where several new resources being added (i.e Workspace Run T
 
 The test suite contains many acceptance tests that are run against the latest version of Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in [TESTS.md](TESTS.md). Our CI system (Github Actions) will not test your fork until a one-time approval takes place.
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
 ## Test Splitting
 
 Our CI workflow makes use of multiple nodes to run our tests in a more efficient manner. To prevent your test from running across all nodes, you **must** add `skipIfNotCINode(t)` to your top level test before any other helper or test logic.
 
->>>>>>> e307d93 (rename from checktestnode to skipIfNotCINode)
-=======
-## Test Splitting
-
-Our CI workflow makes use of multiple nodes to run our tests in a more efficient manner. To prevent your test from running across all nodes, you **must** add `checkTestNodeEnv(t)` to your top level test before any other helper or test logic.
-
->>>>>>> d0e4157 (Update contributing docs to mention test splitting)
 ## Editor Settings
 
 We've included VSCode settings to assist with configuring the go extension. For other editors that integrate with the [Go Language Server](https://github.com/golang/tools/tree/master/gopls), the main thing to do is to add the `integration` build tags so that the test files are found by the language server. See `.vscode/settings.json` for more details.
@@ -412,3 +402,26 @@ func validateExampleIncludeParams(params []ExampleIncludeOpt) error {
 	return nil
 }
 ```
+
+## Rebasing a fork to trigger CI (Maintainers Only)
+
+Pull requests that originate from a fork will not have access to this repository's secrets, thus resulting in the inability to test against our CI instance. In order to trigger the CI action workflow, there is a handy script `./scripts/rebase-fork.sh` that automates the steps for you. It will:
+
+* Checkout the fork PR locally onto your machine and create a new branch prefixed as follows: `local/{name_of_fork_branch}`
+* Push your newly created branch to Github, appending an empty commit stating the original branch that was rebased.
+* Copy the contents of the fork's pull request (title and description) and create a new pull request, triggering the CI workflow.
+
+**Important**: This script does not handle subsequent commits to the original PR and would require you to rebase them manually. Therefore, it is important that authors include test results in their description and changes are approved before this script is executed.
+
+This script depends on `gh` and `jq`. It also requires you to `gh auth login`, providing a SSO-authorized personal access token with the following scopes enabled:
+
+- repo
+- read:org
+- read:discussion
+
+### Example Usage
+
+```sh
+./scripts/rebase-fork.sh 557
+```
+

--- a/scripts/rebase-fork.sh
+++ b/scripts/rebase-fork.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+if [[ -z $1 ]]; then
+    echo "Please specify the pull request number you want to rebase to a local branch."
+    echo "Usage: ./scripts/rebase-fork.sh <pr number>"
+    echo ""
+    echo "Example: ./scripts/rebase-fork.sh 557"
+    exit 1
+fi
+
+PR_NUMBER=$1
+
+declare -a req_tools=("gh" "git" "jq")
+for tool in "${req_tools[@]}"; do
+  if ! command -v "${tool}" > /dev/null; then
+    echo "It looks like '${tool}' is not installed; please install it and run this script again."
+    exit 1
+  fi
+done
+
+# Check if the PR specified is a valid number
+re='^[0-9]+$'
+if ! [[ ${PR_NUMBER} =~ ${re} ]] ; then
+   echo "The PR you specify must be a valid integer number." >&2; exit 1
+fi
+
+# Check if the specified PR exists
+# We only capture stderr here and redirect stdout to /dev/null
+errormsg=$(gh pr view ${PR_NUMBER} 2>&1 1>/dev/null)
+if [[ ! -z ${errormsg} ]]; then
+    # strip GraphQL log prefix to keep the error message clean
+    errormsg=${errormsg#"GraphQL: "}
+    echo "Failed to fetch pull request #${PR_NUMBER}: ${errormsg}"
+    exit 1
+fi
+
+# Check if the pull request we want to rebase is already closed. If so
+# exit.
+closed=$(gh pr view ${PR_NUMBER} --json closed | jq '.closed')
+if [[ $closed = "true" ]]; then
+    echo "The pull request #${PR_NUMBER} to rebase is already closed."
+    exit 1
+fi
+
+# Save the name of the current branch we're in so we can go back to it after
+# we are done
+CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
+# Checkout the fork PR locally
+gh pr checkout ${PR_NUMBER}
+
+# Grab the PR title and branch name
+FORK_PR_TITLE=$(gh pr view ${PR_NUMBER} --json title | jq '.title' | tr -d '"')
+FORK_PR_BRANCH=$(gh pr view ${PR_NUMBER} --json headRefName | jq '.headRefName')
+
+# Fetch the username of the user currently authenticated with gh cli
+USER=$(gh api user | jq -r '.login')
+
+# Name of the local branch that will be pushed upstream
+LOCAL_BRANCH="${USER}/$(echo ${FORK_PR_BRANCH} | tr -d '"')"
+
+# Fetch the PR body and write to local markdown file
+gh pr view ${PR_NUMBER} --json body | jq -r '.body' > ${PR_NUMBER}.md
+
+git checkout -b ${LOCAL_BRANCH}
+git commit --allow-empty -m "Rebased ${FORK_PR_BRANCH} onto a local branch"
+git push -u origin ${LOCAL_BRANCH}
+
+# Finally we can automagically open a new PR using the fork PR's original title
+# and description
+gh pr create --title="${FORK_PR_TITLE}" --body-file=${PR_NUMBER}.md
+
+# Cleanup
+rm ${PR_NUMBER}.md
+git checkout ${CURRENT_BRANCH}
+


### PR DESCRIPTION
## Description

There exists a current limitation in our CI pipeline where any pull request that originates from a fork will not have access to this repository's GH secrets. Github does this for security reasons and we found possible workarounds to be cumbersome or hard to remember. In order to circumvent this, I decided to write a simple script that automates the steps, making use of the `gh` cli tool to "copy pasta" the fork PR onto a base PR. 

This script will:
* Checkout the fork PR locally onto your machine and create a new branch prefixed as follows: `local/{name_of_fork_branch}`
* Push this new local branch to Github, appending an empty commit stating the original branch was rebased.
* Copy the contents of the fork's pull request (title and description) and create a new pull request, triggering the CI workflow. 

**Important**: This script does not handle subsequent commits to the original PR and would require you to rebase them manually. Therefore, it is important that authors include test results in their description and changes are approved before this script is executed.

This script depends on `gh` and `jq`. It also requires you to `gh auth login`, providing a SSO-authorized personal access token with the following scopes enabled:

- repo
- read:org
- read:discussion

### Usage

```sh
./scripts/rebase-fork.sh <some pr number>
```

## Testing plan

This script is "source" agnostic. You can test with any pull request (fork or base) and effectively clone the PR. It is of course intended for use with PRs originating from forks. 

To see an example, see: #557 and #560 
