### PR TITLE
Use `make lint` instead of custom action

### DIFF
--- a/.github/actions/lint-go-tfe/action.yml
+++ b/.github/actions/lint-go-tfe/action.yml
@@ -15,9 +15,14 @@ runs:
     - run: make fmtcheck
       shell: bash
 
-    - uses: golangci/golangci-lint-action@v3
-      with:
-        version: v1.50.1
+    - name: Install golangci-lint
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCILINT_VERSION
+      shell: bash
+      env:
+        GOLANGCILINT_VERSION: v1.52.2
+
+    - run: make lint
+      shell: bash
 
     - name: Ensure generate_mocks.sh ends in a newline
       run: test "" = "$(tail -c1 "generate_mocks.sh")"

--- a/.github/actions/lint-go-tfe/action.yml
+++ b/.github/actions/lint-go-tfe/action.yml
@@ -16,7 +16,7 @@ runs:
       shell: bash
 
     - name: Install golangci-lint
-      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCILINT_VERSION
+      run: curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/0b5709648c8ba9780e821faf16c5c2bb3262ce3e/install.sh | sh -s -- -b $(go env GOPATH)/bin $GOLANGCILINT_VERSION
       shell: bash
       env:
         GOLANGCILINT_VERSION: v1.52.2

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -55,6 +55,7 @@ linters-settings:
       - hugeParam
       - singleCaseSwitch
       - ifElseChain
+      - sloppyTestFuncName
   revive:
     # see https://github.com/mgechev/revive#available-rules for details.
     ignore-generated-header: false #recommended in their configuration

--- a/helper_test.go
+++ b/helper_test.go
@@ -2339,6 +2339,7 @@ func randomSemver(t *testing.T) string {
 
 // skips a test if the environment is for Terraform Cloud.
 func skipUnlessEnterprise(t *testing.T) {
+	t.Helper()
 	if !enterpriseEnabled() {
 		t.Skip("Skipping test related to Terraform Cloud. Set ENABLE_TFE=1 to run.")
 	}
@@ -2346,6 +2347,7 @@ func skipUnlessEnterprise(t *testing.T) {
 
 // skips a test if the environment is for Terraform Enterprise
 func skipIfEnterprise(t *testing.T) {
+	t.Helper()
 	if enterpriseEnabled() {
 		t.Skip("Skipping test related to Terraform Enterprise. Set ENABLE_TFE=0 to run.")
 	}
@@ -2359,6 +2361,7 @@ func skipIfEnterprise(t *testing.T) {
 //
 // See CONTRIBUTING.md for details
 func skipUnlessBeta(t *testing.T) {
+	t.Helper()
 	if !betaFeaturesEnabled() {
 		t.Skip("Skipping test related to a Terraform Cloud beta feature. Set ENABLE_BETA=1 to run.")
 	}
@@ -2366,6 +2369,7 @@ func skipUnlessBeta(t *testing.T) {
 
 // skips a test if the architecture is not linux_amd64
 func skipUnlessLinuxAMD64(t *testing.T) {
+	t.Helper()
 	if !linuxAmd64() {
 		t.Skip("Skipping test if architecture is not linux_amd64")
 	}


### PR DESCRIPTION
At some point, the custom action stopped leaving annotations on the PR and also doesn't offer log output in the action output.