### PR TITLE
Re-add allowed-workspaces field to AgentPoolUpdateOptions

### DIFF
--- a/agent_pool.go
+++ b/agent_pool.go
@@ -196,6 +196,9 @@ type AgentPoolUpdateOptions struct {
 
 	// True if the agent pool is organization scoped, false otherwise.
 	OrganizationScoped *bool `jsonapi:"attr,organization-scoped,omitempty"`
+
+	// A new list of workspaces that are associated with an agent pool.
+	AllowedWorkspaces []*Workspace `jsonapi:"relation,allowed-workspaces,omitempty"`
 }
 
 // AgentPoolUpdateAllowedWorkspacesOptions represents the options for updating the allowed workspace on an agent pool
@@ -211,6 +214,7 @@ type AgentPoolAllowedWorkspacesUpdateOptions struct {
 }
 
 // Update an agent pool by its ID.
+// **Note:** This method cannot be used to clear the allowed workspaces field, instead use UpdateAllowedWorkspaces
 func (s *agentPools) Update(ctx context.Context, agentPoolID string, options AgentPoolUpdateOptions) (*AgentPool, error) {
 	if !validStringID(&agentPoolID) {
 		return nil, ErrInvalidAgentPoolID

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -316,6 +316,26 @@ func TestAgentPoolsUpdate(t *testing.T) {
 		assert.NotEqual(t, kBefore.OrganizationScoped, kAfter.OrganizationScoped)
 		assert.Equal(t, organizationScoped, kAfter.OrganizationScoped)
 	})
+
+	t.Run("when updating allowed-workspaces", func(t *testing.T) {
+		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
+		defer kTestCleanup()
+
+		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
+		defer workspaceTestCleanup()
+
+		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
+			AllowedWorkspaces: []*Workspace{
+				workspaceTest,
+			},
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, kBefore.Name, kAfter.Name)
+		assert.NotEqual(t, kBefore.AllowedWorkspaces, kAfter.AllowedWorkspaces)
+		assert.Equal(t, 1, len(kAfter.AllowedWorkspaces))
+		assert.Equal(t, workspaceTest.ID, kAfter.AllowedWorkspaces[0].ID)
+	})
 }
 
 func TestAgentPoolsUpdateAllowedWorkspaces(t *testing.T) {


### PR DESCRIPTION
## Description

https://github.com/hashicorp/go-tfe/pull/701 made a breaking change to the AgentPoolUpdateOptions struct. This fixes that and re-adds a related test.

## Testing plan

- Run integration tests


