### PR TITLE
fix bug where overridable is not updated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Unreleased
 
-## Bug Fixes
+## Enhancements
 
-* Fixes `policy set` update api parameters (`Overridable`), which was not being set in the PolicySetUpdateOptions @mrinalirao [#594](https://github.com/hashicorp/go-tfe/pull/594)
+* Adds Beta parameter `Overridable` for OPA `policy set` update API (`PolicySetUpdateOptions`) @mrinalirao [#594](https://github.com/hashicorp/go-tfe/pull/594)
+* Adds new task stage status values representing `canceled`, `errored`, `unreachable` @mrinalirao [#594](https://github.com/hashicorp/go-tfe/pull/594)
 
 # v1.13.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# Unreleased
+
+## Bug Fixes
+
+* Fixes `policy set` update api parameters (`Overridable`), which was not being set in the PolicySetUpdateOptions @mrinalirao [#594](https://github.com/hashicorp/go-tfe/pull/594)
+
 # v1.13.0
 
 ## Bug Fixes

--- a/policy_set.go
+++ b/policy_set.go
@@ -195,6 +195,10 @@ type PolicySetUpdateOptions struct {
 	// Optional: Whether or not the policy set is global.
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
+	// **Note: This field is still in BETA and subject to change.**
+	// Optional: Whether or not users can override this policy when it fails during a run. Only valid for OPA policies.
+	Overridable *bool `jsonapi:"attr,overridable,omitempty"`
+
 	// Optional: The sub-path within the attached VCS repository to ingress. All
 	// files and directories outside of this sub-path will be ignored.
 	// This option may only be specified when a VCS repo is present.

--- a/policy_set_integration_beta_test.go
+++ b/policy_set_integration_beta_test.go
@@ -331,3 +331,36 @@ func TestPolicySetsCreate_Beta(t *testing.T) {
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 }
+
+func TestPolicySetsUpdate_Beta(t *testing.T) {
+	skipIfFreeOnly(t)
+	skipIfBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
+
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, "opa")
+	defer psTestCleanup()
+
+	t.Run("with valid attributes", func(t *testing.T) {
+		options := PolicySetUpdateOptions{
+			Name:        String("global"),
+			Description: String("Policies in this set will be checked in ALL workspaces!"),
+			Global:      Bool(true),
+			Overridable: Bool(true),
+		}
+
+		ps, err := client.PolicySets.Update(ctx, psTest.ID, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, ps.Name, *options.Name)
+		assert.Equal(t, ps.Description, *options.Description)
+		assert.True(t, ps.Global)
+		assert.True(t, ps.Global)
+	})
+}

--- a/policy_set_integration_beta_test.go
+++ b/policy_set_integration_beta_test.go
@@ -361,6 +361,6 @@ func TestPolicySetsUpdate_Beta(t *testing.T) {
 		assert.Equal(t, ps.Name, *options.Name)
 		assert.Equal(t, ps.Description, *options.Description)
 		assert.True(t, ps.Global)
-		assert.True(t, ps.Global)
+		assert.True(t, *ps.Overridable)
 	})
 }

--- a/task_stages.go
+++ b/task_stages.go
@@ -46,6 +46,9 @@ const (
 	TaskStagePassed           TaskStageStatus = "passed"
 	TaskStageFailed           TaskStageStatus = "failed"
 	TaskStageAwaitingOverride TaskStageStatus = "awaiting_override"
+	TaskStageCanceled         TaskStageStatus = "canceled"
+	TaskStageErrored          TaskStageStatus = "errored"
+	TaskStageUnreachable      TaskStageStatus = "unreachable"
 )
 
 // Permissions represents the permission types for overridding a task stage


### PR DESCRIPTION
## Description

Update the PolicySetUpdateOptions with the overridable property which was earlier missing

## Testing plan

Added Acceptance tests


## Output from tests
```
TestPolicySetsUpdate_Beta\E$
=== RUN   TestPolicySetsUpdate_Beta
--- PASS: TestPolicySetsUpdate_Beta (2.35s)
=== RUN   TestPolicySetsUpdate_Beta/with_valid_attributes
    --- PASS: TestPolicySetsUpdate_Beta/with_valid_attributes (0.32s)
PASS
```