### PR TITLE
[WIP] Add support for a new variable field 'version-id'

### DIFF
--- a/variable.go
+++ b/variable.go
@@ -63,6 +63,7 @@ type Variable struct {
 	Category    CategoryType `jsonapi:"attr,category"`
 	HCL         bool         `jsonapi:"attr,hcl"`
 	Sensitive   bool         `jsonapi:"attr,sensitive"`
+	VersionID   string       `jsonapi:"attr,version-id"`
 
 	// Relations
 	Workspace *Workspace `jsonapi:"relation,configurable"`

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -86,6 +86,7 @@ func TestVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Category, v.Category)
 		// The workspace isn't returned correcly by the API.
 		// assert.Equal(t, *options.Workspace, v.Workspace)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options has an empty string value", func(t *testing.T) {
@@ -104,6 +105,7 @@ func TestVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Value, v.Value)
 		assert.Equal(t, *options.Description, v.Description)
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options has an empty string description", func(t *testing.T) {
@@ -122,6 +124,7 @@ func TestVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Value, v.Value)
 		assert.Equal(t, *options.Description, v.Description)
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options has a too-long description", func(t *testing.T) {
@@ -149,6 +152,7 @@ func TestVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, "", v.Value)
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options is missing key", func(t *testing.T) {
@@ -210,6 +214,7 @@ func TestVariablesRead(t *testing.T) {
 		assert.Equal(t, vTest.Key, v.Key)
 		assert.Equal(t, vTest.Sensitive, v.Sensitive)
 		assert.Equal(t, vTest.Value, v.Value)
+		assert.Equal(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("when the variable does not exist", func(t *testing.T) {
@@ -251,6 +256,7 @@ func TestVariablesUpdate(t *testing.T) {
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, *options.HCL, v.HCL)
 		assert.Equal(t, *options.Value, v.Value)
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
@@ -264,6 +270,7 @@ func TestVariablesUpdate(t *testing.T) {
 
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, *options.HCL, v.HCL)
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("with sensitive set", func(t *testing.T) {
@@ -276,6 +283,7 @@ func TestVariablesUpdate(t *testing.T) {
 
 		assert.Equal(t, *options.Sensitive, v.Sensitive)
 		assert.Empty(t, v.Value) // Because its now sensitive
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("with category set", func(t *testing.T) {
@@ -288,6 +296,7 @@ func TestVariablesUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("without any changes", func(t *testing.T) {
@@ -297,7 +306,14 @@ func TestVariablesUpdate(t *testing.T) {
 		v, err := client.Variables.Update(ctx, vTest.Workspace.ID, vTest.ID, VariableUpdateOptions{})
 		require.NoError(t, err)
 
-		assert.Equal(t, vTest, v)
+		assert.Equal(t, vTest.ID, v.ID)
+		assert.Equal(t, vTest.Key, v.Key)
+		assert.Equal(t, vTest.Value, v.Value)
+		assert.Equal(t, vTest.Description, v.Description)
+		assert.Equal(t, vTest.Category, v.Category)
+		assert.Equal(t, vTest.HCL, v.HCL)
+		assert.Equal(t, vTest.Sensitive, v.Sensitive)
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("with invalid variable ID", func(t *testing.T) {

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -50,6 +50,7 @@ type VariableSetVariable struct {
 	Category    CategoryType `jsonapi:"attr,category"`
 	HCL         bool         `jsonapi:"attr,hcl"`
 	Sensitive   bool         `jsonapi:"attr,sensitive"`
+	VersionID   string       `jsonapi:"attr,version-id"`
 
 	// Relations
 	VariableSet *VariableSet `jsonapi:"relation,varset"`

--- a/variable_set_variable_test.go
+++ b/variable_set_variable_test.go
@@ -99,6 +99,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Value, v.Value)
 		assert.Equal(t, *options.Description, v.Description)
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options has an empty string value", func(t *testing.T) {
@@ -117,6 +118,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Value, v.Value)
 		assert.Equal(t, *options.Description, v.Description)
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options has an empty string description", func(t *testing.T) {
@@ -135,6 +137,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Value, v.Value)
 		assert.Equal(t, *options.Description, v.Description)
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options has a too-long description", func(t *testing.T) {
@@ -162,6 +165,7 @@ func TestVariableSetVariablesCreate(t *testing.T) {
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, "", v.Value)
 		assert.Equal(t, *options.Category, v.Category)
+		assert.NotEmpty(t, v.VersionID)
 	})
 
 	t.Run("when options is missing key", func(t *testing.T) {
@@ -229,6 +233,7 @@ func TestVariableSetVariablesRead(t *testing.T) {
 		assert.Equal(t, vTest.Key, v.Key)
 		assert.Equal(t, vTest.Sensitive, v.Sensitive)
 		assert.Equal(t, vTest.Value, v.Value)
+		assert.Equal(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("when the variable does not exist", func(t *testing.T) {
@@ -273,6 +278,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, *options.HCL, v.HCL)
 		assert.Equal(t, *options.Value, v.Value)
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
@@ -286,6 +292,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, *options.HCL, v.HCL)
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("with sensitive set", func(t *testing.T) {
@@ -298,6 +305,7 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 
 		assert.Equal(t, *options.Sensitive, v.Sensitive)
 		assert.Empty(t, v.Value) // Because its now sensitive
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("without any changes", func(t *testing.T) {
@@ -315,7 +323,14 @@ func TestVariableSetVariablesUpdate(t *testing.T) {
 		v, err := client.VariableSetVariables.Update(ctx, vsTest.ID, vTest.ID, &options)
 		require.NoError(t, err)
 
-		assert.Equal(t, vTest, v)
+		assert.Equal(t, vTest.ID, v.ID)
+		assert.Equal(t, vTest.Key, v.Key)
+		assert.Equal(t, vTest.Value, v.Value)
+		assert.Equal(t, vTest.Description, v.Description)
+		assert.Equal(t, vTest.Category, v.Category)
+		assert.Equal(t, vTest.HCL, v.HCL)
+		assert.Equal(t, vTest.Sensitive, v.Sensitive)
+		assert.NotEqual(t, vTest.VersionID, v.VersionID)
 	})
 
 	t.Run("with invalid variable ID", func(t *testing.T) {


### PR DESCRIPTION
## Description

This PR adds support for a new workspace variable field `version-id` that was recently added to the API.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspace-variables) _search for `variable-id`_

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
