### PR TITLE
TF-5568 add support for project custom permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ## Enhancements
 * Added BETA support for including `projects` relationship and `projects-count` attribute to policy_set on create by @hs26gill [#737](https://github.com/hashicorp/go-tfe/pull/737)
 * Added BETA method `AddProjects` and `RemoveProjects` for attaching/detaching policy set to projects by @Netra2104 [#735](https://github.com/hashicorp/go-tfe/pull/735)
+* Added BETA support for adding and updating custom permissions to `TeamProjectAccesses`. A `TeamProjectAccessType` of `"custom"` can set various permissions applied at
+the project level to the project itself (`ProjectAccessOptions`) and all of the workspaces in a project (`WorkspaceAccessOptions`).[#745](https://github.com/hashicorp/go-tfe/pull/745)
 
 # v1.30.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 * Added BETA support for including `projects` relationship and `projects-count` attribute to policy_set on create by @hs26gill [#737](https://github.com/hashicorp/go-tfe/pull/737)
 * Added BETA method `AddProjects` and `RemoveProjects` for attaching/detaching policy set to projects by @Netra2104 [#735](https://github.com/hashicorp/go-tfe/pull/735)
 * Added BETA support for adding and updating custom permissions to `TeamProjectAccesses`. A `TeamProjectAccessType` of `"custom"` can set various permissions applied at
-the project level to the project itself (`ProjectAccessOptions`) and all of the workspaces in a project (`WorkspaceAccessOptions`).[#745](https://github.com/hashicorp/go-tfe/pull/745)
+the project level to the project itself (`TeamProjectAccessProjectPermissionsOptions`) and all of the workspaces in a project (`TeamProjectAccessWorkspacePermissionsOptions`) by @rberecka [#745](https://github.com/hashicorp/go-tfe/pull/745)
 
 # v1.30.0
 

--- a/team_project_access.go
+++ b/team_project_access.go
@@ -74,7 +74,7 @@ type TeamProjectAccessProjectPermissions struct {
 	ProjectTeamsPermission    ProjectTeamsPermissionType    `jsonapi:"attr,teams"`
 }
 
-// Workspacepermissions represents the team's permission on all workspaces in its project
+// WorkspacePermissions represents the team's permission on all workspaces in its project
 type TeamProjectAccessWorkspacePermissions struct {
 	WorkspaceRunsPermission          WorkspaceRunsPermissionType          `jsonapi:"attr,runs"`
 	WorkspaceSentinelMocksPermission WorkspaceSentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks"`

--- a/team_project_access.go
+++ b/team_project_access.go
@@ -47,6 +47,7 @@ const (
 	TeamProjectAccessMaintain TeamProjectAccessType = "maintain"
 	TeamProjectAccessWrite    TeamProjectAccessType = "write"
 	TeamProjectAccessRead     TeamProjectAccessType = "read"
+	TeamProjectAccessCustom   TeamProjectAccessType = "custom"
 )
 
 // TeamProjectAccessList represents a list of team project accesses
@@ -57,12 +58,103 @@ type TeamProjectAccessList struct {
 
 // TeamProjectAccess represents a project access for a team
 type TeamProjectAccess struct {
-	ID     string                `jsonapi:"primary,team-projects"`
-	Access TeamProjectAccessType `jsonapi:"attr,access"`
+	ID              string                                 `jsonapi:"primary,team-projects"`
+	Access          TeamProjectAccessType                  `jsonapi:"attr,access"`
+	ProjectAccess   *TeamProjectAccessProjectPermissions   `jsonapi:"attr,project-access"`
+	WorkspaceAccess *TeamProjectAccessWorkspacePermissions `jsonapi:"attr,workspace-access"`
 
 	// Relations
 	Team    *Team    `jsonapi:"relation,team"`
 	Project *Project `jsonapi:"relation,project"`
+}
+
+// ProjectPermissions represents the team's permissions on its project
+type TeamProjectAccessProjectPermissions struct {
+	ProjectSettingsPermission ProjectSettingsPermissionType `jsonapi:"attr,settings"`
+	ProjectTeamsPermission    ProjectTeamsPermissionType    `jsonapi:"attr,teams"`
+}
+
+type TeamProjectAccessWorkspacePermissions struct {
+	WorkspaceRunsPermission          WorkspaceRunsPermissionType          `jsonapi:"attr,runs"`
+	WorkspaceSentinelMocksPermission WorkspaceSentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks"`
+	WorkspaceStateVersionsPermission WorkspaceStateVersionsPermissionType `jsonapi:"attr,state-versions"`
+	WorkspaceVariablesPermission     WorkspaceVariablesPermissionType     `jsonapi:"attr,variables"`
+	WorkspaceCreatePermission        bool                                 `jsonapi:"attr,create"`
+	WorkspaceLockingPermission       bool                                 `jsonapi:"attr,locking"`
+	WorkspaceMovePermission          bool                                 `jsonapi:"attr,move"`
+	WorkspaceDeletePermission        bool                                 `jsonapi:"attr,delete"`
+	WorkspaceRunTasksPermission      bool                                 `jsonapi:"attr,run-tasks"`
+}
+
+// ProjectSettingsPermissionType represents the permissiontype to a project's settings
+type ProjectSettingsPermissionType string
+
+const (
+	ProjectSettingsPermissionRead   ProjectSettingsPermissionType = "read"
+	ProjectSettingsPermissionUpdate ProjectSettingsPermissionType = "update"
+	ProjectSettingsPermissionDelete ProjectSettingsPermissionType = "delete"
+)
+
+// ProjectTeamsPermissionType represents the permissiontype to a project's teams
+type ProjectTeamsPermissionType string
+
+const (
+	ProjectTeamsPermissionNone   ProjectTeamsPermissionType = "none"
+	ProjectTeamsPermissionRead   ProjectTeamsPermissionType = "read"
+	ProjectTeamsPermissionManage ProjectTeamsPermissionType = "manage"
+)
+
+// WorkspaceRunsPermissionType represents the permissiontype to project workspaces' runs
+type WorkspaceRunsPermissionType string
+
+const (
+	WorkspaceRunsPermissionRead  WorkspaceRunsPermissionType = "read"
+	WorkspaceRunsPermissionPlan  WorkspaceRunsPermissionType = "plan"
+	WorkspaceRunsPermissionApply WorkspaceRunsPermissionType = "apply"
+)
+
+// WorkspaceSentinelMocksPermissionType represents the permissiontype to project workspaces' sentinel-mocks
+type WorkspaceSentinelMocksPermissionType string
+
+const (
+	WorkspaceSentinelMocksPermissionNone WorkspaceSentinelMocksPermissionType = "none"
+	WorkspaceSentinelMocksPermissionRead WorkspaceSentinelMocksPermissionType = "read"
+)
+
+// WorkspaceStateVersionsPermissionType represents the permissiontype to project workspaces' state-versions
+type WorkspaceStateVersionsPermissionType string
+
+const (
+	WorkspaceStateVersionsPermissionNone        WorkspaceStateVersionsPermissionType = "none"
+	WorkspaceStateVersionsPermissionReadOutputs WorkspaceStateVersionsPermissionType = "read-outputs"
+	WorkspaceStateVersionsPermissionRead        WorkspaceStateVersionsPermissionType = "read"
+	WorkspaceStateVersionsPermissionWrite       WorkspaceStateVersionsPermissionType = "write"
+)
+
+// WorkspaceVariablesPermissionType represents the permissiontype to project workspaces' variables
+type WorkspaceVariablesPermissionType string
+
+const (
+	WorkspaceVariablesPermissionNone  WorkspaceVariablesPermissionType = "none"
+	WorkspaceVariablesPermissionRead  WorkspaceVariablesPermissionType = "read"
+	WorkspaceVariablesPermissionWrite WorkspaceVariablesPermissionType = "write"
+)
+
+type TeamProjectAccessProjectPermissionsOptions struct {
+	Settings *ProjectSettingsPermissionType `json:"settings,omitempty"`
+	Teams    *ProjectTeamsPermissionType    `json:"teams,omitempty"`
+}
+
+type TeamProjectAccessWorkspacePermissionsOptions struct {
+	Runs          *WorkspaceRunsPermissionType          `json:"runs,omitempty"`
+	SentinelMocks *WorkspaceSentinelMocksPermissionType `json:"sentinel-mocks,omitempty"`
+	StateVersions *WorkspaceStateVersionsPermissionType `json:"state-versions,omitempty"`
+	Variables     *WorkspaceVariablesPermissionType     `json:"variables,omitempty"`
+	Create        *bool                                 `json:"create,omitempty"`
+	Locking       *bool                                 `json:"locking,omitempty"`
+	Move          *bool                                 `json:"move,omitempty"`
+	Delete        *bool                                 `json:"delete,omitempty"`
+	RunTasks      *bool                                 `json:"run-tasks,omitempty"`
 }
 
 // TeamProjectAccessListOptions represents the options for listing team project accesses
@@ -80,6 +172,9 @@ type TeamProjectAccessAddOptions struct {
 	Type string `jsonapi:"primary,team-projects"`
 	// The type of access to grant.
 	Access TeamProjectAccessType `jsonapi:"attr,access"`
+	// The levels that project and workspace permissions grant
+	ProjectAccess   *TeamProjectAccessProjectPermissionsOptions   `jsonapi:"attr,project-access,omitempty"`
+	WorkspaceAccess *TeamProjectAccessWorkspacePermissionsOptions `jsonapi:"attr,workspace-access,omitempty"`
 
 	// The team to add to the project
 	Team *Team `jsonapi:"relation,team"`
@@ -95,7 +190,9 @@ type TeamProjectAccessUpdateOptions struct {
 	// https://jsonapi.org/format/#crud-creating
 	Type string `jsonapi:"primary,team-projects"`
 	// The type of access to grant.
-	Access *TeamProjectAccessType `jsonapi:"attr,access,omitempty"`
+	Access          *TeamProjectAccessType                        `jsonapi:"attr,access,omitempty"`
+	ProjectAccess   *TeamProjectAccessProjectPermissionsOptions   `jsonapi:"attr,project-access,omitempty"`
+	WorkspaceAccess *TeamProjectAccessWorkspacePermissionsOptions `jsonapi:"attr,workspace-access,omitempty"`
 }
 
 // List all team accesses for a given project.
@@ -229,7 +326,8 @@ func validateTeamProjectAccessType(t TeamProjectAccessType) error {
 	case TeamProjectAccessAdmin,
 		TeamProjectAccessMaintain,
 		TeamProjectAccessWrite,
-		TeamProjectAccessRead:
+		TeamProjectAccessRead,
+		TeamProjectAccessCustom:
 		// do nothing
 	default:
 		return ErrInvalidTeamProjectAccessType

--- a/team_project_access.go
+++ b/team_project_access.go
@@ -74,6 +74,7 @@ type TeamProjectAccessProjectPermissions struct {
 	ProjectTeamsPermission    ProjectTeamsPermissionType    `jsonapi:"attr,teams"`
 }
 
+// Workspacepermissions represents the team's permission on all workspaces in its project
 type TeamProjectAccessWorkspacePermissions struct {
 	WorkspaceRunsPermission          WorkspaceRunsPermissionType          `jsonapi:"attr,runs"`
 	WorkspaceSentinelMocksPermission WorkspaceSentinelMocksPermissionType `jsonapi:"attr,sentinel-mocks"`

--- a/team_project_access_integration_test.go
+++ b/team_project_access_integration_test.go
@@ -5,8 +5,9 @@ package tfe
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
 )
@@ -164,6 +165,102 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 		}
 	})
 
+	t.Run("with valid options for all custom TeamProject permissions", func(t *testing.T) {
+		skipUnlessBeta(t)
+		options := TeamProjectAccessAddOptions{
+			Access:  *ProjectAccess(TeamProjectAccessCustom),
+			Team:    tmTest,
+			Project: pTest,
+			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{
+				Settings: ProjectSettingsPermission(ProjectSettingsPermissionUpdate),
+				Teams:    ProjectTeamsPermission(ProjectTeamsPermissionManage),
+			},
+			WorkspaceAccess: &TeamProjectAccessWorkspacePermissionsOptions{
+				Runs:          WorkspaceRunsPermission(WorkspaceRunsPermissionApply),
+				SentinelMocks: WorkspaceSentinelMocksPermission(WorkspaceSentinelMocksPermissionRead),
+				StateVersions: WorkspaceStateVersionsPermission(WorkspaceStateVersionsPermissionWrite),
+				Variables:     WorkspaceVariablesPermission(WorkspaceVariablesPermissionWrite),
+				Create:        Bool(true),
+				Locking:       Bool(true),
+				Move:          Bool(true),
+				Delete:        Bool(false),
+				RunTasks:      Bool(false),
+			},
+		}
+
+		tpa, err := client.TeamProjectAccess.Add(ctx, options)
+		defer func() {
+			err := client.TeamProjectAccess.Remove(ctx, tpa.ID)
+			if err != nil {
+				t.Logf("error removing team access (%s): %s", tpa.ID, err)
+			}
+		}()
+
+		require.NoError(t, err)
+
+		// Get a refreshed view from the API.
+		refreshed, err := client.TeamProjectAccess.Read(ctx, tpa.ID)
+		require.NoError(t, err)
+
+		for _, item := range []*TeamProjectAccess{
+			tpa,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, options.Access, item.Access)
+			assert.Equal(t, *options.ProjectAccess.Settings, item.ProjectAccess.ProjectSettingsPermission)
+			assert.Equal(t, *options.ProjectAccess.Teams, item.ProjectAccess.ProjectTeamsPermission)
+			assert.Equal(t, *options.WorkspaceAccess.Runs, item.WorkspaceAccess.WorkspaceRunsPermission)
+			assert.Equal(t, *options.WorkspaceAccess.SentinelMocks, item.WorkspaceAccess.WorkspaceSentinelMocksPermission)
+			assert.Equal(t, *options.WorkspaceAccess.StateVersions, item.WorkspaceAccess.WorkspaceStateVersionsPermission)
+			assert.Equal(t, *options.WorkspaceAccess.Variables, item.WorkspaceAccess.WorkspaceVariablesPermission)
+			assert.Equal(t, item.WorkspaceAccess.WorkspaceCreatePermission, true)
+			assert.Equal(t, item.WorkspaceAccess.WorkspaceLockingPermission, true)
+			assert.Equal(t, item.WorkspaceAccess.WorkspaceMovePermission, true)
+			assert.Equal(t, item.WorkspaceAccess.WorkspaceDeletePermission, false)
+			assert.Equal(t, item.WorkspaceAccess.WorkspaceRunTasksPermission, false)
+		}
+	})
+
+	t.Run("with valid options for some custom TeamProject permissions", func(t *testing.T) {
+		skipUnlessBeta(t)
+		options := TeamProjectAccessAddOptions{
+			Access:  *ProjectAccess(TeamProjectAccessCustom),
+			Team:    tmTest,
+			Project: pTest,
+			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{
+				Settings: ProjectSettingsPermission(ProjectSettingsPermissionUpdate),
+			},
+			WorkspaceAccess: &TeamProjectAccessWorkspacePermissionsOptions{
+				Runs: WorkspaceRunsPermission(WorkspaceRunsPermissionApply),
+			},
+		}
+
+		tpa, err := client.TeamProjectAccess.Add(ctx, options)
+		t.Cleanup(func() {
+			err := client.TeamProjectAccess.Remove(ctx, tpa.ID)
+			if err != nil {
+				t.Logf("error removing team access (%s): %s", tpa.ID, err)
+			}
+		})
+
+		require.NoError(t, err)
+
+		// Get a refreshed view from the API.
+		refreshed, err := client.TeamProjectAccess.Read(ctx, tpa.ID)
+		require.NoError(t, err)
+
+		for _, item := range []*TeamProjectAccess{
+			tpa,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, options.Access, item.Access)
+			assert.Equal(t, *options.ProjectAccess.Settings, item.ProjectAccess.ProjectSettingsPermission)
+			assert.Equal(t, *options.WorkspaceAccess.Runs, item.WorkspaceAccess.WorkspaceRunsPermission)
+		}
+	})
+
 	t.Run("when the team already has access to the project", func(t *testing.T) {
 		_, tpaTestCleanup := createTeamProjectAccess(t, client, tmTest, pTest, nil)
 		defer tpaTestCleanup()
@@ -205,6 +302,20 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 		assert.Equal(t, err, ErrRequiredProject)
 	})
 
+	t.Run("when invalid custom project permission is provided in options", func(t *testing.T) {
+		skipUnlessBeta(t)
+		tpa, err := client.TeamProjectAccess.Add(ctx, TeamProjectAccessAddOptions{
+			Access:  *ProjectAccess(TeamProjectAccessCustom),
+			Team:    tmTest,
+			Project: pTest,
+			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{
+				Teams: ProjectTeamsPermission(badIdentifier),
+			},
+		})
+		assert.Nil(t, tpa)
+		assert.Error(t, err)
+	})
+
 	t.Run("when invalid access is provided in options", func(t *testing.T) {
 		tpa, err := client.TeamProjectAccess.Add(ctx, TeamProjectAccessAddOptions{
 			Access:  badIdentifier,
@@ -241,6 +352,101 @@ func TestTeamProjectAccessesUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, tpa.Access, TeamProjectAccessRead)
+	})
+
+	t.Run("with valid custom permissions attributes for all permissions", func(t *testing.T) {
+		skipUnlessBeta(t)
+		options := TeamProjectAccessUpdateOptions{
+			Access: ProjectAccess(TeamProjectAccessCustom),
+			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{
+				Settings: ProjectSettingsPermission(ProjectSettingsPermissionUpdate),
+				Teams:    ProjectTeamsPermission(ProjectTeamsPermissionManage),
+			},
+			WorkspaceAccess: &TeamProjectAccessWorkspacePermissionsOptions{
+				Runs:          WorkspaceRunsPermission(WorkspaceRunsPermissionPlan),
+				SentinelMocks: WorkspaceSentinelMocksPermission(WorkspaceSentinelMocksPermissionNone),
+				StateVersions: WorkspaceStateVersionsPermission(WorkspaceStateVersionsPermissionReadOutputs),
+				Variables:     WorkspaceVariablesPermission(WorkspaceVariablesPermissionRead),
+				Create:        Bool(false),
+				Locking:       Bool(false),
+				Move:          Bool(false),
+				Delete:        Bool(true),
+				RunTasks:      Bool(true),
+			},
+		}
+
+		tpa, err := client.TeamProjectAccess.Update(ctx, tpaTest.ID, options)
+		require.NoError(t, err)
+		require.NotNil(t, options.ProjectAccess)
+		require.NotNil(t, options.WorkspaceAccess)
+		assert.Equal(t, tpa.Access, TeamProjectAccessCustom)
+		assert.Equal(t, *options.ProjectAccess.Teams, tpa.ProjectAccess.ProjectTeamsPermission)
+		assert.Equal(t, *options.ProjectAccess.Settings, tpa.ProjectAccess.ProjectSettingsPermission)
+		assert.Equal(t, *options.WorkspaceAccess.Runs, tpa.WorkspaceAccess.WorkspaceRunsPermission)
+		assert.Equal(t, *options.WorkspaceAccess.SentinelMocks, tpa.WorkspaceAccess.WorkspaceSentinelMocksPermission)
+		assert.Equal(t, *options.WorkspaceAccess.StateVersions, tpa.WorkspaceAccess.WorkspaceStateVersionsPermission)
+		assert.Equal(t, *options.WorkspaceAccess.Variables, tpa.WorkspaceAccess.WorkspaceVariablesPermission)
+		assert.Equal(t, false, tpa.WorkspaceAccess.WorkspaceCreatePermission)
+		assert.Equal(t, false, tpa.WorkspaceAccess.WorkspaceLockingPermission)
+		assert.Equal(t, false, tpa.WorkspaceAccess.WorkspaceMovePermission)
+		assert.Equal(t, true, tpa.WorkspaceAccess.WorkspaceDeletePermission)
+		assert.Equal(t, true, tpa.WorkspaceAccess.WorkspaceRunTasksPermission)
+	})
+
+	t.Run("with valid custom permissions attributes for some permissions", func(t *testing.T) {
+		skipUnlessBeta(t)
+		// create tpaCustomTest to verify unupdated attributes stay the same for custom permissions
+		// because going from admin to read to custom changes the values of all custom permissions
+		tm2Test, tm2TestCleanup := createTeam(t, client, orgTest)
+		defer tm2TestCleanup()
+
+		TpaOptions := TeamProjectAccessAddOptions{
+			Access:  *ProjectAccess(TeamProjectAccessCustom),
+			Team:    tm2Test,
+			Project: pTest,
+		}
+
+		tpaCustomTest, err := client.TeamProjectAccess.Add(ctx, TpaOptions)
+		require.NoError(t, err)
+
+		options := TeamProjectAccessUpdateOptions{
+			Access: ProjectAccess(TeamProjectAccessCustom),
+			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{
+				Teams: ProjectTeamsPermission(ProjectTeamsPermissionManage),
+			},
+			WorkspaceAccess: &TeamProjectAccessWorkspacePermissionsOptions{
+				Create: Bool(false),
+			},
+		}
+
+		tpa, err := client.TeamProjectAccess.Update(ctx, tpaCustomTest.ID, options)
+		require.NoError(t, err)
+		require.NotNil(t, options.ProjectAccess)
+		require.NotNil(t, options.WorkspaceAccess)
+		assert.Equal(t, *options.ProjectAccess.Teams, tpa.ProjectAccess.ProjectTeamsPermission)
+		assert.Equal(t, false, tpa.WorkspaceAccess.WorkspaceCreatePermission)
+		// assert that other attributes remain the same
+		assert.Equal(t, tpaCustomTest.ProjectAccess.ProjectSettingsPermission, tpa.ProjectAccess.ProjectSettingsPermission)
+		assert.Equal(t, tpaCustomTest.WorkspaceAccess.WorkspaceLockingPermission, tpa.WorkspaceAccess.WorkspaceLockingPermission)
+		assert.Equal(t, tpaCustomTest.WorkspaceAccess.WorkspaceMovePermission, tpa.WorkspaceAccess.WorkspaceMovePermission)
+		assert.Equal(t, tpaCustomTest.WorkspaceAccess.WorkspaceDeletePermission, tpa.WorkspaceAccess.WorkspaceDeletePermission)
+		assert.Equal(t, tpaCustomTest.WorkspaceAccess.WorkspaceRunsPermission, tpa.WorkspaceAccess.WorkspaceRunsPermission)
+		assert.Equal(t, tpaCustomTest.WorkspaceAccess.WorkspaceSentinelMocksPermission, tpa.WorkspaceAccess.WorkspaceSentinelMocksPermission)
+		assert.Equal(t, tpaCustomTest.WorkspaceAccess.WorkspaceStateVersionsPermission, tpa.WorkspaceAccess.WorkspaceStateVersionsPermission)
+	})
+	t.Run("with invalid custom permissions attributes", func(t *testing.T) {
+		skipUnlessBeta(t)
+		options := TeamProjectAccessUpdateOptions{
+			Access: ProjectAccess(TeamProjectAccessCustom),
+			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{
+				Teams: ProjectTeamsPermission(badIdentifier),
+			},
+		}
+
+		tpa, err := client.TeamProjectAccess.Update(ctx, tpaTest.ID, options)
+
+		assert.Nil(t, tpa)
+		assert.Error(t, err)
 	})
 }
 

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -13,6 +13,36 @@ func ProjectAccess(v TeamProjectAccessType) *TeamProjectAccessType {
 	return &v
 }
 
+// ProjectSettingsPermission returns a pointer to the given team access project type.
+func ProjectSettingsPermission(v ProjectSettingsPermissionType) *ProjectSettingsPermissionType {
+	return &v
+}
+
+// ProjectTeamsPermission returns a pointer to the given team access project type.
+func ProjectTeamsPermission(v ProjectTeamsPermissionType) *ProjectTeamsPermissionType {
+	return &v
+}
+
+// WorkspaceRunsPermission returns a pointer to the given team access project type.
+func WorkspaceRunsPermission(v WorkspaceRunsPermissionType) *WorkspaceRunsPermissionType {
+	return &v
+}
+
+// WorkspaceSentinelMocksPermission returns a pointer to the given team access project type.
+func WorkspaceSentinelMocksPermission(v WorkspaceSentinelMocksPermissionType) *WorkspaceSentinelMocksPermissionType {
+	return &v
+}
+
+// WorkspaceStateVersionsPermission returns a pointer to the given team access project type.
+func WorkspaceStateVersionsPermission(v WorkspaceStateVersionsPermissionType) *WorkspaceStateVersionsPermissionType {
+	return &v
+}
+
+// WorkspaceStateVersionsPermission returns a pointer to the given team access project type.
+func WorkspaceVariablesPermission(v WorkspaceVariablesPermissionType) *WorkspaceVariablesPermissionType {
+	return &v
+}
+
 // RunsPermission returns a pointer to the given team runs permission type.
 func RunsPermission(v RunsPermissionType) *RunsPermissionType {
 	return &v


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Add ability to choose custom access for team projects. Once selected, users can then choose to set a variety of customizable permissions to different levels of access. For example, if I add a team project and set the `TeamProjectAccessAddOptions` to include `access: "custom"` I can then also configure different permissions that will apply to either the project itself (`project-access`) or all workspace in the project (`workspace-access`).

Authored with @jbonhag 
## Testing plan

Pull down locally
Run tests below and comment out the `skipUnlessBeta(t)` flag. Once we have roll out the feature to TFE and remove the feature flag, we'll remove these skips as well.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://github.com/hashicorp/terraform-docs-common/pull/371)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx) Does not exist yet.
- [All permissions and their possible values](https://github.com/hashicorp/atlas/blob/main/app/models/team_project.rb#L42-L58)

-->

## Output from tests
If you run atlas locally you can run the tests with the `ENABLE_BETA=1` environment variable.

```
$ ENABLE_BETA=1 TFE_ADDRESS=http://localhost:21080/ TFE_TOKEN=<API TOKEN> go test -run TestTeamProjectAccessesAdd
$ ENABLE_BETA=1 TFE_ADDRESS=http://localhost:21080/ TFE_TOKEN=<API TOKEN> go test -run TestTeamProjectAccessesUpdate
...
```
