### PR TITLE
Add provisional for ConfigurationVersions; Add current-configuration-version to Workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Added BETA method `AddProjects` and `RemoveProjects` for attaching/detaching policy set to projects by @Netra2104 [#735](https://github.com/hashicorp/go-tfe/pull/735)
 * Added BETA support for adding and updating custom permissions to `TeamProjectAccesses`. A `TeamProjectAccessType` of `"custom"` can set various permissions applied at
 the project level to the project itself (`TeamProjectAccessProjectPermissionsOptions`) and all of the workspaces in a project (`TeamProjectAccessWorkspacePermissionsOptions`) by @rberecka [#745](https://github.com/hashicorp/go-tfe/pull/745)
+* Added BETA field `Provisional` to `ConfigurationVersions` by @brandonc [#746](https://github.com/hashicorp/go-tfe/pull/746)
 
 # v1.30.0
 

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -96,6 +96,7 @@ type ConfigurationVersion struct {
 	ErrorMessage     string              `jsonapi:"attr,error-message"`
 	Source           ConfigurationSource `jsonapi:"attr,source"`
 	Speculative      bool                `jsonapi:"attr,speculative"`
+	Provisional      bool                `jsonapi:"attr,provisional"`
 	Status           ConfigurationStatus `jsonapi:"attr,status"`
 	StatusTimestamps *CVStatusTimestamps `jsonapi:"attr,status-timestamps"`
 	UploadURL        string              `jsonapi:"attr,upload-url"`
@@ -154,6 +155,10 @@ type ConfigurationVersionCreateOptions struct {
 
 	// Optional: When true, this configuration version can only be used for planning.
 	Speculative *bool `jsonapi:"attr,speculative,omitempty"`
+
+	// Optional: When true, does not become the workspace's current configuration until
+	// a run referencing it is ultimately applied.
+	Provisional *bool `jsonapi:"attr,provisional,omitempty"`
 }
 
 // IngressAttributes include commit information associated with configuration versions sourced from VCS.

--- a/workspace.go
+++ b/workspace.go
@@ -154,14 +154,15 @@ type Workspace struct {
 	TagNames                   []string              `jsonapi:"attr,tag-names"`
 
 	// Relations
-	AgentPool           *AgentPool          `jsonapi:"relation,agent-pool"`
-	CurrentRun          *Run                `jsonapi:"relation,current-run"`
-	CurrentStateVersion *StateVersion       `jsonapi:"relation,current-state-version"`
-	Organization        *Organization       `jsonapi:"relation,organization"`
-	SSHKey              *SSHKey             `jsonapi:"relation,ssh-key"`
-	Outputs             []*WorkspaceOutputs `jsonapi:"relation,outputs"`
-	Project             *Project            `jsonapi:"relation,project"`
-	Tags                []*Tag              `jsonapi:"relation,tags"`
+	AgentPool                   *AgentPool            `jsonapi:"relation,agent-pool"`
+	CurrentRun                  *Run                  `jsonapi:"relation,current-run"`
+	CurrentStateVersion         *StateVersion         `jsonapi:"relation,current-state-version"`
+	Organization                *Organization         `jsonapi:"relation,organization"`
+	SSHKey                      *SSHKey               `jsonapi:"relation,ssh-key"`
+	Outputs                     []*WorkspaceOutputs   `jsonapi:"relation,outputs"`
+	Project                     *Project              `jsonapi:"relation,project"`
+	Tags                        []*Tag                `jsonapi:"relation,tags"`
+	CurrentConfigurationVersion *ConfigurationVersion `jsonapi:"relation,current-configuration-version,omitempty"`
 
 	// Links
 	Links map[string]interface{} `jsonapi:"links,omitempty"`
@@ -379,7 +380,7 @@ type WorkspaceCreateOptions struct {
 	Tags []*Tag `jsonapi:"relation,tags,omitempty"`
 
 	// Associated Project with the workspace. If not provided, default project
-	// of the organization will be assigned to the workspace
+	// of the organization will be assigned to the workspace.
 	Project *Project `jsonapi:"relation,project,omitempty"`
 }
 


### PR DESCRIPTION
## Description

- Adds BETA field Provisional (does not set configuration version as workspace current)
- Adds CurrentConfigurationVersion relation to Workspace

## Testing plan

See automated test output

```
$ ENABLE_BETA=1 go test ./... -run TestConfigurationVersionsCreate -v
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestConfigurationVersionsCreate
=== RUN   TestConfigurationVersionsCreate/with_valid_options
=== RUN   TestConfigurationVersionsCreate/with_invalid_workspace_id
=== RUN   TestConfigurationVersionsCreate/provisional
--- PASS: TestConfigurationVersionsCreate (16.65s)
    --- PASS: TestConfigurationVersionsCreate/with_valid_options (3.39s)
    --- PASS: TestConfigurationVersionsCreate/with_invalid_workspace_id (0.00s)
    --- PASS: TestConfigurationVersionsCreate/provisional (3.26s)
PASS
ok  	github.com/hashicorp/go-tfe	16.952s
...
```
