### PR TITLE
Capture all 3 kinds of workspace safe-delete conflict errors

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -53,14 +53,26 @@ var (
 
 // Resource Errors
 var (
-	ErrWorkspaceLocked = errors.New("workspace already locked") // ErrWorkspaceLocked is returned when trying to lock a
-	// locked workspace.
+	// ErrWorkspaceLocked is returned when trying to lock a locked workspace.
+	ErrWorkspaceLocked = errors.New("workspace already locked")
 
-	ErrWorkspaceNotLocked = errors.New("workspace already unlocked") // ErrWorkspaceNotLocked is returned when trying to unlock
-	// a unlocked workspace.
+	// ErrWorkspaceNotLocked is returned when trying to unlock a unlocked workspace.
+	ErrWorkspaceNotLocked = errors.New("workspace already unlocked")
 
-	ErrWorkspaceLockedByRun = errors.New("unable to unlock workspace locked by run") // ErrWorkspaceLockedByRun is returned when trying to unlock a
-	// workspace locked by a run
+	// ErrWorkspaceLockedByRun is returned when trying to unlock a workspace locked by a run.
+	ErrWorkspaceLockedByRun = errors.New("unable to unlock workspace locked by run")
+
+	// ErrWorkspaceStillProcessing is returned when a workspace is still processing state
+	// to determine if it is safe to delete. "conflict" followed by newline is used to
+	// preserve go-tfe version compatibility with the error constructed at runtime before it was
+	// defined here.
+	ErrWorkspaceStillProcessing = errors.New("conflict\nworkspace is still being processed to discover resources")
+
+	// ErrWorkspaceNotSafeToDelete is returned when a workspace has processed state and
+	// is determined to still have resources present. "conflict" followed by newline is used to
+	// preserve go-tfe version compatibility with the error constructed at runtime before it was
+	// defined here.
+	ErrWorkspaceNotSafeToDelete = errors.New("conflict\nworkspace cannot be safely deleted because it is still managing resources")
 )
 
 // Invalid values for resources/struct fields

--- a/tfe.go
+++ b/tfe.go
@@ -871,6 +871,19 @@ func checkResponseCode(r *http.Response) error {
 			return ErrWorkspaceNotLocked
 		case strings.HasSuffix(r.Request.URL.Path, "actions/force-unlock"):
 			return ErrWorkspaceNotLocked
+		case strings.HasSuffix(r.Request.URL.Path, "actions/safe-delete"):
+			errs, err = decodeErrorPayload(r)
+			if err != nil {
+				return err
+			}
+			if errorPayloadContains(errs, "locked") {
+				return ErrWorkspaceLocked
+			}
+			if errorPayloadContains(errs, "being processed") {
+				return ErrWorkspaceStillProcessing
+			}
+
+			return ErrWorkspaceNotSafeToDelete
 		}
 	}
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1559,7 +1559,7 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 		_, svTestCleanup := createStateVersion(t, client, 0, wTest)
 		t.Cleanup(svTestCleanup)
 
-		retry(func() (interface{}, error) {
+		_, err := retry(func() (interface{}, error) {
 			err := client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
 			if errors.Is(err, ErrWorkspaceStillProcessing) {
 				return nil, err
@@ -1568,7 +1568,11 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 			return nil, nil
 		})
 
-		err := client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
+		if err != nil {
+			t.Fatalf("Workspace still processing after retrying: %s", err)
+		}
+
+		err = client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
 		assert.True(t, errors.Is(err, ErrWorkspaceNotSafeToDelete))
 	})
 }
@@ -1614,7 +1618,7 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 		_, svTestCleanup := createStateVersion(t, client, 0, wTest)
 		t.Cleanup(svTestCleanup)
 
-		retry(func() (interface{}, error) {
+		_, err := retry(func() (interface{}, error) {
 			err := client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
 			if errors.Is(err, ErrWorkspaceStillProcessing) {
 				return nil, err
@@ -1623,7 +1627,11 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 			return nil, nil
 		})
 
-		err := client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
+		if err != nil {
+			t.Fatalf("Workspace still processing after retrying: %s", err)
+		}
+
+		err = client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
 		assert.True(t, errors.Is(err, ErrWorkspaceNotSafeToDelete))
 	})
 }

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -1549,8 +1550,7 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 		require.True(t, w.Locked)
 
 		err = client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
-		assert.Contains(t, err.Error(), "conflict")
-		assert.Contains(t, err.Error(), "currently locked")
+		assert.True(t, errors.Is(err, ErrWorkspaceLocked))
 	})
 
 	t.Run("when workspace has resources under management", func(t *testing.T) {
@@ -1559,10 +1559,17 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 		_, svTestCleanup := createStateVersion(t, client, 0, wTest)
 		t.Cleanup(svTestCleanup)
 
+		retry(func() (interface{}, error) {
+			err := client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
+			if errors.Is(err, ErrWorkspaceStillProcessing) {
+				return nil, err
+			}
+
+			return nil, nil
+		})
+
 		err := client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
-		// cant verify the exact error here because it is timing dependent on the backend
-		// based on whether the state version has been processed yet
-		assert.Contains(t, err.Error(), "conflict")
+		assert.True(t, errors.Is(err, ErrWorkspaceNotSafeToDelete))
 	})
 }
 
@@ -1598,8 +1605,7 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 		require.True(t, w.Locked)
 
 		err = client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
-		assert.Contains(t, err.Error(), "conflict")
-		assert.Contains(t, err.Error(), "currently locked")
+		assert.True(t, errors.Is(err, ErrWorkspaceLocked))
 	})
 
 	t.Run("when workspace has resources under management", func(t *testing.T) {
@@ -1608,10 +1614,17 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 		_, svTestCleanup := createStateVersion(t, client, 0, wTest)
 		t.Cleanup(svTestCleanup)
 
+		retry(func() (interface{}, error) {
+			err := client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
+			if errors.Is(err, ErrWorkspaceStillProcessing) {
+				return nil, err
+			}
+
+			return nil, nil
+		})
+
 		err := client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
-		// cant verify the exact error here because it is timing dependent on the backend
-		// based on whether the state version has been processed yet
-		assert.Contains(t, err.Error(), "conflict")
+		assert.True(t, errors.Is(err, ErrWorkspaceNotSafeToDelete))
 	})
 }
 


### PR DESCRIPTION
## Description

When deleting workspaces, we need to differentiate between 409 errors that indicate that 1) state version is still being processed 2) workspace still has resources under management or 3) workspace is locked

## Testing plan

I'm going to integrate this with a hashicorp/tfe PR before merging.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
$ go test ./... -run TestWorkspacesSafeDelete -v
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestWorkspacesSafeDelete
=== RUN   TestWorkspacesSafeDelete/with_valid_options
=== RUN   TestWorkspacesSafeDelete/when_organization_is_invalid
=== RUN   TestWorkspacesSafeDelete/when_workspace_is_invalid
=== RUN   TestWorkspacesSafeDelete/when_workspace_is_locked
=== RUN   TestWorkspacesSafeDelete/when_workspace_has_resources_under_management
--- PASS: TestWorkspacesSafeDelete (29.99s)
    --- PASS: TestWorkspacesSafeDelete/with_valid_options (2.57s)
    --- PASS: TestWorkspacesSafeDelete/when_organization_is_invalid (0.00s)
    --- PASS: TestWorkspacesSafeDelete/when_workspace_is_invalid (0.00s)
    --- PASS: TestWorkspacesSafeDelete/when_workspace_is_locked (5.71s)
    --- PASS: TestWorkspacesSafeDelete/when_workspace_has_resources_under_management (15.08s)
=== RUN   TestWorkspacesSafeDeleteByID
=== RUN   TestWorkspacesSafeDeleteByID/with_valid_options
=== RUN   TestWorkspacesSafeDeleteByID/without_a_valid_workspace_ID
=== RUN   TestWorkspacesSafeDeleteByID/when_workspace_is_locked
=== RUN   TestWorkspacesSafeDeleteByID/when_workspace_has_resources_under_management
--- PASS: TestWorkspacesSafeDeleteByID (30.21s)
    --- PASS: TestWorkspacesSafeDeleteByID/with_valid_options (2.78s)
    --- PASS: TestWorkspacesSafeDeleteByID/without_a_valid_workspace_ID (0.00s)
    --- PASS: TestWorkspacesSafeDeleteByID/when_workspace_is_locked (5.94s)
    --- PASS: TestWorkspacesSafeDeleteByID/when_workspace_has_resources_under_management (14.23s)
PASS
ok  	github.com/hashicorp/go-tfe	61.078s```
