### PR TITLE
Add comments to state_version.go about fields that get populated async

### DIFF
--- a/state_version.go
+++ b/state_version.go
@@ -38,7 +38,9 @@ type StateVersions interface {
 	// Download retrieves the actual stored state of a state version
 	Download(ctx context.Context, url string) ([]byte, error)
 
-	// ListOutputs retrieves all the outputs of a state version by its ID.
+	// ListOutputs retrieves all the outputs of a state version by its ID. IMPORTANT: Terraform Cloud might
+	// process outputs asynchronously. When consuming outputs or other async StateVersion fields, be sure to
+	// wait for ResourcesProcessed to become `true` before assuming they are empty.
 	ListOutputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
 }
 
@@ -55,18 +57,25 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID                 string                   `jsonapi:"primary,state-versions"`
-	CreatedAt          time.Time                `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL        string                   `jsonapi:"attr,hosted-state-download-url"`
-	Serial             int64                    `jsonapi:"attr,serial"`
-	VCSCommitSHA       string                   `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL       string                   `jsonapi:"attr,vcs-commit-url"`
-	ResourcesProcessed bool                     `jsonapi:"attr,resources-processed"`
-	StateVersion       int                      `jsonapi:"attr,state-version"`
-	TerraformVersion   string                   `jsonapi:"attr,terraform-version"`
-	Modules            *StateVersionModules     `jsonapi:"attr,modules"`
-	Providers          *StateVersionProviders   `jsonapi:"attr,providers"`
-	Resources          []*StateVersionResources `jsonapi:"attr,resources"`
+	ID           string    `jsonapi:"primary,state-versions"`
+	CreatedAt    time.Time `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL  string    `jsonapi:"attr,hosted-state-download-url"`
+	Serial       int64     `jsonapi:"attr,serial"`
+	VCSCommitSHA string    `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL string    `jsonapi:"attr,vcs-commit-url"`
+	// Whether Terraform Cloud has finished populating any StateVersion fields that required async processing.
+	// If `false`, some fields may appear empty even if they should actually contain data; see comments on
+	// individual fields for details.
+	ResourcesProcessed bool `jsonapi:"attr,resources-processed"`
+	StateVersion       int  `jsonapi:"attr,state-version"`
+	// Populated asynchronously.
+	TerraformVersion string `jsonapi:"attr,terraform-version"`
+	// Populated asynchronously.
+	Modules *StateVersionModules `jsonapi:"attr,modules"`
+	// Populated asynchronously.
+	Providers *StateVersionProviders `jsonapi:"attr,providers"`
+	// Populated asynchronously.
+	Resources []*StateVersionResources `jsonapi:"attr,resources"`
 
 	// Relations
 	Run     *Run                  `jsonapi:"relation,run"`
@@ -306,7 +315,9 @@ func (s *stateVersions) Download(ctx context.Context, u string) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
-// ListOutputs retrieves all the outputs of a state version by its ID.
+// ListOutputs retrieves all the outputs of a state version by its ID. IMPORTANT: Terraform Cloud might
+// process outputs asynchronously. When consuming outputs or other async StateVersion fields, be sure to
+// wait for ResourcesProcessed to become `true` before assuming they are empty.
 func (s *stateVersions) ListOutputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {
 	if !validStringID(&svID) {
 		return nil, ErrInvalidStateVerID


### PR DESCRIPTION
## Description

This is a common pitfall when consuming stuff in state versions that needs to be pulled out of the actual raw state data, and even our own tests have run afoul of it! So let's document it nice and clearly.

## Testing plan / tests output

- Comments-only PR.
