### PR TITLE
Add `UploadTarGzip` methods to `RegistryModule` and `ConfigurationVersion` interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
 # Unreleased
 
-## Bug Fixes
-
 ## Enhancements
 * Add Beta endpoint `TeamProjectAccesses` to manage Project Access for Teams by @hs26gill [#599](https://github.com/hashicorp/go-tfe/pull/599)
 * Updates api doc links from terraform.io to developer.hashicorp domain by @uk1288 [#629](https://github.com/hashicorp/go-tfe/pull/629)
+* Adds `UploadTarGzip()` method to `RegistryModules` and `ConfigurationVersions` interface by @sebasslash [#623](https://github.com/hashicorp/go-tfe/pull/623)
 
 # v1.16.0
 

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"os"
 	"testing"
 	"time"
 
@@ -222,6 +223,42 @@ func TestConfigurationVersionsUpload(t *testing.T) {
 			"nonexisting",
 		)
 		assert.Error(t, err)
+	})
+}
+
+func TestConfigurationVersionsUploadTarGzip(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	cv, cvCleanup := createConfigurationVersion(t, client, nil)
+	t.Cleanup(cvCleanup)
+
+	t.Run("with custom go-slug", func(t *testing.T) {
+		packer, err := slug.NewPacker(
+			slug.DereferenceSymlinks(),
+			slug.ApplyTerraformIgnore(),
+			slug.AllowSymlinkTarget("/target/symlink/path/foo"),
+		)
+		require.NoError(t, err)
+
+		body := bytes.NewBuffer(nil)
+		_, err = packer.Pack("test-fixtures/config-version", body)
+		require.NoError(t, err)
+
+		err = client.ConfigurationVersions.UploadTarGzip(ctx, cv.UploadURL, body)
+		require.NoError(t, err)
+	})
+
+	t.Run("with custom tar archive", func(t *testing.T) {
+		archivePath := "test-fixtures/config-archive.tar.gz"
+		createTarGzipArchive(t, []string{"test-fixtures/config-version/main.tf"}, archivePath)
+
+		archive, err := os.Open(archivePath)
+		require.NoError(t, err)
+		defer archive.Close()
+
+		err = client.ConfigurationVersions.UploadTarGzip(ctx, cv.UploadURL, archive)
+		require.NoError(t, err)
 	})
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -8,9 +8,75 @@ import (
 	slug "github.com/hashicorp/go-slug"
 )
 
+func ExampleOrganizations() {
+	config := &Config{
+		Token:             "insert-your-token-here",
+		RetryServerErrors: true,
+	}
+
+	client, err := NewClient(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a context
+	ctx := context.Background()
+
+	// Create a new organization
+	options := OrganizationCreateOptions{
+		Name:  String("example"),
+		Email: String("info@example.com"),
+	}
+
+	org, err := client.Organizations.Create(ctx, options)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Delete an organization
+	err = client.Organizations.Delete(ctx, org.Name)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleWorkspaces() {
+	config := &Config{
+		Token:             "insert-your-token-here",
+		RetryServerErrors: true,
+	}
+
+	client, err := NewClient(config)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a context
+	ctx := context.Background()
+
+	// Create a new workspace
+	w, err := client.Workspaces.Create(ctx, "org-name", WorkspaceCreateOptions{
+		Name: String("my-app-tst"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Update the workspace
+	w, err = client.Workspaces.Update(ctx, "org-name", w.Name, WorkspaceUpdateOptions{
+		AutoApply:        Bool(false),
+		TerraformVersion: String("0.11.1"),
+		WorkingDirectory: String("my-app/infra"),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
 func ExampleConfigurationVersions_UploadTarGzip() {
 	ctx := context.Background()
 	client, err := NewClient(&Config{
+		Token:             "insert-your-token-here",
 		RetryServerErrors: true,
 	})
 	if err != nil {
@@ -51,6 +117,7 @@ func ExampleConfigurationVersions_UploadTarGzip() {
 func ExampleRegistryModules_UploadTarGzip() {
 	ctx := context.Background()
 	client, err := NewClient(&Config{
+		Token:             "insert-your-token-here",
 		RetryServerErrors: true,
 	})
 	if err != nil {

--- a/example_test.go
+++ b/example_test.go
@@ -1,0 +1,109 @@
+package tfe
+
+import (
+	"bytes"
+	"context"
+	"log"
+
+	slug "github.com/hashicorp/go-slug"
+)
+
+func ExampleConfigurationVersions_UploadTarGzip() {
+	ctx := context.Background()
+	client, err := NewClient(&Config{
+		RetryServerErrors: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	packer, err := slug.NewPacker(
+		slug.DereferenceSymlinks(),            // dereferences symlinks
+		slug.ApplyTerraformIgnore(),           // ignores paths specified in .terraformignore
+		slug.AllowSymlinkTarget("/some/path"), // allow certain symlink target paths
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rawConfig := bytes.NewBuffer(nil)
+	// Pass in a path
+	_, err = packer.Pack("test-fixtures/config", rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a configuration version
+	cv, err := client.ConfigurationVersions.Create(ctx, "ws-12345678", ConfigurationVersionCreateOptions{
+		AutoQueueRuns: Bool(false),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Upload the buffer
+	err = client.ConfigurationVersions.UploadTarGzip(ctx, cv.UploadURL, rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+}
+
+func ExampleRegistryModules_UploadTarGzip() {
+	ctx := context.Background()
+	client, err := NewClient(&Config{
+		RetryServerErrors: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	packer, err := slug.NewPacker(
+		slug.DereferenceSymlinks(),            // dereferences symlinks
+		slug.ApplyTerraformIgnore(),           // ignores paths specified in .terraformignore
+		slug.AllowSymlinkTarget("/some/path"), // allow certain symlink target paths
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rawConfig := bytes.NewBuffer(nil)
+	// Pass in a path
+	_, err = packer.Pack("test-fixtures/config", rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a registry module
+	rm, err := client.RegistryModules.Create(ctx, "hashicorp", RegistryModuleCreateOptions{
+		Name:         String("my-module"),
+		Provider:     String("provider"),
+		RegistryName: PrivateRegistry,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	opts := RegistryModuleCreateVersionOptions{
+		Version: String("1.1.0"),
+	}
+
+	// Create a registry module version
+	rmv, err := client.RegistryModules.CreateVersion(ctx, RegistryModuleID{
+		Organization: "hashicorp",
+		Name:         rm.Name,
+		Provider:     rm.Provider,
+	}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	uploadURL, ok := rmv.Links["upload"].(string)
+	if !ok {
+		log.Fatal("upload url must be a valid string")
+	}
+	// Upload the buffer
+	err = client.RegistryModules.UploadTarGzip(ctx, uploadURL, rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/configuration_versions/main.go
+++ b/examples/configuration_versions/main.go
@@ -1,0 +1,50 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-slug"
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := tfe.NewClient(&tfe.Config{
+		RetryServerErrors: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	packer, err := slug.NewPacker(
+		slug.DereferenceSymlinks(),            // dereferences symlinks
+		slug.ApplyTerraformIgnore(),           // ignores paths specified in .terraformignore
+		slug.AllowSymlinkTarget("/some/path"), // allow certain symlink target paths
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rawConfig := bytes.NewBuffer(nil)
+	// Pass in a path
+	_, err = packer.Pack("test-fixtures/config", rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a configuration version
+	cv, err := client.ConfigurationVersions.Create(ctx, "ws-12345678", tfe.ConfigurationVersionCreateOptions{
+		AutoQueueRuns: tfe.Bool(false),
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Upload the configuration
+	err = client.ConfigurationVersions.UploadTarGzip(ctx, cv.UploadURL, rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/organizations/main.go
+++ b/examples/organizations/main.go
@@ -9,7 +9,8 @@ import (
 
 func main() {
 	config := &tfe.Config{
-		Token: "insert-your-token-here",
+		Token:             "insert-your-token-here",
+		RetryServerErrors: true,
 	}
 
 	client, err := tfe.NewClient(config)

--- a/examples/registry_modules/main.go
+++ b/examples/registry_modules/main.go
@@ -1,0 +1,70 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"log"
+
+	"github.com/hashicorp/go-slug"
+	tfe "github.com/hashicorp/go-tfe"
+)
+
+func main() {
+	ctx := context.Background()
+	client, err := tfe.NewClient(&tfe.Config{
+		RetryServerErrors: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	packer, err := slug.NewPacker(
+		slug.DereferenceSymlinks(),            // dereferences symlinks
+		slug.ApplyTerraformIgnore(),           // ignores paths specified in .terraformignore
+		slug.AllowSymlinkTarget("/some/path"), // allow certain symlink target paths
+	)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	rawConfig := bytes.NewBuffer(nil)
+	// Pass in the configuration path
+	_, err = packer.Pack("test-fixtures/config", rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	// Create a registry module
+	rm, err := client.RegistryModules.Create(ctx, "hashicorp", tfe.RegistryModuleCreateOptions{
+		Name:         tfe.String("my-module"),
+		Provider:     tfe.String("provider"),
+		RegistryName: tfe.PrivateRegistry,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	opts := tfe.RegistryModuleCreateVersionOptions{
+		Version: tfe.String("1.1.0"),
+	}
+
+	// Create a registry module version
+	rmv, err := client.RegistryModules.CreateVersion(ctx, tfe.RegistryModuleID{
+		Organization: "hashicorp",
+		Name:         rm.Name,
+		Provider:     rm.Provider,
+	}, opts)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	uploadURL, ok := rmv.Links["upload"].(string)
+	if !ok {
+		log.Fatal("upload url must be a valid string")
+	}
+	// Upload the buffer
+	err = client.RegistryModules.UploadTarGzip(ctx, uploadURL, rawConfig)
+	if err != nil {
+		log.Fatal(err)
+	}
+}

--- a/examples/workspaces/main.go
+++ b/examples/workspaces/main.go
@@ -9,7 +9,8 @@ import (
 
 func main() {
 	config := &tfe.Config{
-		Token: "insert-your-token-here",
+		Token:             "insert-your-token-here",
+		RetryServerErrors: true,
 	}
 
 	client, err := tfe.NewClient(config)

--- a/mocks/configuration_version_mocks.go
+++ b/mocks/configuration_version_mocks.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -136,4 +137,18 @@ func (m *MockConfigurationVersions) Upload(ctx context.Context, url, path string
 func (mr *MockConfigurationVersionsMockRecorder) Upload(ctx, url, path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockConfigurationVersions)(nil).Upload), ctx, url, path)
+}
+
+// UploadTarGzip mocks base method.
+func (m *MockConfigurationVersions) UploadTarGzip(ctx context.Context, url string, archive io.Reader) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadTarGzip", ctx, url, archive)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadTarGzip indicates an expected call of UploadTarGzip.
+func (mr *MockConfigurationVersionsMockRecorder) UploadTarGzip(ctx, url, archive interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadTarGzip", reflect.TypeOf((*MockConfigurationVersions)(nil).UploadTarGzip), ctx, url, archive)
 }

--- a/mocks/registry_module_mocks.go
+++ b/mocks/registry_module_mocks.go
@@ -6,6 +6,7 @@ package mocks
 
 import (
 	context "context"
+	io "io"
 	reflect "reflect"
 
 	gomock "github.com/golang/mock/gomock"
@@ -179,4 +180,18 @@ func (m *MockRegistryModules) Upload(ctx context.Context, rmv tfe.RegistryModule
 func (mr *MockRegistryModulesMockRecorder) Upload(ctx, rmv, path interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Upload", reflect.TypeOf((*MockRegistryModules)(nil).Upload), ctx, rmv, path)
+}
+
+// UploadTarGzip mocks base method.
+func (m *MockRegistryModules) UploadTarGzip(ctx context.Context, url string, r io.Reader) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UploadTarGzip", ctx, url, r)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UploadTarGzip indicates an expected call of UploadTarGzip.
+func (mr *MockRegistryModulesMockRecorder) UploadTarGzip(ctx, url, r interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UploadTarGzip", reflect.TypeOf((*MockRegistryModules)(nil).UploadTarGzip), ctx, url, r)
 }


### PR DESCRIPTION
## Description

The goal here is to add a simple interface for users who wish to upload their configurations using something other than the default method (using go-slug with default settings). There are particular use cases that either require a custom go-slug object to pack a Terraform config directory or to use something else entirely. One known issue with go-slug revolves around double symlinks as reported here:
- #604 
- [(go-slug) Pack fails to handle multiple levels of symlinks #32](https://github.com/hashicorp/go-slug/issues/32)
- [(terraform) archive/tar: write too long error when files are symlinked at least twice](https://github.com/hashicorp/terraform/issues/31895)

I have been unable to reproduce this issue, but I'm wondering if go-slug's `AllowSymlinkTarget()` configuration option may be a solution here ([It was introduced v0.10](https://github.com/hashicorp/go-slug/pull/29)). 

I have added `UploadRaw()` to the `RegistryModules` and `ConfigurationVersions` interface. Anything that implements `io.Writer` can be passed to `UploadRaw()`. 
 
## Testing plan

```sh
go test -v ./... -run TestConfigurationVersionsUploadRaw
go test -v ./... -run TestRegistryModulesUploadRaw
```

Check out the examples in `example_test.go`

