### PR TITLE
[TF-5841] Use TFC admin role tokens in tests

### DIFF
--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -5,7 +5,6 @@ package tfe
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -38,9 +37,6 @@ func TestAdminUsers_List(t *testing.T) {
 				PageSize:   100,
 			},
 		})
-
-		fmt.Printf("%v+", ul.Items)
-
 		require.NoError(t, err)
 		// Out of range page number, so the items should be empty
 		assert.Empty(t, ul.Items)

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -37,6 +38,9 @@ func TestAdminUsers_List(t *testing.T) {
 				PageSize:   100,
 			},
 		})
+
+		fmt.Printf("%v+", ul.Items)
+
 		require.NoError(t, err)
 		// Out of range page number, so the items should be empty
 		assert.Empty(t, ul.Items)

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -22,6 +22,8 @@ import (
 // behavior of these endpoints.
 
 func TestAdminWorkspaces_ListWithFilter(t *testing.T) {
+	skipUnlessEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -53,6 +55,8 @@ func TestAdminWorkspaces_ListWithFilter(t *testing.T) {
 }
 
 func TestAdminWorkspaces_ListWithSort(t *testing.T) {
+	skipUnlessEnterprise(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -35,10 +35,6 @@ type WorkspaceTableTest struct {
 
 func TestWorkspacesList(t *testing.T) {
 	client := testClient(t)
-
-	fmt.Println("host: " + client.baseURL.Host)
-	fmt.Println("token: " + client.token)
-
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -35,6 +35,10 @@ type WorkspaceTableTest struct {
 
 func TestWorkspacesList(t *testing.T) {
 	client := testClient(t)
+
+	fmt.Println("host: " + client.baseURL.Host)
+	fmt.Println("token: " + client.token)
+
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
@@ -832,6 +836,9 @@ func TestWorkspacesReadWithHistory(t *testing.T) {
 	}
 }
 
+// If you've set your own GITHUB_POLICY_SET_IDENTIFIER, make sure the readme
+// starts with the string: This is a simple test
+// Otherwise the test will not pass
 func TestWorkspacesReadReadme(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Use the TFC Admin Role tokens for tests.

## Testing plan

If you're testing with a local tfcdev instance, you'll want to use the branch in the Related PR.

1. Create a token for your terraform user and set the environment variable `TFE_TOKEN` to that value (I'm using the envchain env called `tfe-local` to manage my local env vars). Invoke the following test where TOKEN is the token you just created.

```
TFE_ADMIN_PROVISION_LICENSES_TOKEN=TOKEN  ENABLE_TFE=0 envchain tfe-local go test -run TestGPGKey -v ./... -tags=integration
```

The test should fail.

2. Change your user to the `provision-licenses` admin role:

```
tfcdev stack console
./bin/rails c
u = User.find_by(username: 'USERNAME')
u.admin_role = 'provision-licenses'
u.save!
```

3. Rerun the test again and it should pass.

4. I also ran the admin tests against staging (I enabled the feature flag on staging):

```
ENABLE_TFE=0 envchain tfe-staging go test -run TestAdmin -v ./... -tags=integration
```

and the tests passed with this branch.

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/hashicorp/atlas/pull/15612)

## Output from tests

I ran these tests locally:

* TestGPGKey
* TestRegistryProvider
* TestPolicySet

### TestGPGKey

#### Command

```
TFE_ADMIN_PROVISION_LICENSES_TOKEN=TOKEN  ENABLE_TFE=0 envchain tfe-local go test -run TestGPGKey -v ./... -tags=integration
```

#### Output
```
=== RUN   TestGPGKeyList
=== RUN   TestGPGKeyList/with_single_namespace
=== RUN   TestGPGKeyList/with_multiple_namespaces
    gpg_key_integration_test.go:53: Skipping due to GPG Key API not returning keys for multiple namespaces
=== RUN   TestGPGKeyList/with_list_options
=== RUN   TestGPGKeyList/with_invalid_options
=== RUN   TestGPGKeyList/with_invalid_options/invalid_namespace
--- PASS: TestGPGKeyList (12.27s)
    --- PASS: TestGPGKeyList/with_single_namespace (0.19s)
    --- SKIP: TestGPGKeyList/with_multiple_namespaces (0.00s)
    --- PASS: TestGPGKeyList/with_list_options (0.20s)
    --- PASS: TestGPGKeyList/with_invalid_options (0.00s)
        --- PASS: TestGPGKeyList/with_invalid_options/invalid_namespace (0.00s)
=== RUN   TestGPGKeyCreate
=== RUN   TestGPGKeyCreate/with_valid_options
=== RUN   TestGPGKeyCreate/with_invalid_registry_name
=== RUN   TestGPGKeyCreate/with_invalid_options
--- PASS: TestGPGKeyCreate (2.96s)
    --- PASS: TestGPGKeyCreate/with_valid_options (0.20s)
    --- PASS: TestGPGKeyCreate/with_invalid_registry_name (0.00s)
    --- PASS: TestGPGKeyCreate/with_invalid_options (0.00s)
=== RUN   TestGPGKeyRead
=== RUN   TestGPGKeyRead/when_the_gpg_key_exists
=== RUN   TestGPGKeyRead/when_the_key_does_not_exist
--- PASS: TestGPGKeyRead (3.53s)
    --- PASS: TestGPGKeyRead/when_the_gpg_key_exists (0.19s)
    --- PASS: TestGPGKeyRead/when_the_key_does_not_exist (0.19s)
=== RUN   TestGPGKeyUpdate
=== RUN   TestGPGKeyUpdate/when_using_an_invalid_namespace
=== RUN   TestGPGKeyUpdate/when_updating_to_a_valid_namespace
--- PASS: TestGPGKeyUpdate (5.51s)
    --- PASS: TestGPGKeyUpdate/when_using_an_invalid_namespace (0.28s)
    --- PASS: TestGPGKeyUpdate/when_updating_to_a_valid_namespace (1.56s)
=== RUN   TestGPGKeyDelete
=== RUN   TestGPGKeyDelete/when_a_key_exists
--- PASS: TestGPGKeyDelete (3.10s)
    --- PASS: TestGPGKeyDelete/when_a_key_exists (0.19s)
PASS
ok  	github.com/hashicorp/go-tfe	27.637s
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]

```

### TestRegistryProvider

#### Command

```
TFE_ADMIN_PROVISION_LICENSES_TOKEN=TOKEN ENABLE_TFE=0 envchain tfe-local go test -run TestRegistryProvider -v ./... -tags=integration
```

#### Output

```
=== RUN   TestRegistryProvidersList
=== RUN   TestRegistryProvidersList/with_providers
=== RUN   TestRegistryProvidersList/with_providers/returns_all_providers
=== RUN   TestRegistryProvidersList/with_providers/with_list_options
=== RUN   TestRegistryProvidersList/with_providers/filters_on_registry_name
=== RUN   TestRegistryProvidersList/with_providers/searches
=== RUN   TestRegistryProvidersList/without_providers
=== RUN   TestRegistryProvidersList/with_include_provider_versions
--- PASS: TestRegistryProvidersList (12.91s)
    --- PASS: TestRegistryProvidersList/with_providers (6.81s)
        --- PASS: TestRegistryProvidersList/with_providers/returns_all_providers (0.34s)
        --- PASS: TestRegistryProvidersList/with_providers/with_list_options (0.20s)
        --- PASS: TestRegistryProvidersList/with_providers/filters_on_registry_name (0.25s)
        --- PASS: TestRegistryProvidersList/with_providers/searches (0.26s)
    --- PASS: TestRegistryProvidersList/without_providers (1.49s)
    --- PASS: TestRegistryProvidersList/with_include_provider_versions (4.07s)
=== RUN   TestRegistryProvidersCreate
=== RUN   TestRegistryProvidersCreate/with_valid_options
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_public_provider
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_public_provider/permissions_are_properly_decoded
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_public_provider/relationships_are_properly_decoded
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_public_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_private_provider
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_private_provider/permissions_are_properly_decoded
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_private_provider/relationships_are_properly_decoded
=== RUN   TestRegistryProvidersCreate/with_valid_options/with_private_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryProvidersCreate/with_invalid_options
=== RUN   TestRegistryProvidersCreate/with_invalid_options/without_a_name
=== RUN   TestRegistryProvidersCreate/with_invalid_options/with_an_invalid_name
=== RUN   TestRegistryProvidersCreate/with_invalid_options/without_a_namespace
=== RUN   TestRegistryProvidersCreate/with_invalid_options/with_an_invalid_namespace
=== RUN   TestRegistryProvidersCreate/with_invalid_options/without_a_registry-name
=== RUN   TestRegistryProvidersCreate/with_invalid_options/with_an_invalid_registry-name
=== RUN   TestRegistryProvidersCreate/without_a_valid_organization
--- PASS: TestRegistryProvidersCreate (2.30s)
    --- PASS: TestRegistryProvidersCreate/with_valid_options (0.45s)
        --- PASS: TestRegistryProvidersCreate/with_valid_options/with_public_provider (0.22s)
            --- PASS: TestRegistryProvidersCreate/with_valid_options/with_public_provider/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersCreate/with_valid_options/with_public_provider/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersCreate/with_valid_options/with_public_provider/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProvidersCreate/with_valid_options/with_private_provider (0.23s)
            --- PASS: TestRegistryProvidersCreate/with_valid_options/with_private_provider/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersCreate/with_valid_options/with_private_provider/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersCreate/with_valid_options/with_private_provider/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryProvidersCreate/with_invalid_options (0.40s)
        --- PASS: TestRegistryProvidersCreate/with_invalid_options/without_a_name (0.00s)
        --- PASS: TestRegistryProvidersCreate/with_invalid_options/with_an_invalid_name (0.00s)
        --- PASS: TestRegistryProvidersCreate/with_invalid_options/without_a_namespace (0.00s)
        --- PASS: TestRegistryProvidersCreate/with_invalid_options/with_an_invalid_namespace (0.00s)
        --- PASS: TestRegistryProvidersCreate/with_invalid_options/without_a_registry-name (0.20s)
        --- PASS: TestRegistryProvidersCreate/with_invalid_options/with_an_invalid_registry-name (0.21s)
    --- PASS: TestRegistryProvidersCreate/without_a_valid_organization (0.00s)
=== RUN   TestRegistryProvidersRead
=== RUN   TestRegistryProvidersRead/with_public_provider
=== RUN   TestRegistryProvidersRead/with_public_provider/with_valid_provider
=== RUN   TestRegistryProvidersRead/with_public_provider/with_valid_provider/permissions_are_properly_decoded
=== RUN   TestRegistryProvidersRead/with_public_provider/with_valid_provider/relationships_are_properly_decoded
=== RUN   TestRegistryProvidersRead/with_public_provider/with_valid_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryProvidersRead/with_public_provider/when_the_registry_provider_does_not_exist
=== RUN   TestRegistryProvidersRead/with_private_provider
=== RUN   TestRegistryProvidersRead/with_private_provider/with_valid_provider
=== RUN   TestRegistryProvidersRead/with_private_provider/with_valid_provider/permissions_are_properly_decoded
=== RUN   TestRegistryProvidersRead/with_private_provider/with_valid_provider/relationships_are_properly_decoded
=== RUN   TestRegistryProvidersRead/with_private_provider/with_valid_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryProvidersRead/with_private_provider/when_the_registry_provider_does_not_exist
=== RUN   TestRegistryProvidersRead/populates_version_relationships
--- PASS: TestRegistryProvidersRead (6.59s)
    --- PASS: TestRegistryProvidersRead/with_public_provider (0.89s)
        --- PASS: TestRegistryProvidersRead/with_public_provider/with_valid_provider (0.68s)
            --- PASS: TestRegistryProvidersRead/with_public_provider/with_valid_provider/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersRead/with_public_provider/with_valid_provider/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersRead/with_public_provider/with_valid_provider/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProvidersRead/with_public_provider/when_the_registry_provider_does_not_exist (0.21s)
    --- PASS: TestRegistryProvidersRead/with_private_provider (0.88s)
        --- PASS: TestRegistryProvidersRead/with_private_provider/with_valid_provider (0.69s)
            --- PASS: TestRegistryProvidersRead/with_private_provider/with_valid_provider/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersRead/with_private_provider/with_valid_provider/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryProvidersRead/with_private_provider/with_valid_provider/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProvidersRead/with_private_provider/when_the_registry_provider_does_not_exist (0.19s)
    --- PASS: TestRegistryProvidersRead/populates_version_relationships (2.81s)
=== RUN   TestRegistryProvidersDelete
=== RUN   TestRegistryProvidersDelete/with_public_provider
=== RUN   TestRegistryProvidersDelete/with_public_provider/with_valid_provider
=== RUN   TestRegistryProvidersDelete/with_public_provider/when_the_registry_provider_does_not_exist
=== RUN   TestRegistryProvidersDelete/with_private_provider
=== RUN   TestRegistryProvidersDelete/with_private_provider/with_valid_provider
=== RUN   TestRegistryProvidersDelete/with_private_provider/when_the_registry_provider_does_not_exist
--- PASS: TestRegistryProvidersDelete (3.33s)
    --- PASS: TestRegistryProvidersDelete/with_public_provider (0.82s)
        --- PASS: TestRegistryProvidersDelete/with_public_provider/with_valid_provider (0.63s)
        --- PASS: TestRegistryProvidersDelete/with_public_provider/when_the_registry_provider_does_not_exist (0.19s)
    --- PASS: TestRegistryProvidersDelete/with_private_provider (0.85s)
        --- PASS: TestRegistryProvidersDelete/with_private_provider/with_valid_provider (0.67s)
        --- PASS: TestRegistryProvidersDelete/with_private_provider/when_the_registry_provider_does_not_exist (0.18s)
=== RUN   TestRegistryProvidersIDValidation
=== RUN   TestRegistryProvidersIDValidation/valid
=== RUN   TestRegistryProvidersIDValidation/without_a_name
=== RUN   TestRegistryProvidersIDValidation/with_an_invalid_name
=== RUN   TestRegistryProvidersIDValidation/without_a_namespace
=== RUN   TestRegistryProvidersIDValidation/with_an_invalid_namespace
=== RUN   TestRegistryProvidersIDValidation/without_a_registry-name
=== RUN   TestRegistryProvidersIDValidation/without_a_valid_organization
--- PASS: TestRegistryProvidersIDValidation (0.00s)
    --- PASS: TestRegistryProvidersIDValidation/valid (0.00s)
    --- PASS: TestRegistryProvidersIDValidation/without_a_name (0.00s)
    --- PASS: TestRegistryProvidersIDValidation/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryProvidersIDValidation/without_a_namespace (0.00s)
    --- PASS: TestRegistryProvidersIDValidation/with_an_invalid_namespace (0.00s)
    --- PASS: TestRegistryProvidersIDValidation/without_a_registry-name (0.00s)
    --- PASS: TestRegistryProvidersIDValidation/without_a_valid_organization (0.00s)
=== RUN   TestRegistryProviderPlatformsCreate
=== RUN   TestRegistryProviderPlatformsCreate/with_valid_options
=== RUN   TestRegistryProviderPlatformsCreate/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryProviderPlatformsCreate/with_valid_options/attributes_are_properly_decoded
=== RUN   TestRegistryProviderPlatformsCreate/with_invalid_options
=== RUN   TestRegistryProviderPlatformsCreate/with_invalid_options/without_an_OS
=== RUN   TestRegistryProviderPlatformsCreate/with_invalid_options/without_an_arch
=== RUN   TestRegistryProviderPlatformsCreate/with_invalid_options/without_a_shasum
=== RUN   TestRegistryProviderPlatformsCreate/with_invalid_options/without_a_filename
=== RUN   TestRegistryProviderPlatformsCreate/with_invalid_options/with_a_public_provider
=== RUN   TestRegistryProviderPlatformsCreate/with_invalid_options/without_a_valid_registry_provider_version_id
--- PASS: TestRegistryProviderPlatformsCreate (3.06s)
    --- PASS: TestRegistryProviderPlatformsCreate/with_valid_options (0.53s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_valid_options/attributes_are_properly_decoded (0.00s)
    --- PASS: TestRegistryProviderPlatformsCreate/with_invalid_options (0.00s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_invalid_options/without_an_OS (0.00s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_invalid_options/without_an_arch (0.00s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_invalid_options/without_a_shasum (0.00s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_invalid_options/without_a_filename (0.00s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_invalid_options/with_a_public_provider (0.00s)
        --- PASS: TestRegistryProviderPlatformsCreate/with_invalid_options/without_a_valid_registry_provider_version_id (0.00s)
=== RUN   TestRegistryProviderPlatformsDelete
=== RUN   TestRegistryProviderPlatformsDelete/with_a_valid_version
=== RUN   TestRegistryProviderPlatformsDelete/with_a_non-existent_version
--- PASS: TestRegistryProviderPlatformsDelete (3.22s)
    --- PASS: TestRegistryProviderPlatformsDelete/with_a_valid_version (0.58s)
    --- PASS: TestRegistryProviderPlatformsDelete/with_a_non-existent_version (0.20s)
=== RUN   TestRegistryProviderPlatformsRead
=== RUN   TestRegistryProviderPlatformsRead/with_valid_platform
=== RUN   TestRegistryProviderPlatformsRead/with_valid_platform/relationships_are_properly_decoded
=== RUN   TestRegistryProviderPlatformsRead/with_valid_platform/includes_provider_binary_upload_link
=== RUN   TestRegistryProviderPlatformsRead/with_non-existent_os
=== RUN   TestRegistryProviderPlatformsRead/with_non-existent_arch
--- PASS: TestRegistryProviderPlatformsRead (3.93s)
    --- PASS: TestRegistryProviderPlatformsRead/with_valid_platform (0.26s)
        --- PASS: TestRegistryProviderPlatformsRead/with_valid_platform/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProviderPlatformsRead/with_valid_platform/includes_provider_binary_upload_link (0.00s)
    --- PASS: TestRegistryProviderPlatformsRead/with_non-existent_os (0.22s)
    --- PASS: TestRegistryProviderPlatformsRead/with_non-existent_arch (0.21s)
=== RUN   TestRegistryProviderPlatformsList
=== RUN   TestRegistryProviderPlatformsList/with_platforms
=== RUN   TestRegistryProviderPlatformsList/with_platforms/with_no_list_options
=== RUN   TestRegistryProviderPlatformsList/with_platforms/with_list_options
=== RUN   TestRegistryProviderPlatformsList/without_platforms
--- PASS: TestRegistryProviderPlatformsList (6.39s)
    --- PASS: TestRegistryProviderPlatformsList/with_platforms (3.27s)
        --- PASS: TestRegistryProviderPlatformsList/with_platforms/with_no_list_options (0.30s)
        --- PASS: TestRegistryProviderPlatformsList/with_platforms/with_list_options (0.21s)
    --- PASS: TestRegistryProviderPlatformsList/without_platforms (2.46s)
=== RUN   TestRegistryProviderVersionsIDValidation
=== RUN   TestRegistryProviderVersionsIDValidation/valid
=== RUN   TestRegistryProviderVersionsIDValidation/without_a_version
=== RUN   TestRegistryProviderVersionsIDValidation/without_a_key-id
=== RUN   TestRegistryProviderVersionsIDValidation/invalid_version
    registry_provider_version_integration_test.go:61: This is skipped as we don't actually validate version is a valid semver - the registry does this validation
=== RUN   TestRegistryProviderVersionsIDValidation/invalid_registry_for_parent_provider
=== RUN   TestRegistryProviderVersionsIDValidation/without_a_valid_registry_provider_id
--- PASS: TestRegistryProviderVersionsIDValidation (0.00s)
    --- PASS: TestRegistryProviderVersionsIDValidation/valid (0.00s)
    --- PASS: TestRegistryProviderVersionsIDValidation/without_a_version (0.00s)
    --- PASS: TestRegistryProviderVersionsIDValidation/without_a_key-id (0.00s)
    --- SKIP: TestRegistryProviderVersionsIDValidation/invalid_version (0.00s)
    --- PASS: TestRegistryProviderVersionsIDValidation/invalid_registry_for_parent_provider (0.00s)
    --- PASS: TestRegistryProviderVersionsIDValidation/without_a_valid_registry_provider_id (0.00s)
=== RUN   TestRegistryProviderVersionsCreate
=== RUN   TestRegistryProviderVersionsCreate/with_valid_options
=== RUN   TestRegistryProviderVersionsCreate/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryProviderVersionsCreate/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryProviderVersionsCreate/with_valid_options/includes_upload_links
=== RUN   TestRegistryProviderVersionsCreate/with_valid_options/doesn't_include_download_links
=== RUN   TestRegistryProviderVersionsCreate/with_invalid_options
=== RUN   TestRegistryProviderVersionsCreate/with_invalid_options/without_a_version
=== RUN   TestRegistryProviderVersionsCreate/with_invalid_options/without_a_key-id
=== RUN   TestRegistryProviderVersionsCreate/with_invalid_options/with_a_public_provider
=== RUN   TestRegistryProviderVersionsCreate/with_invalid_options/without_a_valid_provider_id
--- PASS: TestRegistryProviderVersionsCreate (2.39s)
    --- PASS: TestRegistryProviderVersionsCreate/with_valid_options (0.31s)
        --- PASS: TestRegistryProviderVersionsCreate/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProviderVersionsCreate/with_valid_options/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProviderVersionsCreate/with_valid_options/includes_upload_links (0.00s)
        --- PASS: TestRegistryProviderVersionsCreate/with_valid_options/doesn't_include_download_links (0.00s)
    --- PASS: TestRegistryProviderVersionsCreate/with_invalid_options (0.01s)
        --- PASS: TestRegistryProviderVersionsCreate/with_invalid_options/without_a_version (0.00s)
        --- PASS: TestRegistryProviderVersionsCreate/with_invalid_options/without_a_key-id (0.00s)
        --- PASS: TestRegistryProviderVersionsCreate/with_invalid_options/with_a_public_provider (0.00s)
        --- PASS: TestRegistryProviderVersionsCreate/with_invalid_options/without_a_valid_provider_id (0.00s)
=== RUN   TestRegistryProviderVersionsList
=== RUN   TestRegistryProviderVersionsList/with_versions
=== RUN   TestRegistryProviderVersionsList/with_versions/returns_all_versions
=== RUN   TestRegistryProviderVersionsList/with_versions/returns_pages
=== RUN   TestRegistryProviderVersionsList/with_versions/returns_pages/returns_page_0_of_versions
=== RUN   TestRegistryProviderVersionsList/with_versions/returns_pages/returns_page_1_of_versions
=== RUN   TestRegistryProviderVersionsList/without_versions
--- PASS: TestRegistryProviderVersionsList (9.19s)
    --- PASS: TestRegistryProviderVersionsList/with_versions (6.66s)
        --- PASS: TestRegistryProviderVersionsList/with_versions/returns_all_versions (0.72s)
        --- PASS: TestRegistryProviderVersionsList/with_versions/returns_pages (0.95s)
            --- PASS: TestRegistryProviderVersionsList/with_versions/returns_pages/returns_page_0_of_versions (0.43s)
            --- PASS: TestRegistryProviderVersionsList/with_versions/returns_pages/returns_page_1_of_versions (0.52s)
    --- PASS: TestRegistryProviderVersionsList/without_versions (1.92s)
=== RUN   TestRegistryProviderVersionsDelete
=== RUN   TestRegistryProviderVersionsDelete/with_valid_version
=== RUN   TestRegistryProviderVersionsDelete/with_non_existing_version
--- PASS: TestRegistryProviderVersionsDelete (2.83s)
    --- PASS: TestRegistryProviderVersionsDelete/with_valid_version (0.59s)
    --- PASS: TestRegistryProviderVersionsDelete/with_non_existing_version (0.20s)
=== RUN   TestRegistryProviderVersionsRead
=== RUN   TestRegistryProviderVersionsRead/with_valid_version
=== RUN   TestRegistryProviderVersionsRead/with_valid_version/relationships_are_properly_decoded
=== RUN   TestRegistryProviderVersionsRead/with_valid_version/timestamps_are_properly_decoded
=== RUN   TestRegistryProviderVersionsRead/with_valid_version/includes_upload_links
=== RUN   TestRegistryProviderVersionsRead/with_non_existing_version
--- PASS: TestRegistryProviderVersionsRead (4.65s)
    --- PASS: TestRegistryProviderVersionsRead/with_valid_version (2.13s)
        --- PASS: TestRegistryProviderVersionsRead/with_valid_version/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProviderVersionsRead/with_valid_version/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryProviderVersionsRead/with_valid_version/includes_upload_links (0.00s)
    --- PASS: TestRegistryProviderVersionsRead/with_non_existing_version (1.90s)
PASS
ok  	github.com/hashicorp/go-tfe	61.077s
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```

### TestPolicySet

#### Command

```
TFE_ADMIN_PROVISION_LICENSES_TOKEN=TOKEN  ENABLE_TFE=0 envchain tfe-local go test -run TestPolicySet -v ./... -tags=integration
```

#### Output
Note - the failures are because my environment is not setup correctly for the VCS related tests.


```
=== RUN   TestPolicySetOutcomeList_Beta
    helper_test.go:1154: Polling run "run-vBep2RBzRhXHkuaq" for status included in ["cost_estimated" "errored"] with deadline of 2023-05-25 15:49:44.614043 -0600 MDT m=+124.249744584
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "plan_queued"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "post_plan_running"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "post_plan_running"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "cost_estimating"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-vBep2RBzRhXHkuaq"
    helper_test.go:1166: Run "run-vBep2RBzRhXHkuaq" had status "cost_estimated"
=== RUN   TestPolicySetOutcomeList_Beta/with_no_params
=== RUN   TestPolicySetOutcomeList_Beta/with_non-matching_filters
=== RUN   TestPolicySetOutcomeList_Beta/with_matching_filters
--- PASS: TestPolicySetOutcomeList_Beta (37.44s)
    --- PASS: TestPolicySetOutcomeList_Beta/with_no_params (0.52s)
    --- PASS: TestPolicySetOutcomeList_Beta/with_non-matching_filters (0.53s)
    --- PASS: TestPolicySetOutcomeList_Beta/with_matching_filters (0.51s)
=== RUN   TestPolicySetOutcomeRead_Beta
    helper_test.go:1154: Polling run "run-WUka4waDk4Xqh9we" for status included in ["cost_estimated" "errored"] with deadline of 2023-05-25 15:50:21.56083 -0600 MDT m=+161.202941334
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "post_plan_running"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "post_plan_running"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-WUka4waDk4Xqh9we"
    helper_test.go:1166: Run "run-WUka4waDk4Xqh9we" had status "cost_estimated"
=== RUN   TestPolicySetOutcomeRead_Beta/with_a_valid_policy_set_outcome_ID
=== RUN   TestPolicySetOutcomeRead_Beta/with_a_invalid_policy_set_outcome_ID
--- PASS: TestPolicySetOutcomeRead_Beta (34.10s)
    --- PASS: TestPolicySetOutcomeRead_Beta/with_a_valid_policy_set_outcome_ID (0.74s)
    --- PASS: TestPolicySetOutcomeRead_Beta/with_a_invalid_policy_set_outcome_ID (0.00s)
=== RUN   TestPolicySetsList_Beta
=== RUN   TestPolicySetsList_Beta/without_list_options
=== RUN   TestPolicySetsList_Beta/with_pagination
=== RUN   TestPolicySetsList_Beta/with_search
=== RUN   TestPolicySetsList_Beta/with_include_param
=== RUN   TestPolicySetsList_Beta/filter_by_kind
=== RUN   TestPolicySetsList_Beta/without_a_valid_organization
--- PASS: TestPolicySetsList_Beta (5.75s)
    --- PASS: TestPolicySetsList_Beta/without_list_options (0.31s)
    --- PASS: TestPolicySetsList_Beta/with_pagination (0.25s)
    --- PASS: TestPolicySetsList_Beta/with_search (0.27s)
    --- PASS: TestPolicySetsList_Beta/with_include_param (0.34s)
    --- PASS: TestPolicySetsList_Beta/filter_by_kind (0.28s)
    --- PASS: TestPolicySetsList_Beta/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsCreate_Beta
=== RUN   TestPolicySetsCreate_Beta/with_valid_attributes
=== RUN   TestPolicySetsCreate_Beta/with_kind_missing
=== RUN   TestPolicySetsCreate_Beta/with_all_attributes_provided_-_sentinel
=== RUN   TestPolicySetsCreate_Beta/with_all_attributes_provided_-_OPA
=== RUN   TestPolicySetsCreate_Beta/with_missing_overridable_attribute
=== RUN   TestPolicySetsCreate_Beta/with_policies_and_workspaces_provided
=== RUN   TestPolicySetsCreate_Beta/with_vcs_policy_set
    policy_set_integration_beta_test.go:256:
        	Error Trace:	/Users/awinkler/dev/go-tfe/policy_set_integration_beta_test.go:256
        	Error:      	Received unexpected error:
        	            	bad request

        	            	The specified VCS branch "policies" doesn't exist.
        	Test:       	TestPolicySetsCreate_Beta/with_vcs_policy_set
=== RUN   TestPolicySetsCreate_Beta/with_vcs_policy_updated
    policy_set_integration_beta_test.go:297:
        	Error Trace:	/Users/awinkler/dev/go-tfe/policy_set_integration_beta_test.go:297
        	Error:      	Received unexpected error:
        	            	invalid value for policy set ID
        	Test:       	TestPolicySetsCreate_Beta/with_vcs_policy_updated
=== RUN   TestPolicySetsCreate_Beta/without_a_name_provided
=== RUN   TestPolicySetsCreate_Beta/with_an_invalid_name_provided
=== RUN   TestPolicySetsCreate_Beta/without_a_valid_organization
--- FAIL: TestPolicySetsCreate_Beta (7.94s)
    --- PASS: TestPolicySetsCreate_Beta/with_valid_attributes (0.60s)
    --- PASS: TestPolicySetsCreate_Beta/with_kind_missing (0.23s)
    --- PASS: TestPolicySetsCreate_Beta/with_all_attributes_provided_-_sentinel (0.22s)
    --- PASS: TestPolicySetsCreate_Beta/with_all_attributes_provided_-_OPA (0.22s)
    --- PASS: TestPolicySetsCreate_Beta/with_missing_overridable_attribute (0.24s)
    --- PASS: TestPolicySetsCreate_Beta/with_policies_and_workspaces_provided (1.32s)
    --- FAIL: TestPolicySetsCreate_Beta/with_vcs_policy_set (1.71s)
    --- FAIL: TestPolicySetsCreate_Beta/with_vcs_policy_updated (0.73s)
    --- PASS: TestPolicySetsCreate_Beta/without_a_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate_Beta/with_an_invalid_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate_Beta/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsUpdate_Beta
=== RUN   TestPolicySetsUpdate_Beta/with_valid_attributes
--- PASS: TestPolicySetsUpdate_Beta (3.08s)
    --- PASS: TestPolicySetsUpdate_Beta/with_valid_attributes (0.23s)
=== RUN   TestPolicySetsList
=== RUN   TestPolicySetsList/without_list_options
=== RUN   TestPolicySetsList/with_pagination
=== RUN   TestPolicySetsList/with_search
=== RUN   TestPolicySetsList/with_include_param
=== RUN   TestPolicySetsList/without_a_valid_organization
--- PASS: TestPolicySetsList (5.08s)
    --- PASS: TestPolicySetsList/without_list_options (0.32s)
    --- PASS: TestPolicySetsList/with_pagination (0.38s)
    --- PASS: TestPolicySetsList/with_search (0.26s)
    --- PASS: TestPolicySetsList/with_include_param (0.31s)
    --- PASS: TestPolicySetsList/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsCreate
=== RUN   TestPolicySetsCreate/with_valid_attributes
=== RUN   TestPolicySetsCreate/with_all_attributes_provided
=== RUN   TestPolicySetsCreate/with_policies_and_workspaces_provided
=== RUN   TestPolicySetsCreate/with_vcs_policy_set
    policy_set_integration_test.go:178:
        	Error Trace:	/Users/awinkler/dev/go-tfe/policy_set_integration_test.go:178
        	Error:      	Received unexpected error:
        	            	bad request

        	            	The specified VCS branch "policies" doesn't exist.
        	Test:       	TestPolicySetsCreate/with_vcs_policy_set
=== RUN   TestPolicySetsCreate/with_vcs_policy_updated
    policy_set_integration_test.go:218:
        	Error Trace:	/Users/awinkler/dev/go-tfe/policy_set_integration_test.go:218
        	Error:      	Received unexpected error:
        	            	invalid value for policy set ID
        	Test:       	TestPolicySetsCreate/with_vcs_policy_updated
=== RUN   TestPolicySetsCreate/without_a_name_provided
=== RUN   TestPolicySetsCreate/with_an_invalid_name_provided
=== RUN   TestPolicySetsCreate/without_a_valid_organization
--- FAIL: TestPolicySetsCreate (6.49s)
    --- PASS: TestPolicySetsCreate/with_valid_attributes (0.55s)
    --- PASS: TestPolicySetsCreate/with_all_attributes_provided (0.23s)
    --- PASS: TestPolicySetsCreate/with_policies_and_workspaces_provided (1.23s)
    --- FAIL: TestPolicySetsCreate/with_vcs_policy_set (1.64s)
    --- FAIL: TestPolicySetsCreate/with_vcs_policy_updated (0.72s)
    --- PASS: TestPolicySetsCreate/without_a_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/with_an_invalid_name_provided (0.00s)
    --- PASS: TestPolicySetsCreate/without_a_valid_organization (0.00s)
=== RUN   TestPolicySetsCreateWithGithubApp
    policy_set_integration_test.go:260: Export a valid GITHUB_APP_INSTALLATION_ID before running this test!
--- SKIP: TestPolicySetsCreateWithGithubApp (0.00s)
=== RUN   TestPolicySetsRead
=== RUN   TestPolicySetsRead/with_a_valid_ID
=== RUN   TestPolicySetsRead/without_a_valid_ID
=== RUN   TestPolicySetsRead/with_policy_set_version
--- PASS: TestPolicySetsRead (4.71s)
    --- PASS: TestPolicySetsRead/with_a_valid_ID (0.21s)
    --- PASS: TestPolicySetsRead/without_a_valid_ID (0.00s)
    --- PASS: TestPolicySetsRead/with_policy_set_version (1.64s)
=== RUN   TestPolicySetsUpdate
=== RUN   TestPolicySetsUpdate/with_valid_attributes
=== RUN   TestPolicySetsUpdate/with_invalid_attributes
=== RUN   TestPolicySetsUpdate/without_a_valid_ID
--- PASS: TestPolicySetsUpdate (3.02s)
    --- PASS: TestPolicySetsUpdate/with_valid_attributes (0.21s)
    --- PASS: TestPolicySetsUpdate/with_invalid_attributes (0.00s)
    --- PASS: TestPolicySetsUpdate/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsAddPolicies
=== RUN   TestPolicySetsAddPolicies/with_policies_provided
=== RUN   TestPolicySetsAddPolicies/without_policies_provided
=== RUN   TestPolicySetsAddPolicies/with_empty_policies_slice
=== RUN   TestPolicySetsAddPolicies/without_a_valid_ID
--- PASS: TestPolicySetsAddPolicies (4.11s)
    --- PASS: TestPolicySetsAddPolicies/with_policies_provided (0.45s)
    --- PASS: TestPolicySetsAddPolicies/without_policies_provided (0.00s)
    --- PASS: TestPolicySetsAddPolicies/with_empty_policies_slice (0.00s)
    --- PASS: TestPolicySetsAddPolicies/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsRemovePolicies
=== RUN   TestPolicySetsRemovePolicies/with_policies_provided
=== RUN   TestPolicySetsRemovePolicies/without_policies_provided
=== RUN   TestPolicySetsRemovePolicies/with_empty_policies_slice
=== RUN   TestPolicySetsRemovePolicies/without_a_valid_ID
--- PASS: TestPolicySetsRemovePolicies (4.11s)
    --- PASS: TestPolicySetsRemovePolicies/with_policies_provided (0.43s)
    --- PASS: TestPolicySetsRemovePolicies/without_policies_provided (0.00s)
    --- PASS: TestPolicySetsRemovePolicies/with_empty_policies_slice (0.00s)
    --- PASS: TestPolicySetsRemovePolicies/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsAddWorkspaces
=== RUN   TestPolicySetsAddWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsAddWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsAddWorkspaces (4.37s)
    --- PASS: TestPolicySetsAddWorkspaces/with_workspaces_provided (0.41s)
    --- PASS: TestPolicySetsAddWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsRemoveWorkspaces
=== RUN   TestPolicySetsRemoveWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsRemoveWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsRemoveWorkspaces (4.18s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_workspaces_provided (0.40s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsDelete
=== RUN   TestPolicySetsDelete/with_valid_options
=== RUN   TestPolicySetsDelete/when_the_policy_does_not_exist
=== RUN   TestPolicySetsDelete/when_the_policy_ID_is_invalid
--- PASS: TestPolicySetsDelete (3.03s)
    --- PASS: TestPolicySetsDelete/with_valid_options (0.37s)
    --- PASS: TestPolicySetsDelete/when_the_policy_does_not_exist (0.16s)
    --- PASS: TestPolicySetsDelete/when_the_policy_ID_is_invalid (0.00s)
=== RUN   TestPolicySetParametersList
=== RUN   TestPolicySetParametersList/without_list_options
    policy_set_parameter_integration_test.go:35: paging not supported yet in API
=== RUN   TestPolicySetParametersList/with_list_options
    policy_set_parameter_integration_test.go:41: paging not supported yet in API
=== RUN   TestPolicySetParametersList/when_policy_set_ID_is_invalid_ID
--- PASS: TestPolicySetParametersList (2.82s)
    --- SKIP: TestPolicySetParametersList/without_list_options (0.32s)
    --- SKIP: TestPolicySetParametersList/with_list_options (0.00s)
    --- PASS: TestPolicySetParametersList/when_policy_set_ID_is_invalid_ID (0.00s)
=== RUN   TestPolicySetParametersCreate
=== RUN   TestPolicySetParametersCreate/with_valid_options
=== RUN   TestPolicySetParametersCreate/when_options_has_an_empty_string_value
=== RUN   TestPolicySetParametersCreate/when_options_is_missing_value
=== RUN   TestPolicySetParametersCreate/when_options_is_missing_key
=== RUN   TestPolicySetParametersCreate/when_options_has_an_empty_key
=== RUN   TestPolicySetParametersCreate/when_options_is_missing_category
=== RUN   TestPolicySetParametersCreate/when_policy_set_ID_is_invalid
--- PASS: TestPolicySetParametersCreate (2.26s)
    --- PASS: TestPolicySetParametersCreate/with_valid_options (0.20s)
    --- PASS: TestPolicySetParametersCreate/when_options_has_an_empty_string_value (0.21s)
    --- PASS: TestPolicySetParametersCreate/when_options_is_missing_value (0.22s)
    --- PASS: TestPolicySetParametersCreate/when_options_is_missing_key (0.00s)
    --- PASS: TestPolicySetParametersCreate/when_options_has_an_empty_key (0.00s)
    --- PASS: TestPolicySetParametersCreate/when_options_is_missing_category (0.00s)
    --- PASS: TestPolicySetParametersCreate/when_policy_set_ID_is_invalid (0.00s)
=== RUN   TestPolicySetParametersRead
=== RUN   TestPolicySetParametersRead/when_the_parameter_exists
=== RUN   TestPolicySetParametersRead/when_the_parameter_does_not_exist
=== RUN   TestPolicySetParametersRead/without_a_valid_policy_set_ID
=== RUN   TestPolicySetParametersRead/without_a_valid_parameter_ID
--- PASS: TestPolicySetParametersRead (2.44s)
    --- PASS: TestPolicySetParametersRead/when_the_parameter_exists (0.22s)
    --- PASS: TestPolicySetParametersRead/when_the_parameter_does_not_exist (0.20s)
    --- PASS: TestPolicySetParametersRead/without_a_valid_policy_set_ID (0.00s)
    --- PASS: TestPolicySetParametersRead/without_a_valid_parameter_ID (0.00s)
=== RUN   TestPolicySetParametersUpdate
=== RUN   TestPolicySetParametersUpdate/with_valid_options
=== RUN   TestPolicySetParametersUpdate/when_updating_a_subset_of_values
=== RUN   TestPolicySetParametersUpdate/with_sensitive_set
=== RUN   TestPolicySetParametersUpdate/without_any_changes
=== RUN   TestPolicySetParametersUpdate/with_invalid_parameter_ID
=== RUN   TestPolicySetParametersUpdate/with_invalid_parameter_ID#01
--- PASS: TestPolicySetParametersUpdate (4.95s)
    --- PASS: TestPolicySetParametersUpdate/with_valid_options (0.22s)
    --- PASS: TestPolicySetParametersUpdate/when_updating_a_subset_of_values (0.21s)
    --- PASS: TestPolicySetParametersUpdate/with_sensitive_set (0.22s)
    --- PASS: TestPolicySetParametersUpdate/without_any_changes (1.73s)
    --- PASS: TestPolicySetParametersUpdate/with_invalid_parameter_ID (0.00s)
    --- PASS: TestPolicySetParametersUpdate/with_invalid_parameter_ID#01 (0.00s)
=== RUN   TestPolicySetParametersDelete
=== RUN   TestPolicySetParametersDelete/with_valid_options
=== RUN   TestPolicySetParametersDelete/with_non_existing_parameter_ID
=== RUN   TestPolicySetParametersDelete/with_invalid_policy_set_ID
=== RUN   TestPolicySetParametersDelete/with_invalid_parameter_ID
--- PASS: TestPolicySetParametersDelete (2.31s)
    --- PASS: TestPolicySetParametersDelete/with_valid_options (0.21s)
    --- PASS: TestPolicySetParametersDelete/with_non_existing_parameter_ID (0.19s)
    --- PASS: TestPolicySetParametersDelete/with_invalid_policy_set_ID (0.00s)
    --- PASS: TestPolicySetParametersDelete/with_invalid_parameter_ID (0.00s)
=== RUN   TestPolicySetVersionsCreate
=== RUN   TestPolicySetVersionsCreate/with_valid_identifier
=== RUN   TestPolicySetVersionsCreate/with_invalid_identifier
--- PASS: TestPolicySetVersionsCreate (1.96s)
    --- PASS: TestPolicySetVersionsCreate/with_valid_identifier (0.25s)
    --- PASS: TestPolicySetVersionsCreate/with_invalid_identifier (0.00s)
=== RUN   TestPolicySetVersionsRead
=== RUN   TestPolicySetVersionsRead/with_valid_id
=== RUN   TestPolicySetVersionsRead/with_invalid_id
--- PASS: TestPolicySetVersionsRead (2.42s)
    --- PASS: TestPolicySetVersionsRead/with_valid_id (0.21s)
    --- PASS: TestPolicySetVersionsRead/with_invalid_id (0.18s)
=== RUN   TestPolicySetVersionsUpload
=== RUN   TestPolicySetVersionsUpload/with_valid_upload_URL
=== RUN   TestPolicySetVersionsUpload/with_missing_upload_URL
--- PASS: TestPolicySetVersionsUpload (2.99s)
    --- PASS: TestPolicySetVersionsUpload/with_valid_upload_URL (1.07s)
    --- PASS: TestPolicySetVersionsUpload/with_missing_upload_URL (0.00s)
=== RUN   TestPolicySetVersionsUploadURL
=== RUN   TestPolicySetVersionsUploadURL/successfully_returns_upload_link
=== RUN   TestPolicySetVersionsUploadURL/errors_when_there_is_no_upload_key_in_the_Links
=== RUN   TestPolicySetVersionsUploadURL/errors_when_the_upload_link_is_empty
--- PASS: TestPolicySetVersionsUploadURL (0.00s)
    --- PASS: TestPolicySetVersionsUploadURL/successfully_returns_upload_link (0.00s)
    --- PASS: TestPolicySetVersionsUploadURL/errors_when_there_is_no_upload_key_in_the_Links (0.00s)
    --- PASS: TestPolicySetVersionsUploadURL/errors_when_the_upload_link_is_empty (0.00s)
FAIL
FAIL	github.com/hashicorp/go-tfe	149.854s
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
FAIL
```