### PR TITLE
Set tokens for admin roles in the environment

### DIFF
--- a/.github/actions/test-go-tfe/action.yml
+++ b/.github/actions/test-go-tfe/action.yml
@@ -13,6 +13,27 @@ inputs:
   address:
     description: Address of the Terraform Cloud instance to test against
     required: true
+  admin_configuration_token:
+    description: TFC Admin API Configuration role token
+    required: true
+  admin_provision_licenses_token:
+    description: TFC Admin API Provision Licenses role token
+    required: true
+  admin_security_maintenance_token:
+    description: TFC Admin API Security Maintenance role token
+    required: true
+  admin_site_admin_token:
+    description: TFC Admin API Site Admin role token
+    required: true
+  admin_subscription_token:
+    description: TFC Admin API Subscription role token
+    required: true
+  admin_support_token:
+    description: TFC Admin API Support role token
+    required: true
+  admin_version_maintenance_token:
+    description: TFC Admin API Version Maintenance role token
+    required: true
   token:
     description: Terraform Cloud token
     required: true
@@ -64,6 +85,13 @@ runs:
       env:
         TFE_ADDRESS: ${{ inputs.address }}
         TFE_TOKEN: ${{ inputs.token }}
+        TFE_ADMIN_CONFIGURATION_TOKEN: ${{ inputs.admin_configuration_token }}
+        TFE_ADMIN_PROVISION_LICENSES_TOKEN: ${{ inputs.admin_provision_licenses_token }}
+        TFE_ADMIN_SECURITY_MAINTENANCE_TOKEN: ${{ inputs.admin_security_maintenance_token }}
+        TFE_ADMIN_SITE_ADMIN_TOKEN: ${{ inputs.admin_site_admin_token }}
+        TFE_ADMIN_SUBSCRIPTION_TOKEN: ${{ inputs.admin_subscription_token }}
+        TFE_ADMIN_SUPPORT_TOKEN: ${{ inputs.admin_support_token }}
+        TFE_ADMIN_VERSION_MAINTENANCE_TOKEN: ${{ inputs.admin_version_maintenance_token }}
         TFC_RUN_TASK_URL: "http://testing-mocks.tfe:22180/runtasks/pass"
         GITHUB_POLICY_SET_IDENTIFIER: "hashicorp/test-policy-set"
         GITHUB_REGISTRY_MODULE_IDENTIFIER: "hashicorp/terraform-random-module"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,13 @@ jobs:
           matrix_total: ${{ matrix.total }}
           address: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_address }}
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
+          admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}
+          admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision_licenses }}
+          admin_security_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.security_maintenance }}
+          admin_site_admin_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.site_admin }}
+          admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
+          admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
+          admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version_maintenance }}
           oauth-client-github-token: ${{ secrets.OAUTH_CLIENT_GITHUB_TOKEN }}
 
   tests-combine-summaries:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
       - name: terraform-cloud-outputs
         id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@v1
+        uses: hashicorp-forge/terraform-cloud-action/outputs@4adbe7eea886138ac10a4c09e63c5c568aaa6672
         with:
           token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           organization: hashicorp-v2
@@ -44,12 +44,12 @@ jobs:
           address: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_address }}
           token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_token }}
           admin_configuration_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.configuration }}
-          admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision_licenses }}
-          admin_security_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.security_maintenance }}
-          admin_site_admin_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.site_admin }}
+          admin_provision_licenses_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.provision-licenses }}
+          admin_security_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.security-maintenance }}
+          admin_site_admin_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.site-admin }}
           admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
           admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
-          admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version_maintenance }}
+          admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
           oauth-client-github-token: ${{ secrets.OAUTH_CLIENT_GITHUB_TOKEN }}
 
   tests-combine-summaries:

--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: terraform-cloud/apply
-        uses: hashicorp-forge/terraform-cloud-action/apply@v1
+        uses: hashicorp-forge/terraform-cloud-action/apply@4adbe7eea886138ac10a4c09e63c5c568aaa6672
         with:
           organization: hashicorp-v2
           workspace: tflocal-go-tfe-nightly
@@ -29,7 +29,7 @@ jobs:
     steps:
       - name: terraform-cloud/outputs
         id: tflocal
-        uses: hashicorp-forge/terraform-cloud-action/outputs@v1
+        uses: hashicorp-forge/terraform-cloud-action/outputs@4adbe7eea886138ac10a4c09e63c5c568aaa6672
         with:
           token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           organization: hashicorp-v2
@@ -97,7 +97,7 @@ jobs:
     if: "${{ always() }}"
     steps:
       - name: terraform-cloud/destroy
-        uses: hashicorp-forge/terraform-cloud-action/destroy@v1
+        uses: hashicorp-forge/terraform-cloud-action/destroy@4adbe7eea886138ac10a4c09e63c5c568aaa6672
         with:
           token: ${{ secrets.TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN }}
           organization: hashicorp-v2


### PR DESCRIPTION
## Description

We output admin tokens by role, so let's take that and set an environment variable to use in future tests.

## Testing plan

1. Nothing should change.
