### PR TITLE
Fix flaky test TestPolicySetsRead

### DIFF
--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -380,6 +381,10 @@ func TestPolicySetsRead(t *testing.T) {
 			"test-fixtures/policy-set-version",
 		)
 		require.NoError(t, err)
+
+		// give TFC some time to process uploading the
+		// policy set version before reading.
+		time.Sleep(waitForPolicySetVersionUpload)
 
 		opts := &PolicySetReadOptions{
 			Include: []PolicySetIncludeOpt{PolicySetCurrentVersion, PolicySetNewestVersion},

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -79,8 +79,8 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// give TFC soe time to process uploading the
-		// policy set version before reaeding..
+		// give TFC some time to process uploading the
+		// policy set version before reading.
 		time.Sleep(waitForPolicySetVersionUpload)
 
 		psv, err = client.PolicySetVersions.Read(ctx, psv.ID)


### PR DESCRIPTION
## Description

I noticed that the test `TestPolicySetsRead` was flaking on my [PR](https://github.com/hashicorp/go-tfe/actions/runs/4949620331/jobs/8852036102#step:4:780) and other [PRs](https://github.com/hashicorp/go-tfe/actions/runs/4949620331/jobs/8852036102).

The test uploads a policy set, and I noticed that in the PolicySetVersion tests, there is a sleep after an upload (e.g., [here](https://github.com/hashicorp/go-tfe/blob/db09c8776628d7e427123522b29c6075c73b3a48/policy_set_version_integration_test.go#L84)).

This PR adds a sleep with the same amount of time after the PolicySetVersion upload in hopes that this will fix the flaky test.

## Testing plan

This test passes reliably.


## Output from tests

```
~/dev/go-tfe  ‹aw/fix-flaky-test› $ ENABLE_TFE=0 envchain tfe-local go test -run TestPolicySetsRead -v ./... -tags=integration
=== RUN   TestPolicySetsRead
=== RUN   TestPolicySetsRead/with_a_valid_ID
=== RUN   TestPolicySetsRead/without_a_valid_ID
=== RUN   TestPolicySetsRead/with_policy_set_version
--- PASS: TestPolicySetsRead (4.69s)
    --- PASS: TestPolicySetsRead/with_a_valid_ID (0.23s)
    --- PASS: TestPolicySetsRead/without_a_valid_ID (0.00s)
    --- PASS: TestPolicySetsRead/with_policy_set_version (1.69s)
PASS
ok  	github.com/hashicorp/go-tfe	5.495s
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
...
```
