### PR TITLE
SPIKE: add missing json field for source-module-id : Workspace struct

### DIFF
--- a/workspace.go
+++ b/workspace.go
@@ -138,6 +138,7 @@ type Workspace struct {
 	SpeculativeEnabled         bool                  `jsonapi:"attr,speculative-enabled"`
 	SourceName                 string                `jsonapi:"attr,source-name"`
 	SourceURL                  string                `jsonapi:"attr,source-url"`
+	SourceModuleID             string                `jsonapi:"attr,source-module-id"`
 	StructuredRunOutputEnabled bool                  `jsonapi:"attr,structured-run-output-enabled"`
 	TerraformVersion           string                `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes            []string              `jsonapi:"attr,trigger-prefixes"`
@@ -345,6 +346,9 @@ type WorkspaceCreateOptions struct {
 	// can be the URL of a related resource in another app, or a link to
 	// documentation or other info about the client.
 	SourceURL *string `jsonapi:"attr,source-url,omitempty"`
+
+	// The SourceModuleID : {MODULE_NAMESPACE}/{TFCLOUD_ORGANIZATION}/{MODULE_NAME}/{MODULE_VERSION}
+	SourceModuleID *string `jsonapi:"attr,source-module-id,omitempty"`
 
 	// BETA. Enable the experimental advanced run user interface.
 	// This only applies to runs using Terraform version 0.15.2 or newer,

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -565,6 +565,63 @@ func TestWorkspacesCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("with options including non-empty SourceModuleID", func(t *testing.T) {
+		options := WorkspaceCreateOptions{
+			Name:                       String("foo"),
+			AllowDestroyPlan:           Bool(false),
+			AutoApply:                  Bool(true),
+			Description:                String("qux"),
+			AssessmentsEnabled:         Bool(false),
+			FileTriggersEnabled:        Bool(true),
+			Operations:                 Bool(true),
+			QueueAllRuns:               Bool(true),
+			SpeculativeEnabled:         Bool(true),
+			SourceModuleID:             String("public/terraform-google-modules/vpc-service-controls/google/5.1.0"),
+			StructuredRunOutputEnabled: Bool(true),
+			TerraformVersion:           String("0.11.0"),
+			TriggerPrefixes:            []string{"/modules", "/shared"},
+			WorkingDirectory:           String("bar/"),
+			Tags: []*Tag{
+				{
+					Name: "tag1",
+				},
+				{
+					Name: "tag2",
+				},
+			},
+		}
+
+		w, err := client.Workspaces.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		// Get a refreshed view from the API.
+		refreshed, err := client.Workspaces.Read(ctx, orgTest.Name, *options.Name)
+		require.NoError(t, err)
+
+		for _, item := range []*Workspace{
+			w,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.Description, item.Description)
+			assert.Equal(t, *options.AllowDestroyPlan, item.AllowDestroyPlan)
+			assert.Equal(t, *options.AutoApply, item.AutoApply)
+			assert.Equal(t, *options.AssessmentsEnabled, item.AssessmentsEnabled)
+			assert.Equal(t, *options.FileTriggersEnabled, item.FileTriggersEnabled)
+			assert.Equal(t, *options.Operations, item.Operations)
+			assert.Equal(t, *options.QueueAllRuns, item.QueueAllRuns)
+			assert.Equal(t, *options.SpeculativeEnabled, item.SpeculativeEnabled)
+			assert.Equal(t, *options.SourceModuleID, item.SourceModuleID)
+			assert.Equal(t, *options.StructuredRunOutputEnabled, item.StructuredRunOutputEnabled)
+			assert.Equal(t, options.Tags[0].Name, item.TagNames[0])
+			assert.Equal(t, options.Tags[1].Name, item.TagNames[1])
+			assert.Equal(t, *options.TerraformVersion, item.TerraformVersion)
+			assert.Equal(t, options.TriggerPrefixes, item.TriggerPrefixes)
+			assert.Equal(t, *options.WorkingDirectory, item.WorkingDirectory)
+		}
+	})
+
 	t.Run("when options is missing name", func(t *testing.T) {
 		w, err := client.Workspaces.Create(ctx, "foo", WorkspaceCreateOptions{})
 		assert.Nil(t, w)


### PR DESCRIPTION
SPIKE: add source-module-id into Workspace struct

<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
