### PR TITLE
Add `IsCloud()` and `IsEnterprise()` helper methods to client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,15 +1,14 @@
 # Unreleased
 
-FEATURES:
-* Add beta endpoints `ApplyToProjects`  and `RemoveFromProjects` to `VariableSets`.  Applying a variable set to a project will apply that variable set to all current and future workspaces in that project. 
-* Add beta endpoint `ListForProject` to `VariableSets` to list all variable sets applied to a project.
-
 ## Enhancements
+* Add beta endpoints `ApplyToProjects`  and `RemoveFromProjects` to `VariableSets`.  Applying a variable set to a project will apply that variable set to all current and future workspaces in that project.
+* Add beta endpoint `ListForProject` to `VariableSets` to list all variable sets applied to a project.
 * Adds `ProjectID` filter to allow filtering of workspaces of a given project in an organization by @hs26gill [#671](https://github.com/hashicorp/go-tfe/pull/671)
 * Adds `Name` filter to allow filtering of projects by @hs26gill [#668](https://github.com/hashicorp/go-tfe/pull/668/files)
 * Adds `ManageMembership` permission to team `OrganizationAccess` by @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/652)
 * Adds `RotateKey` and `TrimKey` Admin endpoints by @mpminardi [#666](https://github.com/hashicorp/go-tfe/pull/666)
 * Adds `Permissions` to `User` by @jeevanragula [#674](https://github.com/hashicorp/go-tfe/pull/674)
+* Adds `IsEnterprise` and `IsCloud` boolean methods to the client by @sebasslash [#675](https://github.com/hashicorp/go-tfe/pull/675)
 
 # v1.20.0
 

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -25,6 +25,11 @@ func TestClient_newClient(t *testing.T) {
 		w.Header().Set("X-RateLimit-Limit", "30")
 		w.Header().Set("TFP-API-Version", "34.21.9")
 		w.Header().Set("X-TFE-Version", "202205-1")
+		if enterpriseEnabled() {
+			w.Header().Set("TFP-AppName", "Terraform Enterprise")
+		} else {
+			w.Header().Set("TFP-AppName", "Terraform Cloud")
+		}
 		w.WriteHeader(204) // We query the configured ping URL which should return a 204.
 	}))
 	defer ts.Close()
@@ -83,6 +88,12 @@ func TestClient_newClient(t *testing.T) {
 		}
 		if want := "202205-1"; client.RemoteTFEVersion() != want {
 			t.Errorf("unexpected remote TFE version %q; want %q", client.RemoteTFEVersion(), want)
+		}
+
+		if enterpriseEnabled() {
+			assert.True(t, client.IsEnterprise())
+		} else {
+			assert.True(t, client.IsCloud())
 		}
 
 		client.SetFakeRemoteAPIVersion("1.0")


### PR DESCRIPTION
## Description

These are helper methods that will enable external tools using a go-tfe client to make TFC or TFE-specific decisions. Thus far we haven't had an authoritative, simple way to determine if an instance is TFC or TFE. TFC and future TFE releases will start including a header `TFP-AppName` which will let us know if the given instance is TFC or TFE. For most users however, they will know beforehand what kind of instance their client is interacting with.