### PR TITLE
Add filtering option to list workspaces of a particular project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ FEATURES:
 * Add beta endpoint `ListForProject` to `VariableSets` to list all variable sets applied to a project.
 
 ## Enhancements
+* Adds `ProjectID` filter to allow filtering of workspaces of a given project in an organization by @hs26gill [#671](https://github.com/hashicorp/go-tfe/pull/671)
 * Adds `Name` filter to allow filtering of projects by @hs26gill [#668](https://github.com/hashicorp/go-tfe/pull/668/files)
 * Adds `ManageMembership` permission to team `OrganizationAccess` by @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/652)
 * Adds `RotateKey` and `TrimKey` Admin endpoints by @mpminardi [#666](https://github.com/hashicorp/go-tfe/pull/666)

--- a/workspace.go
+++ b/workspace.go
@@ -263,6 +263,9 @@ type WorkspaceListOptions struct {
 	// Optional: A search on substring matching to filter the results.
 	WildcardName string `url:"search[wildcard-name],omitempty"`
 
+	// Optional: A filter string to list all the workspaces linked to a given project id in the organization.
+	ProjectID string `url:"filter[project][id],omitempty"`
+
 	// Optional: A list of relations to include. See available resources https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#available-related-resources
 	Include []WSIncludeOpt `url:"include,omitempty"`
 }

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -217,6 +217,26 @@ func TestWorkspacesList(t *testing.T) {
 		assert.NotEmpty(t, wTest.ID)
 		assert.Equal(t, 0, wl.TotalCount)
 	})
+
+	t.Run("when filtering using project id", func(t *testing.T) {
+		p, pTestCleanup := createProject(t, client, orgTest)
+		defer pTestCleanup()
+
+		// create a workspace with project
+		w, wTestCleanup := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
+			Name:    String(randomString(t)),
+			Project: p,
+		})
+		defer wTestCleanup()
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
+			ProjectID: p.ID,
+		})
+		require.NoError(t, err)
+		assert.Contains(t, wl.Items, w)
+	})
 }
 
 func TestWorkspacesCreateTableDriven(t *testing.T) {

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -218,24 +218,36 @@ func TestWorkspacesList(t *testing.T) {
 		assert.Equal(t, 0, wl.TotalCount)
 	})
 
-	t.Run("when filtering using project id", func(t *testing.T) {
+	t.Run("when using project id filter and project contains workspaces", func(t *testing.T) {
+		// create a project in the orgTest
 		p, pTestCleanup := createProject(t, client, orgTest)
 		defer pTestCleanup()
-
 		// create a workspace with project
 		w, wTestCleanup := createWorkspaceWithOptions(t, client, orgTest, WorkspaceCreateOptions{
 			Name:    String(randomString(t)),
 			Project: p,
 		})
 		defer wTestCleanup()
-		// Request a page number which is out of range. The result should
-		// be successful, but return no results if the paging options are
-		// properly passed along.
+
+		// List all the workspaces under the given ProjectID
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
 			ProjectID: p.ID,
 		})
 		require.NoError(t, err)
 		assert.Contains(t, wl.Items, w)
+	})
+
+	t.Run("when using project id filter but project contains no workspaces", func(t *testing.T) {
+		// create a project in the orgTest
+		p, pTestCleanup := createProject(t, client, orgTest)
+		defer pTestCleanup()
+
+		// List all the workspaces under the given ProjectID
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
+			ProjectID: p.ID,
+		})
+		require.NoError(t, err)
+		assert.Empty(t, wl.Items)
 	})
 }
 


### PR DESCRIPTION
## Description

This add the support for users to list all the workspaces associated to a particular project in an organization by providing project_id filter option. API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#list-workspaces

## Testing plan
Integration tests have been added to cover this. You can run them using the below command:

```
go test -run TestWorkspacesList  -v ./... -tags=integration
```

## External links
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#list-workspaces)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/829)