### PR TITLE
Add support for POST/DELETE policy_sets/:policy_set_id/relationships/projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
     * New `RunPlannedAndSaved` `RunStatus` value
     * New `PlannedAndSavedAt` field in `RunStatusTimestamps`
     * New `RunOperationSavePlan` constant for run list filters
+* Added BETA support for including `projects` relationship and `projects-count` attribute to policy_set on create by @hs26gill [#737](https://github.com/hashicorp/go-tfe/pull/737)
 
 # v1.28.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ## Enhancements
 * Added BETA support for including `projects` relationship and `projects-count` attribute to policy_set on create by @hs26gill [#737](https://github.com/hashicorp/go-tfe/pull/737)
-
+* Added BETA method `AddProjects` and `RemoveProjects` for attaching/detaching policy set to projects by Netra2104 [#735](https://github.com/hashicorp/go-tfe/pull/735)
+  
 # v1.30.0
 
 ## Enhancements
@@ -18,7 +19,6 @@
     * New `RunPlannedAndSaved` `RunStatus` value
     * New `PlannedAndSavedAt` field in `RunStatusTimestamps`
     * New `RunOperationSavePlan` constant for run list filters
-* Added BETA support for including `projects` relationship and `projects-count` attribute to policy_set on create by @hs26gill [#737](https://github.com/hashicorp/go-tfe/pull/737)
 
 # v1.28.0
 

--- a/errors.go
+++ b/errors.go
@@ -284,6 +284,8 @@ var (
 
 	ErrWorkspaceMinLimit = errors.New("must provide at least one workspace")
 
+	ErrProjectMinLimit = errors.New("must provide at least one project")
+
 	ErrRequiredPlan = errors.New("plan is required")
 
 	ErrRequiredPolicies = errors.New("policies is required")

--- a/generate_mocks.sh
+++ b/generate_mocks.sh
@@ -69,4 +69,3 @@ mockgen -source=agent.go -destination=mocks/agents.go -package=mocks
 mockgen -source=policy_evaluation.go -destination=mocks/policy_evaluation.go -package=mocks
 mockgen -source=project.go -destination=mocks/project_mocks.go -package=mocks
 mockgen -source=registry_no_code_module.go -destination=mocks/registry_no_code_module_mocks.go -package=mocks
-mockgen -source=policy_set.go -destination=mocks/policy_set_mocks.go -package=mocks

--- a/generate_mocks.sh
+++ b/generate_mocks.sh
@@ -69,3 +69,4 @@ mockgen -source=agent.go -destination=mocks/agents.go -package=mocks
 mockgen -source=policy_evaluation.go -destination=mocks/policy_evaluation.go -package=mocks
 mockgen -source=project.go -destination=mocks/project_mocks.go -package=mocks
 mockgen -source=registry_no_code_module.go -destination=mocks/registry_no_code_module_mocks.go -package=mocks
+mockgen -source=policy_set.go -destination=mocks/policy_set_mocks.go -package=mocks

--- a/helper_test.go
+++ b/helper_test.go
@@ -619,7 +619,7 @@ func createPolicySetParameter(t *testing.T, client *Client, ps *PolicySet) (*Pol
 	}
 }
 
-func createPolicySet(t *testing.T, client *Client, org *Organization, policies []*Policy, workspaces []*Workspace, kind PolicyKind) (*PolicySet, func()) {
+func createPolicySet(t *testing.T, client *Client, org *Organization, policies []*Policy, workspaces []*Workspace, projects []*Project, kind PolicyKind) (*PolicySet, func()) {
 	var orgCleanup func()
 
 	if org == nil {
@@ -631,6 +631,7 @@ func createPolicySet(t *testing.T, client *Client, org *Organization, policies [
 		Name:       String(randomString(t)),
 		Policies:   policies,
 		Workspaces: workspaces,
+		Projects:   projects,
 		Kind:       kind,
 	})
 	if err != nil {

--- a/helper_test.go
+++ b/helper_test.go
@@ -593,7 +593,7 @@ func createPolicySetParameter(t *testing.T, client *Client, ps *PolicySet) (*Pol
 	var psCleanup func()
 
 	if ps == nil {
-		ps, psCleanup = createPolicySet(t, client, nil, nil, nil, "")
+		ps, psCleanup = createPolicySet(t, client, nil, nil, nil, nil, "")
 	}
 
 	ctx := context.Background()
@@ -685,7 +685,7 @@ func createPolicySetVersion(t *testing.T, client *Client, ps *PolicySet) (*Polic
 	var psCleanup func()
 
 	if ps == nil {
-		ps, psCleanup = createPolicySet(t, client, nil, nil, nil, "")
+		ps, psCleanup = createPolicySet(t, client, nil, nil, nil, nil, "")
 	}
 
 	ctx := context.Background()

--- a/mocks/policy_set_mocks.go
+++ b/mocks/policy_set_mocks.go
@@ -49,6 +49,20 @@ func (mr *MockPolicySetsMockRecorder) AddPolicies(ctx, policySetID, options inte
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddPolicies", reflect.TypeOf((*MockPolicySets)(nil).AddPolicies), ctx, policySetID, options)
 }
 
+// AddProjects mocks base method.
+func (m *MockPolicySets) AddProjects(ctx context.Context, policySetID string, options tfe.PolicySetAddProjectsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddProjects", ctx, policySetID, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddProjects indicates an expected call of AddProjects.
+func (mr *MockPolicySetsMockRecorder) AddProjects(ctx, policySetID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProjects", reflect.TypeOf((*MockPolicySets)(nil).AddProjects), ctx, policySetID, options)
+}
+
 // AddWorkspaces mocks base method.
 func (m *MockPolicySets) AddWorkspaces(ctx context.Context, policySetID string, options tfe.PolicySetAddWorkspacesOptions) error {
 	m.ctrl.T.Helper()
@@ -149,6 +163,20 @@ func (m *MockPolicySets) RemovePolicies(ctx context.Context, policySetID string,
 func (mr *MockPolicySetsMockRecorder) RemovePolicies(ctx, policySetID, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemovePolicies", reflect.TypeOf((*MockPolicySets)(nil).RemovePolicies), ctx, policySetID, options)
+}
+
+// RemoveProjects mocks base method.
+func (m *MockPolicySets) RemoveProjects(ctx context.Context, policySetID string, options tfe.PolicySetRemoveProjectsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveProjects", ctx, policySetID, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveProjects indicates an expected call of RemoveProjects.
+func (mr *MockPolicySetsMockRecorder) RemoveProjects(ctx, policySetID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveProjects", reflect.TypeOf((*MockPolicySets)(nil).RemoveProjects), ctx, policySetID, options)
 }
 
 // RemoveWorkspaces mocks base method.

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -28,7 +28,7 @@ func TestPolicyChecksList(t *testing.T) {
 	defer policyCleanup2()
 	wTest, wsCleanup := createWorkspace(t, client, orgTest)
 	defer wsCleanup()
-	createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, []*Workspace{wTest}, "")
+	createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, []*Workspace{wTest}, nil, "")
 
 	rTest, runCleanup := createPolicyCheckedRun(t, client, wTest)
 	defer runCleanup()
@@ -90,7 +90,7 @@ func TestPolicyChecksRead(t *testing.T) {
 
 	pTest, _ := createUploadedPolicy(t, client, true, orgTest)
 	wTest, _ := createWorkspace(t, client, orgTest)
-	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, "")
+	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, nil, "")
 
 	rTest, _ := createPolicyCheckedRun(t, client, wTest)
 	require.Equal(t, 1, len(rTest.PolicyChecks))
@@ -134,7 +134,7 @@ func TestPolicyChecksOverride(t *testing.T) {
 
 		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 		defer wTestCleanup()
-		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, "")
+		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, nil, "")
 		rTest, tTestCleanup := createPolicyCheckedRun(t, client, wTest)
 		defer tTestCleanup()
 
@@ -159,7 +159,7 @@ func TestPolicyChecksOverride(t *testing.T) {
 
 		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 		defer wTestCleanup()
-		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, "")
+		createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, nil, "")
 		rTest, rTestCleanup := createPolicyCheckedRun(t, client, wTest)
 		defer rTestCleanup()
 
@@ -190,7 +190,7 @@ func TestPolicyChecksLogs(t *testing.T) {
 	defer pTestCleanup()
 	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 	defer wTestCleanup()
-	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, "")
+	createPolicySet(t, client, orgTest, []*Policy{pTest}, []*Workspace{wTest}, nil, "")
 
 	rTest, rTestCleanup := createPolicyCheckedRun(t, client, wTest)
 	defer rTestCleanup()

--- a/policy_evaluation_beta_test.go
+++ b/policy_evaluation_beta_test.go
@@ -37,7 +37,7 @@ func TestPolicyEvaluationList_Beta(t *testing.T) {
 	defer policyTestCleanup()
 
 	policySet := []*Policy{policyTest}
-	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, OPA)
+	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, nil, OPA)
 	defer psTestCleanup1()
 
 	rTest, rTestCleanup := createRun(t, client, wkspaceTest)
@@ -92,7 +92,7 @@ func TestPolicySetOutcomeList_Beta(t *testing.T) {
 	defer policyTestCleanup()
 
 	policySet := []*Policy{policyTest}
-	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, OPA)
+	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, nil, OPA)
 	defer psTestCleanup1()
 
 	rTest, rTestCleanup := createPlannedRun(t, client, wkspaceTest)
@@ -203,7 +203,7 @@ func TestPolicySetOutcomeRead_Beta(t *testing.T) {
 	defer policyTestCleanup()
 
 	policySet := []*Policy{policyTest}
-	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, OPA)
+	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, nil, OPA)
 	defer psTestCleanup1()
 
 	rTest, rTestCleanup := createPlannedRun(t, client, wkspaceTest)

--- a/policy_set.go
+++ b/policy_set.go
@@ -445,7 +445,7 @@ func (s *policySets) RemoveWorkspaces(ctx context.Context, policySetID string, o
 	return req.Do(ctx, nil)
 }
 
-// AddProjects adds projects to a policy set.
+// AddProjects adds projects to a given policy set.
 func (s *policySets) AddProjects(ctx context.Context, policySetID string, options PolicySetAddProjectsOptions) error {
 	if !validStringID(&policySetID) {
 		return ErrInvalidPolicySetID

--- a/policy_set_integration_beta_test.go
+++ b/policy_set_integration_beta_test.go
@@ -28,11 +28,11 @@ func TestPolicySetsList_Beta(t *testing.T) {
 	workspace, workspaceCleanup := createWorkspace(t, client, orgTest)
 	defer workspaceCleanup()
 
-	psTest1, psTestCleanup1 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, "")
+	psTest1, psTestCleanup1 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, nil, "")
 	defer psTestCleanup1()
-	psTest2, psTestCleanup2 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, "")
+	psTest2, psTestCleanup2 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, nil, "")
 	defer psTestCleanup2()
-	psTest3, psTestCleanup3 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, OPA)
+	psTest3, psTestCleanup3 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, nil, OPA)
 	defer psTestCleanup3()
 
 	t.Run("without list options", func(t *testing.T) {
@@ -344,7 +344,7 @@ func TestPolicySetsUpdate_Beta(t *testing.T) {
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
-	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, "opa")
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "opa")
 	defer psTestCleanup()
 
 	t.Run("with valid attributes", func(t *testing.T) {

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -715,6 +715,7 @@ func TestPolicySetsRemoveWorkspaces(t *testing.T) {
 }
 
 func TestPolicySetsAddProjects(t *testing.T) {
+    skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -784,6 +785,7 @@ func TestPolicySetsAddProjects(t *testing.T) {
 }
 
 func TestPolicySetsRemoveProjects(t *testing.T) {
+    skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -27,9 +27,9 @@ func TestPolicySetsList(t *testing.T) {
 	workspace, workspaceCleanup := createWorkspace(t, client, orgTest)
 	defer workspaceCleanup()
 
-	psTest1, psTestCleanup1 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, "")
+	psTest1, psTestCleanup1 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, nil, "")
 	defer psTestCleanup1()
-	psTest2, psTestCleanup2 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, "")
+	psTest2, psTestCleanup2 := createPolicySet(t, client, orgTest, nil, []*Workspace{workspace}, nil, "")
 	defer psTestCleanup2()
 
 	t.Run("without list options", func(t *testing.T) {
@@ -373,7 +373,7 @@ func TestPolicySetsRead(t *testing.T) {
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
-	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with a valid ID", func(t *testing.T) {
@@ -443,7 +443,7 @@ func TestPolicySetsUpdate(t *testing.T) {
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
-	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with valid attributes", func(t *testing.T) {
@@ -491,7 +491,7 @@ func TestPolicySetsAddPolicies(t *testing.T) {
 	defer pTestCleanup1()
 	pTest2, pTestCleanup2 := createPolicy(t, client, orgTest)
 	defer pTestCleanup2()
-	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with policies provided", func(t *testing.T) {
@@ -546,7 +546,7 @@ func TestPolicySetsRemovePolicies(t *testing.T) {
 	defer pTestCleanup1()
 	pTest2, pTestCleanup2 := createPolicy(t, client, orgTest)
 	defer pTestCleanup2()
-	psTest, psTestCleanup := createPolicySet(t, client, orgTest, []*Policy{pTest1, pTest2}, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with policies provided", func(t *testing.T) {
@@ -595,7 +595,7 @@ func TestPolicySetsAddWorkspaces(t *testing.T) {
 	defer wTestCleanup1()
 	wTest2, wTestCleanup2 := createWorkspace(t, client, orgTest)
 	defer wTestCleanup2()
-	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with workspaces provided", func(t *testing.T) {
@@ -664,7 +664,7 @@ func TestPolicySetsRemoveWorkspaces(t *testing.T) {
 	defer wTestCleanup1()
 	wTest2, wTestCleanup2 := createWorkspace(t, client, orgTest)
 	defer wTestCleanup2()
-	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, []*Workspace{wTest1, wTest2}, "")
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, []*Workspace{wTest1, wTest2}, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with workspaces provided", func(t *testing.T) {
@@ -714,6 +714,138 @@ func TestPolicySetsRemoveWorkspaces(t *testing.T) {
 	})
 }
 
+func TestPolicySetsAddProjects(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
+
+	pTest1, pTestCleanup1 := createProject(t, client, orgTest)
+	defer pTestCleanup1()
+	pTest2, pTestCleanup2 := createProject(t, client, orgTest)
+	defer pTestCleanup2()
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "")
+	defer psTestCleanup()
+
+	t.Run("with projects provided", func(t *testing.T) {
+		err := client.PolicySets.AddProjects(
+			ctx,
+			psTest.ID,
+			PolicySetAddProjectsOptions{
+				Projects: []*Project{pTest1, pTest2},
+			},
+		)
+		require.NoError(t, err)
+
+		ps, err := client.PolicySets.Read(ctx, psTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 2, ps.ProjectCount)
+
+		ids := []string{}
+		for _, ws := range ps.Projects {
+			ids = append(ids, ws.ID)
+		}
+
+		assert.Contains(t, ids, pTest1.ID)
+		assert.Contains(t, ids, pTest2.ID)
+	})
+
+	t.Run("without projects provided", func(t *testing.T) {
+		err := client.PolicySets.AddProjects(
+			ctx,
+			psTest.ID,
+			PolicySetAddProjectsOptions{},
+		)
+		assert.Equal(t, err, ErrRequiredProject)
+	})
+
+	t.Run("with empty projects slice", func(t *testing.T) {
+		err := client.PolicySets.AddProjects(
+			ctx,
+			psTest.ID,
+			PolicySetAddProjectsOptions{Projects: []*Project{}},
+		)
+		assert.Equal(t, err, ErrProjectMinLimit)
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.AddProjects(
+			ctx,
+			badIdentifier,
+			PolicySetAddProjectsOptions{
+				Projects: []*Project{pTest1, pTest2},
+			},
+		)
+		assert.Equal(t, err, ErrInvalidPolicySetID)
+	})
+}
+
+func TestPolicySetsRemoveProjects(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
+
+	pTest1, pTestCleanup1 := createProject(t, client, orgTest)
+	defer pTestCleanup1()
+	pTest2, pTestCleanup2 := createProject(t, client, orgTest)
+	defer pTestCleanup2()
+	psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, []*Project{pTest1, pTest2}, "")
+	defer psTestCleanup()
+
+	t.Run("with projects provided", func(t *testing.T) {
+		err := client.PolicySets.RemoveProjects(
+			ctx,
+			psTest.ID,
+			PolicySetRemoveProjectsOptions{
+				Projects: []*Project{pTest1, pTest2},
+			},
+		)
+		require.NoError(t, err)
+
+		ps, err := client.PolicySets.Read(ctx, psTest.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, 0, ps.ProjectCount)
+		assert.Empty(t, ps.Projects)
+	})
+
+	t.Run("without projects provided", func(t *testing.T) {
+		err := client.PolicySets.RemoveProjects(
+			ctx,
+			psTest.ID,
+			PolicySetRemoveProjectsOptions{},
+		)
+		assert.Equal(t, err, ErrRequiredProject)
+	})
+
+	t.Run("with empty projects slice", func(t *testing.T) {
+		err := client.PolicySets.RemoveProjects(
+			ctx,
+			psTest.ID,
+			PolicySetRemoveProjectsOptions{Projects: []*Project{}},
+		)
+		assert.Equal(t, err, ErrProjectMinLimit)
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.RemoveProjects(
+			ctx,
+			badIdentifier,
+			PolicySetRemoveProjectsOptions{
+				Projects: []*Project{pTest1, pTest2},
+			},
+		)
+		assert.Equal(t, err, ErrInvalidPolicySetID)
+	})
+}
+
 func TestPolicySetsDelete(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -723,7 +855,7 @@ func TestPolicySetsDelete(t *testing.T) {
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
-	psTest, _ := createPolicySet(t, client, orgTest, nil, nil, "")
+	psTest, _ := createPolicySet(t, client, orgTest, nil, nil, nil, "")
 
 	t.Run("with valid options", func(t *testing.T) {
 		err := client.PolicySets.Delete(ctx, psTest.ID)

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -715,7 +715,7 @@ func TestPolicySetsRemoveWorkspaces(t *testing.T) {
 }
 
 func TestPolicySetsAddProjects(t *testing.T) {
-    skipUnlessBeta(t)
+	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -785,7 +785,7 @@ func TestPolicySetsAddProjects(t *testing.T) {
 }
 
 func TestPolicySetsRemoveProjects(t *testing.T) {
-    skipUnlessBeta(t)
+	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/policy_set_parameter_integration_test.go
+++ b/policy_set_parameter_integration_test.go
@@ -18,7 +18,7 @@ func TestPolicySetParametersList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	psTest, pTestCleanup := createPolicySet(t, client, orgTest, nil, nil, "")
+	psTest, pTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, "")
 	defer pTestCleanup()
 
 	pTest1, pTestCleanup1 := createPolicySetParameter(t, client, psTest)
@@ -65,7 +65,7 @@ func TestPolicySetParametersCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
@@ -266,7 +266,7 @@ func TestPolicySetParametersDelete(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	pTest, _ := createPolicySetParameter(t, client, psTest)

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -18,7 +18,7 @@ func TestPolicySetVersionsCreate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	t.Run("with valid identifier", func(t *testing.T) {
@@ -40,7 +40,7 @@ func TestPolicySetVersionsRead(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, "")
+	psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, nil, "")
 	defer psTestCleanup()
 
 	origPSV, err := client.PolicySetVersions.Create(ctx, psTest.ID)

--- a/task_stages_integration_beta_test.go
+++ b/task_stages_integration_beta_test.go
@@ -41,7 +41,7 @@ func TestTaskStagesRead_Beta(t *testing.T) {
 	defer policyTestCleanup()
 
 	policySet := []*Policy{policyTest}
-	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, OPA)
+	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, nil, OPA)
 	defer psTestCleanup1()
 
 	wrTaskTest, wrTaskTestCleanup := createWorkspaceRunTask(t, client, wkspaceTest, runTaskTest)
@@ -144,11 +144,11 @@ func TestTaskStagesList_Beta(t *testing.T) {
 	defer policyTestCleanup2()
 
 	policySet := []*Policy{policyTest, policyTest2}
-	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, OPA)
+	_, psTestCleanup1 := createPolicySet(t, client, orgTest, policySet, []*Workspace{wkspaceTest}, nil, OPA)
 	defer psTestCleanup1()
 
 	policySet2 := []*Policy{policyTest2}
-	_, psTestCleanup2 := createPolicySet(t, client, orgTest, policySet2, []*Workspace{wkspaceTest}, OPA)
+	_, psTestCleanup2 := createPolicySet(t, client, orgTest, policySet2, []*Workspace{wkspaceTest}, nil, OPA)
 	defer psTestCleanup2()
 
 	_, wrTaskTestCleanup := createWorkspaceRunTask(t, client, wkspaceTest, runTaskTest)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

User should be able to add/remove policy sets using POST/DELETE policy_sets/:policy_set_id/relationships/projects in the policy_set resource similar to AddWorkspace and RemoveWorkspace.

## Testing plan
Integration test is added to complete the testing plan
<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links
[Related PR](https://hashicorp.atlassian.net/jira/software/c/projects/TF/boards/593?modal=detail&selectedIssue=TF-6270)
<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._


-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ envchain go-tfe go test -run TestPolicySetsRemoveWorkspaces -v ./...                                                
=== RUN   TestPolicySetsRemoveWorkspaces
=== RUN   TestPolicySetsRemoveWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsRemoveWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsRemoveWorkspaces (4.10s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_workspaces_provided (0.30s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsRemoveWorkspaces/without_a_valid_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     5.069s
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]

```

```
envchain go-tfe go test -run TestPolicySetsAddWorkspaces -v ./...
=== RUN   TestPolicySetsAddWorkspaces
=== RUN   TestPolicySetsAddWorkspaces/with_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/without_workspaces_provided
=== RUN   TestPolicySetsAddWorkspaces/with_empty_workspaces_slice
=== RUN   TestPolicySetsAddWorkspaces/without_a_valid_ID
--- PASS: TestPolicySetsAddWorkspaces (3.07s)
    --- PASS: TestPolicySetsAddWorkspaces/with_workspaces_provided (0.24s)
    --- PASS: TestPolicySetsAddWorkspaces/without_workspaces_provided (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/with_empty_workspaces_slice (0.00s)
    --- PASS: TestPolicySetsAddWorkspaces/without_a_valid_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     3.303s
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```
