### PR TITLE
[TF-7968] Add BETA support for listing commits and reading the registry module version

### DIFF
--- a/generate_mocks.sh
+++ b/generate_mocks.sh
@@ -69,3 +69,5 @@ mockgen -source=agent.go -destination=mocks/agents.go -package=mocks
 mockgen -source=policy_evaluation.go -destination=mocks/policy_evaluation.go -package=mocks
 mockgen -source=project.go -destination=mocks/project_mocks.go -package=mocks
 mockgen -source=registry_no_code_module.go -destination=mocks/registry_no_code_module_mocks.go -package=mocks
+mockgen -source=registry_module.go -destination=mocks/registry_module_mocks.go -package=mocks
+mockgen -source=registry_module.go -destination=mocks/registry_module_mocks.go -package=mocks

--- a/mocks/registry_module_mocks.go
+++ b/mocks/registry_module_mocks.go
@@ -138,6 +138,21 @@ func (mr *MockRegistryModulesMockRecorder) List(ctx, organization, options inter
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockRegistryModules)(nil).List), ctx, organization, options)
 }
 
+// ListCommits mocks base method.
+func (m *MockRegistryModules) ListCommits(ctx context.Context, moduleID tfe.RegistryModuleID) (*tfe.CommitList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListCommits", ctx, moduleID)
+	ret0, _ := ret[0].(*tfe.CommitList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListCommits indicates an expected call of ListCommits.
+func (mr *MockRegistryModulesMockRecorder) ListCommits(ctx, moduleID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListCommits", reflect.TypeOf((*MockRegistryModules)(nil).ListCommits), ctx, moduleID)
+}
+
 // Read mocks base method.
 func (m *MockRegistryModules) Read(ctx context.Context, moduleID tfe.RegistryModuleID) (*tfe.RegistryModule, error) {
 	m.ctrl.T.Helper()
@@ -151,6 +166,21 @@ func (m *MockRegistryModules) Read(ctx context.Context, moduleID tfe.RegistryMod
 func (mr *MockRegistryModulesMockRecorder) Read(ctx, moduleID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRegistryModules)(nil).Read), ctx, moduleID)
+}
+
+// ReadVersion mocks base method.
+func (m *MockRegistryModules) ReadVersion(ctx context.Context, moduleID tfe.RegistryModuleID, version string) (*tfe.RegistryModuleVersion, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadVersion", ctx, moduleID, version)
+	ret0, _ := ret[0].(*tfe.RegistryModuleVersion)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadVersion indicates an expected call of ReadVersion.
+func (mr *MockRegistryModulesMockRecorder) ReadVersion(ctx, moduleID, version interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadVersion", reflect.TypeOf((*MockRegistryModules)(nil).ReadVersion), ctx, moduleID, version)
 }
 
 // Update mocks base method.

--- a/registry_module.go
+++ b/registry_module.go
@@ -25,6 +25,8 @@ type RegistryModules interface {
 	List(ctx context.Context, organization string, options *RegistryModuleListOptions) (*RegistryModuleList, error)
 
 	// ListCommits List the commits for the registry module
+	// This returns the latest 20 commits for the connected VCS repo.
+	// Pagination is not applicable due to inconsistent support from the VCS providers.
 	ListCommits(ctx context.Context, moduleID RegistryModuleID) (*CommitList, error)
 
 	// Create a registry module without a VCS repo

--- a/registry_module.go
+++ b/registry_module.go
@@ -24,6 +24,9 @@ type RegistryModules interface {
 	// List all the registory modules within an organization
 	List(ctx context.Context, organization string, options *RegistryModuleListOptions) (*RegistryModuleList, error)
 
+	// ListCommits List the commits for the registry module
+	ListCommits(ctx context.Context, moduleID RegistryModuleID) (*CommitList, error)
+
 	// Create a registry module without a VCS repo
 	Create(ctx context.Context, organization string, options RegistryModuleCreateOptions) (*RegistryModule, error)
 
@@ -35,6 +38,9 @@ type RegistryModules interface {
 
 	// Read a registry module
 	Read(ctx context.Context, moduleID RegistryModuleID) (*RegistryModule, error)
+
+	// ReadVersion Read a registry module version
+	ReadVersion(ctx context.Context, moduleID RegistryModuleID, version string) (*RegistryModuleVersion, error)
 
 	// Delete a registry module
 	Delete(ctx context.Context, organization string, name string) error
@@ -108,6 +114,12 @@ type RegistryModuleList struct {
 	Items []*RegistryModule
 }
 
+// CommitList represents a list of the latest commits from the registry module
+type CommitList struct {
+	*Pagination
+	Items []*Commit
+}
+
 // RegistryModule represents a registry module
 type RegistryModule struct {
 	ID              string                          `jsonapi:"primary,registry-modules"`
@@ -125,6 +137,18 @@ type RegistryModule struct {
 
 	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`
+}
+
+// Commit represents a commit
+type Commit struct {
+	ID              string `jsonapi:"primary,commit"`
+	Sha             string `jsonapi:"attr,sha"`
+	Date            string `jsonapi:"attr,date"`
+	URL             string `jsonapi:"attr,url"`
+	Author          string `jsonapi:"attr,author"`
+	AuthorAvatarURL string `jsonapi:"attr,author-avatar-url"`
+	AuthorHTMLURL   string `jsonapi:"attr,author-html-url"`
+	Message         string `jsonapi:"attr,message"`
 }
 
 // RegistryModuleVersion represents a registry module version
@@ -190,6 +214,8 @@ type RegistryModuleCreateVersionOptions struct {
 	Type string `jsonapi:"primary,registry-module-versions"`
 
 	Version *string `jsonapi:"attr,version"`
+
+	CommitSHA *string `jsonapi:"attr,commit-sha"`
 }
 
 // RegistryModuleCreateWithVCSConnectionOptions is used when creating a registry module with a VCS repo
@@ -244,6 +270,33 @@ func (r *registryModules) List(ctx context.Context, organization string, options
 	}
 
 	return ml, nil
+}
+
+// List the last 20 commits for the registry modules within an organization.
+func (r *registryModules) ListCommits(ctx context.Context, moduleID RegistryModuleID) (*CommitList, error) {
+	if !validStringID(&moduleID.Organization) {
+		return nil, ErrInvalidOrg
+	}
+
+	u := fmt.Sprintf(
+		"organizations/%s/registry-modules/private/%s/%s/%s/commits",
+		url.QueryEscape(moduleID.Organization),
+		url.QueryEscape(moduleID.Organization),
+		url.QueryEscape(moduleID.Name),
+		url.QueryEscape(moduleID.Provider),
+	)
+	req, err := r.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	cl := &CommitList{}
+	err = req.Do(ctx, cl)
+	if err != nil {
+		return nil, err
+	}
+
+	return cl, nil
 }
 
 // Upload uploads Terraform configuration files for the provided registry module version. It
@@ -438,6 +491,37 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 	}
 
 	return rm, nil
+}
+func (r *registryModules) ReadVersion(ctx context.Context, moduleID RegistryModuleID, version string) (*RegistryModuleVersion, error) {
+	if err := moduleID.valid(); err != nil {
+		return nil, err
+	}
+	if !validString(&version) {
+		return nil, ErrRequiredVersion
+	}
+	if !validStringID(&version) {
+		return nil, ErrInvalidVersion
+	}
+	u := fmt.Sprintf(
+		"organizations/%s/registry-modules/private/%s/%s/%s/version?module_version=%s",
+		url.QueryEscape(moduleID.Organization),
+		url.QueryEscape(moduleID.Organization),
+		url.QueryEscape(moduleID.Name),
+		url.QueryEscape(moduleID.Provider),
+		url.QueryEscape(version),
+	)
+	req, err := r.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	rmv := &RegistryModuleVersion{}
+	err = req.Do(ctx, rmv)
+	if err != nil {
+		return nil, err
+	}
+
+	return rmv, nil
 }
 
 // Delete is used to delete the entire registry module

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -446,6 +446,158 @@ func TestRegistryModulesCreateVersion(t *testing.T) {
 	})
 }
 
+func TestRegistryModulesShowVersion(t *testing.T) {
+	skipUnlessBeta(t)
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	registryModuleTest, registryModuleTestCleanup := createRegistryModule(t, client, orgTest, PrivateRegistry)
+	defer registryModuleTestCleanup()
+
+	t.Run("when the version exists", func(t *testing.T) {
+		options := RegistryModuleCreateVersionOptions{
+			Version: String("1.2.7"),
+		}
+
+		registryModuleIDTest := RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         registryModuleTest.Name,
+			Provider:     registryModuleTest.Provider,
+		}
+
+		rmv, err := client.RegistryModules.CreateVersion(ctx, registryModuleIDTest, options)
+		require.NoError(t, err)
+		assert.NotEmpty(t, rmv.ID)
+		assert.Equal(t, *options.Version, rmv.Version)
+
+		rmvRead, errRead := client.RegistryModules.ReadVersion(ctx, registryModuleIDTest, *options.Version)
+
+		require.NoError(t, errRead)
+		assert.NotEmpty(t, rmvRead.ID)
+
+		t.Run("relationships are properly decoded", func(t *testing.T) {
+			assert.Equal(t, registryModuleTest.ID, rmvRead.RegistryModule.ID)
+		})
+
+		t.Run("timestamps are properly decoded", func(t *testing.T) {
+			assert.NotEmpty(t, rmvRead.CreatedAt)
+			assert.NotEmpty(t, rmvRead.UpdatedAt)
+		})
+
+		t.Run("links are properly decoded", func(t *testing.T) {
+			assert.NotEmpty(t, rmvRead.Links["upload"])
+			assert.Contains(t, rmvRead.Links["upload"], "/object/")
+		})
+	})
+
+	t.Run("when the version does not exist", func(t *testing.T) {
+		options := RegistryModuleCreateVersionOptions{
+			Version: String("1.2.3"),
+		}
+
+		registryModuleIDTest := RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         registryModuleTest.Name,
+			Provider:     registryModuleTest.Provider,
+		}
+
+		rmv, err := client.RegistryModules.CreateVersion(ctx, registryModuleIDTest, options)
+		require.NoError(t, err)
+		assert.NotEmpty(t, rmv.ID)
+		assert.Equal(t, *options.Version, rmv.Version)
+
+		invalidVersion := String("1.5.5")
+
+		rmvRead, errRead := client.RegistryModules.ReadVersion(ctx, registryModuleIDTest, *invalidVersion)
+
+		require.Error(t, errRead)
+		assert.Empty(t, rmvRead)
+	})
+}
+
+func TestRegistryModulesListCommit(t *testing.T) {
+	skipUnlessBeta(t)
+	githubIdentifier := os.Getenv("GITHUB_REGISTRY_MODULE_IDENTIFIER")
+	if githubIdentifier == "" {
+		t.Skip("Export a valid GITHUB_REGISTRY_MODULE_IDENTIFIER before running this test")
+	}
+	repositoryName := strings.Split(githubIdentifier, "/")[1]
+	registryModuleProvider := strings.SplitN(repositoryName, "-", 3)[1]
+	registryModuleName := strings.SplitN(repositoryName, "-", 3)[2]
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	oauthTokenTest, oauthTokenTestCleanup := createOAuthToken(t, client, orgTest)
+	defer oauthTokenTestCleanup()
+
+	t.Run("with valid options", func(t *testing.T) {
+		options := RegistryModuleCreateWithVCSConnectionOptions{
+			VCSRepo: &RegistryModuleVCSRepoOptions{
+				Identifier:        String(githubIdentifier),
+				OAuthTokenID:      String(oauthTokenTest.ID),
+				DisplayIdentifier: String(githubIdentifier),
+			},
+		}
+		rm, err := client.RegistryModules.CreateWithVCSConnection(ctx, options)
+		require.NoError(t, err)
+		assert.NotEmpty(t, rm.ID)
+		assert.Equal(t, registryModuleName, rm.Name)
+		assert.Equal(t, registryModuleProvider, rm.Provider)
+		assert.Equal(t, rm.VCSRepo.Branch, "")
+		assert.Equal(t, rm.VCSRepo.DisplayIdentifier, githubIdentifier)
+		assert.Equal(t, rm.VCSRepo.Identifier, githubIdentifier)
+		assert.Equal(t, rm.VCSRepo.IngressSubmodules, true)
+		assert.Equal(t, rm.VCSRepo.OAuthTokenID, oauthTokenTest.ID)
+		assert.Equal(t, rm.VCSRepo.RepositoryHTTPURL, fmt.Sprintf("https://github.com/%s", githubIdentifier))
+		assert.Equal(t, rm.VCSRepo.ServiceProvider, string(ServiceProviderGithub))
+		assert.Regexp(t, fmt.Sprintf("^%s/webhooks/vcs/[a-f0-9]{8}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{4}-[a-f0-9]{12}$", regexp.QuoteMeta(DefaultConfig().Address)), rm.VCSRepo.WebhookURL)
+
+		t.Run("permissions are properly decoded", func(t *testing.T) {
+			assert.True(t, rm.Permissions.CanDelete)
+			assert.True(t, rm.Permissions.CanResync)
+			assert.True(t, rm.Permissions.CanRetry)
+		})
+
+		t.Run("listing commits", func(t *testing.T) {
+			cm, errCm := client.RegistryModules.ListCommits(ctx, RegistryModuleID{
+				Organization: orgTest.Name,
+				Provider:     registryModuleProvider,
+				Name:         registryModuleName,
+			})
+
+			assert.NotEmpty(t, cm)
+			assert.NotEmpty(t, cm.Items[0])
+			assert.NotEmpty(t, cm.Items[0].ID)
+			assert.NotEmpty(t, cm.Items[0].Sha)
+			assert.NotEmpty(t, cm.Items[0].Message)
+			assert.NotEmpty(t, cm.Items[0].Date)
+			require.NoError(t, errCm)
+		})
+	})
+	t.Run("when a VCS connection is not present", func(t *testing.T) {
+		registryModuleTest, registryModuleTestCleanup := createRegistryModule(t, client, orgTest, PrivateRegistry)
+		defer registryModuleTestCleanup()
+
+		t.Run("listing commits", func(t *testing.T) {
+			cm, errCm := client.RegistryModules.ListCommits(ctx, RegistryModuleID{
+				Organization: orgTest.Name,
+				Provider:     registryModuleTest.Provider,
+				Name:         registryModuleTest.Name,
+			})
+
+			assert.Empty(t, cm)
+			require.Error(t, errCm)
+		})
+	})
+}
+
 func TestRegistryModulesCreateWithVCSConnection(t *testing.T) {
 	githubIdentifier := os.Getenv("GITHUB_REGISTRY_MODULE_IDENTIFIER")
 	if githubIdentifier == "" {

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -514,6 +514,7 @@ func TestRegistryModulesShowVersion(t *testing.T) {
 		rmvRead, errRead := client.RegistryModules.ReadVersion(ctx, registryModuleIDTest, *invalidVersion)
 
 		require.Error(t, errRead)
+		assert.Equal(t, ErrResourceNotFound, err)
 		assert.Empty(t, rmvRead)
 	})
 }
@@ -594,6 +595,7 @@ func TestRegistryModulesListCommit(t *testing.T) {
 
 			assert.Empty(t, cm)
 			require.Error(t, errCm)
+			assert.Equal(t, ErrResourceNotFound, errCm)
 		})
 	})
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
This change adds support for the following
- Retrieving a list of commits for a Registry Module with a VCS connection (`registryModule.ListCommits`)
- Retrieving the published registry module version (`registryModule.ReadVersion`)

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test -run TestRegistryModulesShowVersion -v ./... -tags=integration
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestRegistryModulesShowVersion
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/relationships_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/links_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_the_version_does_not_exist
--- PASS: TestRegistryModulesShowVersion (17.31s)
    --- PASS: TestRegistryModulesShowVersion/when_the_version_exists (0.92s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/links_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesShowVersion/when_the_version_does_not_exist (0.61s)
PASS
ok      github.com/hashicorp/go-tfe     17.487s
...
```
