### PR TITLE
Add ExpiredAt to Organization,  Team, User Authentication Tokens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * Add beta endpoints `Create`, `Read`, `Update`, and `Delete` to manage no-code provisioning for a `RegistryModule`. This allows users to enable no-code provisioning for a registry module, and to configure the provisioning settings for that module version. This also allows users to disable no-code provisioning for a module version. @dsa0x [#669](https://github.com/hashicorp/go-tfe/pull/669)
 
 ## Enhancements
-* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will be available in TFE release, v202304-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
+* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will be available in TFE release, v202305-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
 
 # v1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * Add beta endpoints `Create`, `Read`, `Update`, and `Delete` to manage no-code provisioning for a `RegistryModule`. This allows users to enable no-code provisioning for a registry module, and to configure the provisioning settings for that module version. This also allows users to disable no-code provisioning for a module version. @dsa0x [#669](https://github.com/hashicorp/go-tfe/pull/669)
 
 ## Enhancements
-* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken` by @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
+* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will remain in beta until the next TFE release, v202304-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
 
 # v1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 * Adds support for a new variable field `version-id` by @arybolovlev [#697](https://github.com/hashicorp/go-tfe/pull/697)
+* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will be available in TFE release, v202305-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
 
 # v1.23.0
 
@@ -11,7 +12,6 @@
 
 ## Enhancements
 * Adds `OrganizationScoped` and `AllowedWorkspaces` fields for creating workspace scoped agent pools and adds `AllowedWorkspacesName` for filtering agents pools associated with a given workspace by @hs26gill [#682](https://github.com/hashicorp/go-tfe/pull/682/files)
-* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will be available in TFE release, v202305-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
 ## Features
 * Add beta endpoints `Create`, `Read`, `Update`, and `Delete` to manage no-code provisioning for a `RegistryModule`. This allows users to enable no-code provisioning for a registry module, and to configure the provisioning settings for that module version. This also allows users to disable no-code provisioning for a module version. @dsa0x [#669](https://github.com/hashicorp/go-tfe/pull/669)
 
+## Enhancements
+* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken` by @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
+
 # v1.21.0
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * Add beta endpoints `Create`, `Read`, `Update`, and `Delete` to manage no-code provisioning for a `RegistryModule`. This allows users to enable no-code provisioning for a registry module, and to configure the provisioning settings for that module version. This also allows users to disable no-code provisioning for a module version. @dsa0x [#669](https://github.com/hashicorp/go-tfe/pull/669)
 
 ## Enhancements
-* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will remain in beta until the next TFE release, v202304-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
+* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will be available in TFE release, v202304-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
 
 # v1.21.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ## Enhancements
 * Adds `OrganizationScoped` and `AllowedWorkspaces` fields for creating workspace scoped agent pools and adds `AllowedWorkspacesName` for filtering agents pools associated with a given workspace by @hs26gill [#682](https://github.com/hashicorp/go-tfe/pull/682/files)
+* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will be available in TFE release, v202305-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
 
 ## Bug Fixes
 
@@ -22,9 +23,6 @@
 
 ## Features
 * Add beta endpoints `Create`, `Read`, `Update`, and `Delete` to manage no-code provisioning for a `RegistryModule`. This allows users to enable no-code provisioning for a registry module, and to configure the provisioning settings for that module version. This also allows users to disable no-code provisioning for a module version. @dsa0x [#669](https://github.com/hashicorp/go-tfe/pull/669)
-
-## Enhancements
-* Adds `ExpiredAt` field to `OrganizationToken`, `TeamToken`, and `UserToken`. This feature will be available in TFE release, v202305-1. @JuliannaTetreault [#672](https://github.com/hashicorp/go-tfe/pull/672)
 
 # v1.21.0
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -902,7 +902,33 @@ func createOrganizationToken(t *testing.T, client *Client, org *Organization) (*
 	}
 
 	ctx := context.Background()
-	tk, err := client.OrganizationTokens.Create(ctx, org.Name, OrganizationTokenCreateOptions{})
+	tk, err := client.OrganizationTokens.Create(ctx, org.Name)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tk, func() {
+		if err := client.OrganizationTokens.Delete(ctx, org.Name); err != nil {
+			t.Errorf("Error destroying organization token! WARNING: Dangling resources\n"+
+				"may exist! The full error is shown below.\n\n"+
+				"OrganizationToken: %s\nError: %s", tk.ID, err)
+		}
+
+		if orgCleanup != nil {
+			orgCleanup()
+		}
+	}
+}
+
+func createOrganizationTokenWithOptions(t *testing.T, client *Client, org *Organization) (*OrganizationToken, func()) {
+	var orgCleanup func()
+
+	if org == nil {
+		org, orgCleanup = createOrganization(t, client)
+	}
+
+	ctx := context.Background()
+	tk, err := client.OrganizationTokens.CreateWithOptions(ctx, org.Name, OrganizationTokenCreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1735,7 +1761,33 @@ func createTeamToken(t *testing.T, client *Client, tm *Team) (*TeamToken, func()
 	}
 
 	ctx := context.Background()
-	tt, err := client.TeamTokens.Create(ctx, tm.ID, TeamTokenCreateOptions{})
+	tt, err := client.TeamTokens.Create(ctx, tm.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return tt, func() {
+		if err := client.TeamTokens.Delete(ctx, tm.ID); err != nil {
+			t.Errorf("Error destroying team token! WARNING: Dangling resources\n"+
+				"may exist! The full error is shown below.\n\n"+
+				"TeamToken: %s\nError: %s", tm.ID, err)
+		}
+
+		if tmCleanup != nil {
+			tmCleanup()
+		}
+	}
+}
+
+func createTeamTokenWithOptions(t *testing.T, client *Client, tm *Team) (*TeamToken, func()) {
+	var tmCleanup func()
+
+	if tm == nil {
+		tm, tmCleanup = createTeam(t, client, nil)
+	}
+
+	ctx := context.Background()
+	tt, err := client.TeamTokens.CreateWithOptions(ctx, tm.ID, TeamTokenCreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -902,7 +902,7 @@ func createOrganizationToken(t *testing.T, client *Client, org *Organization) (*
 	}
 
 	ctx := context.Background()
-	tk, err := client.OrganizationTokens.Create(ctx, org.Name)
+	tk, err := client.OrganizationTokens.Create(ctx, org.Name, OrganizationTokenCreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1735,7 +1735,7 @@ func createTeamToken(t *testing.T, client *Client, tm *Team) (*TeamToken, func()
 	}
 
 	ctx := context.Background()
-	tt, err := client.TeamTokens.Create(ctx, tm.ID)
+	tt, err := client.TeamTokens.Create(ctx, tm.ID, TeamTokenCreateOptions{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helper_test.go
+++ b/helper_test.go
@@ -920,7 +920,7 @@ func createOrganizationToken(t *testing.T, client *Client, org *Organization) (*
 	}
 }
 
-func createOrganizationTokenWithOptions(t *testing.T, client *Client, org *Organization) (*OrganizationToken, func()) {
+func createOrganizationTokenWithOptions(t *testing.T, client *Client, org *Organization, options OrganizationTokenCreateOptions) (*OrganizationToken, func()) {
 	var orgCleanup func()
 
 	if org == nil {
@@ -928,7 +928,7 @@ func createOrganizationTokenWithOptions(t *testing.T, client *Client, org *Organ
 	}
 
 	ctx := context.Background()
-	tk, err := client.OrganizationTokens.CreateWithOptions(ctx, org.Name, OrganizationTokenCreateOptions{})
+	tk, err := client.OrganizationTokens.CreateWithOptions(ctx, org.Name, options)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1779,7 +1779,7 @@ func createTeamToken(t *testing.T, client *Client, tm *Team) (*TeamToken, func()
 	}
 }
 
-func createTeamTokenWithOptions(t *testing.T, client *Client, tm *Team) (*TeamToken, func()) {
+func createTeamTokenWithOptions(t *testing.T, client *Client, tm *Team, options TeamTokenCreateOptions) (*TeamToken, func()) {
 	var tmCleanup func()
 
 	if tm == nil {
@@ -1787,7 +1787,7 @@ func createTeamTokenWithOptions(t *testing.T, client *Client, tm *Team) (*TeamTo
 	}
 
 	ctx := context.Background()
-	tt, err := client.TeamTokens.CreateWithOptions(ctx, tm.ID, TeamTokenCreateOptions{})
+	tt, err := client.TeamTokens.CreateWithOptions(ctx, tm.ID, options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mocks/organization_token_mocks.go
+++ b/mocks/organization_token_mocks.go
@@ -50,6 +50,21 @@ func (mr *MockOrganizationTokensMockRecorder) Create(ctx, organization interface
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockOrganizationTokens)(nil).Create), ctx, organization)
 }
 
+// CreateWithOptions mocks base method.
+func (m *MockOrganizationTokens) CreateWithOptions(ctx context.Context, organization string, options tfe.OrganizationTokenCreateOptions) (*tfe.OrganizationToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWithOptions", ctx, organization, options)
+	ret0, _ := ret[0].(*tfe.OrganizationToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWithOptions indicates an expected call of CreateWithOptions.
+func (mr *MockOrganizationTokensMockRecorder) CreateWithOptions(ctx, organization, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWithOptions", reflect.TypeOf((*MockOrganizationTokens)(nil).CreateWithOptions), ctx, organization, options)
+}
+
 // Delete mocks base method.
 func (m *MockOrganizationTokens) Delete(ctx context.Context, organization string) error {
 	m.ctrl.T.Helper()

--- a/mocks/team_token_mocks.go
+++ b/mocks/team_token_mocks.go
@@ -50,6 +50,21 @@ func (mr *MockTeamTokensMockRecorder) Create(ctx, teamID interface{}) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockTeamTokens)(nil).Create), ctx, teamID)
 }
 
+// CreateWithOptions mocks base method.
+func (m *MockTeamTokens) CreateWithOptions(ctx context.Context, teamID string, options tfe.TeamTokenCreateOptions) (*tfe.TeamToken, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWithOptions", ctx, teamID, options)
+	ret0, _ := ret[0].(*tfe.TeamToken)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWithOptions indicates an expected call of CreateWithOptions.
+func (mr *MockTeamTokensMockRecorder) CreateWithOptions(ctx, teamID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWithOptions", reflect.TypeOf((*MockTeamTokens)(nil).CreateWithOptions), ctx, teamID, options)
+}
+
 // Delete mocks base method.
 func (m *MockTeamTokens) Delete(ctx context.Context, teamID string) error {
 	m.ctrl.T.Helper()

--- a/organization_token.go
+++ b/organization_token.go
@@ -50,7 +50,7 @@ type OrganizationToken struct {
 // OrganizationTokenCreateOptions contains the options for creating an organization token.
 type OrganizationTokenCreateOptions struct {
 	// Optional: The token's expiration date.
-	// Heads up: This feature will remain in beta until the next TFE release, v202304-1
+	// Heads up: This feature will be available in TFE release, v202304-1
 	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 

--- a/organization_token.go
+++ b/organization_token.go
@@ -50,7 +50,7 @@ type OrganizationToken struct {
 // OrganizationTokenCreateOptions contains the options for creating an organization token.
 type OrganizationTokenCreateOptions struct {
 	// Optional: The token's expiration date.
-	// Heads up: This feature will be available in TFE release, v202304-1
+	// Heads up: his feature is available in TFE release v202305-1 and later
 	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 

--- a/organization_token.go
+++ b/organization_token.go
@@ -49,7 +49,8 @@ type OrganizationToken struct {
 
 // OrganizationTokenCreateOptions contains the options for creating an organization token.
 type OrganizationTokenCreateOptions struct {
-	// Optional: The token's expiration date
+	// Optional: The token's expiration date.
+	// Heads up: This feature will remain in beta until the next TFE release, v202304-1
 	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 

--- a/organization_token.go
+++ b/organization_token.go
@@ -55,23 +55,7 @@ type OrganizationTokenCreateOptions struct {
 
 // Create a new organization token, replacing any existing token.
 func (s *organizationTokens) Create(ctx context.Context, organization string) (*OrganizationToken, error) {
-	if !validStringID(&organization) {
-		return nil, ErrInvalidOrg
-	}
-
-	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	ot := &OrganizationToken{}
-	err = req.Do(ctx, ot)
-	if err != nil {
-		return nil, err
-	}
-
-	return ot, err
+	return s.CreateWithOptions(ctx, organization, OrganizationTokenCreateOptions{})
 }
 
 // CreateWithOptions a new organization token with options, replacing any existing token.

--- a/organization_token.go
+++ b/organization_token.go
@@ -50,7 +50,7 @@ type OrganizationToken struct {
 // OrganizationTokenCreateOptions contains the options for creating an organization token.
 type OrganizationTokenCreateOptions struct {
 	// Optional: The token's expiration date.
-	// Heads up: his feature is available in TFE release v202305-1 and later
+	// This feature is available in TFE release v202305-1 and later
 	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 

--- a/organization_token.go
+++ b/organization_token.go
@@ -41,6 +41,7 @@ type OrganizationToken struct {
 	Description string    `jsonapi:"attr,description"`
 	LastUsedAt  time.Time `jsonapi:"attr,last-used-at,iso8601"`
 	Token       string    `jsonapi:"attr,token"`
+	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601"`
 }
 
 // Create a new organization token, replacing any existing token.

--- a/organization_token.go
+++ b/organization_token.go
@@ -20,7 +20,7 @@ var _ OrganizationTokens = (*organizationTokens)(nil)
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organization-tokens
 type OrganizationTokens interface {
 	// Create a new organization token, replacing any existing token.
-	Create(ctx context.Context, organization string) (*OrganizationToken, error)
+	Create(ctx context.Context, organization string, options OrganizationTokenCreateOptions) (*OrganizationToken, error)
 
 	// Read an organization token.
 	Read(ctx context.Context, organization string) (*OrganizationToken, error)
@@ -44,8 +44,14 @@ type OrganizationToken struct {
 	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601"`
 }
 
+// OrganizationTokenCreateOptions contains the options for creating an organization token.
+type OrganizationTokenCreateOptions struct {
+	// Optional: The token's expiration date
+	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
+}
+
 // Create a new organization token, replacing any existing token.
-func (s *organizationTokens) Create(ctx context.Context, organization string) (*OrganizationToken, error) {
+func (s *organizationTokens) Create(ctx context.Context, organization string, options OrganizationTokenCreateOptions) (*OrganizationToken, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}

--- a/organization_token.go
+++ b/organization_token.go
@@ -57,7 +57,7 @@ func (s *organizationTokens) Create(ctx context.Context, organization string, op
 	}
 
 	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -73,6 +73,7 @@ func TestOrganizationTokens_CreateWithOptions(t *testing.T) {
 		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
+		assert.Empty(t, ot.ExpiredAt)
 		tkToken = ot.Token
 	})
 

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -38,6 +38,13 @@ func TestOrganizationTokensCreate(t *testing.T) {
 		assert.Nil(t, ot)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
+
+	t.Run("without an expiration date", func(t *testing.T) {
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
+		require.NoError(t, err)
+		require.NotEmpty(t, ot.Token)
+		tkToken = ot.Token
+	})
 }
 
 func TestOrganizationTokensRead(t *testing.T) {

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -83,7 +83,7 @@ func TestOrganizationTokens_CreateWithOptions(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
-		assert.Equal(t, ot.ExpiredAt, &start)
+		assert.Equal(t, ot.ExpiredAt, start)
 		tkToken = ot.Token
 	})
 }
@@ -106,11 +106,14 @@ func TestOrganizationTokensRead(t *testing.T) {
 	})
 
 	t.Run("with an expiration date passed as a valid option", func(t *testing.T) {
-		_, otTestCleanup := createOrganizationTokenWithOptions(t, client, orgTest)
+		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+
+		_, otTestCleanup := createOrganizationTokenWithOptions(t, client, orgTest, OrganizationTokenCreateOptions{ExpiredAt: &start})
 
 		ot, err := client.OrganizationTokens.Read(ctx, orgTest.Name)
 		require.NoError(t, err)
 		assert.NotEmpty(t, ot)
+		assert.Equal(t, ot.ExpiredAt, start)
 
 		otTestCleanup()
 	})

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -21,27 +21,56 @@ func TestOrganizationTokensCreate(t *testing.T) {
 
 	var tkToken string
 	t.Run("with valid options", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		tkToken = ot.Token
 	})
 
 	t.Run("when a token already exists", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		assert.NotEqual(t, tkToken, ot.Token)
 	})
 
 	t.Run("without valid organization", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, badIdentifier, OrganizationTokenCreateOptions{})
+		ot, err := client.OrganizationTokens.Create(ctx, badIdentifier)
+		assert.Nil(t, ot)
+		assert.EqualError(t, err, ErrInvalidOrg.Error())
+	})
+}
+
+func TestOrganizationTokens_CreateWithOptions(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	var tkToken string
+	t.Run("with valid options", func(t *testing.T) {
+		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, ot.Token)
+		tkToken = ot.Token
+	})
+
+	t.Run("when a token already exists", func(t *testing.T) {
+		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, ot.Token)
+		assert.NotEqual(t, tkToken, ot.Token)
+	})
+
+	t.Run("without valid organization", func(t *testing.T) {
+		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, badIdentifier, OrganizationTokenCreateOptions{})
 		assert.Nil(t, ot)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("without an expiration date", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
+		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		tkToken = ot.Token
@@ -49,7 +78,7 @@ func TestOrganizationTokensCreate(t *testing.T) {
 
 	t.Run("with an expiration date", func(t *testing.T) {
 		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
-		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{
+		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, orgTest.Name, OrganizationTokenCreateOptions{
 			ExpiredAt: &start,
 		})
 		require.NoError(t, err)
@@ -68,6 +97,16 @@ func TestOrganizationTokensRead(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		_, otTestCleanup := createOrganizationToken(t, client, orgTest)
+
+		ot, err := client.OrganizationTokens.Read(ctx, orgTest.Name)
+		require.NoError(t, err)
+		assert.NotEmpty(t, ot)
+
+		otTestCleanup()
+	})
+
+	t.Run("with an expiration date passed as a valid option", func(t *testing.T) {
+		_, otTestCleanup := createOrganizationTokenWithOptions(t, client, orgTest)
 
 		ot, err := client.OrganizationTokens.Read(ctx, orgTest.Name)
 		require.NoError(t, err)

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -54,6 +54,7 @@ func TestOrganizationTokensCreate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
+		assert.Equal(t, ot.ExpiredAt, &start)
 		tkToken = ot.Token
 	})
 }

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -78,7 +78,7 @@ func TestOrganizationTokens_CreateWithOptions(t *testing.T) {
 	})
 
 	t.Run("with an expiration date", func(t *testing.T) {
-		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+		start := time.Date(2024, 1, 15, 22, 3, 4, 0, time.UTC)
 		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, orgTest.Name, OrganizationTokenCreateOptions{
 			ExpiredAt: &start,
 		})
@@ -107,7 +107,7 @@ func TestOrganizationTokensRead(t *testing.T) {
 	})
 
 	t.Run("with an expiration date passed as a valid option", func(t *testing.T) {
-		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+		start := time.Date(2024, 1, 15, 22, 3, 4, 0, time.UTC)
 
 		_, otTestCleanup := createOrganizationTokenWithOptions(t, client, orgTest, OrganizationTokenCreateOptions{ExpiredAt: &start})
 

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,27 +21,37 @@ func TestOrganizationTokensCreate(t *testing.T) {
 
 	var tkToken string
 	t.Run("with valid options", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		tkToken = ot.Token
 	})
 
 	t.Run("when a token already exists", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		assert.NotEqual(t, tkToken, ot.Token)
 	})
 
 	t.Run("without valid organization", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, badIdentifier)
+		ot, err := client.OrganizationTokens.Create(ctx, badIdentifier, OrganizationTokenCreateOptions{})
 		assert.Nil(t, ot)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
 	})
 
 	t.Run("without an expiration date", func(t *testing.T) {
-		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name)
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, ot.Token)
+		tkToken = ot.Token
+	})
+
+	t.Run("with an expiration date", func(t *testing.T) {
+		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+		ot, err := client.OrganizationTokens.Create(ctx, orgTest.Name, OrganizationTokenCreateOptions{
+			ExpiredAt: &start,
+		})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
 		tkToken = ot.Token

--- a/team_token.go
+++ b/team_token.go
@@ -49,7 +49,8 @@ type TeamToken struct {
 
 // TeamTokenCreateOptions contains the options for creating a team token.
 type TeamTokenCreateOptions struct {
-	// Optional: The token's expiration date
+	// Optional: The token's expiration date.
+	// This feature is available in TFE release v202305-1 and later
 	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 

--- a/team_token.go
+++ b/team_token.go
@@ -57,7 +57,7 @@ func (s *teamTokens) Create(ctx context.Context, teamID string, options TeamToke
 	}
 
 	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
-	req, err := s.client.NewRequest("POST", u, nil)
+	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
 	}

--- a/team_token.go
+++ b/team_token.go
@@ -55,23 +55,7 @@ type TeamTokenCreateOptions struct {
 
 // Create a new team token, replacing any existing token.
 func (s *teamTokens) Create(ctx context.Context, teamID string) (*TeamToken, error) {
-	if !validStringID(&teamID) {
-		return nil, ErrInvalidTeamID
-	}
-
-	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
-	req, err := s.client.NewRequest("POST", u, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	tt := &TeamToken{}
-	err = req.Do(ctx, tt)
-	if err != nil {
-		return nil, err
-	}
-
-	return tt, err
+	return s.CreateWithOptions(ctx, teamID, TeamTokenCreateOptions{})
 }
 
 // CreateWithOptions a new team token, with options, replacing any existing token.

--- a/team_token.go
+++ b/team_token.go
@@ -20,7 +20,7 @@ var _ TeamTokens = (*teamTokens)(nil)
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/team-tokens
 type TeamTokens interface {
 	// Create a new team token, replacing any existing token.
-	Create(ctx context.Context, teamID string) (*TeamToken, error)
+	Create(ctx context.Context, teamID string, options TeamTokenCreateOptions) (*TeamToken, error)
 
 	// Read a team token by its ID.
 	Read(ctx context.Context, teamID string) (*TeamToken, error)
@@ -44,8 +44,14 @@ type TeamToken struct {
 	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601"`
 }
 
+// TeamTokenCreateOptions contains the options for creating a team token.
+type TeamTokenCreateOptions struct {
+	// Optional: The token's expiration date
+	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
+}
+
 // Create a new team token, replacing any existing token.
-func (s *teamTokens) Create(ctx context.Context, teamID string) (*TeamToken, error) {
+func (s *teamTokens) Create(ctx context.Context, teamID string, options TeamTokenCreateOptions) (*TeamToken, error) {
 	if !validStringID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}

--- a/team_token.go
+++ b/team_token.go
@@ -41,6 +41,7 @@ type TeamToken struct {
 	Description string    `jsonapi:"attr,description"`
 	LastUsedAt  time.Time `jsonapi:"attr,last-used-at,iso8601"`
 	Token       string    `jsonapi:"attr,token"`
+	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601"`
 }
 
 // Create a new team token, replacing any existing token.

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -78,7 +78,7 @@ func TestTeamTokens_CreateWithOptions(t *testing.T) {
 	})
 
 	t.Run("with an expiration date", func(t *testing.T) {
-		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+		start := time.Date(2024, 1, 15, 22, 3, 4, 0, time.UTC)
 		tt, err := client.TeamTokens.CreateWithOptions(ctx, tmTest.ID, TeamTokenCreateOptions{
 			ExpiredAt: &start,
 		})
@@ -107,7 +107,7 @@ func TestTeamTokensRead(t *testing.T) {
 	})
 
 	t.Run("with an expiration date passed as a valid option", func(t *testing.T) {
-		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+		start := time.Date(2024, 1, 15, 22, 3, 4, 0, time.UTC)
 
 		_, ttTestCleanup := createTeamTokenWithOptions(t, client, tmTest, TeamTokenCreateOptions{ExpiredAt: &start})
 

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -21,27 +21,56 @@ func TestTeamTokensCreate(t *testing.T) {
 
 	var tmToken string
 	t.Run("with valid options", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{})
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		tmToken = tt.Token
 	})
 
 	t.Run("when a token already exists", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{})
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		assert.NotEqual(t, tmToken, tt.Token)
 	})
 
 	t.Run("without valid team ID", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, badIdentifier, TeamTokenCreateOptions{})
+		tt, err := client.TeamTokens.Create(ctx, badIdentifier)
+		assert.Nil(t, tt)
+		assert.Equal(t, err, ErrInvalidTeamID)
+	})
+}
+
+func TestTeamTokens_CreateWithOptions(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	tmTest, tmTestCleanup := createTeam(t, client, nil)
+	defer tmTestCleanup()
+
+	var tmToken string
+	t.Run("with valid options", func(t *testing.T) {
+		tt, err := client.TeamTokens.CreateWithOptions(ctx, tmTest.ID, TeamTokenCreateOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, tt.Token)
+		tmToken = tt.Token
+	})
+
+	t.Run("when a token already exists", func(t *testing.T) {
+		tt, err := client.TeamTokens.CreateWithOptions(ctx, tmTest.ID, TeamTokenCreateOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, tt.Token)
+		assert.NotEqual(t, tmToken, tt.Token)
+	})
+
+	t.Run("without valid team ID", func(t *testing.T) {
+		tt, err := client.TeamTokens.CreateWithOptions(ctx, badIdentifier, TeamTokenCreateOptions{})
 		assert.Nil(t, tt)
 		assert.Equal(t, err, ErrInvalidTeamID)
 	})
 
 	t.Run("without an expiration date", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{})
+		tt, err := client.TeamTokens.CreateWithOptions(ctx, tmTest.ID, TeamTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		tmToken = tt.Token
@@ -49,7 +78,7 @@ func TestTeamTokensCreate(t *testing.T) {
 
 	t.Run("with an expiration date", func(t *testing.T) {
 		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
-		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{
+		tt, err := client.TeamTokens.CreateWithOptions(ctx, tmTest.ID, TeamTokenCreateOptions{
 			ExpiredAt: &start,
 		})
 		require.NoError(t, err)
@@ -58,6 +87,7 @@ func TestTeamTokensCreate(t *testing.T) {
 		tmToken = tt.Token
 	})
 }
+
 func TestTeamTokensRead(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -67,6 +97,16 @@ func TestTeamTokensRead(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		_, ttTestCleanup := createTeamToken(t, client, tmTest)
+
+		tt, err := client.TeamTokens.Read(ctx, tmTest.ID)
+		require.NoError(t, err)
+		assert.NotEmpty(t, tt)
+
+		ttTestCleanup()
+	})
+
+	t.Run("with an expiration date passed as a valid option", func(t *testing.T) {
+		_, ttTestCleanup := createTeamTokenWithOptions(t, client, tmTest)
 
 		tt, err := client.TeamTokens.Read(ctx, tmTest.ID)
 		require.NoError(t, err)

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -83,7 +83,7 @@ func TestTeamTokens_CreateWithOptions(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
-		assert.Equal(t, tt.ExpiredAt, &start)
+		assert.Equal(t, tt.ExpiredAt, start)
 		tmToken = tt.Token
 	})
 }
@@ -106,11 +106,14 @@ func TestTeamTokensRead(t *testing.T) {
 	})
 
 	t.Run("with an expiration date passed as a valid option", func(t *testing.T) {
-		_, ttTestCleanup := createTeamTokenWithOptions(t, client, tmTest)
+		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+
+		_, ttTestCleanup := createTeamTokenWithOptions(t, client, tmTest, TeamTokenCreateOptions{ExpiredAt: &start})
 
 		tt, err := client.TeamTokens.Read(ctx, tmTest.ID)
 		require.NoError(t, err)
 		assert.NotEmpty(t, tt)
+		assert.Equal(t, tt.ExpiredAt, start)
 
 		ttTestCleanup()
 	})

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -73,6 +73,7 @@ func TestTeamTokens_CreateWithOptions(t *testing.T) {
 		tt, err := client.TeamTokens.CreateWithOptions(ctx, tmTest.ID, TeamTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
+		assert.Empty(t, tt.ExpiredAt)
 		tmToken = tt.Token
 	})
 

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -54,6 +54,7 @@ func TestTeamTokensCreate(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
+		assert.Equal(t, tt.ExpiredAt, &start)
 		tmToken = tt.Token
 	})
 }

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -38,6 +38,13 @@ func TestTeamTokensCreate(t *testing.T) {
 		assert.Nil(t, tt)
 		assert.Equal(t, err, ErrInvalidTeamID)
 	})
+
+	t.Run("without an expiration date", func(t *testing.T) {
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
+		require.NoError(t, err)
+		require.NotEmpty(t, tt.Token)
+		tmToken = tt.Token
+	})
 }
 func TestTeamTokensRead(t *testing.T) {
 	client := testClient(t)

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -20,27 +21,37 @@ func TestTeamTokensCreate(t *testing.T) {
 
 	var tmToken string
 	t.Run("with valid options", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		tmToken = tt.Token
 	})
 
 	t.Run("when a token already exists", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		assert.NotEqual(t, tmToken, tt.Token)
 	})
 
 	t.Run("without valid team ID", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, badIdentifier)
+		tt, err := client.TeamTokens.Create(ctx, badIdentifier, TeamTokenCreateOptions{})
 		assert.Nil(t, tt)
 		assert.Equal(t, err, ErrInvalidTeamID)
 	})
 
 	t.Run("without an expiration date", func(t *testing.T) {
-		tt, err := client.TeamTokens.Create(ctx, tmTest.ID)
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{})
+		require.NoError(t, err)
+		require.NotEmpty(t, tt.Token)
+		tmToken = tt.Token
+	})
+
+	t.Run("with an expiration date", func(t *testing.T) {
+		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+		tt, err := client.TeamTokens.Create(ctx, tmTest.ID, TeamTokenCreateOptions{
+			ExpiredAt: &start,
+		})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
 		tmToken = tt.Token

--- a/user_token.go
+++ b/user_token.go
@@ -50,12 +50,14 @@ type UserToken struct {
 	Description string    `jsonapi:"attr,description"`
 	LastUsedAt  time.Time `jsonapi:"attr,last-used-at,iso8601"`
 	Token       string    `jsonapi:"attr,token"`
+	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601"`
 }
 
 // UserTokenCreateOptions the options for creating a user token.
 type UserTokenCreateOptions struct {
-	// Optional: Description of the token
-	Description string `jsonapi:"attr,description,omitempty"`
+	// Optional: Description of the token and its expiration date
+	Description string    `jsonapi:"attr,description,omitempty"`
+	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 
 // Create a new user token

--- a/user_token.go
+++ b/user_token.go
@@ -55,10 +55,10 @@ type UserToken struct {
 
 // UserTokenCreateOptions contains the options for creating a user token.
 type UserTokenCreateOptions struct {
+	Description string `jsonapi:"attr,description,omitempty"`
 	// Optional: The token's expiration date.
 	// This feature is available in TFE release v202305-1 and later
-	Description string     `jsonapi:"attr,description,omitempty"`
-	ExpiredAt   *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
+	ExpiredAt *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 
 // Create a new user token

--- a/user_token.go
+++ b/user_token.go
@@ -53,11 +53,11 @@ type UserToken struct {
 	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601"`
 }
 
-// UserTokenCreateOptions the options for creating a user token.
+// UserTokenCreateOptions contains the options for creating a user token.
 type UserTokenCreateOptions struct {
 	// Optional: Description of the token and its expiration date
-	Description string    `jsonapi:"attr,description,omitempty"`
-	ExpiredAt   time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
+	Description string     `jsonapi:"attr,description,omitempty"`
+	ExpiredAt   *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }
 
 // Create a new user token

--- a/user_token.go
+++ b/user_token.go
@@ -55,7 +55,8 @@ type UserToken struct {
 
 // UserTokenCreateOptions contains the options for creating a user token.
 type UserTokenCreateOptions struct {
-	// Optional: Description of the token and its expiration date
+	// Optional: The token's expiration date.
+	// This feature is available in TFE release v202305-1 and later
 	Description string     `jsonapi:"attr,description,omitempty"`
 	ExpiredAt   *time.Time `jsonapi:"attr,expired-at,iso8601,omitempty"`
 }

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -72,6 +73,24 @@ func TestUserTokens_Create(t *testing.T) {
 	t.Run("create token with description", func(t *testing.T) {
 		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
 			Description: fmt.Sprintf("go-tfe-user-token-test-%s", randomString(t)),
+		})
+		tokens = append(tokens, token.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("create token without an expiration date", func(t *testing.T) {
+		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{})
+		tokens = append(tokens, token.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	t.Run("create token with an expiration date", func(t *testing.T) {
+		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
+			ExpiredAt: time.Now().Add(48 * time.Hour),
 		})
 		tokens = append(tokens, token.ID)
 		if err != nil {

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -6,11 +6,10 @@ package tfe
 import (
 	"context"
 	"fmt"
-	"testing"
-	"time"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"testing"
+	"time"
 )
 
 // TestUserTokens_List tests listing user tokens
@@ -89,8 +88,9 @@ func TestUserTokens_Create(t *testing.T) {
 	})
 
 	t.Run("create token with an expiration date", func(t *testing.T) {
+		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
 		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
-			ExpiredAt: time.Now().Add(48 * time.Hour),
+			ExpiredAt: &start,
 		})
 		tokens = append(tokens, token.ID)
 		if err != nil {

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -85,6 +85,7 @@ func TestUserTokens_Create(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		assert.Empty(t, token.ExpiredAt)
 	})
 
 	t.Run("create token with an expiration date", func(t *testing.T) {

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -89,7 +89,7 @@ func TestUserTokens_Create(t *testing.T) {
 	})
 
 	t.Run("create token with an expiration date", func(t *testing.T) {
-		start := time.Date(2024, 01, 15, 22, 03, 04, 0, time.UTC)
+		start := time.Date(2024, 1, 15, 22, 3, 4, 0, time.UTC)
 		token, err := client.UserTokens.Create(ctx, user.ID, UserTokenCreateOptions{
 			ExpiredAt: &start,
 		})

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -96,7 +96,7 @@ func TestUserTokens_Create(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Equal(t, token.ExpiredAt, &start)
+		assert.Equal(t, token.ExpiredAt, start)
 	})
 }
 

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -96,6 +96,7 @@ func TestUserTokens_Create(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		assert.Equal(t, token.ExpiredAt, &start)
 	})
 }
 


### PR DESCRIPTION
## Description

Adds `ExpiredAt` to Organization, Team, and User tokens and updates the accompanying tests. This is part of a larger change which adds a time-to-live to API authentication tokens.

## Testing plan

1. Verify that you can set the properties by using `go-tfe` within the TFE provider.
2. Verify that all tests still pass.

## Output from tests

#### `team_token_integration_test.go` results:
```
=== RUN   TestTeamTokensCreate
--- PASS: TestTeamTokensCreate (2.31s)
=== RUN   TestTeamTokensCreate/with_valid_options
    --- PASS: TestTeamTokensCreate/with_valid_options (0.21s)
=== RUN   TestTeamTokensCreate/when_a_token_already_exists
    --- PASS: TestTeamTokensCreate/when_a_token_already_exists (0.26s)
=== RUN   TestTeamTokensCreate/without_valid_team_ID
    --- PASS: TestTeamTokensCreate/without_valid_team_ID (0.00s)
PASS

Process finished with the exit code 0

...

=== RUN   TestTeamTokens_CreateWithOptions
--- PASS: TestTeamTokens_CreateWithOptions (2.54s)
=== RUN   TestTeamTokens_CreateWithOptions/with_valid_options
    --- PASS: TestTeamTokens_CreateWithOptions/with_valid_options (0.21s)
=== RUN   TestTeamTokens_CreateWithOptions/when_a_token_already_exists
    --- PASS: TestTeamTokens_CreateWithOptions/when_a_token_already_exists (0.22s)
=== RUN   TestTeamTokens_CreateWithOptions/without_valid_team_ID
    --- PASS: TestTeamTokens_CreateWithOptions/without_valid_team_ID (0.00s)
=== RUN   TestTeamTokens_CreateWithOptions/without_an_expiration_date
    --- PASS: TestTeamTokens_CreateWithOptions/without_an_expiration_date (0.22s)
=== RUN   TestTeamTokens_CreateWithOptions/with_an_expiration_date
    --- PASS: TestTeamTokens_CreateWithOptions/with_an_expiration_date (0.21s)
PASS

Process finished with the exit code 0

...

=== RUN   TestTeamTokensRead
--- PASS: TestTeamTokensRead (3.31s)
=== RUN   TestTeamTokensRead/with_valid_options
    --- PASS: TestTeamTokensRead/with_valid_options (0.65s)
=== RUN   TestTeamTokensRead/with_an_expiration_date_passed_as_a_valid_option
    --- PASS: TestTeamTokensRead/with_an_expiration_date_passed_as_a_valid_option (0.65s)
=== RUN   TestTeamTokensRead/when_a_token_doesn't_exists
    --- PASS: TestTeamTokensRead/when_a_token_doesn't_exists (0.20s)
=== RUN   TestTeamTokensRead/without_valid_organization
    --- PASS: TestTeamTokensRead/without_valid_organization (0.00s)
PASS

Process finished with the exit code 0
```

#### `organization_token_integration_test.go` results:
```
=== RUN   TestOrganizationTokensCreate
--- PASS: TestOrganizationTokensCreate (1.62s)
=== RUN   TestOrganizationTokensCreate/with_valid_options
    --- PASS: TestOrganizationTokensCreate/with_valid_options (0.22s)
=== RUN   TestOrganizationTokensCreate/when_a_token_already_exists
    --- PASS: TestOrganizationTokensCreate/when_a_token_already_exists (0.21s)
=== RUN   TestOrganizationTokensCreate/without_valid_organization
    --- PASS: TestOrganizationTokensCreate/without_valid_organization (0.00s)
PASS

Process finished with the exit code 0

...

=== RUN   TestOrganizationTokens_CreateWithOptions
--- PASS: TestOrganizationTokens_CreateWithOptions (2.15s)
=== RUN   TestOrganizationTokens_CreateWithOptions/with_valid_options
    --- PASS: TestOrganizationTokens_CreateWithOptions/with_valid_options (0.25s)
=== RUN   TestOrganizationTokens_CreateWithOptions/when_a_token_already_exists
    --- PASS: TestOrganizationTokens_CreateWithOptions/when_a_token_already_exists (0.26s)
=== RUN   TestOrganizationTokens_CreateWithOptions/without_valid_organization
    --- PASS: TestOrganizationTokens_CreateWithOptions/without_valid_organization (0.00s)
=== RUN   TestOrganizationTokens_CreateWithOptions/without_an_expiration_date
    --- PASS: TestOrganizationTokens_CreateWithOptions/without_an_expiration_date (0.21s)
=== RUN   TestOrganizationTokens_CreateWithOptions/with_an_expiration_date
    --- PASS: TestOrganizationTokens_CreateWithOptions/with_an_expiration_date (0.21s)
PASS

Process finished with the exit code 0

...

=== RUN   TestOrganizationTokensRead
--- PASS: TestOrganizationTokensRead (2.60s)
=== RUN   TestOrganizationTokensRead/with_valid_options
    --- PASS: TestOrganizationTokensRead/with_valid_options (0.64s)
=== RUN   TestOrganizationTokensRead/with_an_expiration_date_passed_as_a_valid_option
    --- PASS: TestOrganizationTokensRead/with_an_expiration_date_passed_as_a_valid_option (0.63s)
=== RUN   TestOrganizationTokensRead/when_a_token_doesn't_exists
    --- PASS: TestOrganizationTokensRead/when_a_token_doesn't_exists (0.19s)
=== RUN   TestOrganizationTokensRead/without_valid_organization
    --- PASS: TestOrganizationTokensRead/without_valid_organization (0.00s)
PASS

Process finished with the exit code 0
```

#### `user_token_integration_test.go` results:
```
=== RUN   TestUserTokens_Create
--- PASS: TestUserTokens_Create (2.24s)
=== RUN   TestUserTokens_Create/create_token_with_no_description
    --- PASS: TestUserTokens_Create/create_token_with_no_description (0.27s)
=== RUN   TestUserTokens_Create/create_token_with_description
    --- PASS: TestUserTokens_Create/create_token_with_description (0.21s)
=== RUN   TestUserTokens_Create/create_token_without_an_expiration_date
    --- PASS: TestUserTokens_Create/create_token_without_an_expiration_date (0.19s)
=== RUN   TestUserTokens_Create/create_token_with_an_expiration_date
    --- PASS: TestUserTokens_Create/create_token_with_an_expiration_date (0.19s)
PASS

Process finished with the exit code 0
```