### PR TITLE
Fixes audit trail pagination data within list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Bug Fixes
+
+* Fixes `AuditTrail` pagination parameters (`CurrentPage`, `PreviousPage`, `NextPage`, `TotalPages`, `TotalCount`), which were not deserialized after reading from the List endpoint by @brandonc [#586](https://github.com/hashicorp/go-tfe/pull/586)
+
 ## Enhancements
 
 * Add OPA support to the Policy Set APIs by @mrinalirao [#575](https://github.com/hashicorp/go-tfe/pull/575)

--- a/audit_trail.go
+++ b/audit_trail.go
@@ -52,6 +52,14 @@ type AuditTrailResource struct {
 	Meta   map[string]interface{} `json:"meta"`
 }
 
+type AuditTrailPagination struct {
+	CurrentPage  int `json:"current_page"`
+	PreviousPage int `json:"prev_page"`
+	NextPage     int `json:"next_page"`
+	TotalPages   int `json:"total_pages"`
+	TotalCount   int `json:"total_count"`
+}
+
 // AuditTrail represents an event in the TFC audit log.
 type AuditTrail struct {
 	ID        string    `json:"id"`
@@ -66,9 +74,8 @@ type AuditTrail struct {
 
 // AuditTrailList represents a list of audit trails.
 type AuditTrailList struct {
-	*Pagination
-
-	Items []*AuditTrail `json:"data"`
+	*AuditTrailPagination `json:"pagination"`
+	Items                 []*AuditTrail `json:"data"`
 }
 
 // AuditTrailListOptions represents the options for listing audit trails.


### PR DESCRIPTION
Closes #585

## Description

The Audit Trails endpoint is a bit of a snowflake and uses different keys than what was conventional. Added test coverage.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/audit-trails)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
go test ./... -v -run TestAuditTrailsList
=== RUN   TestAuditTrailsList
=== RUN   TestAuditTrailsList/with_no_specified_timeframe
=== RUN   TestAuditTrailsList/with_no_specified_timeframe/pagination_parameters
=== RUN   TestAuditTrailsList/with_no_specified_timeframe/with_resource_deserialized_correctly
=== RUN   TestAuditTrailsList/with_no_specified_timeframe/with_auth_deserialized_correctly
=== RUN   TestAuditTrailsList/with_no_specified_timeframe/with_request_deserialized_correctly
=== RUN   TestAuditTrailsList/using_since_query_param
--- PASS: TestAuditTrailsList (12.45s)
    --- PASS: TestAuditTrailsList/with_no_specified_timeframe (1.32s)
        --- PASS: TestAuditTrailsList/with_no_specified_timeframe/pagination_parameters (0.76s)
        --- PASS: TestAuditTrailsList/with_no_specified_timeframe/with_resource_deserialized_correctly (0.00s)
        --- PASS: TestAuditTrailsList/with_no_specified_timeframe/with_auth_deserialized_correctly (0.00s)
        --- PASS: TestAuditTrailsList/with_no_specified_timeframe/with_request_deserialized_correctly (0.00s)
    --- PASS: TestAuditTrailsList/using_since_query_param (2.60s)
PASS
ok  	github.com/hashicorp/go-tfe	13.245s
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/internal/testsetup	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
...
```
