### PR TITLE
add new API attributes to support import and config generation

### DIFF
--- a/apply.go
+++ b/apply.go
@@ -54,6 +54,7 @@ type Apply struct {
 	ResourceAdditions    int                    `jsonapi:"attr,resource-additions"`
 	ResourceChanges      int                    `jsonapi:"attr,resource-changes"`
 	ResourceDestructions int                    `jsonapi:"attr,resource-destructions"`
+	ResourceImports      int                    `jsonapi:"attr,resource-imports"`
 	Status               ApplyStatus            `jsonapi:"attr,status"`
 	StatusTimestamps     *ApplyStatusTimestamps `jsonapi:"attr,status-timestamps"`
 }

--- a/plan.go
+++ b/plan.go
@@ -53,14 +53,16 @@ const (
 
 // Plan represents a Terraform Enterprise plan.
 type Plan struct {
-	ID                   string                `jsonapi:"primary,plans"`
-	HasChanges           bool                  `jsonapi:"attr,has-changes"`
-	LogReadURL           string                `jsonapi:"attr,log-read-url"`
-	ResourceAdditions    int                   `jsonapi:"attr,resource-additions"`
-	ResourceChanges      int                   `jsonapi:"attr,resource-changes"`
-	ResourceDestructions int                   `jsonapi:"attr,resource-destructions"`
-	Status               PlanStatus            `jsonapi:"attr,status"`
-	StatusTimestamps     *PlanStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	ID                     string                `jsonapi:"primary,plans"`
+	HasChanges             bool                  `jsonapi:"attr,has-changes"`
+	GeneratedConfiguration bool                  `jsonapi:"attr,generated-configuration"`
+	LogReadURL             string                `jsonapi:"attr,log-read-url"`
+	ResourceAdditions      int                   `jsonapi:"attr,resource-additions"`
+	ResourceChanges        int                   `jsonapi:"attr,resource-changes"`
+	ResourceDestructions   int                   `jsonapi:"attr,resource-destructions"`
+	ResourceImports        int                   `jsonapi:"attr,resource-imports"`
+	Status                 PlanStatus            `jsonapi:"attr,status"`
+	StatusTimestamps       *PlanStatusTimestamps `jsonapi:"attr,status-timestamps"`
 
 	// Relations
 	Exports []*PlanExport `jsonapi:"relation,exports"`

--- a/run.go
+++ b/run.go
@@ -117,6 +117,7 @@ type Run struct {
 	ID                     string               `jsonapi:"primary,runs"`
 	Actions                *RunActions          `jsonapi:"attr,actions"`
 	AutoApply              bool                 `jsonapi:"attr,auto-apply,omitempty"`
+	AllowConfigGeneration  *bool                `jsonapi:"attr,allow-config-generation,omitempty"`
 	AllowEmptyApply        bool                 `jsonapi:"attr,allow-empty-apply"`
 	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
 	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
@@ -256,6 +257,11 @@ type RunCreateOptions struct {
 	// It is not a user-defined value and does not need to be set.
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,runs"`
+
+	// AllowConfigGeneration specifies whether generated resource configuration may be created as a side
+	// effect of an import block in this run. Setting this does not mean that configuration _will_ be generated,
+	// only that it can be.
+	AllowConfigGeneration *bool `jsonapi:"attr,allow-config-generation,omitempty"`
 
 	// AllowEmptyApply specifies whether Terraform can apply the run even when the plan contains no changes.
 	// Often used to upgrade state after upgrading a workspace to a new terraform version.


### PR DESCRIPTION
## Description

Add new API attributes to the `Run`, `Plan`, and `Apply` structs to support import and config generation.

I'm not sure what the protocol is on tests when adding new API attributes these days; I'd prefer not to add tests for this logic just yet, since all this is still behind a feature flag in Terraform Cloud so tests will fail.

## External links

- [Terraform CLI PR depending on these new attributes](https://github.com/hashicorp/terraform/pull/33278)
