### PR TITLE
Fix or ignore all outsanding golangci-lint errors

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,11 +1,10 @@
 name: Linter
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
 jobs:
-  golangci:
-    name: lint
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -14,4 +13,4 @@ jobs:
           go-version-file: 'go.mod'
       - uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.42
+          version: v1.50.1

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -9,15 +9,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - name: Set local Go version
-        run: |
-          VERSION=`cat .go-version| awk '{printf$1}'`
-          echo "go_version=$VERSION" >> $GITHUB_ENV
-      - name: Setup Go Environment
-        uses: actions/setup-go@v3
+      - uses: actions/setup-go@v3
         with:
-          go-version: "${{ env.go_version }}"
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+          go-version-file: 'go.mod'
+      - uses: golangci/golangci-lint-action@v3
         with:
           version: v1.42

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -20,19 +20,27 @@ linters:
     - misspell #https://github.com/client9/misspell
 issues:
   exclude-rules:
+  - path: tfe_integration_test.go
+    linters:
+    - errcheck # Many calls in this test are known to return an error and not checked
+  - linters:
+      - stylecheck
+    text: "Ascii" # Permanently part of the public interface unless we break the API
   - path: _test\.go
     linters:
     - unused
     - deadcode
+    - unparam
 linters-settings:
   errcheck:
     # https://github.com/kisielk/errcheck#excluding-functions
     check-type-assertions: true
-    check-blank: true  
+    check-blank: true
   goconst:
-    min-len: 20 
-    min-occurrences: 5 
+    min-len: 20
+    min-occurrences: 5
     ignore-calls: false
+    ignore-tests: true
   gocritic:
     enabled-tags:
       - diagnostic

--- a/admin_setting_cost_estimation_integration_test.go
+++ b/admin_setting_cost_estimation_integration_test.go
@@ -26,11 +26,11 @@ func TestAdminSettings_CostEstimation_Update(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	costEstimationSettings, err := client.Admin.Settings.CostEstimation.Read(ctx)
+	_, err := client.Admin.Settings.CostEstimation.Read(ctx)
 	require.NoError(t, err)
 
 	costEnabled := false
-	costEstimationSettings, err = client.Admin.Settings.CostEstimation.Update(ctx, AdminCostEstimationSettingOptions{
+	costEstimationSettings, err := client.Admin.Settings.CostEstimation.Update(ctx, AdminCostEstimationSettingOptions{
 		Enabled: Bool(costEnabled),
 	})
 	require.NoError(t, err)

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -42,13 +42,13 @@ func TestAdminSettings_SAML_Update(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	samlSettings, err := client.Admin.Settings.SAML.Read(ctx)
+	_, err := client.Admin.Settings.SAML.Read(ctx)
 	require.NoError(t, err)
 
 	enabled := false
 	debug := false
 
-	samlSettings, err = client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
+	samlSettings, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
 		Enabled: Bool(enabled),
 		Debug:   Bool(debug),
 	})

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -103,7 +103,7 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
 			Version:          String(version),
 			URL:              String("https://www.hashicorp.com"),
-			Sha:              String(genSha(t, "secret", "data")),
+			Sha:              String(genSha(t)),
 			Deprecated:       Bool(true),
 			DeprecatedReason: String("Test Reason"),
 			Official:         Bool(false),
@@ -133,7 +133,7 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
 			Version: String(version),
 			URL:     String("https://www.hashicorp.com"),
-			Sha:     String(genSha(t, "secret", "data")),
+			Sha:     String(genSha(t)),
 		}
 		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
 		require.NoError(t, err)
@@ -170,7 +170,7 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
 			Version:          String(version),
 			URL:              String("https://www.hashicorp.com"),
-			Sha:              String(genSha(t, "secret", "data")),
+			Sha:              String(genSha(t)),
 			Official:         Bool(false),
 			Deprecated:       Bool(true),
 			DeprecatedReason: String("Test Reason"),

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -130,7 +130,6 @@ func TestAdminUsers_Delete(t *testing.T) {
 		assert.Empty(t, ul.Items)
 		assert.Equal(t, 1, ul.CurrentPage)
 		assert.Equal(t, 0, ul.TotalCount)
-
 	})
 
 	t.Run("an non-existing user", func(t *testing.T) {

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -130,7 +130,7 @@ func TestAdminWorkspaces_Read(t *testing.T) {
 		assert.Nil(t, workspace)
 	})
 
-	t.Run("it fails to read a workspace that is non existant", func(t *testing.T) {
+	t.Run("it fails to read a workspace that is non existent", func(t *testing.T) {
 		workspaceID := fmt.Sprintf("non-existent-%s", randomString(t))
 		adminWorkspace, err := client.Admin.Workspaces.Read(ctx, workspaceID)
 		require.Error(t, err)
@@ -138,7 +138,7 @@ func TestAdminWorkspaces_Read(t *testing.T) {
 		assert.Nil(t, adminWorkspace)
 	})
 
-	t.Run("it reads a worksapce successfully", func(t *testing.T) {
+	t.Run("it reads a workspace successfully", func(t *testing.T) {
 		org, orgCleanup := createOrganization(t, client)
 		defer orgCleanup()
 

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -69,7 +69,6 @@ func TestAgentPoolsList(t *testing.T) {
 	})
 
 	t.Run("with query options", func(t *testing.T) {
-
 		pools, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
 			Query: agentPool.Name,
 		})

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -252,13 +252,13 @@ func (s *configurationVersions) ReadWithOptions(ctx context.Context, cvID string
 // Upload packages and uploads Terraform configuration files. It requires the
 // upload URL from a configuration version and the path to the configuration
 // files on disk.
-func (s *configurationVersions) Upload(ctx context.Context, url string, path string) error {
+func (s *configurationVersions) Upload(ctx context.Context, uploadURL, path string) error {
 	body, err := packContents(path)
 	if err != nil {
 		return err
 	}
 
-	req, err := s.client.NewRequest("PUT", url, body)
+	req, err := s.client.NewRequest("PUT", uploadURL, body)
 	if err != nil {
 		return err
 	}

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -16,7 +16,9 @@ There are instances where several new resources being added (i.e Workspace Run T
 
 **Note HashiCorp Employees Only:** When submitting a new set of endpoints please ensure that one of your respective team members approves the changes as well before merging.
 
-## Running the Linters Locally
+## Linting
+
+Linting is not necessarily required for a change to be merged, but it helps smooth the review process and catch common mistakes early. If you'd like to run the linters manually, follow these steps:
 
 1. Ensure you have [installed golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
 2. From the CLI, run `make lint`

--- a/errors.go
+++ b/errors.go
@@ -313,7 +313,7 @@ var (
 
 	ErrRequiredFilename = errors.New("filename is required")
 
-	ErrInvalidAsciiArmor = errors.New("ascii armor is invalid")
+	ErrInvalidAsciiArmor = errors.New("ASCII Armor is invalid")
 
 	ErrRequiredNamespace = errors.New("namespace is required for public registry")
 

--- a/ip_ranges.go
+++ b/ip_ranges.go
@@ -47,7 +47,7 @@ func (i *ipRanges) Read(ctx context.Context, modifiedSince string) (*IPRange, er
 	}
 
 	ir := &IPRange{}
-	err = req.doIpRanges(ctx, ir)
+	err = req.doIPRanges(ctx, ir)
 	if err != nil {
 		return nil, err
 	}

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -326,7 +326,6 @@ func (o NotificationConfigurationCreateOptions) valid() error {
 	if *o.DestinationType == NotificationDestinationTypeGeneric ||
 		*o.DestinationType == NotificationDestinationTypeSlack ||
 		*o.DestinationType == NotificationDestinationTypeMicrosoftTeams {
-
 		if o.URL == nil {
 			return ErrRequiredURL
 		}

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -50,7 +50,7 @@ func TestOrganizationMembershipsList(t *testing.T) {
 		assert.Empty(t, ml.Items)
 		assert.Equal(t, 999, ml.CurrentPage)
 
-		// Three because the creator of the organizaiton is a member, in addition to the two we added to setup the test.
+		// Three because the creator of the organization is a member, in addition to the two we added to setup the test.
 		assert.Equal(t, 3, ml.TotalCount)
 	})
 

--- a/policy_evaluation_beta_test.go
+++ b/policy_evaluation_beta_test.go
@@ -57,7 +57,6 @@ func TestPolicyEvaluationList_Beta(t *testing.T) {
 	})
 
 	t.Run("with a invalid policy evaluation ID", func(t *testing.T) {
-
 		policyEvaluationeID := "invalid ID"
 
 		_, err := client.PolicyEvaluations.List(ctx, policyEvaluationeID, nil)
@@ -239,7 +238,6 @@ func TestPolicySetOutcomeRead_Beta(t *testing.T) {
 	})
 
 	t.Run("with a invalid policy set outcome ID", func(t *testing.T) {
-
 		policySetOutcomeID := "invalid ID"
 
 		_, err := client.PolicySetOutcomes.Read(ctx, policySetOutcomeID)

--- a/project.go
+++ b/project.go
@@ -27,7 +27,7 @@ type Projects interface {
 	// Update a project.
 	Update(ctx context.Context, projectID string, options ProjectUpdateOptions) (*Project, error)
 
-	//Delete a project.
+	// Delete a project.
 	Delete(ctx context.Context, projectID string) error
 }
 

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -1,12 +1,10 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )

--- a/registry_module.go
+++ b/registry_module.go
@@ -217,13 +217,13 @@ type RegistryModuleVCSRepoOptions struct {
 }
 
 // List all the registory modules within an organization.
-func (s *registryModules) List(ctx context.Context, organization string, options *RegistryModuleListOptions) (*RegistryModuleList, error) {
+func (r *registryModules) List(ctx context.Context, organization string, options *RegistryModuleListOptions) (*RegistryModuleList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
 	u := fmt.Sprintf("organizations/%s/registry-modules", url.QueryEscape(organization))
-	req, err := s.client.NewRequest("GET", u, options)
+	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
 	}
@@ -306,9 +306,9 @@ func (r *registryModules) Update(ctx context.Context, moduleID RegistryModuleID,
 	namespace := url.QueryEscape(moduleID.Namespace)
 	name := url.QueryEscape(moduleID.Name)
 	provider := url.QueryEscape(moduleID.Provider)
-	url := fmt.Sprintf("organizations/%s/registry-modules/%s/%s/%s/%s", org, registryName, namespace, name, provider)
+	registryModuleURL := fmt.Sprintf("organizations/%s/registry-modules/%s/%s/%s/%s", org, registryName, namespace, name, provider)
 
-	req, err := r.client.NewRequest(http.MethodPatch, url, &options)
+	req, err := r.client.NewRequest(http.MethodPatch, registryModuleURL, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -294,7 +294,6 @@ func TestRegistryModuleUpdate(t *testing.T) {
 		require.NoError(t, err)
 		assert.False(t, rm.NoCode)
 	})
-
 }
 
 func TestRegistryModulesCreateVersion(t *testing.T) {
@@ -441,7 +440,6 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 		assert.Nil(t, rmv)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
-
 }
 
 func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
@@ -547,7 +545,6 @@ func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 		assert.Nil(t, rm)
 		assert.Equal(t, err, ErrRequiredVCSRepo)
 	})
-
 }
 
 func TestRegistryModulesRead(t *testing.T) {

--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -161,7 +161,6 @@ func TestRegistryProvidersCreate(t *testing.T) {
 	defer orgTestCleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
-
 		publicProviderOptions := RegistryProviderCreateOptions{
 			Name:         "provider_name",
 			Namespace:    "public_namespace",

--- a/registry_provider_platform_integration_test.go
+++ b/registry_provider_platform_integration_test.go
@@ -66,9 +66,9 @@ func TestRegistryProviderPlatformsCreate(t *testing.T) {
 				Filename: "filename",
 			}
 
-			sad_rpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
+			sadRpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
 
-			assert.Nil(t, sad_rpp)
+			assert.Nil(t, sadRpp)
 			assert.EqualError(t, err, ErrRequiredOS.Error())
 		})
 
@@ -80,9 +80,9 @@ func TestRegistryProviderPlatformsCreate(t *testing.T) {
 				Filename: "filename",
 			}
 
-			sad_rpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
+			sadRpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
 
-			assert.Nil(t, sad_rpp)
+			assert.Nil(t, sadRpp)
 			assert.EqualError(t, err, ErrRequiredArch.Error())
 		})
 
@@ -94,9 +94,9 @@ func TestRegistryProviderPlatformsCreate(t *testing.T) {
 				Filename: "filename",
 			}
 
-			sad_rpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
+			sadRpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
 
-			assert.Nil(t, sad_rpp)
+			assert.Nil(t, sadRpp)
 			assert.EqualError(t, err, ErrRequiredShasum.Error())
 		})
 
@@ -108,9 +108,9 @@ func TestRegistryProviderPlatformsCreate(t *testing.T) {
 				Filename: "",
 			}
 
-			sad_rpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
+			sadRpp, err := client.RegistryProviderPlatforms.Create(ctx, versionID, options)
 
-			assert.Nil(t, sad_rpp)
+			assert.Nil(t, sadRpp)
 			assert.EqualError(t, err, ErrRequiredFilename.Error())
 		})
 
@@ -195,7 +195,7 @@ func TestRegistryProviderPlatformsDelete(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("with a non-existant version", func(t *testing.T) {
+	t.Run("with a non-existent version", func(t *testing.T) {
 		platformID := RegistryProviderPlatformID{
 			RegistryProviderVersionID: versionID,
 			OS:                        "nope",
@@ -262,7 +262,7 @@ func TestRegistryProviderPlatformsRead(t *testing.T) {
 		})
 	})
 
-	t.Run("with non-existant os", func(t *testing.T) {
+	t.Run("with non-existent os", func(t *testing.T) {
 		platformID := RegistryProviderPlatformID{
 			RegistryProviderVersionID: versionID,
 			OS:                        "DoesNotExist",
@@ -273,7 +273,7 @@ func TestRegistryProviderPlatformsRead(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("with non-existant arch", func(t *testing.T) {
+	t.Run("with non-existent arch", func(t *testing.T) {
 		platformID := RegistryProviderPlatformID{
 			RegistryProviderVersionID: versionID,
 			OS:                        platform.OS,

--- a/registry_provider_version_integration_test.go
+++ b/registry_provider_version_integration_test.go
@@ -11,19 +11,19 @@ import (
 
 func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 	version := "1.0.0"
-	validRegistryProviderId := RegistryProviderID{
+	validRegistryProviderID := RegistryProviderID{
 		OrganizationName: "orgName",
 		RegistryName:     PrivateRegistry,
 		Namespace:        "namespace",
 		Name:             "name",
 	}
-	invalidRegistryProviderId := RegistryProviderID{
+	invalidRegistryProviderID := RegistryProviderID{
 		OrganizationName: badIdentifier,
 		RegistryName:     PrivateRegistry,
 		Namespace:        "namespace",
 		Name:             "name",
 	}
-	publicRegistryProviderId := RegistryProviderID{
+	publicRegistryProviderID := RegistryProviderID{
 		OrganizationName: "orgName",
 		RegistryName:     PublicRegistry,
 		Namespace:        "namespace",
@@ -33,7 +33,7 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 	t.Run("valid", func(t *testing.T) {
 		id := RegistryProviderVersionID{
 			Version:            version,
-			RegistryProviderID: validRegistryProviderId,
+			RegistryProviderID: validRegistryProviderID,
 		}
 		require.NoError(t, id.valid())
 	})
@@ -41,7 +41,7 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 	t.Run("without a version", func(t *testing.T) {
 		id := RegistryProviderVersionID{
 			Version:            "",
-			RegistryProviderID: validRegistryProviderId,
+			RegistryProviderID: validRegistryProviderID,
 		}
 		assert.EqualError(t, id.valid(), ErrInvalidVersion.Error())
 	})
@@ -49,7 +49,7 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 	t.Run("without a key-id", func(t *testing.T) {
 		id := RegistryProviderVersionID{
 			Version:            "",
-			RegistryProviderID: validRegistryProviderId,
+			RegistryProviderID: validRegistryProviderID,
 		}
 		assert.EqualError(t, id.valid(), ErrInvalidVersion.Error())
 	})
@@ -58,7 +58,7 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 		t.Skip("This is skipped as we don't actually validate version is a valid semver - the registry does this validation")
 		id := RegistryProviderVersionID{
 			Version:            "foo",
-			RegistryProviderID: validRegistryProviderId,
+			RegistryProviderID: validRegistryProviderID,
 		}
 		assert.EqualError(t, id.valid(), ErrInvalidVersion.Error())
 	})
@@ -66,7 +66,7 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 	t.Run("invalid registry for parent provider", func(t *testing.T) {
 		id := RegistryProviderVersionID{
 			Version:            version,
-			RegistryProviderID: publicRegistryProviderId,
+			RegistryProviderID: publicRegistryProviderID,
 		}
 		assert.EqualError(t, id.valid(), ErrRequiredPrivateRegistry.Error())
 	})
@@ -76,7 +76,7 @@ func TestRegistryProviderVersionsIDValidation(t *testing.T) {
 		// it is assumed that validity of the registry provider id is delegated to its own valid method
 		id := RegistryProviderVersionID{
 			Version:            version,
-			RegistryProviderID: invalidRegistryProviderId,
+			RegistryProviderID: invalidRegistryProviderID,
 		}
 		assert.EqualError(t, id.valid(), ErrInvalidOrg.Error())
 	})
@@ -89,7 +89,7 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 	providerTest, providerTestCleanup := createRegistryProvider(t, client, nil, PrivateRegistry)
 	defer providerTestCleanup()
 
-	providerId := RegistryProviderID{
+	providerID := RegistryProviderID{
 		OrganizationName: providerTest.Organization.Name,
 		RegistryName:     providerTest.RegistryName,
 		Namespace:        providerTest.Namespace,
@@ -101,7 +101,7 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 			Version: "1.0.0",
 			KeyID:   "abcdefg",
 		}
-		prvv, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+		prvv, err := client.RegistryProviderVersions.Create(ctx, providerID, options)
 		require.NoError(t, err)
 		assert.NotEmpty(t, prvv.ID)
 		assert.Equal(t, options.Version, prvv.Version)
@@ -145,7 +145,7 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 				Version: "",
 				KeyID:   "abcdefg",
 			}
-			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerID, options)
 			assert.Nil(t, rm)
 			assert.EqualError(t, err, ErrInvalidVersion.Error())
 		})
@@ -155,7 +155,7 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 				Version: "1.0.0",
 				KeyID:   "",
 			}
-			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerID, options)
 			assert.Nil(t, rm)
 			assert.EqualError(t, err, ErrInvalidKeyID.Error())
 		})
@@ -165,13 +165,13 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 				Version: "1.0.0",
 				KeyID:   "abcdefg",
 			}
-			providerId := RegistryProviderID{
+			providerID := RegistryProviderID{
 				OrganizationName: providerTest.Organization.Name,
 				RegistryName:     PublicRegistry,
 				Namespace:        providerTest.Namespace,
 				Name:             providerTest.Name,
 			}
-			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerID, options)
 			assert.Nil(t, rm)
 			assert.EqualError(t, err, ErrRequiredPrivateRegistry.Error())
 		})
@@ -181,13 +181,13 @@ func TestRegistryProviderVersionsCreate(t *testing.T) {
 				Version: "1.0.0",
 				KeyID:   "abcdefg",
 			}
-			providerId := RegistryProviderID{
+			providerID := RegistryProviderID{
 				OrganizationName: badIdentifier,
 				RegistryName:     providerTest.RegistryName,
 				Namespace:        providerTest.Namespace,
 				Name:             providerTest.Name,
 			}
-			rm, err := client.RegistryProviderVersions.Create(ctx, providerId, options)
+			rm, err := client.RegistryProviderVersions.Create(ctx, providerID, options)
 			assert.Nil(t, rm)
 			assert.EqualError(t, err, ErrInvalidOrg.Error())
 		})
@@ -291,10 +291,6 @@ func TestRegistryProviderVersionsList(t *testing.T) {
 		assert.Empty(t, versions.Items)
 		assert.Equal(t, 0, versions.TotalCount)
 		assert.Equal(t, 0, versions.TotalPages)
-	})
-
-	// TODO
-	t.Run("with include provider platforms", func(t *testing.T) {
 	})
 }
 
@@ -400,5 +396,4 @@ func TestRegistryProviderVersionsRead(t *testing.T) {
 		_, err := client.RegistryProviderVersions.Read(ctx, versionID)
 		assert.Error(t, err)
 	})
-
 }

--- a/request.go
+++ b/request.go
@@ -64,9 +64,9 @@ func (r ClientRequest) Do(ctx context.Context, model interface{}) error {
 	return unmarshalResponse(resp.Body, model)
 }
 
-// doIpRanges is similar to Do except that The IP ranges API is not returning jsonapi
+// doIPRanges is similar to Do except that The IP ranges API is not returning jsonapi
 // like every other endpoint which means we need to handle it differently.
-func (r *ClientRequest) doIpRanges(ctx context.Context, ir *IPRange) error {
+func (r *ClientRequest) doIPRanges(ctx context.Context, ir *IPRange) error {
 	// Wait will block until the limiter can obtain a new token
 	// or returns an error if the given context is canceled.
 	if err := r.limiter.Wait(ctx); err != nil {

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -226,7 +226,8 @@ func TestRunTasksAttachToWorkspace(t *testing.T) {
 		wr, err := client.RunTasks.AttachToWorkspace(ctx, wkspaceTest.ID, runTaskTest.ID, Advisory)
 
 		defer func() {
-			client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+			err = client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+			require.NoError(t, err)
 		}()
 
 		require.NoError(t, err)

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -316,6 +316,7 @@ func TestStateVersionsRead(t *testing.T) {
 
 	t.Run("when the state version exists", func(t *testing.T) {
 		var sv *StateVersion
+		var ok bool
 		sv, err := client.StateVersions.Read(ctx, svTest.ID)
 		require.NoError(t, err)
 
@@ -335,7 +336,10 @@ func TestStateVersionsRead(t *testing.T) {
 				t.Fatalf("error retrying state version read, err=%s", err)
 			}
 
-			sv = svRetry.(*StateVersion)
+			sv, ok = svRetry.(*StateVersion)
+			if !ok {
+				t.Fatalf("Expected sv to be type *StateVersion, got %T", sv)
+			}
 		}
 
 		assert.NotEmpty(t, sv.DownloadURL)
@@ -528,5 +532,4 @@ func TestStateVersionOutputs(t *testing.T) {
 		assert.Nil(t, outputs)
 		assert.Error(t, err)
 	})
-
 }

--- a/task_stages_integration_beta_test.go
+++ b/task_stages_integration_beta_test.go
@@ -1,6 +1,3 @@
-//go:build integration
-// +build integration
-
 package tfe
 
 import (
@@ -106,7 +103,6 @@ func TestTaskStagesRead_Beta(t *testing.T) {
 			assert.NotEmpty(t, taskStage.PolicyEvaluations[0].UpdatedAt)
 			assert.NotNil(t, taskStage.PolicyEvaluations[0].ResultCount)
 		})
-
 	})
 }
 
@@ -258,7 +254,7 @@ func TestTaskStageOverride_Beta(t *testing.T) {
 		taskStageOverrideOptions := TaskStageOverrideOptions{
 			Comment: String("test comment"),
 		}
-		ts, err := client.TaskStages.Override(ctx, taskStageList.Items[0].ID, taskStageOverrideOptions)
+		_, err = client.TaskStages.Override(ctx, taskStageList.Items[0].ID, taskStageOverrideOptions)
 		require.NoError(t, err)
 	})
 

--- a/tfe.go
+++ b/tfe.go
@@ -40,7 +40,8 @@ const (
 	DefaultBasePath     = "/api/v2/"
 	DefaultRegistryPath = "/api/registry/"
 	// PingEndpoint is a no-op API endpoint used to configure the rate limiter
-	PingEndpoint = "ping"
+	PingEndpoint       = "ping"
+	ContentTypeJSONAPI = "application/vnd.api+json"
 )
 
 // RetryLogHook allows a function to run before each retry.
@@ -214,7 +215,7 @@ func (c *Client) NewRequestWithAdditionalQueryParams(method, path string, reqAtt
 	var body interface{}
 	switch method {
 	case "GET":
-		reqHeaders.Set("Accept", "application/vnd.api+json")
+		reqHeaders.Set("Accept", ContentTypeJSONAPI)
 
 		if reqAttr != nil {
 			q, err := query.Values(reqAttr)
@@ -227,8 +228,8 @@ func (c *Client) NewRequestWithAdditionalQueryParams(method, path string, reqAtt
 			u.RawQuery = encodeQueryParams(q)
 		}
 	case "DELETE", "PATCH", "POST":
-		reqHeaders.Set("Accept", "application/vnd.api+json")
-		reqHeaders.Set("Content-Type", "application/vnd.api+json")
+		reqHeaders.Set("Accept", ContentTypeJSONAPI)
+		reqHeaders.Set("Content-Type", ContentTypeJSONAPI)
 
 		if reqAttr != nil {
 			if body, err = serializeRequestBody(reqAttr); err != nil {
@@ -571,7 +572,7 @@ func (c *Client) getRawAPIMetadata() (rawAPIMetadata, error) {
 	for k, v := range c.headers {
 		req.Header[k] = v
 	}
-	req.Header.Set("Accept", "application/vnd.api+json")
+	req.Header.Set("Accept", ContentTypeJSONAPI)
 	req.Header.Set("Authorization", "Bearer "+c.token)
 
 	// Make a single request to retrieve the rate limit headers.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -166,14 +166,15 @@ func TestWorkspacesList(t *testing.T) {
 
 		foundWTest1 := false
 		for _, ws := range wl.Items {
-			if ws.ID == wTest1.ID {
-				foundWTest1 = true
-				require.NotNil(t, wl.Items[0].CurrentStateVersion)
-				assert.NotEmpty(t, wl.Items[0].CurrentStateVersion.DownloadURL)
-
-				require.NotNil(t, wl.Items[0].CurrentRun)
-				assert.NotEmpty(t, wl.Items[0].CurrentRun.Message)
+			if ws.ID != wTest1.ID {
+				continue
 			}
+			foundWTest1 = true
+			require.NotNil(t, wl.Items[0].CurrentStateVersion)
+			assert.NotEmpty(t, wl.Items[0].CurrentStateVersion.DownloadURL)
+
+			require.NotNil(t, wl.Items[0].CurrentRun)
+			assert.NotEmpty(t, wl.Items[0].CurrentRun.Message)
 		}
 
 		assert.True(t, foundWTest1)
@@ -1827,7 +1828,6 @@ func TestWorkspaces_UpdateRemoteStateConsumers(t *testing.T) {
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(rsc.Items))
 		assert.Contains(t, rsc.Items, wTestConsumer2)
-
 	})
 
 	t.Run("with invalid options", func(t *testing.T) {
@@ -2080,7 +2080,8 @@ func TestWorkspace_Unmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	iso8601TimeFormat := "2006-01-02T15:04:05Z"
-	parsedTime, _ := time.Parse(iso8601TimeFormat, "2020-07-15T23:38:43.821Z")
+	parsedTime, err := time.Parse(iso8601TimeFormat, "2020-07-15T23:38:43.821Z")
+	assert.NoError(t, err)
 
 	assert.Equal(t, ws.ID, "ws-1234")
 	assert.Equal(t, ws.Name, "my-workspace")
@@ -2181,5 +2182,4 @@ func TestWorkspacesProjects(t *testing.T) {
 			assert.NotNil(t, item.Project.ID, "No project ID set on workspace %s at idx %d", item.ID, idx)
 		}
 	})
-
 }

--- a/workspace_run_task_integration_test.go
+++ b/workspace_run_task_integration_test.go
@@ -31,7 +31,8 @@ func TestWorkspaceRunTasksCreate(t *testing.T) {
 
 		require.NoError(t, err)
 		defer func() {
-			client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+			err = client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+			require.NoError(t, err)
 		}()
 
 		assert.NotEmpty(t, wr.ID)
@@ -70,7 +71,8 @@ func TestWorkspaceRunTasksCreateBeta(t *testing.T) {
 
 		require.NoError(t, err)
 		defer func() {
-			client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+			err = client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
+			require.NoError(t, err)
 		}()
 
 		assert.NotEmpty(t, wr.ID)


### PR DESCRIPTION
...As reported by "make lint"

Also fixed incorrect build tag in two tests that were causing the tests to be skipped, which linting should have caught (!!!)

Thanks to @estenssoros for the efforts to improve the code!

Co-Authored-By: Sebastian Estenssoro <seb.estenssoro@gmail.com>
