### PR TITLE
Since we only have one test suite, remove integration build flag

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -45,7 +45,7 @@ Including output from tests may require access to a TFE instance. Ignore this se
 _Please run the tests locally for any files you changes and include the output here._
 -->
 ```
-$ TFE_ADDRESS="https://example" TFE_TOKEN="example" TF_ACC="1" go test ./... -v -tags=integration -run TestFunctionsAffectedByChange
+$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange
 
 ...
 ```

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,6 @@ jobs:
         with:
           index: ${{ matrix.index }}
           total: ${{ matrix.parallel }}
-          flags: -tags=integration
 
       - name: Fetch outputs
         env:
@@ -91,7 +90,7 @@ jobs:
           GO111MODULE: "on"
         run: |
           source $HOME/.env
-          gotestsum --format short-verbose -- -timeout=29m -tags=integration -run "${{ steps.test_split.outputs.run }}"
+          gotestsum --format short-verbose -- -timeout=29m -run "${{ steps.test_split.outputs.run }}"
 
 
 

--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -102,7 +102,7 @@ jobs:
           GO111MODULE: "on"
         run: |
           source $HOME/.env
-          gotestsum --format short-verbose -- -timeout=40m -tags=integration
+          gotestsum --format short-verbose -- -timeout=40m
 
   cleanup:
     runs-on: ubuntu-latest

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,2 @@
 {
-  "go.buildFlags": [
-      "-tags=integration"
-  ],
-  "go.lintFlags": [
-    "-tags=integration"
-  ],
-  "go.testTags": "integration",
 }

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ lint:
 	golangci-lint run .
 
 test:
-	go test ./... $(TESTARGS) -tags=integration -timeout=30m
+	go test ./... $(TESTARGS) -timeout=30m
 
 # Make target to generate mocks for specified FILENAME
 mocks: check-filename

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_run_integration_test.go
+++ b/admin_run_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_setting_cost_estimation_integration_test.go
+++ b/admin_setting_cost_estimation_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_setting_customization_integration_test.go
+++ b/admin_setting_customization_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_setting_general_integration_test.go
+++ b/admin_setting_general_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_setting_smtp_integration_test.go
+++ b/admin_setting_smtp_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_setting_twilio_integration_test.go
+++ b/admin_setting_twilio_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/agent_integration_test.go
+++ b/agent_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/agent_token_integration_test.go
+++ b/agent_token_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/apply_integration_test.go
+++ b/apply_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/audit_trail_integration_test.go
+++ b/audit_trail_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/comment_integration_test.go
+++ b/comment_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-slug"
+	slug "github.com/hashicorp/go-slug"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/cost_estimate_integration_test.go
+++ b/cost_estimate_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,5 +1,7 @@
 # Running tests
 
+go-tfe relies on acceptance tests against either the Terraform Cloud and Terraform Enterprise APIs. go-tfe is tested against Terraform Cloud by our CI environment, and against Terraform Enterprise prior to release or otherwise as needed.
+
 ## 1. (Optional) Create repositories for policy sets and registry modules
 
 If you are planning to run the full suite of tests or work on policy sets or registry modules, you'll need to set up repositories for them in GitHub.
@@ -64,12 +66,12 @@ Typically, you'll want to run specific tests. The commands below use notificatio
 
 #### With envchain:
 ```sh
-$ envchain YOUR_NAMESPACE_HERE go test -run TestNotificationConfiguration -v ./... -tags=integration
+$ envchain YOUR_NAMESPACE_HERE go test -run TestNotificationConfiguration -v ./...
 ```
 
 #### Without envchain:
 ```sh
-$ TFE_TOKEN=xyz TFE_ADDRESS=xyz ENABLE_TFE=1 go test -run TestNotificationConfiguration -v ./... -tags=integration
+$ TFE_TOKEN=xyz TFE_ADDRESS=xyz ENABLE_TFE=1 go test -run TestNotificationConfiguration -v ./...
 ```
 
 #### Using Makefile target `test`
@@ -82,12 +84,12 @@ It takes about 20 minutes to run all of the tests, so specify a larger timeout w
 
 #### With envchain:
 ```sh
-$ envchain YOUR_NAMESPACE_HERE go test ./... -timeout=30m -tags=integration
+$ envchain YOUR_NAMESPACE_HERE go test ./... -timeout=30m
 ```
 
 #### Without envchain:
 ```sh
-$ TFE_TOKEN=xyz TFE_ADDRESS=xyz ENABLE_TFE=1 go test ./... -timeout=30m -tags=integration
+$ TFE_TOKEN=xyz TFE_ADDRESS=xyz ENABLE_TFE=1 go test ./... -timeout=30m
 ```
 
 ### Running tests for TFC features that require paid plans (HashiCorp Employees)

--- a/gpg_key_integration_test.go
+++ b/gpg_key_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/ip_ranges_integration_test.go
+++ b/ip_ranges_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/logreader_integration_test.go
+++ b/logreader_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/notification_configuration_integration_test.go
+++ b/notification_configuration_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/oauth_token_integration_test.go
+++ b/oauth_token_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/plan_export_integration_test.go
+++ b/plan_export_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/plan_integration_test.go
+++ b/plan_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/policy_integration_test.go
+++ b/policy_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/policy_set_parameter_integration_test.go
+++ b/policy_set_parameter_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/registry_provider_platform_integration_test.go
+++ b/registry_provider_platform_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/registry_provider_version_integration_test.go
+++ b/registry_provider_version_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/run_trigger_integration_test.go
+++ b/run_trigger_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/scripts/generate_resource/templates.go
+++ b/scripts/generate_resource/templates.go
@@ -149,10 +149,7 @@ func Delete(ctx context.Context, {{ .ResourceID }} string) error {
     panic("not yet implemented")
 }`
 
-const testTemplate = `//go:build integration
-// +build integration
-
-package tfe
+const testTemplate = `package tfe
 
 import (
   "context"

--- a/ssh_key_integration_test.go
+++ b/ssh_key_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/state_version_output_integration_test.go
+++ b/state_version_output_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/task_stages_integration_test.go
+++ b/task_stages_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/team_access_integration_test.go
+++ b/team_access_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/team_member_integration_test.go
+++ b/team_member_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/hashicorp/jsonapi"
 	"github.com/stretchr/testify/assert"
 	"golang.org/x/time/rate"

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -11,8 +11,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hashicorp/go-retryablehttp"
-
+	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (

--- a/workspace_run_task_integration_test.go
+++ b/workspace_run_task_integration_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (


### PR DESCRIPTION
There are quite a few tests that are skipped because the author forgot to add this flag to new test files and I'm not sure what this is used for.