### PR TITLE
Add `List()` to GPG Keys, `ProviderBinaryUploaded` to registry platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Enhancements
 * Adds `List()` method to `GPGKeys` interface by @sebasslash [#]()
+* Adds `ProviderBinaryUploaded` field to `RegistryPlatforms` struct by @sebasslash [#]()
 
 # v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## Bug Fixes
 
 ## Enhancements
-* Adds `List()` method to `GPGKeys` interface by @sebasslash [#]()
-* Adds `ProviderBinaryUploaded` field to `RegistryPlatforms` struct by @sebasslash [#]()
+* Adds `List()` method to `GPGKeys` interface by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
+* Adds `ProviderBinaryUploaded` field to `RegistryPlatforms` struct by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
 
 # v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Bug Fixes
 
 ## Enhancements
+* Adds `List()` method to `GPGKeys` interface by @sebasslash [#]()
 
 # v1.15.0
 

--- a/mocks/gpg_key_mocks.go
+++ b/mocks/gpg_key_mocks.go
@@ -64,6 +64,21 @@ func (mr *MockGPGKeysMockRecorder) Delete(ctx, keyID interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockGPGKeys)(nil).Delete), ctx, keyID)
 }
 
+// ListPrivate mocks base method.
+func (m *MockGPGKeys) ListPrivate(ctx context.Context, options tfe.GPGKeyListOptions) (*tfe.GPGKeyList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListPrivate", ctx, options)
+	ret0, _ := ret[0].(*tfe.GPGKeyList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListPrivate indicates an expected call of ListPrivate.
+func (mr *MockGPGKeysMockRecorder) ListPrivate(ctx, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPrivate", reflect.TypeOf((*MockGPGKeys)(nil).ListPrivate), ctx, options)
+}
+
 // Read mocks base method.
 func (m *MockGPGKeys) Read(ctx context.Context, keyID tfe.GPGKeyID) (*tfe.GPGKey, error) {
 	m.ctrl.T.Helper()

--- a/registry_provider_platform.go
+++ b/registry_provider_platform.go
@@ -33,11 +33,12 @@ type registryProviderPlatforms struct {
 
 // RegistryProviderPlatform represents a registry provider platform
 type RegistryProviderPlatform struct {
-	ID       string `jsonapi:"primary,registry-provider-platforms"`
-	OS       string `jsonapi:"attr,os"`
-	Arch     string `jsonapi:"attr,arch"`
-	Filename string `jsonapi:"attr,filename"`
-	Shasum   string `jsonapi:"attr,shasum"`
+	ID                     string `jsonapi:"primary,registry-provider-platforms"`
+	OS                     string `jsonapi:"attr,os"`
+	Arch                   string `jsonapi:"attr,arch"`
+	Filename               string `jsonapi:"attr,filename"`
+	Shasum                 string `jsonapi:"attr,shasum"`
+	ProviderBinaryUploaded bool   `jsonapi:"attr,provider-binary-uploaded"`
 
 	// Relations
 	RegistryProviderVersion *RegistryProviderVersion `jsonapi:"relation,registry-provider-version"`

--- a/registry_provider_platform_integration_test.go
+++ b/registry_provider_platform_integration_test.go
@@ -43,6 +43,7 @@ func TestRegistryProviderPlatformsCreate(t *testing.T) {
 		assert.Equal(t, options.Arch, rpp.Arch)
 		assert.Equal(t, options.Shasum, rpp.Shasum)
 		assert.Equal(t, options.Filename, rpp.Filename)
+		assert.False(t, rpp.ProviderBinaryUploaded)
 
 		t.Run("relationships are properly decoded", func(t *testing.T) {
 			assert.Equal(t, version.ID, rpp.RegistryProviderVersion.ID)
@@ -245,6 +246,7 @@ func TestRegistryProviderPlatformsRead(t *testing.T) {
 		assert.Equal(t, platformID.Arch, readPlatform.Arch)
 		assert.Equal(t, platform.Filename, readPlatform.Filename)
 		assert.Equal(t, platform.Shasum, readPlatform.Shasum)
+		assert.Equal(t, platform.ProviderBinaryUploaded, readPlatform.ProviderBinaryUploaded)
 
 		t.Run("relationships are properly decoded", func(t *testing.T) {
 			assert.Equal(t, platform.RegistryProviderVersion.ID, readPlatform.RegistryProviderVersion.ID)


### PR DESCRIPTION
## Description

These are two feature requests submitted by @straubt1 (thank you!):
* Add support for listing GPG keys (#471)
* Add `provider-binary-upload` field to response (#470)

Effectively, this PR adds `List()` to the `GPGKeys` interface and `ProviderBinaryUploaded` field to `RegistryPlatform` struct. 

**Note:** There does seem to be an issue in our tests with requesting GPG keys for multiple namespaces. The docs specify a [comma separated list](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/gpg-keys#query-parameters) -- which go-tfe will [automagically encode](https://github.com/hashicorp/go-tfe/blob/6c8979908ba9431a84e85c3cffca7093c1a3a842/tfe.go#L632-L636) any `[]string` to a comma-separated string if the param starts with `filter[`. I have skipped the test for now. 

## Testing plan

```sh
go test -v ./... -run TestGPGKeysList
go test -v ./... -run TestRegistryProviderPlatformsList
go test -v ./... -run TestRegistryProviderPlatformsRead
```
