### PR TITLE
Fix failing config version test

### DIFF
--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -263,7 +263,8 @@ func TestConfigurationVersionsArchive(t *testing.T) {
 		// configuration version should not be archived, since it's the latest version
 		err = client.ConfigurationVersions.Archive(ctx, cv.ID)
 		assert.Error(t, err)
-		assert.EqualError(t, err, "transition not allowed")
+		assert.ErrorContains(t, err, "transition not allowed")
+		assert.ErrorContains(t, err, "configuration could not be archived because it is current")
 
 		// create subsequent version, since the latest configuration version cannot be archived
 		newCv, newCvCleanup := createConfigurationVersion(t, client, w)


### PR DESCRIPTION
Fixes [this test](https://github.com/hashicorp/go-tfe/blob/main/configuration_version_integration_test.go#L253) which has started to fail because of [this atlas change](https://github.com/hashicorp/atlas/pull/13288/files#diff-42de4f4e06a79c933dc219d1e0d683c042a9314373f3b730e5a0bf2e1cc9def1R309)