### PR TITLE
Update for creating and filtering workspace scoped agent pools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 * `ApplyToProjects` and `RemoveFromProjects` to `VariableSets` endpoints now generally available.
 * `ListForProject` to `VariableSets` endpoints now generally available.
 
+## Enhancements
+* Adds `OrganizationScoped` and `AllowedWorkspaces` fields for creating workspace scoped agent pools and adds `AllowedWorkspacesName` for filtering agents pools associated with a given workspace by @hs26gill [#682](https://github.com/hashicorp/go-tfe/pull/682/files)
+
+## Bug Fixes
+
+
 # v1.22.0
 
 ## Beta API Changes

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -79,6 +79,9 @@ type AgentPoolListOptions struct {
 
 	// Optional: A search query string used to filter agent pool. Agent pools are searchable by name
 	Query string `url:"q,omitempty"`
+
+	// Optional: String (workspace name) used to filter the results.
+	AllowedWorkspacesName string `url:"filter[allowed_workspaces][name],omitempty"`
 }
 
 // AgentPoolCreateOptions represents the options for creating an agent pool.
@@ -91,6 +94,12 @@ type AgentPoolCreateOptions struct {
 
 	// Required: A name to identify the agent pool.
 	Name *string `jsonapi:"attr,name"`
+
+	// True if the agent pool is organization scoped, false otherwise.
+	OrganizationScoped *bool `jsonapi:"attr,organization-scoped,omitempty"`
+
+	// List of workspaces that are associated with an agent pool.
+	AllowedWorkspaces []*Workspace `jsonapi:"relation,allowed-workspaces,omitempty"`
 }
 
 // List all the agent pools of the given organization.
@@ -186,7 +195,7 @@ type AgentPoolUpdateOptions struct {
 	OrganizationScoped *bool `jsonapi:"attr,organization-scoped,omitempty"`
 
 	// A new list of workspaces that are associated with an agent pool.
-	AllowedWorkspaces []*Workspace `jsonapi:"relation,allowed-workspaces"`
+	AllowedWorkspaces []*Workspace `jsonapi:"relation,allowed-workspaces,omitempty"`
 }
 
 // Update an agent pool by its ID.

--- a/helper_test.go
+++ b/helper_test.go
@@ -339,6 +339,32 @@ func createAgentPool(t *testing.T, client *Client, org *Organization) (*AgentPoo
 	}
 }
 
+func createAgentPoolWithOptions(t *testing.T, client *Client, org *Organization, opts AgentPoolCreateOptions) (*AgentPool, func()) {
+	var orgCleanup func()
+
+	if org == nil {
+		org, orgCleanup = createOrganization(t, client)
+	}
+
+	ctx := context.Background()
+	pool, err := client.AgentPools.Create(ctx, org.Name, opts)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return pool, func() {
+		if err := client.AgentPools.Delete(ctx, pool.ID); err != nil {
+			t.Logf("Error destroying agent pool! WARNING: Dangling resources "+
+				"may exist! The full error is shown below.\n\n"+
+				"Agent pool ID: %s\nError: %s", pool.ID, err)
+		}
+
+		if orgCleanup != nil {
+			orgCleanup()
+		}
+	}
+}
+
 func createAgentToken(t *testing.T, client *Client, ap *AgentPool) (*AgentToken, func()) {
 	var apCleanup func()
 

--- a/variable_set.go
+++ b/variable_set.go
@@ -381,7 +381,6 @@ func (s *variableSets) RemoveFromWorkspaces(ctx context.Context, variableSetID s
 
 // ApplyToProjects applies the variable set to projects in the supplied list.
 // This method will return an error if the variable set has global = true.
-// **Note: This feature is still in BETA and subject to change.**
 func (s variableSets) ApplyToProjects(ctx context.Context, variableSetID string, options VariableSetApplyToProjectsOptions) error {
 	if !validStringID(&variableSetID) {
 		return ErrInvalidVariableSetID
@@ -401,7 +400,6 @@ func (s variableSets) ApplyToProjects(ctx context.Context, variableSetID string,
 
 // RemoveFromProjects removes the variable set from projects in the supplied list.
 // This method will return an error if the variable set has global = true.
-// **Note: This feature is still in BETA and subject to change.**
 func (s variableSets) RemoveFromProjects(ctx context.Context, variableSetID string, options VariableSetRemoveFromProjectsOptions) error {
 	if !validStringID(&variableSetID) {
 		return ErrInvalidVariableSetID


### PR DESCRIPTION
## Description

Atlas enables the creation of agent pools that are tailored to specific workspaces, rather than being on the organization level. With this pull request, users can specify the `OrganizationScoped` and `AllowedWorkspaces` fields to establish a scope for the agent pool that includes only the permitted workspaces. Additionally, a `AllowedWorkspacesName` filter has been included to facilitate the listing of Agent Pools that are associated with a specific workspace.

## Testing plan

Verify that all tests still pass.

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/agents)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/453)

## Output from tests

```
=== RUN   TestAgentPoolsList
--- PASS: TestAgentPoolsList (9.52s)
=== RUN   TestAgentPoolsList/without_list_options
    --- PASS: TestAgentPoolsList/without_list_options (0.46s)
=== RUN   TestAgentPoolsList/with_Include_option
    helper_test.go:806: Export a valid OAUTH_CLIENT_GITHUB_TOKEN before running this test!
    --- SKIP: TestAgentPoolsList/with_Include_option (0.00s)

Test ignored.
=== RUN   TestAgentPoolsList/with_list_options
    --- PASS: TestAgentPoolsList/with_list_options (0.32s)
=== RUN   TestAgentPoolsList/without_a_valid_organization
    --- PASS: TestAgentPoolsList/without_a_valid_organization (0.00s)
=== RUN   TestAgentPoolsList/with_query_options
    --- PASS: TestAgentPoolsList/with_query_options (0.76s)
=== RUN   TestAgentPoolsList/with_allowed_workspace_name_filter
    --- PASS: TestAgentPoolsList/with_allowed_workspace_name_filter (3.34s)

Test ignored.
PASS


=== RUN   TestAgentPoolsCreate
--- PASS: TestAgentPoolsCreate (4.57s)
=== RUN   TestAgentPoolsCreate/with_valid_options
    --- PASS: TestAgentPoolsCreate/with_valid_options (1.11s)
=== RUN   TestAgentPoolsCreate/when_options_is_missing_name
    --- PASS: TestAgentPoolsCreate/when_options_is_missing_name (0.00s)
=== RUN   TestAgentPoolsCreate/with_an_invalid_organization
    --- PASS: TestAgentPoolsCreate/with_an_invalid_organization (0.00s)
=== RUN   TestAgentPoolsCreate/with_allowed-workspaces_options
    --- PASS: TestAgentPoolsCreate/with_allowed-workspaces_options (1.46s)
PASS
```
