### PR TITLE
Update Workspace API for projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Enhancements
 * Adds `RunPreApplyRunning` and `RunQueuingApply` run statuses by @uk1288 [#712](https://github.com/hashicorp/go-tfe/pull/712)
+* Update `Workspaces` to include associated `project` resource by @glennsarti [#714](https://github.com/hashicorp/go-tfe/pull/714)
 
 ## Bug Fixes
 * AgentPool `Update` is not able to remove all allowed workspaces from an agent pool. That operation is now handled by a separate `UpdateAllowedWorkspaces` method using `AgentPoolAllowedWorkspacesUpdateOptions` by @hs26gill [#701](https://github.com/hashicorp/go-tfe/pull/701)

--- a/workspace.go
+++ b/workspace.go
@@ -238,6 +238,7 @@ const (
 	WSReadme                     WSIncludeOpt = "readme"
 	WSOutputs                    WSIncludeOpt = "outputs"
 	WSCurrentStateVer            WSIncludeOpt = "current-state-version"
+	WSProject                    WSIncludeOpt = "project"
 )
 
 // WorkspaceReadOptions represents the options for reading a workspace.


### PR DESCRIPTION
## Description

This commit updates the include list for the workspaces API, which can now include the related project resource.

## Testing plan

N/A

## External links

- [API documentation](https://github.com/hashicorp/terraform-docs-common/pull/367)

## Output from tests

N/A
