### PR TITLE
Add safe-delete workspace API, and org setting to restrict force-delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 * Add `Query` and `Status` fields to `OrganizationMembershipListOptions` to allow filtering memberships by status or username by @sebasslash [#550](https://github.com/hashicorp/go-tfe/pull/550)
 * Add `ListForWorkspace` method to `VariableSets` interface to enable fetching variable sets associated with a workspace by @tstapler [#552](https://github.com/hashicorp/go-tfe/pull/552)
 * Add `NotificationTriggerAssessmentDrifted` and `NotificationTriggerAssessmentFailed` notification trigger types by @lawliet89 [#542](https://github.com/hashicorp/go-tfe/pull/542)
+* Add `AllowForceDeleteWorkspaces` setting to `Organizations` by @JarrettSpiker [#539](https://github.com/hashicorp/go-tfe/pull/539)
+* Add `SafeDelete` and `SafeDeleteID` APIs to `Workspaces` by @JarrettSpiker [#539](https://github.com/hashicorp/go-tfe/pull/539)
+
 
 ## Bug Fixes
 * Fix marshalling of run variables in `RunCreateOptions`. The `Variables` field type in `Run` struct has changed from `[]*RunVariable` to `[]*RunVariableAttr` by @Uk1288 [#531](https://github.com/hashicorp/go-tfe/pull/531)

--- a/helper_test.go
+++ b/helper_test.go
@@ -1599,6 +1599,12 @@ func createWorkspaceWithOptions(t *testing.T, client *Client, org *Organization,
 
 	return w, func() {
 		if err := client.Workspaces.Delete(ctx, org.Name, w.Name); err != nil {
+
+			// if the workspace has already been cleaned up, or destroyed in the testing process, no need to raise the alarm
+			if err == ErrResourceNotFound {
+				return
+			}
+
 			t.Errorf("Error destroying workspace! WARNING: Dangling resources\n"+
 				"may exist! The full error is shown below.\n\n"+
 				"Workspace: %s\nError: %s", w.Name, err)

--- a/helper_test.go
+++ b/helper_test.go
@@ -1598,16 +1598,10 @@ func createWorkspaceWithOptions(t *testing.T, client *Client, org *Organization,
 	}
 
 	return w, func() {
-		if err := client.Workspaces.Delete(ctx, org.Name, w.Name); err != nil {
-
-			// if the workspace has already been cleaned up, or destroyed in the testing process, no need to raise the alarm
-			if err == ErrResourceNotFound {
-				return
-			}
-
+		if err := client.Workspaces.DeleteByID(ctx, w.ID); err != nil {
 			t.Errorf("Error destroying workspace! WARNING: Dangling resources\n"+
 				"may exist! The full error is shown below.\n\n"+
-				"Workspace: %s\nError: %s", w.Name, err)
+				"Workspace: %s\nError: %s", w.ID, err)
 		}
 
 		if orgCleanup != nil {

--- a/mocks/workspace_mocks.go
+++ b/mocks/workspace_mocks.go
@@ -330,6 +330,34 @@ func (mr *MockWorkspacesMockRecorder) RemoveVCSConnectionByID(ctx, workspaceID i
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveVCSConnectionByID", reflect.TypeOf((*MockWorkspaces)(nil).RemoveVCSConnectionByID), ctx, workspaceID)
 }
 
+// SafeDelete mocks base method.
+func (m *MockWorkspaces) SafeDelete(ctx context.Context, organization, workspace string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SafeDelete", ctx, organization, workspace)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SafeDelete indicates an expected call of SafeDelete.
+func (mr *MockWorkspacesMockRecorder) SafeDelete(ctx, organization, workspace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeDelete", reflect.TypeOf((*MockWorkspaces)(nil).SafeDelete), ctx, organization, workspace)
+}
+
+// SafeDeleteByID mocks base method.
+func (m *MockWorkspaces) SafeDeleteByID(ctx context.Context, workspaceID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SafeDeleteByID", ctx, workspaceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SafeDeleteByID indicates an expected call of SafeDeleteByID.
+func (mr *MockWorkspacesMockRecorder) SafeDeleteByID(ctx, workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeDeleteByID", reflect.TypeOf((*MockWorkspaces)(nil).SafeDeleteByID), ctx, workspaceID)
+}
+
 // UnassignSSHKey mocks base method.
 func (m *MockWorkspaces) UnassignSSHKey(ctx context.Context, workspaceID string) (*tfe.Workspace, error) {
 	m.ctrl.T.Helper()

--- a/organization.go
+++ b/organization.go
@@ -78,6 +78,7 @@ type Organization struct {
 	TrialExpiresAt                                    time.Time                `jsonapi:"attr,trial-expires-at,iso8601"`
 	TwoFactorConformant                               bool                     `jsonapi:"attr,two-factor-conformant"`
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
+	AllowForceDeleteWorkspaces                        bool                     `jsonapi:"attr,allow-force-delete-workspaces"`
 }
 
 // Capacity represents the current run capacity of an organization.
@@ -166,6 +167,9 @@ type OrganizationCreateOptions struct {
 
 	// Optional: SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
+
+	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
+	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`
 }
 
 // OrganizationUpdateOptions represents the options for updating an organization.
@@ -202,6 +206,9 @@ type OrganizationUpdateOptions struct {
 
 	// SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
+
+	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
+	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`
 }
 
 // ReadRunQueueOptions represents the options for showing the queue.

--- a/organization.go
+++ b/organization.go
@@ -78,7 +78,9 @@ type Organization struct {
 	TrialExpiresAt                                    time.Time                `jsonapi:"attr,trial-expires-at,iso8601"`
 	TwoFactorConformant                               bool                     `jsonapi:"attr,two-factor-conformant"`
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
-	AllowForceDeleteWorkspaces                        bool                     `jsonapi:"attr,allow-force-delete-workspaces"`
+	// Note: This will be false for TFE versions older than v202211, where the setting was introduced.
+	// On those TFE versions, safe delete does not exist, so ALL deletes will be force deletes.
+	AllowForceDeleteWorkspaces bool `jsonapi:"attr,allow-force-delete-workspaces"`
 }
 
 // Capacity represents the current run capacity of an organization.

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -568,6 +568,8 @@ func TestOrganizationsReadRunTasksEntitlement(t *testing.T) {
 }
 
 func TestOrganizationsAllowForceDeleteSetting(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -579,12 +581,12 @@ func TestOrganizationsAllowForceDeleteSetting(t *testing.T) {
 		}
 
 		org, err := client.Organizations.Create(ctx, options)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 
 		t.Cleanup(func() {
 			err := client.Organizations.Delete(ctx, org.Name)
 			if err != nil {
-				t.Logf("error deleting organization (%s): %s", org.Name, err)
+				t.Errorf("error deleting organization (%s): %s", org.Name, err)
 			}
 		})
 
@@ -593,11 +595,11 @@ func TestOrganizationsAllowForceDeleteSetting(t *testing.T) {
 		assert.True(t, org.AllowForceDeleteWorkspaces)
 
 		org, err = client.Organizations.Update(ctx, org.Name, OrganizationUpdateOptions{AllowForceDeleteWorkspaces: Bool(false)})
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.False(t, org.AllowForceDeleteWorkspaces)
 
 		org, err = client.Organizations.Read(ctx, org.Name)
-		assert.Nil(t, err)
+		require.NoError(t, err)
 		assert.False(t, org.AllowForceDeleteWorkspaces)
 	})
 }

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -565,7 +565,41 @@ func TestOrganizationsReadRunTasksEntitlement(t *testing.T) {
 		assert.NotEmpty(t, entitlements.ID)
 		assert.True(t, entitlements.RunTasks)
 	})
+}
 
+func TestOrganizationsAllowForceDeleteSetting(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("creates and updates allow force delete", func(t *testing.T) {
+		options := OrganizationCreateOptions{
+			Name:                       String(randomString(t)),
+			Email:                      String(randomString(t) + "@tfe.local"),
+			AllowForceDeleteWorkspaces: Bool(true),
+		}
+
+		org, err := client.Organizations.Create(ctx, options)
+		assert.Nil(t, err)
+
+		t.Cleanup(func() {
+			err := client.Organizations.Delete(ctx, org.Name)
+			if err != nil {
+				t.Logf("error deleting organization (%s): %s", org.Name, err)
+			}
+		})
+
+		assert.Equal(t, *options.Name, org.Name)
+		assert.Equal(t, *options.Email, org.Email)
+		assert.True(t, org.AllowForceDeleteWorkspaces)
+
+		org, err = client.Organizations.Update(ctx, org.Name, OrganizationUpdateOptions{AllowForceDeleteWorkspaces: Bool(false)})
+		assert.Nil(t, err)
+		assert.False(t, org.AllowForceDeleteWorkspaces)
+
+		org, err = client.Organizations.Read(ctx, org.Name)
+		assert.Nil(t, err)
+		assert.False(t, org.AllowForceDeleteWorkspaces)
+	})
 }
 
 func orgItemsContainsName(items []*Organization, name string) bool {

--- a/workspace.go
+++ b/workspace.go
@@ -50,6 +50,12 @@ type Workspaces interface {
 	// DeleteByID deletes a workspace by its ID.
 	DeleteByID(ctx context.Context, workspaceID string) error
 
+	// SafeDelete a workspace by its name.
+	SafeDelete(ctx context.Context, organization string, workspace string) error
+
+	// SafeDeleteByID deletes a workspace by its ID.
+	SafeDeleteByID(ctx context.Context, workspaceID string) error
+
 	// RemoveVCSConnection from a workspace.
 	RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error)
 
@@ -194,17 +200,18 @@ type WorkspaceActions struct {
 
 // WorkspacePermissions represents the workspace permissions.
 type WorkspacePermissions struct {
-	CanDestroy        bool `jsonapi:"attr,can-destroy"`
-	CanForceUnlock    bool `jsonapi:"attr,can-force-unlock"`
-	CanLock           bool `jsonapi:"attr,can-lock"`
-	CanManageRunTasks bool `jsonapi:"attr,can-manage-run-tasks"`
-	CanQueueApply     bool `jsonapi:"attr,can-queue-apply"`
-	CanQueueDestroy   bool `jsonapi:"attr,can-queue-destroy"`
-	CanQueueRun       bool `jsonapi:"attr,can-queue-run"`
-	CanReadSettings   bool `jsonapi:"attr,can-read-settings"`
-	CanUnlock         bool `jsonapi:"attr,can-unlock"`
-	CanUpdate         bool `jsonapi:"attr,can-update"`
-	CanUpdateVariable bool `jsonapi:"attr,can-update-variable"`
+	CanDestroy        bool  `jsonapi:"attr,can-destroy"`
+	CanForceUnlock    bool  `jsonapi:"attr,can-force-unlock"`
+	CanLock           bool  `jsonapi:"attr,can-lock"`
+	CanManageRunTasks bool  `jsonapi:"attr,can-manage-run-tasks"`
+	CanQueueApply     bool  `jsonapi:"attr,can-queue-apply"`
+	CanQueueDestroy   bool  `jsonapi:"attr,can-queue-destroy"`
+	CanQueueRun       bool  `jsonapi:"attr,can-queue-run"`
+	CanReadSettings   bool  `jsonapi:"attr,can-read-settings"`
+	CanUnlock         bool  `jsonapi:"attr,can-unlock"`
+	CanUpdate         bool  `jsonapi:"attr,can-update"`
+	CanUpdateVariable bool  `jsonapi:"attr,can-update-variable"`
+	CanForceDelete    *bool `jsonapi:"attr,can-force-delete"` // pointer b/c it will be useful to check if this property exists, as opposed to having it default to false
 }
 
 // WSIncludeOpt represents the available options for include query params.
@@ -763,6 +770,43 @@ func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
 
 	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// SafeDelete a workspace by its name.
+func (s *workspaces) SafeDelete(ctx context.Context, organization, workspace string) error {
+	if !validStringID(&organization) {
+		return ErrInvalidOrg
+	}
+	if !validStringID(&workspace) {
+		return ErrInvalidWorkspaceValue
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/workspaces/%s/actions/safe-delete",
+		url.QueryEscape(organization),
+		url.QueryEscape(workspace),
+	)
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// SafeDeleteByID safely deletes a workspace by its ID.
+func (s *workspaces) SafeDeleteByID(ctx context.Context, workspaceID string) error {
+	if !validStringID(&workspaceID) {
+		return ErrInvalidWorkspaceID
+	}
+
+	u := fmt.Sprintf("workspaces/%s/actions/safe-delete", url.QueryEscape(workspaceID))
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
 	}

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -39,12 +39,12 @@ func TestWorkspacesList(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest1, wTest1Cleanup := createWorkspace(t, client, orgTest)
-	defer wTest1Cleanup()
+	t.Cleanup(wTest1Cleanup)
 	wTest2, wTest2Cleanup := createWorkspace(t, client, orgTest)
-	defer wTest2Cleanup()
+	t.Cleanup(wTest2Cleanup)
 
 	t.Run("without list options", func(t *testing.T) {
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, nil)
@@ -193,7 +193,7 @@ func TestWorkspacesCreateTableDriven(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	workspaceTableTests := []WorkspaceTableTest{
 		{
@@ -216,8 +216,8 @@ func TestWorkspacesCreateTableDriven(t *testing.T) {
 				w, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, *options.createOptions)
 
 				return w, func() {
-					defer orgTestCleanup()
-					defer wTestCleanup()
+					t.Cleanup(orgTestCleanup)
+					t.Cleanup(wTestCleanup)
 				}
 			},
 			assertion: func(w *Workspace, options *WorkspaceTableOptions, err error) {
@@ -292,7 +292,7 @@ func TestWorkspacesCreateTableDriven(t *testing.T) {
 				w, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, *options.createOptions)
 
 				return w, func() {
-					defer wTestCleanup()
+					t.Cleanup(wTestCleanup)
 				}
 			},
 			assertion: func(w *Workspace, options *WorkspaceTableOptions, err error) {
@@ -325,7 +325,7 @@ func TestWorkspacesCreate(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceCreateOptions{
@@ -457,7 +457,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			Name:  String("tst-" + randomString(t)[0:20] + "-ff-on"),
 			Email: String(fmt.Sprintf("%s@tfe.local", randomString(t))),
 		})
-		defer orgTestCleanup()
+		t.Cleanup(orgTestCleanup)
 
 		options := WorkspaceCreateOptions{
 			Name:                String("foobar"),
@@ -500,7 +500,7 @@ func TestWorkspacesCreate(t *testing.T) {
 			Name:  String("tst-" + randomString(t)[0:20] + "-ff-on"),
 			Email: String(fmt.Sprintf("%s@tfe.local", randomString(t))),
 		})
-		defer orgTestCleanup()
+		t.Cleanup(orgTestCleanup)
 
 		options := WorkspaceCreateOptions{
 			Name:                String(fmt.Sprintf("foobar-%s", randomString(t))),
@@ -522,10 +522,10 @@ func TestWorkspacesRead(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	t.Run("when the workspace exists", func(t *testing.T) {
 		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
@@ -570,13 +570,13 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	svTest, svTestCleanup := createStateVersion(t, client, 0, wTest)
-	defer svTestCleanup()
+	t.Cleanup(svTestCleanup)
 
 	// give TFC some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
@@ -620,13 +620,13 @@ func TestWorkspacesReadWithHistory(t *testing.T) {
 	client := testClient(t)
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	_, rCleanup := createRunApply(t, client, wTest)
-	defer rCleanup()
+	t.Cleanup(rCleanup)
 
 	_, err := retry(func() (interface{}, error) {
 		w, err := client.Workspaces.Read(context.Background(), orgTest.Name, wTest.Name)
@@ -655,13 +655,13 @@ func TestWorkspacesReadReadme(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{})
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	_, rCleanup := createRunApply(t, client, wTest)
-	defer rCleanup()
+	t.Cleanup(rCleanup)
 
 	t.Run("when the readme exists", func(t *testing.T) {
 		w, err := client.Workspaces.Readme(ctx, wTest.ID)
@@ -697,10 +697,10 @@ func TestWorkspacesReadByID(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	t.Run("when the workspace exists", func(t *testing.T) {
 		w, err := client.Workspaces.ReadByID(ctx, wTest.ID)
@@ -733,7 +733,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
@@ -852,7 +852,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			Name:  String("tst-" + randomString(t)[0:20] + "-ff-on"),
 			Email: String(fmt.Sprintf("%s@tfe.local", randomString(t))),
 		})
-		defer orgTestCleanup()
+		t.Cleanup(orgTestCleanup)
 
 		wTest, wCleanup := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
 			Name:            String(randomString(t)),
@@ -901,7 +901,7 @@ func TestWorkspacesUpdate(t *testing.T) {
 			Name:  String("tst-" + randomString(t)[0:20] + "-ff-on"),
 			Email: String(fmt.Sprintf("%s@tfe.local", randomString(t))),
 		})
-		defer orgTestCleanup()
+		t.Cleanup(orgTestCleanup)
 
 		wTest, wCleanup := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
 			Name:            String(randomString(t)),
@@ -940,7 +940,7 @@ func TestWorkspacesUpdateTableDriven(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wCleanup := createWorkspace(t, client, orgTest)
 	t.Cleanup(wCleanup)
@@ -969,8 +969,8 @@ func TestWorkspacesUpdateTableDriven(t *testing.T) {
 
 				wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, *options.createOptions)
 				return wTest, func() {
-					defer orgTestCleanup()
-					defer wTestCleanup()
+					t.Cleanup(orgTestCleanup)
+					t.Cleanup(wTestCleanup)
 				}
 			},
 			assertion: func(workspace *Workspace, options *WorkspaceTableOptions, _ error) {
@@ -1078,7 +1078,7 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wCleanup := createWorkspace(t, client, orgTest)
 	t.Cleanup(wCleanup)
@@ -1166,10 +1166,10 @@ func TestWorkspacesDelete(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
-	wTest, wCleanup := createWorkspace(t, client, orgTest)
-	t.Cleanup(wCleanup)
+	// ignore workspace cleanup b/c it will be destroyed during tests
+	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.Delete(ctx, orgTest.Name, wTest.Name)
@@ -1198,10 +1198,10 @@ func TestWorkspacesDeleteByID(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
-	wTest, wCleanup := createWorkspace(t, client, orgTest)
-	t.Cleanup(wCleanup)
+	// ignore workspace cleanup b/c it will be destroyed during tests
+	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.DeleteByID(ctx, wTest.ID)
@@ -1248,8 +1248,8 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	wTest, wCleanup := createWorkspace(t, client, orgTest)
-	t.Cleanup(wCleanup)
+	// ignore workspace cleanup b/c it will be destroyed during tests
+	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
@@ -1274,8 +1274,8 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 		wTest, workspaceCleanup := createWorkspace(t, client, orgTest)
 		t.Cleanup(workspaceCleanup)
 		w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
-		assert.NoError(t, err)
-		assert.True(t, w.Locked)
+		require.NoError(t, err)
+		require.True(t, w.Locked)
 
 		err = client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
 		assert.Contains(t, err.Error(), "conflict")
@@ -1304,8 +1304,8 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	wTest, wCleanup := createWorkspace(t, client, orgTest)
-	t.Cleanup(wCleanup)
+	// ignore workspace cleanup b/c it will be destroyed during tests
+	wTest, _ := createWorkspace(t, client, orgTest)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
@@ -1325,8 +1325,8 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 		wTest, workspaceCleanup := createWorkspace(t, client, orgTest)
 		t.Cleanup(workspaceCleanup)
 		w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
-		assert.NoError(t, err)
-		assert.True(t, w.Locked)
+		require.NoError(t, err)
+		require.True(t, w.Locked)
 
 		err = client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
 		assert.Contains(t, err.Error(), "conflict")
@@ -1353,10 +1353,10 @@ func TestWorkspacesRemoveVCSConnection(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{})
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	t.Run("remove vcs integration", func(t *testing.T) {
 		w, err := client.Workspaces.RemoveVCSConnection(ctx, orgTest.Name, wTest.Name)
@@ -1372,10 +1372,10 @@ func TestWorkspacesRemoveVCSConnectionByID(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspaceWithVCS(t, client, orgTest, WorkspaceCreateOptions{})
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	t.Run("remove vcs integration", func(t *testing.T) {
 		w, err := client.Workspaces.RemoveVCSConnectionByID(ctx, wTest.ID)
@@ -1391,10 +1391,10 @@ func TestWorkspacesLock(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
@@ -1421,10 +1421,10 @@ func TestWorkspacesUnlock(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
 	if err != nil {
@@ -1446,10 +1446,10 @@ func TestWorkspacesUnlock(t *testing.T) {
 
 	t.Run("when a workspace is locked by a run", func(t *testing.T) {
 		wTest2, wTest2Cleanup := createWorkspace(t, client, orgTest)
-		defer wTest2Cleanup()
+		t.Cleanup(wTest2Cleanup)
 
 		_, rTestCleanup := createRun(t, client, wTest2)
-		defer rTestCleanup()
+		t.Cleanup(rTestCleanup)
 
 		// Wait for wTest2 to be locked by a run
 		waitForRunLock(t, client, wTest2.ID)
@@ -1472,10 +1472,10 @@ func TestWorkspacesForceUnlock(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
 	if err != nil {
@@ -1509,13 +1509,13 @@ func TestWorkspacesAssignSSHKey(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	sshKeyTest, sshKeyTestCleanup := createSSHKey(t, client, orgTest)
-	defer sshKeyTestCleanup()
+	t.Cleanup(sshKeyTestCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		w, err := client.Workspaces.AssignSSHKey(ctx, wTest.ID, WorkspaceAssignSSHKeyOptions{
@@ -1556,13 +1556,13 @@ func TestWorkspacesUnassignSSHKey(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	sshKeyTest, sshKeyTestCleanup := createSSHKey(t, client, orgTest)
-	defer sshKeyTestCleanup()
+	t.Cleanup(sshKeyTestCleanup)
 
 	w, err := client.Workspaces.AssignSSHKey(ctx, wTest.ID, WorkspaceAssignSSHKeyOptions{
 		SSHKeyID: String(sshKeyTest.ID),
@@ -1594,10 +1594,10 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	// Update workspace to not allow global remote state
 	options := WorkspaceUpdateOptions{
@@ -1608,9 +1608,9 @@ func TestWorkspaces_AddRemoteStateConsumers(t *testing.T) {
 
 	t.Run("successfully adds a remote state consumer", func(t *testing.T) {
 		wTestConsumer1, wTestCleanupConsumer1 := createWorkspace(t, client, orgTest)
-		defer wTestCleanupConsumer1()
+		t.Cleanup(wTestCleanupConsumer1)
 		wTestConsumer2, wTestCleanupConsumer2 := createWorkspace(t, client, orgTest)
-		defer wTestCleanupConsumer2()
+		t.Cleanup(wTestCleanupConsumer2)
 
 		err := client.Workspaces.AddRemoteStateConsumers(ctx, wTest.ID, WorkspaceAddRemoteStateConsumersOptions{
 			Workspaces: []*Workspace{wTestConsumer1, wTestConsumer2},
@@ -1653,10 +1653,10 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	// Update workspace to not allow global remote state
 	options := WorkspaceUpdateOptions{
@@ -1667,9 +1667,9 @@ func TestWorkspaces_RemoveRemoteStateConsumers(t *testing.T) {
 
 	t.Run("successfully removes a remote state consumer", func(t *testing.T) {
 		wTestConsumer1, wTestCleanupConsumer1 := createWorkspace(t, client, orgTest)
-		defer wTestCleanupConsumer1()
+		t.Cleanup(wTestCleanupConsumer1)
 		wTestConsumer2, wTestCleanupConsumer2 := createWorkspace(t, client, orgTest)
-		defer wTestCleanupConsumer2()
+		t.Cleanup(wTestCleanupConsumer2)
 
 		err := client.Workspaces.AddRemoteStateConsumers(ctx, wTest.ID, WorkspaceAddRemoteStateConsumersOptions{
 			Workspaces: []*Workspace{wTestConsumer1, wTestConsumer2},
@@ -1731,10 +1731,10 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	// Update workspace to not allow global remote state
 	options := WorkspaceUpdateOptions{
@@ -1745,9 +1745,9 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 
 	t.Run("successfully updates a remote state consumer", func(t *testing.T) {
 		wTestConsumer1, wTestCleanupConsumer1 := createWorkspace(t, client, orgTest)
-		defer wTestCleanupConsumer1()
+		t.Cleanup(wTestCleanupConsumer1)
 		wTestConsumer2, wTestCleanupConsumer2 := createWorkspace(t, client, orgTest)
-		defer wTestCleanupConsumer2()
+		t.Cleanup(wTestCleanupConsumer2)
 
 		err := client.Workspaces.AddRemoteStateConsumers(ctx, wTest.ID, WorkspaceAddRemoteStateConsumersOptions{
 			Workspaces: []*Workspace{wTestConsumer1},
@@ -1797,10 +1797,10 @@ func TestWorkspaces_AddTags(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	options := WorkspaceAddTagsOptions{
 		Tags: []*Tag{
@@ -1848,7 +1848,7 @@ func TestWorkspaces_AddTags(t *testing.T) {
 
 	t.Run("successfully adds tags by id and name", func(t *testing.T) {
 		wTest2, wTest2Cleanup := createWorkspace(t, client, orgTest)
-		defer wTest2Cleanup()
+		t.Cleanup(wTest2Cleanup)
 
 		// add a tag to another workspace
 		err := client.Workspaces.AddTags(ctx, wTest2.ID, WorkspaceAddTagsOptions{
@@ -1911,10 +1911,10 @@ func TestWorkspaces_RemoveTags(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	tags := []*Tag{
 		{
@@ -2084,10 +2084,10 @@ func TestWorkspacesRunTasksPermission(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
-	defer wTestCleanup()
+	t.Cleanup(wTestCleanup)
 
 	t.Run("when the workspace exists", func(t *testing.T) {
 		w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1234,6 +1234,7 @@ func TestCanForceDeletePermission(t *testing.T) {
 		w, err := client.Workspaces.ReadByID(ctx, wTest.ID)
 		require.NoError(t, err)
 		assert.Equal(t, wTest, w)
+		require.NotNil(t, w.Permissions)
 		assert.NotNil(t, w.Permissions.CanForceDelete)
 		assert.True(t, *w.Permissions.CanForceDelete)
 	})

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -737,7 +737,8 @@ func TestWorkspacesUpdate(t *testing.T) {
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
@@ -853,10 +854,11 @@ func TestWorkspacesUpdate(t *testing.T) {
 		})
 		defer orgTestCleanup()
 
-		wTest, _ := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
+		wTest, wCleanup := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
 			Name:            String(randomString(t)),
 			TriggerPrefixes: []string{"/prefix-1/", "/prefix-2/"},
 		})
+		t.Cleanup(wCleanup)
 		assert.Equal(t, wTest.TriggerPrefixes, []string{"/prefix-1/", "/prefix-2/"}) // Sanity test
 
 		options := WorkspaceUpdateOptions{
@@ -901,10 +903,11 @@ func TestWorkspacesUpdate(t *testing.T) {
 		})
 		defer orgTestCleanup()
 
-		wTest, _ := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
+		wTest, wCleanup := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
 			Name:            String(randomString(t)),
 			TriggerPatterns: []string{"/pattern-1/**/*", "/pattern-2/**/*"},
 		})
+		t.Cleanup(wCleanup)
 		assert.Equal(t, wTest.TriggerPatterns, []string{"/pattern-1/**/*", "/pattern-2/**/*"}) // Sanity test
 
 		options := WorkspaceUpdateOptions{
@@ -939,7 +942,8 @@ func TestWorkspacesUpdateTableDriven(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	workspaceTableTests := []WorkspaceTableTest{
 		{
@@ -1076,7 +1080,8 @@ func TestWorkspacesUpdateByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
 		options := WorkspaceUpdateOptions{
@@ -1163,7 +1168,8 @@ func TestWorkspacesDelete(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.Delete(ctx, orgTest.Name, wTest.Name)
@@ -1194,7 +1200,8 @@ func TestWorkspacesDeleteByID(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.DeleteByID(ctx, wTest.ID)
@@ -1218,9 +1225,10 @@ func TestCanForceDeletePermission(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	t.Run("workspace permission set includes can-force-delete", func(t *testing.T) {
 		w, err := client.Workspaces.ReadByID(ctx, wTest.ID)
@@ -1238,9 +1246,10 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
@@ -1263,7 +1272,7 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 
 	t.Run("when workspace is locked", func(t *testing.T) {
 		wTest, workspaceCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceCleanup()
+		t.Cleanup(workspaceCleanup)
 		w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
 		assert.NoError(t, err)
 		assert.True(t, w.Locked)
@@ -1275,7 +1284,7 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 
 	t.Run("when workspace has resources under management", func(t *testing.T) {
 		wTest, workspaceCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceCleanup()
+		t.Cleanup(workspaceCleanup)
 		_, svTestCleanup := createStateVersion(t, client, 0, wTest)
 		t.Cleanup(svTestCleanup)
 
@@ -1293,9 +1302,10 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
-	wTest, _ := createWorkspace(t, client, orgTest)
+	wTest, wCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
@@ -1313,7 +1323,7 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 
 	t.Run("when workspace is locked", func(t *testing.T) {
 		wTest, workspaceCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceCleanup()
+		t.Cleanup(workspaceCleanup)
 		w, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
 		assert.NoError(t, err)
 		assert.True(t, w.Locked)
@@ -1325,7 +1335,7 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 
 	t.Run("when workspace has resources under management", func(t *testing.T) {
 		wTest, workspaceCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceCleanup()
+		t.Cleanup(workspaceCleanup)
 		_, svTestCleanup := createStateVersion(t, client, 0, wTest)
 		t.Cleanup(svTestCleanup)
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1212,6 +1212,8 @@ func TestWorkspacesDeleteByID(t *testing.T) {
 }
 
 func TestCanForceDeletePermission(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1230,6 +1232,8 @@ func TestCanForceDeletePermission(t *testing.T) {
 }
 
 func TestWorkspacesSafeDelete(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -1283,6 +1287,8 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 }
 
 func TestWorkspacesSafeDeleteByID(t *testing.T) {
+	skipIfNotCINode(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1224,7 +1224,6 @@ func TestCanForceDeletePermission(t *testing.T) {
 		w, err := client.Workspaces.ReadByID(ctx, wTest.ID)
 		require.NoError(t, err)
 		assert.Equal(t, wTest, w)
-		assert.Equal(t, wTest, w)
 		assert.NotNil(t, w.Permissions.CanForceDelete)
 		assert.True(t, *w.Permissions.CanForceDelete)
 	})

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1235,7 +1235,7 @@ func TestCanForceDeletePermission(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, wTest, w)
 		require.NotNil(t, w.Permissions)
-		assert.NotNil(t, w.Permissions.CanForceDelete)
+		require.NotNil(t, w.Permissions.CanForceDelete)
 		assert.True(t, *w.Permissions.CanForceDelete)
 	})
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds the new workspace safe-delete API (and tests)

Adds the can-force-delete permission hash to the workspace permissions hash. This value is a `*bool` which will allow clients to detect if safe vs force delete is available

Adds the allow_force_delete_workspaces setting to organizations

These are all part of a change which adds some guardrails around workspace deletion in TFC. There will be a new safe-delete API to remove a workspace **only** if it does not have resources under management. The existing delete API will continue to function as a force delete, but may be restricted to org owners based on an org level setting

This change is in draft as we complete the feature in TFC and prepare for it in a TFE release

## Testing plan

1.  Test that Safe Delete works when a workspace does not have RUM, and fails when it does
2. Check that force delete still works
3. Check that can-force-delete is returned in workspace GETs
4. Check that can-force-delete is nil when communicating with older versions of TFE
5. Check that allow_force_delete is settable/readable through go-tfe

## External links

- [API documentation](https://github.com/hashicorp/terraform-docs-common/pull/146) (in progress)
- [RFC](https://hashidocs.hashicorp.services/document/1SwO0PmgIu2KxQl6vr7Z55v3veLjcHBbv4YdhjL67lBs)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-719)


## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
❯ go test .  -run TestOrganizationsAllowForceDeleteSetting -tags=integration -v
=== RUN   TestOrganizationsAllowForceDeleteSetting
=== RUN   TestOrganizationsAllowForceDeleteSetting/creates_and_updates_allow_force_delete
--- PASS: TestOrganizationsAllowForceDeleteSetting (1.52s)
    --- PASS: TestOrganizationsAllowForceDeleteSetting/creates_and_updates_allow_force_delete (1.23s)
PASS
ok      github.com/hashicorp/go-tfe     1.658s

❯ go test .  -run TestWorkspacesSafeDelete -tags=integration -v 
=== RUN   TestWorkspacesSafeDelete
=== RUN   TestWorkspacesSafeDelete/with_valid_options
=== RUN   TestWorkspacesSafeDelete/when_organization_is_invalid
=== RUN   TestWorkspacesSafeDelete/when_workspace_is_invalid
=== RUN   TestWorkspacesSafeDelete/when_workspace_is_locked
=== RUN   TestWorkspacesSafeDelete/when_workspace_has_resources_under_management
--- PASS: TestWorkspacesSafeDelete (4.33s)
    --- PASS: TestWorkspacesSafeDelete/with_valid_options (0.35s)
    --- PASS: TestWorkspacesSafeDelete/when_organization_is_invalid (0.00s)
    --- PASS: TestWorkspacesSafeDelete/when_workspace_is_invalid (0.00s)
    --- PASS: TestWorkspacesSafeDelete/when_workspace_is_locked (0.78s)
    --- PASS: TestWorkspacesSafeDelete/when_workspace_has_resources_under_management (1.77s)
=== RUN   TestWorkspacesSafeDeleteByID
=== RUN   TestWorkspacesSafeDeleteByID/with_valid_options
=== RUN   TestWorkspacesSafeDeleteByID/without_a_valid_workspace_ID
=== RUN   TestWorkspacesSafeDeleteByID/when_workspace_is_locked
=== RUN   TestWorkspacesSafeDeleteByID/when_workspace_has_resources_under_management
--- PASS: TestWorkspacesSafeDeleteByID (3.99s)
    --- PASS: TestWorkspacesSafeDeleteByID/with_valid_options (0.34s)
    --- PASS: TestWorkspacesSafeDeleteByID/without_a_valid_workspace_ID (0.00s)
    --- PASS: TestWorkspacesSafeDeleteByID/when_workspace_is_locked (0.78s)
    --- PASS: TestWorkspacesSafeDeleteByID/when_workspace_has_resources_under_management (1.39s)
PASS
ok      github.com/hashicorp/go-tfe     8.436s

❯ go test .  -run TestWorkspacesDelete -tags=integration -v 
=== RUN   TestWorkspacesDelete
=== RUN   TestWorkspacesDelete/with_valid_options
=== RUN   TestWorkspacesDelete/when_organization_is_invalid
=== RUN   TestWorkspacesDelete/when_workspace_is_invalid
--- PASS: TestWorkspacesDelete (1.61s)
    --- PASS: TestWorkspacesDelete/with_valid_options (0.35s)
    --- PASS: TestWorkspacesDelete/when_organization_is_invalid (0.00s)
    --- PASS: TestWorkspacesDelete/when_workspace_is_invalid (0.00s)
=== RUN   TestWorkspacesDeleteByID
=== RUN   TestWorkspacesDeleteByID/with_valid_options
=== RUN   TestWorkspacesDeleteByID/without_a_valid_workspace_ID
--- PASS: TestWorkspacesDeleteByID (1.66s)
    --- PASS: TestWorkspacesDeleteByID/with_valid_options (0.34s)
    --- PASS: TestWorkspacesDeleteByID/without_a_valid_workspace_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     3.378s

❯ go test .  -run TestCanForceDeletePermission -tags=integration -v
=== RUN   TestCanForceDeletePermission
=== RUN   TestCanForceDeletePermission/workspace_permission_set_includes_can-force-delete
--- PASS: TestCanForceDeletePermission (1.59s)
    --- PASS: TestCanForceDeletePermission/workspace_permission_set_includes_can-force-delete (0.26s)
PASS
ok      github.com/hashicorp/go-tfe     1.704s
...
```

