### PR TITLE
Update team project access to include additional project roles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Enhancements
+* Update team project access to include additional project roles by @joekarl [#642](https://github.com/hashicorp/go-tfe/pull/642)
 
 ## Bug Fixes
 

--- a/team_project_access.go
+++ b/team_project_access.go
@@ -43,8 +43,10 @@ type teamProjectAccesses struct {
 type TeamProjectAccessType string
 
 const (
-	TeamProjectAccessAdmin TeamProjectAccessType = "admin"
-	TeamProjectAccessRead  TeamProjectAccessType = "read"
+	TeamProjectAccessAdmin    TeamProjectAccessType = "admin"
+	TeamProjectAccessMaintain TeamProjectAccessType = "maintain"
+	TeamProjectAccessWrite    TeamProjectAccessType = "write"
+	TeamProjectAccessRead     TeamProjectAccessType = "read"
 )
 
 // TeamProjectAccessList represents a list of team project accesses
@@ -224,7 +226,10 @@ func (o TeamProjectAccessAddOptions) valid() error {
 
 func validateTeamProjectAccessType(t TeamProjectAccessType) error {
 	switch t {
-	case TeamProjectAccessAdmin, TeamProjectAccessRead:
+	case TeamProjectAccessAdmin,
+		TeamProjectAccessMaintain,
+		TeamProjectAccessWrite,
+		TeamProjectAccessRead:
 		// do nothing
 	default:
 		return ErrInvalidTeamProjectAccessType


### PR DESCRIPTION
## Description

Updates the available team project access to include upcoming additional project access levels supported by the TFC API.
Should not be merged until those API changes are available.

API Docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/project-team-access#project-team-access-levels

Product Docs: https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/permissions#project-permissions

Tests:

```
go test -run TestTeamProjectAccessesAdd -v ./...
```