### PR TITLE
Add X-TFE-Version header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 * Add `NotificationTriggerAssessmentCheckFailed` notification trigger type by @rexredinger [#549](https://github.com/hashicorp/go-tfe/pull/549)
+* Add `RemoteTFEVersion()` to the `Client` interface, which exposes the `X-TFE-Version` header set by a remote TFE instance by @sebasslash [#563](https://github.com/hashicorp/go-tfe/pull/563)
 
 # v1.11.0
 

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -27,6 +27,7 @@ func TestClient_newClient(t *testing.T) {
 		w.Header().Set("Content-Type", "application/vnd.api+json")
 		w.Header().Set("X-RateLimit-Limit", "30")
 		w.Header().Set("TFP-API-Version", "34.21.9")
+		w.Header().Set("X-TFE-Version", "202205-1")
 		w.WriteHeader(204) // We query the configured ping URL which should return a 204.
 	}))
 	defer ts.Close()
@@ -82,6 +83,9 @@ func TestClient_newClient(t *testing.T) {
 		}
 		if want := "34.21.9"; client.RemoteAPIVersion() != want {
 			t.Errorf("unexpected remote API version %q; want %q", client.RemoteAPIVersion(), want)
+		}
+		if want := "202205-1"; client.RemoteTFEVersion() != want {
+			t.Errorf("unexpected remote TFE version %q; want %q", client.RemoteTFEVersion(), want)
 		}
 
 		client.SetFakeRemoteAPIVersion("1.0")


### PR DESCRIPTION
## Description

Since TFE Version 202208-3, we've included the TFE version string as a header for each response. This PR adds support for the client to retrieve that header during the initial metadata request and cache it locally. That version string can be fetched using the new `Client` method: `RemoteTFEVersion()`

## Testing plan

You can run the integration test:

```sh
go test -run TestClient_newClient -v ./... -tags=integration
```

Optionally, you can test against an actual TFE instance if you have one at your disposal:

```go

func main() {
  ctx := context.Background()
  cfg := &tfe.Config{
    Address: "https://your-tfe-address",
    Token: "your-token",
    RetryServerErrors: true,
  }
  
  client, err := tfe.NewClient(cfg)
  if err != nil {
    // sound the alarm!
  }
  
  if version := client.RemoteTFEVersion(); version == "" {
    panic("sound the alarm again!")
  }
}
```
