### PR TITLE
Add ReadWorkspaces and ReadProjects to Orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 ## Enhancements
 * Adds `List()` method to `GPGKeys` interface by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
 * Adds `ProviderBinaryUploaded` field to `RegistryPlatforms` struct by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
+* Adds `ReadWorkspaces` and `ReadProjects` APIs to `Organizations` by @JuliannaTetreault [#]()
 
 # v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 ## Enhancements
 * Adds `List()` method to `GPGKeys` interface by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
 * Adds `ProviderBinaryUploaded` field to `RegistryPlatforms` struct by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
-* Adds `ReadWorkspaces` and `ReadProjects` APIs to `Organizations` by @JuliannaTetreault [#]()
+* Adds `ReadWorkspaces` and `ReadProjects` permissions to `Organizations` by @JuliannaTetreault [#614](https://github.com/hashicorp/go-tfe/pull/614)
 
 # v1.15.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 * Adds `BaseURL` and `BaseRegistryURL` methods to `Client` to expose its configuration by @brandonc [#638](https://github.com/hashicorp/go-tfe/pull/638)
+* Adds `ReadWorkspaces` and `ReadProjects` permissions to `Organizations` by @JuliannaTetreault [#614](https://github.com/hashicorp/go-tfe/pull/614)
 
 ## Bug Fixes
 
@@ -24,7 +25,6 @@
 ## Enhancements
 * Adds `List()` method to `GPGKeys` interface by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
 * Adds `ProviderBinaryUploaded` field to `RegistryPlatforms` struct by @sebasslash [#602](https://github.com/hashicorp/go-tfe/pull/602)
-* Adds `ReadWorkspaces` and `ReadProjects` permissions to `Organizations` by @JuliannaTetreault [#614](https://github.com/hashicorp/go-tfe/pull/614)
 
 # v1.15.0
 

--- a/team.go
+++ b/team.go
@@ -69,9 +69,9 @@ type OrganizationAccess struct {
 	ManageModules         bool `jsonapi:"attr,manage-modules"`
 	ManageRunTasks        bool `jsonapi:"attr,manage-run-tasks"`
 	// **Note: This field is still in BETA and subject to change.**
-	ManageProjects        bool `jsonapi:"attr,manage-projects"`
-	ReadWorkspaces        bool `jsonapi:"attr,read-workspaces"`
-	ReadProjects          bool `jsonapi:"attr,read-projects"`
+	ManageProjects bool `jsonapi:"attr,manage-projects"`
+	ReadWorkspaces bool `jsonapi:"attr,read-workspaces"`
+	ReadProjects   bool `jsonapi:"attr,read-projects"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -152,9 +152,9 @@ type OrganizationAccessOptions struct {
 	ManageModules         *bool `json:"manage-modules,omitempty"`
 	ManageRunTasks        *bool `json:"manage-run-tasks,omitempty"`
 	// **Note: This field is still in BETA and subject to change.**
-	ManageProjects        *bool `json:"manage-projects,omitempty"`
-	ReadWorkspaces        *bool `json:"read-workspaces,omitempty"`
-	ReadProjects          *bool `json:"read-projects,omitempty"`
+	ManageProjects *bool `json:"manage-projects,omitempty"`
+	ReadWorkspaces *bool `json:"read-workspaces,omitempty"`
+	ReadProjects   *bool `json:"read-projects,omitempty"`
 }
 
 // List all the teams of the given organization.

--- a/team.go
+++ b/team.go
@@ -70,6 +70,8 @@ type OrganizationAccess struct {
 	ManageRunTasks        bool `jsonapi:"attr,manage-run-tasks"`
 	// **Note: This field is still in BETA and subject to change.**
 	ManageProjects bool `jsonapi:"attr,manage-projects"`
+	ReadWorkspaces        bool `jsonapi:"attr,read-workspaces"`
+	ReadProjects          bool `jsonapi:"attr,read-projects"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -149,8 +151,13 @@ type OrganizationAccessOptions struct {
 	ManageProviders       *bool `json:"manage-providers,omitempty"`
 	ManageModules         *bool `json:"manage-modules,omitempty"`
 	ManageRunTasks        *bool `json:"manage-run-tasks,omitempty"`
+<<<<<<< HEAD
 	// **Note: This field is still in BETA and subject to change.**
 	ManageProjects *bool `json:"manage-projects,omitempty"`
+=======
+	ReadWorkspaces        *bool `jsonapi:"read-workspaces,omitempty"`
+	ReadProjects          *bool `jsonapi:"read-projects,omitempty"`
+>>>>>>> 816d125 (Add ReadWorkspaces and ReadProjects to Orgs)
 }
 
 // List all the teams of the given organization.

--- a/team.go
+++ b/team.go
@@ -151,13 +151,10 @@ type OrganizationAccessOptions struct {
 	ManageProviders       *bool `json:"manage-providers,omitempty"`
 	ManageModules         *bool `json:"manage-modules,omitempty"`
 	ManageRunTasks        *bool `json:"manage-run-tasks,omitempty"`
-<<<<<<< HEAD
 	// **Note: This field is still in BETA and subject to change.**
-	ManageProjects *bool `json:"manage-projects,omitempty"`
-=======
-	ReadWorkspaces        *bool `jsonapi:"read-workspaces,omitempty"`
-	ReadProjects          *bool `jsonapi:"read-projects,omitempty"`
->>>>>>> 816d125 (Add ReadWorkspaces and ReadProjects to Orgs)
+	ManageProjects        *bool `json:"manage-projects,omitempty"`
+	ReadWorkspaces        *bool `json:"read-workspaces,omitempty"`
+	ReadProjects          *bool `json:"read-projects,omitempty"`
 }
 
 // List all the teams of the given organization.

--- a/team.go
+++ b/team.go
@@ -69,7 +69,7 @@ type OrganizationAccess struct {
 	ManageModules         bool `jsonapi:"attr,manage-modules"`
 	ManageRunTasks        bool `jsonapi:"attr,manage-run-tasks"`
 	// **Note: This field is still in BETA and subject to change.**
-	ManageProjects bool `jsonapi:"attr,manage-projects"`
+	ManageProjects        bool `jsonapi:"attr,manage-projects"`
 	ReadWorkspaces        bool `jsonapi:"attr,read-workspaces"`
 	ReadProjects          bool `jsonapi:"attr,read-projects"`
 }

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -318,6 +318,8 @@ func TestTeam_Unmarshal(t *testing.T) {
 					"manage-workspaces":   true,
 					"manage-vcs-settings": true,
 					"manage-projects":     true,
+					"read-workspaces":     true,
+					"read-projects":       true,
 				},
 				"permissions": map[string]interface{}{
 					"can-destroy":           true,
@@ -340,7 +342,12 @@ func TestTeam_Unmarshal(t *testing.T) {
 	assert.Equal(t, team.OrganizationAccess.ManageWorkspaces, true)
 	assert.Equal(t, team.OrganizationAccess.ManageVCSSettings, true)
 	assert.Equal(t, team.OrganizationAccess.ManagePolicies, true)
+<<<<<<< HEAD
 	assert.Equal(t, team.OrganizationAccess.ManageProjects, true)
+=======
+	assert.Equal(t, team.OrganizationAccess.ReadWorkspaces, true)
+	assert.Equal(t, team.OrganizationAccess.ReadProjects, true)
+>>>>>>> 816d125 (Add ReadWorkspaces and ReadProjects to Orgs)
 	assert.Equal(t, team.Permissions.CanDestroy, true)
 	assert.Equal(t, team.Permissions.CanUpdateMembership, true)
 }

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -342,12 +342,9 @@ func TestTeam_Unmarshal(t *testing.T) {
 	assert.Equal(t, team.OrganizationAccess.ManageWorkspaces, true)
 	assert.Equal(t, team.OrganizationAccess.ManageVCSSettings, true)
 	assert.Equal(t, team.OrganizationAccess.ManagePolicies, true)
-<<<<<<< HEAD
 	assert.Equal(t, team.OrganizationAccess.ManageProjects, true)
-=======
 	assert.Equal(t, team.OrganizationAccess.ReadWorkspaces, true)
 	assert.Equal(t, team.OrganizationAccess.ReadProjects, true)
->>>>>>> 816d125 (Add ReadWorkspaces and ReadProjects to Orgs)
 	assert.Equal(t, team.Permissions.CanDestroy, true)
 	assert.Equal(t, team.Permissions.CanUpdateMembership, true)
 }


### PR DESCRIPTION
## Description
Adds `ReadWorkspaces` and `ReadProjects` permissions to Organizations in `team.go` and updates the accompanying test, `team_integration_test.go`. These are all part of a larger change which gives read access at an organization level.

This change is in draft as we complete the feature and prepare for its release.

## Testing plan
1.  Verify that you can set the properties by using `go-tfe` within the TFE provider (caveat: this isn't doable yet!)
2. Verify that all tests still pass.

## External links
- [RFC](https://go.hashi.co/rfc/tf-596)
- [Jira](https://hashicorp.atlassian.net/browse/TF-1440)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.
```
=== RUN   TestTeam_Unmarshal
--- PASS: TestTeam_Unmarshal (0.00s)
PASS

Process finished with the exit code 0

=== RUN   TestTeamCreateOptions_Marshal
--- PASS: TestTeamCreateOptions_Marshal (0.00s)
PASS

Process finished with the exit code 0
```
