### PR TITLE
Fix `StateVersionResources` field types

### DIFF
--- a/state_version.go
+++ b/state_version.go
@@ -223,8 +223,8 @@ type ProviderData struct {
 
 type StateVersionResources struct {
 	Name     string `jsonapi:"attr,name"`
-	Count    string `jsonapi:"attr,count"`
-	Type     int    `jsonapi:"attr,type"`
+	Count    int    `jsonapi:"attr,count"`
+	Type     string `jsonapi:"attr,type"`
 	Module   string `jsonapi:"attr,module"`
 	Provider string `jsonapi:"attr,provider"`
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

When calling the `StateVersions.ReadCurrent` function, I noticed that the return `StateVersion` struct's `Resources` slice was always empty, even though `ResourcesProcessed` was `true` and my TFE state version definitely has resources. I used `curl` against the same endpoint and received the resources as expected, which led me to believe there was an unmarshalling error going on.

After debugging for a while, I found that the underlying `jsonapi` dependency was silently discarding the `StateVersionResources` with an error message of: `"The struct field was not of a known number type"`. I went to the code and realized that the `StateVersionResources` `Count` and `Type` had their data types swapped.

Changing `Count` to `int` and `Type` to `string` resolved the issue. I was able to testing using my forked version and swapping that in to my app. I had a look at the existing test suites in this project and I hesitate to change them because none of them seem to check for `StateVersionResources` at this time.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

1. Use the SDK to call any of the `StateVersions.Read*` functions on a workspace that has resources
2. Output the values of `ResourcesProcessed` and `StateVersionResources`

You will see that `ResourcesProcessed == true` and `len(StateVersionResources) == 0` .