### PR TITLE
Fix accidental error incompatibility for safe-delete + ws locked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,9 @@
-# Unreleased
-
-## Features
-
-## Enhancements
+# v1.25.1
 
 ## Bug Fixes
+* Workspace safe delete conflict error when workspace is locked has been restored
+to the original message using the error `ErrWorkspaceLockedCannotDelete` instead of
+`ErrWorkspaceLocked`
 
 # v1.25.0
 

--- a/errors.go
+++ b/errors.go
@@ -73,6 +73,11 @@ var (
 	// preserve go-tfe version compatibility with the error constructed at runtime before it was
 	// defined here.
 	ErrWorkspaceNotSafeToDelete = errors.New("conflict\nworkspace cannot be safely deleted because it is still managing resources")
+
+	// ErrWorkspaceLockedCannotDelete is returned when a workspace cannot be safely deleted when
+	// it is locked. "conflict" followed by newline is used to preserve go-tfe version
+	// compatibility with the error constructed at runtime before it was defined here.
+	ErrWorkspaceLockedCannotDelete = errors.New("conflict\nWorkspace is currently locked. Workspace must be unlocked before it can be safely deleted")
 )
 
 // Invalid values for resources/struct fields

--- a/tfe.go
+++ b/tfe.go
@@ -877,7 +877,7 @@ func checkResponseCode(r *http.Response) error {
 				return err
 			}
 			if errorPayloadContains(errs, "locked") {
-				return ErrWorkspaceLocked
+				return ErrWorkspaceLockedCannotDelete
 			}
 			if errorPayloadContains(errs, "being processed") {
 				return ErrWorkspaceStillProcessing

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1550,7 +1550,7 @@ func TestWorkspacesSafeDelete(t *testing.T) {
 		require.True(t, w.Locked)
 
 		err = client.Workspaces.SafeDelete(ctx, orgTest.Name, wTest.Name)
-		assert.True(t, errors.Is(err, ErrWorkspaceLocked))
+		assert.True(t, errors.Is(err, ErrWorkspaceLockedCannotDelete))
 	})
 
 	t.Run("when workspace has resources under management", func(t *testing.T) {
@@ -1609,7 +1609,7 @@ func TestWorkspacesSafeDeleteByID(t *testing.T) {
 		require.True(t, w.Locked)
 
 		err = client.Workspaces.SafeDeleteByID(ctx, wTest.ID)
-		assert.True(t, errors.Is(err, ErrWorkspaceLocked))
+		assert.True(t, errors.Is(err, ErrWorkspaceLockedCannotDelete))
 	})
 
 	t.Run("when workspace has resources under management", func(t *testing.T) {


### PR DESCRIPTION
In the last release, I unintentionally overwrote the specific error message returned when safe deleting a locked workspace.