### PR TITLE
Add support for the `save-plan` run attr and `save_plan` operation filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Enhancements
 * Adds `RunPreApplyCompleted` run status by @uk1288 [#727](https://github.com/hashicorp/go-tfe/pull/727)
+* Added BETA support for saved plan runs, by @nfagerlund [#724](https://github.com/hashicorp/go-tfe/pull/724)
+    * New `SavePlan` fields in `Run` and `RunCreateOptions`
+    * New `RunPlannedAndSaved` `RunStatus` value
+    * New `PlannedAndSavedAt` field in `RunStatusTimestamps`
+    * New `RunOperationSavePlan` constant for run list filters
 
 # v1.28.0
 

--- a/run.go
+++ b/run.go
@@ -107,7 +107,8 @@ const (
 	RunOperationRefreshOnly RunOperation = "refresh_only"
 	RunOperationDestroy     RunOperation = "destroy"
 	RunOperationEmptyApply  RunOperation = "empty_apply"
-	RunOperationSavePlan    RunOperation = "save_plan"
+	// **Note: This operation type is still in BETA and subject to change.**
+	RunOperationSavePlan RunOperation = "save_plan"
 )
 
 // RunList represents a list of runs.
@@ -118,29 +119,30 @@ type RunList struct {
 
 // Run represents a Terraform Enterprise run.
 type Run struct {
-	ID                     string               `jsonapi:"primary,runs"`
-	Actions                *RunActions          `jsonapi:"attr,actions"`
-	AutoApply              bool                 `jsonapi:"attr,auto-apply,omitempty"`
-	AllowConfigGeneration  *bool                `jsonapi:"attr,allow-config-generation,omitempty"`
-	AllowEmptyApply        bool                 `jsonapi:"attr,allow-empty-apply"`
-	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
-	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
-	HasChanges             bool                 `jsonapi:"attr,has-changes"`
-	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
-	Message                string               `jsonapi:"attr,message"`
-	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
-	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
-	PlanOnly               bool                 `jsonapi:"attr,plan-only"`
-	Refresh                bool                 `jsonapi:"attr,refresh"`
-	RefreshOnly            bool                 `jsonapi:"attr,refresh-only"`
-	ReplaceAddrs           []string             `jsonapi:"attr,replace-addrs,omitempty"`
-	SavePlan               bool                 `jsonapi:"attr,save-plan,omitempty"`
-	Source                 RunSource            `jsonapi:"attr,source"`
-	Status                 RunStatus            `jsonapi:"attr,status"`
-	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
-	TargetAddrs            []string             `jsonapi:"attr,target-addrs,omitempty"`
-	TerraformVersion       string               `jsonapi:"attr,terraform-version"`
-	Variables              []*RunVariableAttr   `jsonapi:"attr,variables"`
+	ID                     string          `jsonapi:"primary,runs"`
+	Actions                *RunActions     `jsonapi:"attr,actions"`
+	AutoApply              bool            `jsonapi:"attr,auto-apply,omitempty"`
+	AllowConfigGeneration  *bool           `jsonapi:"attr,allow-config-generation,omitempty"`
+	AllowEmptyApply        bool            `jsonapi:"attr,allow-empty-apply"`
+	CreatedAt              time.Time       `jsonapi:"attr,created-at,iso8601"`
+	ForceCancelAvailableAt time.Time       `jsonapi:"attr,force-cancel-available-at,iso8601"`
+	HasChanges             bool            `jsonapi:"attr,has-changes"`
+	IsDestroy              bool            `jsonapi:"attr,is-destroy"`
+	Message                string          `jsonapi:"attr,message"`
+	Permissions            *RunPermissions `jsonapi:"attr,permissions"`
+	PositionInQueue        int             `jsonapi:"attr,position-in-queue"`
+	PlanOnly               bool            `jsonapi:"attr,plan-only"`
+	Refresh                bool            `jsonapi:"attr,refresh"`
+	RefreshOnly            bool            `jsonapi:"attr,refresh-only"`
+	ReplaceAddrs           []string        `jsonapi:"attr,replace-addrs,omitempty"`
+	// **Note: This field is still in BETA and subject to change.**
+	SavePlan         bool                 `jsonapi:"attr,save-plan,omitempty"`
+	Source           RunSource            `jsonapi:"attr,source"`
+	Status           RunStatus            `jsonapi:"attr,status"`
+	StatusTimestamps *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	TargetAddrs      []string             `jsonapi:"attr,target-addrs,omitempty"`
+	TerraformVersion string               `jsonapi:"attr,terraform-version"`
+	Variables        []*RunVariableAttr   `jsonapi:"attr,variables"`
 
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
@@ -295,6 +297,7 @@ type RunCreateOptions struct {
 	// SavePlan determines whether this should be a saved-plan run. Saved-plan
 	// runs perform their plan and checks immediately, but won't lock the
 	// workspace and become its current run until they are confirmed for apply.
+	// **Note: This field is still in BETA and subject to change.**
 	SavePlan *bool `jsonapi:"attr,save-plan,omitempty"`
 
 	// Specifies the message to be associated with this run.

--- a/run.go
+++ b/run.go
@@ -70,6 +70,7 @@ const (
 	RunPending                  RunStatus = "pending"
 	RunPlanned                  RunStatus = "planned"
 	RunPlannedAndFinished       RunStatus = "planned_and_finished"
+	RunPlannedAndSaved          RunStatus = "planned_and_saved" // Note: This status is in BETA.
 	RunPlanning                 RunStatus = "planning"
 	RunPlanQueued               RunStatus = "plan_queued"
 	RunPolicyChecked            RunStatus = "policy_checked"

--- a/run.go
+++ b/run.go
@@ -189,17 +189,19 @@ type RunStatusTimestamps struct {
 	FetchingAt           time.Time `jsonapi:"attr,fetching-at,rfc3339"`
 	ForceCanceledAt      time.Time `jsonapi:"attr,force-canceled-at,rfc3339"`
 	PlannedAndFinishedAt time.Time `jsonapi:"attr,planned-and-finished-at,rfc3339"`
-	PlannedAt            time.Time `jsonapi:"attr,planned-at,rfc3339"`
-	PlanningAt           time.Time `jsonapi:"attr,planning-at,rfc3339"`
-	PlanQueueableAt      time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
-	PlanQueuedAt         time.Time `jsonapi:"attr,plan-queued-at,rfc3339"`
-	PolicyCheckedAt      time.Time `jsonapi:"attr,policy-checked-at,rfc3339"`
-	PolicySoftFailedAt   time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
-	PostPlanCompletedAt  time.Time `jsonapi:"attr,post-plan-completed-at,rfc3339"`
-	PostPlanRunningAt    time.Time `jsonapi:"attr,post-plan-running-at,rfc3339"`
-	PrePlanCompletedAt   time.Time `jsonapi:"attr,pre-plan-completed-at,rfc3339"`
-	PrePlanRunningAt     time.Time `jsonapi:"attr,pre-plan-running-at,rfc3339"`
-	QueuingAt            time.Time `jsonapi:"attr,queuing-at,rfc3339"`
+	// **Note: This field is still in BETA and subject to change.**
+	PlannedAndSavedAt   time.Time `jsonapi:"attr,planned-and-saved-at,rfc3339"`
+	PlannedAt           time.Time `jsonapi:"attr,planned-at,rfc3339"`
+	PlanningAt          time.Time `jsonapi:"attr,planning-at,rfc3339"`
+	PlanQueueableAt     time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
+	PlanQueuedAt        time.Time `jsonapi:"attr,plan-queued-at,rfc3339"`
+	PolicyCheckedAt     time.Time `jsonapi:"attr,policy-checked-at,rfc3339"`
+	PolicySoftFailedAt  time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
+	PostPlanCompletedAt time.Time `jsonapi:"attr,post-plan-completed-at,rfc3339"`
+	PostPlanRunningAt   time.Time `jsonapi:"attr,post-plan-running-at,rfc3339"`
+	PrePlanCompletedAt  time.Time `jsonapi:"attr,pre-plan-completed-at,rfc3339"`
+	PrePlanRunningAt    time.Time `jsonapi:"attr,pre-plan-running-at,rfc3339"`
+	QueuingAt           time.Time `jsonapi:"attr,queuing-at,rfc3339"`
 }
 
 // RunIncludeOpt represents the available options for include query params.

--- a/run.go
+++ b/run.go
@@ -107,6 +107,7 @@ const (
 	RunOperationRefreshOnly RunOperation = "refresh_only"
 	RunOperationDestroy     RunOperation = "destroy"
 	RunOperationEmptyApply  RunOperation = "empty_apply"
+	RunOperationSavePlan    RunOperation = "save_plan"
 )
 
 // RunList represents a list of runs.
@@ -133,6 +134,7 @@ type Run struct {
 	Refresh                bool                 `jsonapi:"attr,refresh"`
 	RefreshOnly            bool                 `jsonapi:"attr,refresh-only"`
 	ReplaceAddrs           []string             `jsonapi:"attr,replace-addrs,omitempty"`
+	SavePlan               bool                 `jsonapi:"attr,save-plan,omitempty"`
 	Source                 RunSource            `jsonapi:"attr,source"`
 	Status                 RunStatus            `jsonapi:"attr,status"`
 	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
@@ -289,6 +291,11 @@ type RunCreateOptions struct {
 	// RefreshOnly determines whether the run should ignore config changes
 	// and refresh the state only
 	RefreshOnly *bool `jsonapi:"attr,refresh-only,omitempty"`
+
+	// SavePlan determines whether this should be a saved-plan run. Saved-plan
+	// runs perform their plan and checks immediately, but won't lock the
+	// workspace and become its current run until they are confirmed for apply.
+	SavePlan *bool `jsonapi:"attr,save-plan,omitempty"`
 
 	// Specifies the message to be associated with this run.
 	Message *string `jsonapi:"attr,message,omitempty"`

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -140,14 +140,6 @@ func TestRunsListQueryParams(t *testing.T) {
 			},
 		},
 		{
-			description: "with operation of save_plan parameter",
-			options:     &RunListOptions{Operation: string(RunOperationSavePlan), Include: []RunIncludeOpt{RunWorkspace}},
-			assertion: func(tc testCase, rl *RunList, err error) {
-				require.NoError(t, err)
-				assert.Equal(t, 0, len(rl.Items))
-			},
-		},
-		{
 			description: "with mismatch user & commit parameter",
 			options:     &RunListOptions{User: randomString(t), Commit: randomString(t), Include: []RunIncludeOpt{RunWorkspace}},
 			assertion: func(tc testCase, rl *RunList, err error) {
@@ -157,8 +149,27 @@ func TestRunsListQueryParams(t *testing.T) {
 		},
 	}
 
+	betaTestCases := []testCase{
+		{
+			description: "with operation of save_plan parameter",
+			options:     &RunListOptions{Operation: string(RunOperationSavePlan), Include: []RunIncludeOpt{RunWorkspace}},
+			assertion: func(tc testCase, rl *RunList, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, 0, len(rl.Items))
+			},
+		},
+	}
+
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
+			runs, err := client.Runs.List(ctx, workspaceTest.ID, testCase.options)
+			testCase.assertion(testCase, runs, err)
+		})
+	}
+
+	for _, testCase := range betaTestCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			skipUnlessBeta(t)
 			runs, err := client.Runs.List(ctx, workspaceTest.ID, testCase.options)
 			testCase.assertion(testCase, runs, err)
 		})
@@ -212,6 +223,7 @@ func TestRunsCreate(t *testing.T) {
 	})
 
 	t.Run("with save-plan", func(t *testing.T) {
+		skipUnlessBeta(t)
 		options := RunCreateOptions{
 			Workspace: wTest,
 			SavePlan:  Bool(true),

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -140,6 +140,14 @@ func TestRunsListQueryParams(t *testing.T) {
 			},
 		},
 		{
+			description: "with operation of save_plan parameter",
+			options:     &RunListOptions{Operation: string(RunOperationSavePlan), Include: []RunIncludeOpt{RunWorkspace}},
+			assertion: func(tc testCase, rl *RunList, err error) {
+				require.NoError(t, err)
+				assert.Equal(t, 0, len(rl.Items))
+			},
+		},
+		{
 			description: "with mismatch user & commit parameter",
 			options:     &RunListOptions{User: randomString(t), Commit: randomString(t), Include: []RunIncludeOpt{RunWorkspace}},
 			assertion: func(tc testCase, rl *RunList, err error) {
@@ -201,6 +209,17 @@ func TestRunsCreate(t *testing.T) {
 		r, err := client.Runs.Create(ctx, options)
 		require.NoError(t, err)
 		assert.Equal(t, true, r.AllowEmptyApply)
+	})
+
+	t.Run("with save-plan", func(t *testing.T) {
+		options := RunCreateOptions{
+			Workspace: wTest,
+			SavePlan:  Bool(true),
+		}
+
+		r, err := client.Runs.Create(ctx, options)
+		require.NoError(t, err)
+		assert.Equal(t, true, r.SavePlan)
 	})
 
 	t.Run("with terraform version and plan only", func(t *testing.T) {


### PR DESCRIPTION
## Description

This feature is a work in progress, and is currently behind a feature flag in production. (It's not, however, a secret, as we're developing the Terraform core component of the feature in the open.)

## Testing plan

- With an organization that's been added to the `saved-cloud-plans` feature, use the client to create a run with `SavePlan: true`.
- Examine the returned Run struct, and note that the `SavePlan` field is true.
- If the run filter PR in atlas has been merged yet: List runs in the workspace and include `Operation: RunOperationSavePlan` in the list opts; note that your run is in the list, but normal runs aren't.

## External links

As this feature is feature-flagged, there's no docs for it yet. 

## Output from tests

This is with tfc running in local dev with the un-merged filter PR applied. 

```
=== RUN   TestRunsCreate
=== RUN   TestRunsCreate/without_a_configuration_version
=== RUN   TestRunsCreate/with_a_configuration_version
=== RUN   TestRunsCreate/with_allow_empty_apply
=== RUN   TestRunsCreate/with_save-plan
=== RUN   TestRunsCreate/with_terraform_version_and_plan_only
=== RUN   TestRunsCreate/refresh_defaults_to_true_if_not_set_as_a_create_option
=== RUN   TestRunsCreate/with_refresh-only_requested
    run_integration_test.go:253: Skipping this test until -refresh-only is released in the Terraform CLI
=== RUN   TestRunsCreate/with_auto-apply_requested
=== RUN   TestRunsCreate/without_auto-apply,_defaulting_to_workspace_autoapply
=== RUN   TestRunsCreate/without_a_workspace
=== RUN   TestRunsCreate/with_additional_attributes
=== RUN   TestRunsCreate/with_variables
--- PASS: TestRunsCreate (45.02s)
    --- PASS: TestRunsCreate/without_a_configuration_version (4.42s)
    --- PASS: TestRunsCreate/with_a_configuration_version (1.38s)
    --- PASS: TestRunsCreate/with_allow_empty_apply (1.31s)
    --- PASS: TestRunsCreate/with_save-plan (1.27s)
    --- PASS: TestRunsCreate/with_terraform_version_and_plan_only (1.54s)
    --- PASS: TestRunsCreate/refresh_defaults_to_true_if_not_set_as_a_create_option (2.60s)
    --- SKIP: TestRunsCreate/with_refresh-only_requested (0.00s)
    --- PASS: TestRunsCreate/with_auto-apply_requested (1.34s)
    --- PASS: TestRunsCreate/without_auto-apply,_defaulting_to_workspace_autoapply (1.10s)
    --- PASS: TestRunsCreate/without_a_workspace (0.00s)
    --- PASS: TestRunsCreate/with_additional_attributes (1.27s)
    --- PASS: TestRunsCreate/with_variables (1.33s)
PASS
ok  	github.com/hashicorp/go-tfe	45.568s

=== RUN   TestRunsListQueryParams
    helper_test.go:1154: Polling run "run-CDFMPP7eXrwJxLU4" for status included in ["cost_estimated" "errored"] with deadline of 2023-06-21 15:11:07.827564 -0700 PDT m=+123.692364525
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "planning"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "cost_estimating"
    helper_test.go:1160: ...
    helper_test.go:1181: Reading run "run-CDFMPP7eXrwJxLU4"
    helper_test.go:1166: Run "run-CDFMPP7eXrwJxLU4" had status "cost_estimated"
=== RUN   TestRunsListQueryParams/with_status_query_parameter
=== RUN   TestRunsListQueryParams/with_source_query_parameter
=== RUN   TestRunsListQueryParams/with_operation_of_plan_only_parameter
=== RUN   TestRunsListQueryParams/with_operation_of_save_plan_parameter
=== RUN   TestRunsListQueryParams/with_mismatch_user_&_commit_parameter
--- PASS: TestRunsListQueryParams (26.41s)
    --- PASS: TestRunsListQueryParams/with_status_query_parameter (0.45s)
    --- PASS: TestRunsListQueryParams/with_source_query_parameter (0.53s)
    --- PASS: TestRunsListQueryParams/with_operation_of_plan_only_parameter (0.33s)
    --- PASS: TestRunsListQueryParams/with_operation_of_save_plan_parameter (0.35s)
    --- PASS: TestRunsListQueryParams/with_mismatch_user_&_commit_parameter (0.35s)
PASS
ok  	github.com/hashicorp/go-tfe	26.474s
```
