### PR TITLE
feat: add missing fields from AdminSAMLSetting and AdminSAMLSettingsUpdateOptions structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # UNRELEASED
 
 ## Enhancements
-* Adds `SignatureSigningMethod` and `SignatureDigestMethod` fields in `AdminSAMLSetting` struct by @karvounis-form3
+* Adds `SignatureSigningMethod` and `SignatureDigestMethod` fields in `AdminSAMLSetting` struct by @karvounis-form3 [#731](https://github.com/hashicorp/go-tfe/pull/731)
 
 # v1.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 * Adds `SignatureSigningMethod` and `SignatureDigestMethod` fields in `AdminSAMLSetting` struct by @karvounis-form3 [#731](https://github.com/hashicorp/go-tfe/pull/731)
+* Adds `Certificate`, `PrivateKey`, `TeamManagementEnabled`, `AuthnRequestsSigned`, `WantAssertionsSigned`, `SignatureSigningMethod`, `SignatureDigestMethod` fields in `AdminSAMLSettingsUpdateOptions` struct by @karvounis-form3 [#731](https://github.com/hashicorp/go-tfe/pull/731)
 
 # v1.29.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
 
+## Enhancements
+* Adds `SignatureSigningMethod` and `SignatureDigestMethod` fields in `AdminSAMLSetting` struct by @karvounis-form3
+
 # v1.29.0
 
 ## Enhancements

--- a/admin_setting_saml.go
+++ b/admin_setting_saml.go
@@ -49,6 +49,8 @@ type AdminSAMLSetting struct {
 	AuthnRequestsSigned       bool   `jsonapi:"attr,authn-requests-signed"`
 	WantAssertionsSigned      bool   `jsonapi:"attr,want-assertions-signed"`
 	PrivateKey                string `jsonapi:"attr,private-key"`
+	SignatureSigningMethod    string `jsonapi:"attr,signature-signing-method"`
+	SignatureDigestMethod     string `jsonapi:"attr,signature-digest-method"`
 }
 
 // Read returns the SAML settings.

--- a/admin_setting_saml.go
+++ b/admin_setting_saml.go
@@ -33,6 +33,9 @@ type AdminSAMLSetting struct {
 	ID                        string `jsonapi:"primary,saml-settings"`
 	Enabled                   bool   `jsonapi:"attr,enabled"`
 	Debug                     bool   `jsonapi:"attr,debug"`
+	AuthnRequestsSigned       bool   `jsonapi:"attr,authn-requests-signed"`
+	WantAssertionsSigned      bool   `jsonapi:"attr,want-assertions-signed"`
+	TeamManagementEnabled     bool   `jsonapi:"attr,team-management-enabled"`
 	OldIDPCert                string `jsonapi:"attr,old-idp-cert"`
 	IDPCert                   string `jsonapi:"attr,idp-cert"`
 	SLOEndpointURL            string `jsonapi:"attr,slo-endpoint-url"`
@@ -44,10 +47,7 @@ type AdminSAMLSetting struct {
 	SSOAPITokenSessionTimeout int    `jsonapi:"attr,sso-api-token-session-timeout"`
 	ACSConsumerURL            string `jsonapi:"attr,acs-consumer-url"`
 	MetadataURL               string `jsonapi:"attr,metadata-url"`
-	TeamManagementEnabled     bool   `jsonapi:"attr,team-management-enabled"`
 	Certificate               string `jsonapi:"attr,certificate"`
-	AuthnRequestsSigned       bool   `jsonapi:"attr,authn-requests-signed"`
-	WantAssertionsSigned      bool   `jsonapi:"attr,want-assertions-signed"`
 	PrivateKey                string `jsonapi:"attr,private-key"`
 	SignatureSigningMethod    string `jsonapi:"attr,signature-signing-method"`
 	SignatureDigestMethod     string `jsonapi:"attr,signature-digest-method"`
@@ -76,6 +76,8 @@ type AdminSAMLSettingsUpdateOptions struct {
 	Enabled                   *bool   `jsonapi:"attr,enabled,omitempty"`
 	Debug                     *bool   `jsonapi:"attr,debug,omitempty"`
 	IDPCert                   *string `jsonapi:"attr,idp-cert,omitempty"`
+	Certificate               *string `jsonapi:"attr,certificate,omitempty"`
+	PrivateKey                *string `jsonapi:"attr,private-key,omitempty"`
 	SLOEndpointURL            *string `jsonapi:"attr,slo-endpoint-url,omitempty"`
 	SSOEndpointURL            *string `jsonapi:"attr,sso-endpoint-url,omitempty"`
 	AttrUsername              *string `jsonapi:"attr,attr-username,omitempty"`
@@ -83,6 +85,11 @@ type AdminSAMLSettingsUpdateOptions struct {
 	AttrSiteAdmin             *string `jsonapi:"attr,attr-site-admin,omitempty"`
 	SiteAdminRole             *string `jsonapi:"attr,site-admin-role,omitempty"`
 	SSOAPITokenSessionTimeout *int    `jsonapi:"attr,sso-api-token-session-timeout,omitempty"`
+	TeamManagementEnabled     *bool   `jsonapi:"attr,team-management-enabled,omitempty"`
+	AuthnRequestsSigned       *bool   `jsonapi:"attr,authn-requests-signed,omitempty"`
+	WantAssertionsSigned      *bool   `jsonapi:"attr,want-assertions-signed,omitempty"`
+	SignatureSigningMethod    *string `jsonapi:"attr,signature-signing-method,omitempty"`
+	SignatureDigestMethod     *string `jsonapi:"attr,signature-digest-method,omitempty"`
 }
 
 // Update updates the SAML settings.

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -60,6 +60,48 @@ func TestAdminSettings_SAML_Update(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, enabled, samlSettings.Enabled)
 	assert.Equal(t, debug, samlSettings.Debug)
+	assert.Empty(t, samlSettings.PrivateKey)
+
+	t.Run("with certificate defined", func(t *testing.T) {
+		cert := "testCert"
+		pKey := "testPrivateKey"
+		signatureSigningMethod := "SHA1"
+		signatureDigestMethod := "SHA1"
+		samlSettingsUpd, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
+			Certificate:            String(cert),
+			PrivateKey:             String(pKey),
+			SignatureSigningMethod: String(signatureSigningMethod),
+			SignatureDigestMethod:  String(signatureDigestMethod),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, cert, samlSettingsUpd.Certificate)
+		assert.NotNil(t, samlSettingsUpd.PrivateKey)
+		assert.Equal(t, signatureSigningMethod, samlSettingsUpd.SignatureSigningMethod)
+		assert.Equal(t, signatureDigestMethod, samlSettingsUpd.SignatureDigestMethod)
+	})
+
+	t.Run("with team management enabled", func(t *testing.T) {
+		samlSettingsUpd, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
+			Enabled:               Bool(true),
+			TeamManagementEnabled: Bool(true),
+		})
+		require.NoError(t, err)
+		assert.True(t, samlSettingsUpd.TeamManagementEnabled)
+	})
+
+	t.Run("with invalid signature digest method", func(t *testing.T) {
+		_, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
+			SignatureDigestMethod: String("SHA1234"),
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("with invalid signature signing method", func(t *testing.T) {
+		_, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
+			SignatureSigningMethod: String("SHA1234"),
+		})
+		require.Error(t, err)
+	})
 }
 
 func TestAdminSettings_SAML_RevokeIdpCert(t *testing.T) {

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -37,6 +37,8 @@ func TestAdminSettings_SAML_Read(t *testing.T) {
 	assert.NotNil(t, samlSettings.AuthnRequestsSigned)
 	assert.NotNil(t, samlSettings.WantAssertionsSigned)
 	assert.NotNil(t, samlSettings.PrivateKey)
+	assert.NotNil(t, samlSettings.SignatureSigningMethod)
+	assert.NotNil(t, samlSettings.SignatureDigestMethod)
 }
 
 func TestAdminSettings_SAML_Update(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This change is about adding missing fields to the `AdminSAMLSetting` and `AdminSAMLSettingsUpdateOptions` structs. 

### AdminSAMLSetting

Fields that appear in the JSON response of the TFE v202305-2 when calling the `GET /api/v2/admin/saml-settings` endpoint. Some of them were added to the `AdminSAMLSetting` struct.

```
$ curl -s --header "Authorization: Bearer $TFE_TOKEN" --header "Content-Type: application/vnd.api+json" --request GET https://$TFE_HOSTNAME/api/v2/admin/saml-settings | jq . 
{
  "data": {
    "id": "saml",
    "type": "saml-settings",
    "attributes": {
      "enabled": true,
      "debug": true,
      "idp-cert": "...",
      "old-idp-cert": "...",
      "slo-endpoint-url": "https://example.com/url",
      "sso-endpoint-url": "https://example.com/sso",
      "team-management-enabled": true,
      "attr-username": "...",
      "attr-groups": "MemberOf",
      "attr-site-admin": "SiteAdmin-test",
      "site-admin-role": "site-admins-test",
      "sso-api-token-session-timeout": 1111111,
      "acs-consumer-url": "...",
      "metadata-url": "...",
      "certificate": "testCertificate",
      "authn-requests-signed": true,
      "want-assertions-signed": true,
      "signature-signing-method": "SHA256",
      "signature-digest-method": "SHA1",
      "private-key": null
    }
  }
}
```

### AdminSAMLSettingsUpdateOptions

Fields are also missing from the `AdminSAMLSettingsUpdateOptions` struct. The API request body of the `PATCH /api/v2/admin/saml-settings` request supports more fields.

TFE Documentation is not up to date with the current TFE API.

Closes: https://github.com/hashicorp/go-tfe/issues/730

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

### Read SAML settings

```
$ TFE_ADDRESS="https://example" ENABLE_TFE=1 go test -run TestAdminSettings_SAML_Read -v ./...

=== RUN   TestAdminSettings_SAML_Read
--- PASS: TestAdminSettings_SAML_Read (0.48s)
PASS
ok  	github.com/hashicorp/go-tfe	(cached)
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```

### Update SAML settings

```
$ TFE_ADDRESS="https://example" ENABLE_TFE=1 go test -run TestAdminSettings_SAML_Update -v ./... 

=== RUN   TestAdminSettings_SAML_Update
=== RUN   TestAdminSettings_SAML_Update/with_certificate_defined
=== RUN   TestAdminSettings_SAML_Update/with_team_management_defined
=== RUN   TestAdminSettings_SAML_Update/with_invalid_signature_digest_method
=== RUN   TestAdminSettings_SAML_Update/with_invalid_signature_signing_method
--- PASS: TestAdminSettings_SAML_Update (2.22s)
    --- PASS: TestAdminSettings_SAML_Update/with_certificate_defined (0.12s)
    --- PASS: TestAdminSettings_SAML_Update/with_team_management_defined (0.12s)
    --- PASS: TestAdminSettings_SAML_Update/with_invalid_signature_digest_method (0.12s)
    --- PASS: TestAdminSettings_SAML_Update/with_invalid_signature_signing_method (0.16s)
PASS
ok  	github.com/hashicorp/go-tfe	3.055s
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```
