### PR TITLE
Add Manage Membership to team organization access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 ## Enhancements
+* Adds `ManageMembership` permission to team `OrganizationAccess` by @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/652)
 
 ## Bug Fixes
 

--- a/team.go
+++ b/team.go
@@ -71,6 +71,7 @@ type OrganizationAccess struct {
 	ManageProjects        bool `jsonapi:"attr,manage-projects"`
 	ReadWorkspaces        bool `jsonapi:"attr,read-workspaces"`
 	ReadProjects          bool `jsonapi:"attr,read-projects"`
+	ManageMembership      bool `jsonapi:"attr,manage-membership"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -153,6 +154,7 @@ type OrganizationAccessOptions struct {
 	ManageProjects        *bool `json:"manage-projects,omitempty"`
 	ReadWorkspaces        *bool `json:"read-workspaces,omitempty"`
 	ReadProjects          *bool `json:"read-projects,omitempty"`
+	ManageMembership      *bool `json:"manage-membership,omitempty"`
 }
 
 // List all the teams of the given organization.


### PR DESCRIPTION
## Description

Add Manage Membership to team organization access

## Testing plan

1. Teams should be created with manageMembership as false by default
2. ManageMembership is read for teams
1. ManageMembership should be updatable through `OrganizationAccessOptions `

## External links

- [Teams API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams#update-a-team)
- [Permission documentation](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/permissions#manage-membership)

## Output from tests

```
❯ go test -run TestTeams -v
=== RUN   TestTeamsList
=== RUN   TestTeamsList/without_list_options
    team_integration_test.go:37: paging not supported yet in API
=== RUN   TestTeamsList/with_list_options
    team_integration_test.go:43: paging not supported yet in API
=== RUN   TestTeamsList/without_a_valid_organization
--- PASS: TestTeamsList (4.04s)
    --- SKIP: TestTeamsList/without_list_options (0.36s)
    --- SKIP: TestTeamsList/with_list_options (0.00s)
    --- PASS: TestTeamsList/without_a_valid_organization (0.00s)
=== RUN   TestTeamsCreate
=== RUN   TestTeamsCreate/with_valid_options
=== RUN   TestTeamsCreate/with_sso-team-id
=== RUN   TestTeamsCreate/when_options_is_missing_name
=== RUN   TestTeamsCreate/when_options_has_an_invalid_organization
--- PASS: TestTeamsCreate (2.38s)
    --- PASS: TestTeamsCreate/with_valid_options (0.41s)
    --- PASS: TestTeamsCreate/with_sso-team-id (0.18s)
    --- PASS: TestTeamsCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestTeamsCreate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestTeamsRead
=== RUN   TestTeamsRead/when_the_team_exists
=== RUN   TestTeamsRead/when_the_team_exists/visibility_is_returned
=== RUN   TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded
=== RUN   TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded
=== RUN   TestTeamsRead/when_the_team_exists/SSO_team_id_is_returned
=== RUN   TestTeamsRead/when_the_team_does_not_exist
=== RUN   TestTeamsRead/without_a_valid_team_ID
--- PASS: TestTeamsRead (2.35s)
    --- PASS: TestTeamsRead/when_the_team_exists (0.15s)
        --- PASS: TestTeamsRead/when_the_team_exists/visibility_is_returned (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/permissions_are_properly_decoded (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/organization_access_is_properly_decoded (0.00s)
        --- PASS: TestTeamsRead/when_the_team_exists/SSO_team_id_is_returned (0.00s)
    --- PASS: TestTeamsRead/when_the_team_does_not_exist (0.19s)
    --- PASS: TestTeamsRead/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsUpdate
=== RUN   TestTeamsUpdate/with_valid_options
=== RUN   TestTeamsUpdate/when_the_team_does_not_exist
=== RUN   TestTeamsUpdate/without_a_valid_team_ID
--- PASS: TestTeamsUpdate (2.06s)
    --- PASS: TestTeamsUpdate/with_valid_options (0.35s)
    --- PASS: TestTeamsUpdate/when_the_team_does_not_exist (0.11s)
    --- PASS: TestTeamsUpdate/without_a_valid_team_ID (0.00s)
=== RUN   TestTeamsDelete
=== RUN   TestTeamsDelete/with_valid_options
=== RUN   TestTeamsDelete/without_valid_team_ID
--- PASS: TestTeamsDelete (1.77s)
    --- PASS: TestTeamsDelete/with_valid_options (0.28s)
    --- PASS: TestTeamsDelete/without_valid_team_ID (0.00s)
=== RUN   TestTeamsUpdateRunTasks
    helper_test.go:2334: Skipping test related to a Terraform Cloud beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestTeamsUpdateRunTasks (0.00s)
=== RUN   TestTeamsUpdateManageProjects
=== RUN   TestTeamsUpdateManageProjects/with_valid_options
--- PASS: TestTeamsUpdateManageProjects (2.01s)
    --- PASS: TestTeamsUpdateManageProjects/with_valid_options (0.33s)
=== RUN   TestTeamsUpdateManageManageMembership
--- PASS: TestTeamsUpdateManageManageMembership (2.18s)
PASS
ok  	github.com/hashicorp/go-tfe	16.923s
```