### PR TITLE
Add manage-projects field to teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Add Beta endpoint `TeamProjectAccesses` to manage Project Access for Teams by @hs26gill [#599](https://github.com/hashicorp/go-tfe/pull/599)
 * Updates api doc links from terraform.io to developer.hashicorp domain by @uk1288 [#629](https://github.com/hashicorp/go-tfe/pull/629)
 * Adds `UploadTarGzip()` method to `RegistryModules` and `ConfigurationVersions` interface by @sebasslash [#623](https://github.com/hashicorp/go-tfe/pull/623)
+* Adds `ManageProjects` field to `OrganizationAccess` struct by @hs26gill [#633](https://github.com/hashicorp/go-tfe/pull/633)
 
 # v1.16.0
 

--- a/team.go
+++ b/team.go
@@ -65,6 +65,8 @@ type OrganizationAccess struct {
 	ManageProviders       bool `jsonapi:"attr,manage-providers"`
 	ManageModules         bool `jsonapi:"attr,manage-modules"`
 	ManageRunTasks        bool `jsonapi:"attr,manage-run-tasks"`
+	// **Note: This field is still in BETA and subject to change.**
+	ManageProjects bool `jsonapi:"attr,manage-projects"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -144,6 +146,8 @@ type OrganizationAccessOptions struct {
 	ManageProviders       *bool `json:"manage-providers,omitempty"`
 	ManageModules         *bool `json:"manage-modules,omitempty"`
 	ManageRunTasks        *bool `json:"manage-run-tasks,omitempty"`
+	// **Note: This field is still in BETA and subject to change.**
+	ManageProjects *bool `json:"manage-projects,omitempty"`
 }
 
 // List all the teams of the given organization.


### PR DESCRIPTION
## Description

A new `manage-projects` attribute is added to `Teams` for users to manage project permissions for teams.

## Testing plan

To run the integration test:

```
ENABLE_BETA=1 go test -run TestTeamsUpdateManageProjects  -v ./... -tags=integration
```