### PR TITLE
Add support for rotate / trim admin OIDC endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 * Adds `ManageMembership` permission to team `OrganizationAccess` by @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/652)
+* Adds `RotateKey` and `TrimKey` Admin endpoints by @mpminardi [#666](https://github.com/hashicorp/go-tfe/pull/666)
 
 # v1.20.0
 

--- a/admin_setting.go
+++ b/admin_setting.go
@@ -14,6 +14,7 @@ type AdminSettings struct {
 	SMTP           SMTPSettings
 	Twilio         TwilioSettings
 	Customization  CustomizationSettings
+	OIDC           OIDCSettings
 }
 
 func newAdminSettings(client *Client) *AdminSettings {
@@ -24,5 +25,6 @@ func newAdminSettings(client *Client) *AdminSettings {
 		SMTP:           &adminSMTPSettings{client: client},
 		Twilio:         &adminTwilioSettings{client: client},
 		Customization:  &adminCustomizationSettings{client: client},
+		OIDC:           &adminOIDCSettings{client: client},
 	}
 }

--- a/admin_setting_oidc.go
+++ b/admin_setting_oidc.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+)
+
+// Compile-time proof of interface implementation.
+var _ OIDCSettings = (*adminOIDCSettings)(nil)
+
+// OidcSettings describes all the OIDC admin settings for the Admin Setting API.
+// https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/settings
+type OIDCSettings interface {
+	// Rotate the key used for signing OIDC tokens for workload identity
+	RotateKey(ctx context.Context) error
+
+	// Trim old version of the key used for signing OIDC tokens for workload identity
+	TrimKey(ctx context.Context) error
+}
+
+type adminOIDCSettings struct {
+	client *Client
+}
+
+// Rotate the key used for signing OIDC tokens for workload identity
+func (a *adminOIDCSettings) RotateKey(ctx context.Context) error {
+	req, err := a.client.NewRequest("POST", "admin/oidc-settings/actions/rotate-key", nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// Trim old version of the key used for signing OIDC tokens for workload identity
+func (a *adminOIDCSettings) TrimKey(ctx context.Context) error {
+	req, err := a.client.NewRequest("POST", "admin/oidc-settings/actions/trim-key", nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}

--- a/admin_setting_oidc_integration_test.go
+++ b/admin_setting_oidc_integration_test.go
@@ -1,0 +1,134 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+type Jwks struct {
+	Keys []Key `json:"keys"`
+}
+
+type Key struct {
+	Kid string `json:"kid"`
+}
+
+func TestAdminSettings_Oidc_RotateKey(t *testing.T) {
+	skipUnlessEnterprise(t)
+
+	client := testClient(t)
+	jwksClient := http.Client{
+		Timeout: time.Second * 2,
+	}
+	baseURL := client.baseURL
+	token := client.token
+
+	ctx := context.Background()
+
+	jwks, err := getJwks(jwksClient, baseURL, token)
+	require.NoError(t, err)
+
+	// Don't assume there is only 1 key to start
+	originalNumKeys := len(jwks.Keys)
+
+	err = client.Admin.Settings.OIDC.RotateKey(ctx)
+	require.NoError(t, err)
+
+	jwks, err = getJwks(jwksClient, baseURL, token)
+	require.NoError(t, err)
+
+	newNumKeys := len(jwks.Keys)
+
+	// Rotate should add 1 additional key
+	assert.Equal(t, originalNumKeys+1, newNumKeys)
+}
+
+func TestAdminSettings_Oidc_TrimKey(t *testing.T) {
+	skipUnlessEnterprise(t)
+
+	client := testClient(t)
+	jwksClient := http.Client{
+		Timeout: time.Second * 2,
+	}
+	baseURL := client.baseURL
+	token := client.token
+
+	ctx := context.Background()
+
+	jwks, err := getJwks(jwksClient, baseURL, token)
+	require.NoError(t, err)
+
+	// Don't assume there is only 1 key to start
+	originalNumKeys := len(jwks.Keys)
+
+	originalKids := make([]string, originalNumKeys)
+
+	for i := 0; i < originalNumKeys; i++ {
+		originalKids[i] = jwks.Keys[i].Kid
+	}
+
+	err = client.Admin.Settings.OIDC.RotateKey(ctx)
+	require.NoError(t, err)
+
+	jwks, err = getJwks(jwksClient, baseURL, token)
+	require.NoError(t, err)
+
+	beforeTrimNumKeys := len(jwks.Keys)
+
+	assert.Equal(t, originalNumKeys+1, beforeTrimNumKeys)
+
+	err = client.Admin.Settings.OIDC.TrimKey(ctx)
+	require.NoError(t, err)
+
+	jwks, err = getJwks(jwksClient, baseURL, token)
+	require.NoError(t, err)
+
+	afterTrimNumKeys := len(jwks.Keys)
+
+	assert.Equal(t, 1, afterTrimNumKeys)
+
+	// Make sure we actually trimmed the keys
+	assert.NotContains(t, originalKids, jwks.Keys[0].Kid)
+}
+
+func getJwks(client http.Client, baseURL *url.URL, token string) (*Jwks, error) {
+	jwksEndpoint, err := baseURL.Parse("/.well-known/jwks")
+	if err != nil {
+		return nil, err
+	}
+
+	req, err := http.NewRequest(http.MethodGet, jwksEndpoint.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/json")
+
+	res, getErr := client.Do(req)
+	if getErr != nil {
+		return nil, getErr
+	}
+
+	if res.Body != nil {
+		defer res.Body.Close()
+	}
+
+	var result Jwks
+	jsonErr := json.NewDecoder(res.Body).Decode(&result)
+	if jsonErr != nil {
+		return nil, jsonErr
+	}
+
+	return &result, nil
+}

--- a/admin_setting_oidc_integration_test.go
+++ b/admin_setting_oidc_integration_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -120,6 +121,10 @@ func getJwks(client http.Client, baseURL *url.URL, token string) (*wellKnownJwks
 
 	if res.Body != nil {
 		defer res.Body.Close()
+	}
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("unexpected status code: %d. Expected a 200 response", res.StatusCode)
 	}
 
 	var result wellKnownJwks

--- a/admin_setting_oidc_integration_test.go
+++ b/admin_setting_oidc_integration_test.go
@@ -15,12 +15,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-type Jwks struct {
-	Keys []Key `json:"keys"`
-}
-
-type Key struct {
-	Kid string `json:"kid"`
+type wellKnownJwks struct {
+	Keys []struct {
+		Kid string `json:"kid"`
+	} `json:"keys"`
 }
 
 func TestAdminSettings_Oidc_RotateKey(t *testing.T) {
@@ -101,7 +99,7 @@ func TestAdminSettings_Oidc_TrimKey(t *testing.T) {
 	assert.NotContains(t, originalKids, jwks.Keys[0].Kid)
 }
 
-func getJwks(client http.Client, baseURL *url.URL, token string) (*Jwks, error) {
+func getJwks(client http.Client, baseURL *url.URL, token string) (*wellKnownJwks, error) {
 	jwksEndpoint, err := baseURL.Parse("/.well-known/jwks")
 	if err != nil {
 		return nil, err
@@ -124,7 +122,7 @@ func getJwks(client http.Client, baseURL *url.URL, token string) (*Jwks, error) 
 		defer res.Body.Close()
 	}
 
-	var result Jwks
+	var result wellKnownJwks
 	jsonErr := json.NewDecoder(res.Body).Decode(&result)
 	if jsonErr != nil {
 		return nil, jsonErr


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds support for the rotate key and trim key OIDC admin endpoints.

## Testing plan

<!--
1.  Verify that rotate key properly adds a new entry to `INSTANCE_URL/.well-known/jwks`
1.  Verify that trim key properly removes all but the latest entry from `INSTANCE_URL/.well-known/jwks`
-->

## Output from tests

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
go test -run TestAdminSettings_Oidc -v
=== RUN   TestAdminSettings_Oidc_RotateKey
--- PASS: TestAdminSettings_Oidc_RotateKey (1.23s)
=== RUN   TestAdminSettings_Oidc_TrimKey
--- PASS: TestAdminSettings_Oidc_TrimKey (1.54s)
PASS
ok  	github.com/hashicorp/go-tfe	3.158s
```
