### PR TITLE
hs26gill/TF-5101-Add-name-filter-for-listing-projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * Add beta endpoint `ListForProject` to `VariableSets` to list all variable sets applied to a project.
 
 ## Enhancements
+* Adds `Name` filter to allow filtering of projects by @hs26gill [#668](https://github.com/hashicorp/go-tfe/pull/668/files)
 * Adds `ManageMembership` permission to team `OrganizationAccess` by @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/652)
 * Adds `RotateKey` and `TrimKey` Admin endpoints by @mpminardi [#666](https://github.com/hashicorp/go-tfe/pull/666)
 

--- a/project.go
+++ b/project.go
@@ -58,6 +58,8 @@ type ProjectListOptions struct {
 	ListOptions
 
 	// Optional: String (partial project name) used to filter the results.
+	// If multiple, comma separated values are specified, projects matching
+	// any of the names are returned.
 	Name string `url:"filter[names],omitempty"`
 }
 

--- a/project.go
+++ b/project.go
@@ -56,6 +56,9 @@ type Project struct {
 // ProjectListOptions represents the options for listing projects
 type ProjectListOptions struct {
 	ListOptions
+
+	// Optional: String (partial project name) used to filter the results.
+	Name string `url:"filter[names],omitempty"`
 }
 
 // ProjectCreateOptions represents the options for creating a project
@@ -88,10 +91,6 @@ func (s *projects) List(ctx context.Context, organization string, options *Proje
 		return nil, ErrInvalidOrg
 	}
 
-	if err := options.valid(); err != nil {
-		return nil, err
-	}
-
 	u := fmt.Sprintf("organizations/%s/projects", url.QueryEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -105,14 +104,6 @@ func (s *projects) List(ctx context.Context, organization string, options *Proje
 	}
 
 	return p, nil
-}
-
-func (o *ProjectListOptions) valid() error {
-	if o == nil || o.PageNumber == 0 || o.PageSize == 0 {
-		return ErrInvalidPagination
-	}
-
-	return nil
 }
 
 // Create a project with the given options

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -25,10 +25,13 @@ func TestProjectsList(t *testing.T) {
 	pTest2, pTestCleanup := createProject(t, client, orgTest)
 	defer pTestCleanup()
 
-	t.Run("with invalid options", func(t *testing.T) {
+	t.Run("without list options", func(t *testing.T) {
 		pl, err := client.Projects.List(ctx, orgTest.Name, nil)
-		assert.Nil(t, pl)
-		assert.EqualError(t, err, ErrInvalidPagination.Error())
+		require.NoError(t, err)
+		assert.Contains(t, pl.Items, pTest1)
+
+		assert.Equal(t, 1, pl.CurrentPage)
+		assert.Equal(t, 3, pl.TotalCount)
 	})
 
 	t.Run("with list options", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR adds a name option for listing projects. This will allow the user with the ability to filter projects based on a given name. This also updates the `ProjectListOptions` as optional which is the expected behaviour.

## Testing plan

Unit Tests have been added/updated. To run them, please 

```
go test -run TestTeamsUpdateManageProjects  -v ./... -tags=integration
```