### PR TITLE
TF-7865 Remove beta flags for  custom access for TeamProjectAccess tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # UNRELEASED
 <!-- Add CHANGELOG entry to this section for any PR awaiting the next release -->
-
+* Removed beta tags for TeamProjectAccess by @rberecka [#756](https://github.com/hashicorp/go-tfe/pull/756)
 
 # v1.32.0
 

--- a/team_project_access.go
+++ b/team_project_access.go
@@ -15,8 +15,7 @@ var _ TeamProjectAccesses = (*teamProjectAccesses)(nil)
 // TeamProjectAccesses describes all the team project access related methods that the Terraform
 // Enterprise API supports
 //
-// TFE API docs: Documentation will be linked once this feature is available
-// **Note: This functionality is still in BETA and subject to change.**
+// TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/project-team-access
 type TeamProjectAccesses interface {
 	// List all project accesses for a given project.
 	List(ctx context.Context, options TeamProjectAccessListOptions) (*TeamProjectAccessList, error)

--- a/team_project_access_integration_test.go
+++ b/team_project_access_integration_test.go
@@ -166,7 +166,6 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 	})
 
 	t.Run("with valid options for all custom TeamProject permissions", func(t *testing.T) {
-		skipUnlessBeta(t)
 		options := TeamProjectAccessAddOptions{
 			Access:  *ProjectAccess(TeamProjectAccessCustom),
 			Team:    tmTest,
@@ -223,7 +222,6 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 	})
 
 	t.Run("with valid options for some custom TeamProject permissions", func(t *testing.T) {
-		skipUnlessBeta(t)
 		options := TeamProjectAccessAddOptions{
 			Access:  *ProjectAccess(TeamProjectAccessCustom),
 			Team:    tmTest,
@@ -303,7 +301,6 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 	})
 
 	t.Run("when invalid custom project permission is provided in options", func(t *testing.T) {
-		skipUnlessBeta(t)
 		tpa, err := client.TeamProjectAccess.Add(ctx, TeamProjectAccessAddOptions{
 			Access:  *ProjectAccess(TeamProjectAccessCustom),
 			Team:    tmTest,
@@ -355,7 +352,6 @@ func TestTeamProjectAccessesUpdate(t *testing.T) {
 	})
 
 	t.Run("with valid custom permissions attributes for all permissions", func(t *testing.T) {
-		skipUnlessBeta(t)
 		options := TeamProjectAccessUpdateOptions{
 			Access: ProjectAccess(TeamProjectAccessCustom),
 			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{
@@ -394,7 +390,6 @@ func TestTeamProjectAccessesUpdate(t *testing.T) {
 	})
 
 	t.Run("with valid custom permissions attributes for some permissions", func(t *testing.T) {
-		skipUnlessBeta(t)
 		// create tpaCustomTest to verify unupdated attributes stay the same for custom permissions
 		// because going from admin to read to custom changes the values of all custom permissions
 		tm2Test, tm2TestCleanup := createTeam(t, client, orgTest)
@@ -435,7 +430,6 @@ func TestTeamProjectAccessesUpdate(t *testing.T) {
 		assert.Equal(t, tpaCustomTest.WorkspaceAccess.WorkspaceStateVersionsPermission, tpa.WorkspaceAccess.WorkspaceStateVersionsPermission)
 	})
 	t.Run("with invalid custom permissions attributes", func(t *testing.T) {
-		skipUnlessBeta(t)
 		options := TeamProjectAccessUpdateOptions{
 			Access: ProjectAccess(TeamProjectAccessCustom),
 			ProjectAccess: &TeamProjectAccessProjectPermissionsOptions{


### PR DESCRIPTION
## Description

Removes skipping of Team Project Access tests using custom access now that the feature is fully GA.
Change only includes test code.

## Testing plan

CI should pass

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./...  -v -run TestTeamProjectAccesses  

> PASS
> ok      github.com/hashicorp/go-tfe     12.199s
...
```
