### PR TITLE
TF-5353 Remove beta flag from project varsets tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# v1.23.0 (Unreleased)
+
+## Features
+* `ApplyToProjects` and `RemoveFromProjects` to `VariableSets` endpoints now generally available.
+* `ListForProject` to `VariableSets` endpoints now generally available.
+
 # v1.22.0
 
 ## Beta API Changes

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -112,7 +112,6 @@ func TestVariableSetsListForWorkspace(t *testing.T) {
 }
 
 func TestVariableSetsListForProject(t *testing.T) {
-	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -399,8 +398,6 @@ func TestVariableSetsApplyToAndRemoveFromWorkspaces(t *testing.T) {
 }
 
 func TestVariableSetsApplyToAndRemoveFromProjects(t *testing.T) {
-	// TO DO: Remove when TFE GA
-	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

Applying varsets to projects is now generally available.

## Testing plan
Only test changes; tests should pass.
I think that this is actually reliant on the feature flag being removed from Atlas first in this pr: https://github.com/hashicorp/atlas/pull/15420
I will run the tests again, once that is merged.

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/variable-sets#apply-variable-set-to-projects)
