### PR TITLE
TF-4020 Apply and Remove Varsets from Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+FEATURES:
+* Add beta endpoints `ApplyToProjects`  and `RemoveFromProjects` to `VariableSets`.  Applying a variable set to a project will apply that variable set to all current and future workspaces in that project. 
+* Add beta endpoint `ListForProject` to `VariableSets` to list all variable sets applied to a project.
+
 ## Enhancements
 * Update team project access to include additional project roles by @joekarl [#642](https://github.com/hashicorp/go-tfe/pull/642)
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -2001,6 +2001,35 @@ func applyVariableSetToWorkspace(t *testing.T, client *Client, vsID, wsID string
 	})
 }
 
+func applyVariableSetToProject(t *testing.T, client *Client, vsID, prjID string) {
+	t.Helper()
+	if vsID == "" {
+		t.Fatal("variable set ID must not be empty")
+	}
+
+	if prjID == "" {
+		t.Fatal("project ID must not be empty")
+	}
+
+	opts := VariableSetApplyToProjectsOptions{}
+	opts.Projects = append(opts.Projects, &Project{ID: prjID})
+
+	ctx := context.Background()
+	if err := client.VariableSets.ApplyToProjects(ctx, vsID, opts); err != nil {
+		t.Fatalf("Error applying variable set %s to project %s: %v", vsID, prjID, err)
+	}
+
+	t.Cleanup(func() {
+		removeOpts := VariableSetRemoveFromProjectsOptions{}
+		removeOpts.Projects = append(removeOpts.Projects, &Project{ID: prjID})
+		if err := client.VariableSets.RemoveFromProjects(ctx, vsID, removeOpts); err != nil {
+			t.Errorf("Error removing variable set from project! WARNING: Dangling resources\n"+
+				"may exist! The full error is shown below.\n\n"+
+				"VariableSet ID: %s\nError: %s", vsID, err)
+		}
+	})
+}
+
 func createVariableSetVariable(t *testing.T, client *Client, vs *VariableSet, options VariableSetVariableCreateOptions) (*VariableSetVariable, func()) {
 	var vsCleanup func()
 

--- a/mocks/variable_set_mocks.go
+++ b/mocks/variable_set_mocks.go
@@ -35,6 +35,20 @@ func (m *MockVariableSets) EXPECT() *MockVariableSetsMockRecorder {
 	return m.recorder
 }
 
+// ApplyToProjects mocks base method.
+func (m *MockVariableSets) ApplyToProjects(ctx context.Context, variableSetID string, options tfe.VariableSetApplyToProjectsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ApplyToProjects", ctx, variableSetID, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ApplyToProjects indicates an expected call of ApplyToProjects.
+func (mr *MockVariableSetsMockRecorder) ApplyToProjects(ctx, variableSetID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ApplyToProjects", reflect.TypeOf((*MockVariableSets)(nil).ApplyToProjects), ctx, variableSetID, options)
+}
+
 // ApplyToWorkspaces mocks base method.
 func (m *MockVariableSets) ApplyToWorkspaces(ctx context.Context, variableSetID string, options *tfe.VariableSetApplyToWorkspacesOptions) error {
 	m.ctrl.T.Helper()
@@ -93,6 +107,21 @@ func (mr *MockVariableSetsMockRecorder) List(ctx, organization, options interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockVariableSets)(nil).List), ctx, organization, options)
 }
 
+// ListForProject mocks base method.
+func (m *MockVariableSets) ListForProject(ctx context.Context, projectID string, options *tfe.VariableSetListOptions) (*tfe.VariableSetList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListForProject", ctx, projectID, options)
+	ret0, _ := ret[0].(*tfe.VariableSetList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListForProject indicates an expected call of ListForProject.
+func (mr *MockVariableSetsMockRecorder) ListForProject(ctx, projectID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListForProject", reflect.TypeOf((*MockVariableSets)(nil).ListForProject), ctx, projectID, options)
+}
+
 // ListForWorkspace mocks base method.
 func (m *MockVariableSets) ListForWorkspace(ctx context.Context, workspaceID string, options *tfe.VariableSetListOptions) (*tfe.VariableSetList, error) {
 	m.ctrl.T.Helper()
@@ -121,6 +150,20 @@ func (m *MockVariableSets) Read(ctx context.Context, variableSetID string, optio
 func (mr *MockVariableSetsMockRecorder) Read(ctx, variableSetID, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockVariableSets)(nil).Read), ctx, variableSetID, options)
+}
+
+// RemoveFromProjects mocks base method.
+func (m *MockVariableSets) RemoveFromProjects(ctx context.Context, variableSetID string, options tfe.VariableSetRemoveFromProjectsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveFromProjects", ctx, variableSetID, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveFromProjects indicates an expected call of RemoveFromProjects.
+func (mr *MockVariableSetsMockRecorder) RemoveFromProjects(ctx, variableSetID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveFromProjects", reflect.TypeOf((*MockVariableSets)(nil).RemoveFromProjects), ctx, variableSetID, options)
 }
 
 // RemoveFromWorkspaces mocks base method.


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds the ability to use the new beta varsets/varset_id/relationships/project endpoint, allowing for the ability to apply and remove varsets from projects. Currently the feature flag is only enabled for internal users.

You can also list all of the varsets associated with a project at projects/project_id/varsets.
These changes align with the API additions we have made for enabling scoping varsets to projects.

We are not adding the ability to update projects or create a varset with a project relationship because we can see that the similar methods for workspaces are deprecated in the provider. See the deprecation warnings[ here in the provider](https://github.com/hashicorp/terraform-provider-tfe/blob/55a36f13ed3e0b73b83b113d1fc952664234bdc3/tfe/resource_tfe_variable_set.go#LL197).


## Testing plan

* Run tests against instance with "project-varsets" enabled.
```
ENABLE_BETA=1 TFE_TOKEN=XXXX TFE_HOSTNAME=XXXXXX TESTARGS="-run TestVariableSetsApplyToAndRemoveFromProjects" make testacc
```

## External links

- [API documentation PR](https://github.com/hashicorp/terraform-docs-common/pull/279)

