### PR TITLE
Add force execute for a run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Add `NotificationTriggerAssessmentCheckFailed` notification trigger type by @rexredinger [#549](https://github.com/hashicorp/go-tfe/pull/549)
 * Add `RemoteTFEVersion()` to the `Client` interface, which exposes the `X-TFE-Version` header set by a remote TFE instance by @sebasslash [#563](https://github.com/hashicorp/go-tfe/pull/563)
 * Validate the module version as a version instead of an ID [#409](https://github.com/hashicorp/go-tfe/pull/409)
+* Add `ForceExecute()` to `Runs` to allow force executing a run by @annawinkler [#570](https://github.com/hashicorp/go-tfe/pull/570)
 
 # v1.11.0
 

--- a/mocks/run_mocks.go
+++ b/mocks/run_mocks.go
@@ -106,6 +106,20 @@ func (mr *MockRunsMockRecorder) ForceCancel(ctx, runID, options interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceCancel", reflect.TypeOf((*MockRuns)(nil).ForceCancel), ctx, runID, options)
 }
 
+// ForceExecute mocks base method.
+func (m *MockRuns) ForceExecute(ctx context.Context, runID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ForceExecute", ctx, runID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ForceExecute indicates an expected call of ForceExecute.
+func (mr *MockRunsMockRecorder) ForceExecute(ctx, runID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ForceExecute", reflect.TypeOf((*MockRuns)(nil).ForceExecute), ctx, runID)
+}
+
 // List mocks base method.
 func (m *MockRuns) List(ctx context.Context, workspaceID string, options *tfe.RunListOptions) (*tfe.RunList, error) {
 	m.ctrl.T.Helper()

--- a/run.go
+++ b/run.go
@@ -36,6 +36,9 @@ type Runs interface {
 	// Force-cancel a run by its ID.
 	ForceCancel(ctx context.Context, runID string, options RunForceCancelOptions) error
 
+	// Force execute a run by its ID.
+	ForceExecute(ctx context.Context, runID string) error
+
 	// Discard a run by its ID.
 	Discard(ctx context.Context, runID string, options RunDiscardOptions) error
 }
@@ -457,6 +460,26 @@ func (s *runs) ForceCancel(ctx context.Context, runID string, options RunForceCa
 
 	u := fmt.Sprintf("runs/%s/actions/force-cancel", url.QueryEscape(runID))
 	req, err := s.client.NewRequest("POST", u, &options)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// ForceExecute is used to forcefully execute a run by its ID.
+//
+// Note: While useful at times, force-executing a run circumvents the typical
+// workflow of applying runs using Terraform Cloud. It is not intended for
+// regular use. If you find yourself using it frequently, please reach out to
+// HashiCorp Support for help in developing an alternative approach.
+func (s *runs) ForceExecute(ctx context.Context, runID string) error {
+	if !validStringID(&runID) {
+		return ErrInvalidRunID
+	}
+
+	u := fmt.Sprintf("runs/%s/actions/force-execute", url.QueryEscape(runID))
+	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Description

Add ForceExecute for a run.

## Testing plan

1. Create a workspace
2. Create a run and make sure it's pending
3. Create a second run, and ForceExecute the run
4. Verify the second run has a status that is applyable (cost estimated or planned)

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#forcefully-execute-a-run)

## Output from tests

```
❯ envchain tfe-local go test -run TestRunsForceExecute -v ./... -tags=integration

=== RUN   TestRunsForceExecute
    helper_test.go:928: Polling run "run-ZuWKxopadhyBSoKQ" for status included in ["cost_estimated" "errored"] with deadline of 2022-11-01 12:09:04.016706 -0600 MDT m=+123.207022584
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "cost_estimating"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-ZuWKxopadhyBSoKQ"
    helper_test.go:940: Run "run-ZuWKxopadhyBSoKQ" had status "cost_estimated"
    helper_test.go:928: Polling run "run-MW8nisyjdhg8Utz4" for status included in ["pending" "errored"] with deadline of 2022-11-01 12:09:43.907218 -0600 MDT m=+163.097441917
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "pending"
=== RUN   TestRunsForceExecute/a_successful_force-execute
    helper_test.go:928: Polling run "run-MW8nisyjdhg8Utz4" for status included in ["cost_estimated"] with deadline of 2022-11-01 12:09:46.835586 -0600 MDT m=+166.025803876
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "planning"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "cost_estimating"
    helper_test.go:934: ...
    helper_test.go:955: Reading run "run-MW8nisyjdhg8Utz4"
    helper_test.go:940: Run "run-MW8nisyjdhg8Utz4" had status "cost_estimated"
=== RUN   TestRunsForceExecute/when_the_run_does_not_exist
=== RUN   TestRunsForceExecute/with_invalid_run_ID
--- PASS: TestRunsForceExecute (86.17s)
    --- PASS: TestRunsForceExecute/a_successful_force-execute (39.36s)
    --- PASS: TestRunsForceExecute/when_the_run_does_not_exist (0.20s)
    --- PASS: TestRunsForceExecute/with_invalid_run_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	86.901s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]

```

### Feels gif

![](https://media.giphy.com/media/RiPxTlxRujiMzrsN6B/giphy.gif)