### PR TITLE
Include parameter validation is a maintenance problem for new valid include options

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -233,26 +233,5 @@ func (s *adminOrganizations) Delete(ctx context.Context, organization string) er
 }
 
 func (o *AdminOrganizationListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateAdminOrgIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateAdminOrgIncludeParams(params []AdminOrgIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case AdminOrgOwners:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/admin_run.go
+++ b/admin_run.go
@@ -127,10 +127,6 @@ func (o *AdminRunsListOptions) valid() error {
 		return err
 	}
 
-	if err := validateAdminRunIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -165,19 +161,6 @@ func validateAdminRunFilterParams(runStatus string) error {
 			default:
 				return fmt.Errorf(`invalid value "%s" for run status`, status)
 			}
-		}
-	}
-
-	return nil
-}
-
-func validateAdminRunIncludeParams(params []AdminRunIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case AdminRunWorkspace, AdminRunWorkspaceOrg, AdminRunWorkspaceOrgOwners:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
 		}
 	}
 

--- a/admin_user.go
+++ b/admin_user.go
@@ -235,25 +235,5 @@ func (a *adminUsers) Disable2FA(ctx context.Context, userID string) (*AdminUser,
 }
 
 func (o *AdminUserListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateAdminUserIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateAdminUserIncludeParams(params []AdminUserIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case AdminUserOrgs:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
 	return nil
 }

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -144,26 +144,5 @@ func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error 
 }
 
 func (o *AdminWorkspaceListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateAdminWSIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateAdminWSIncludeParams(params []AdminWorkspaceIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case AdminWorkspaceOrg, AdminWorkspaceCurrentRun, AdminWorkspaceOrgOwners:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -292,36 +292,9 @@ func (o AgentPoolUpdateOptions) valid() error {
 }
 
 func (o *AgentPoolReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-	if err := validateAgentPoolIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 func (o *AgentPoolListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-	if err := validateAgentPoolIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateAgentPoolIncludeParams(params []AgentPoolIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case AgentPoolWorkspaces:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -302,39 +302,10 @@ func (s *configurationVersions) Archive(ctx context.Context, cvID string) error 
 }
 
 func (o *ConfigurationVersionReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateConfigVerIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 func (o *ConfigurationVersionListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateConfigVerIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateConfigVerIncludeParams(params []ConfigVerIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case ConfigVerIngressAttributes, ConfigVerRun:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -255,9 +255,6 @@ func (s *example) List(ctx context.Context, organization string, options *Exampl
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
-	if err := options.valid(); err != nil {
-		return nil, err
-	}
 
 	u := fmt.Sprintf("organizations/%s/examples", url.QueryEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
@@ -283,9 +280,6 @@ func (s *example) Read(ctx context.Context, exampleID string) (*Example, error) 
 func (s *example) ReadWithOptions(ctx context.Context, exampleID string, options *ExampleReadOptions) (*Example, error) {
 	if !validStringID(&exampleID) {
 		return nil, ErrInvalidExampleID
-	}
-	if err := options.valid(); err != nil {
-		return nil, err
 	}
 
 	u := fmt.Sprintf("examples/%s", url.QueryEscape(exampleID))
@@ -362,41 +356,6 @@ func (o *ExampleCreateOptions) valid() error {
 
 	if !validString(&o.URL) {
 		return ErrInvalidRunTaskURL
-	}
-
-	return nil
-}
-
-func (o *ExampleListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-	if err := validateExampleIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func (o *ExampleReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-	if err := validateExampleIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateExampleIncludeParams(params []ExampleIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case ExampleOrganization, ExampleRun:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
 	}
 
 	return nil

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -286,26 +286,5 @@ func (o OAuthClientCreateOptions) valid() error {
 }
 
 func (o *OAuthClientListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateOauthClientIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateOauthClientIncludeParams(params []OAuthClientIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case OauthClientOauthTokens:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -215,10 +215,6 @@ func (o *OrganizationMembershipListOptions) valid() error {
 		return nil
 	}
 
-	if err := validateOrgMembershipIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	if err := validateOrgMembershipEmailParams(o.Emails); err != nil {
 		return err
 	}
@@ -227,23 +223,6 @@ func (o *OrganizationMembershipListOptions) valid() error {
 }
 
 func (o OrganizationMembershipReadOptions) valid() error {
-	if err := validateOrgMembershipIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateOrgMembershipIncludeParams(params []OrgMembershipIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case OrgMembershipUser, OrgMembershipTeam:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }
 

--- a/organization_membership_integration_test.go
+++ b/organization_membership_integration_test.go
@@ -253,7 +253,7 @@ func TestOrganizationMembershipsReadWithOptions(t *testing.T) {
 		require.NoError(t, err)
 	})
 
-	t.Run("without invalid include option", func(t *testing.T) {
+	t.Run("with invalid include option", func(t *testing.T) {
 		_, err := client.OrganizationMemberships.ReadWithOptions(ctx, memTest.ID, OrganizationMembershipReadOptions{
 			Include: []OrgMembershipIncludeOpt{"users"},
 		})

--- a/policy_check.go
+++ b/policy_check.go
@@ -239,26 +239,5 @@ func (s *policyChecks) Logs(ctx context.Context, policyCheckID string) (io.Reade
 }
 
 func (o *PolicyCheckListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validatePolicyCheckIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validatePolicyCheckIncludeParams(params []PolicyCheckIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case PolicyCheckRunWorkspace, PolicyCheckRun:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/policy_set.go
+++ b/policy_set.go
@@ -658,26 +658,5 @@ func (o PolicySetAddProjectsOptions) valid() error {
 }
 
 func (o *PolicySetReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validatePolicySetIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validatePolicySetIncludeParams(params []PolicySetIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case PolicySetPolicies, PolicySetWorkspaces, PolicySetCurrentVersion, PolicySetNewestVersion, PolicySetWorkspaceExclusions, PolicySetProjects:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -244,26 +244,5 @@ func (o *RegistryNoCodeModuleUpdateOptions) valid() error {
 }
 
 func (o *RegistryNoCodeModuleReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateNoCodeIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateNoCodeIncludeParams(params []RegistryNoCodeModuleIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case RegistryNoCodeIncludeVariableOptions:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/run.go
+++ b/run.go
@@ -544,36 +544,9 @@ func (o RunCreateOptions) valid() error {
 }
 
 func (o *RunReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateRunIncludeParam(o.Include); err != nil {
-		return err
-	}
 	return nil
 }
 
 func (o *RunListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateRunIncludeParam(o.Include); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateRunIncludeParam(params []RunIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case RunPlan, RunApply, RunCreatedBy, RunCostEstimate, RunConfigVer, RunConfigVerIngress, RunWorkspace, RunTaskStages:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/run_event.go
+++ b/run_event.go
@@ -127,36 +127,9 @@ func (s *runEvents) ReadWithOptions(ctx context.Context, runEventID string, opti
 }
 
 func (o *RunEventReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateRunEventIncludeParam(o.Include); err != nil {
-		return err
-	}
 	return nil
 }
 
 func (o *RunEventListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateRunEventIncludeParam(o.Include); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateRunEventIncludeParam(params []RunEventIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case RunEventActor, RunEventComment:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/run_task.go
+++ b/run_task.go
@@ -300,38 +300,9 @@ func (o *RunTaskUpdateOptions) valid() error {
 }
 
 func (o *RunTaskListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateRunTaskIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 func (o *RunTaskReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateRunTaskIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateRunTaskIncludeParams(params []RunTaskIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case RunTaskWorkspaceTasks, RunTaskWorkspace:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -194,10 +194,6 @@ func (o *RunTriggerListOptions) valid() error {
 		return err
 	}
 
-	if err := validateRunTriggerIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	return nil
 }
 
@@ -212,19 +208,6 @@ func validateRunTriggerFilterParam(filterParam RunTriggerFilterOp, includeParams
 	if len(includeParams) > 0 {
 		if filterParam != RunTriggerInbound {
 			return ErrUnsupportedRunTriggerType // if user passes RunTriggerOutbound the platform will not return any "include" data
-		}
-	}
-
-	return nil
-}
-
-func validateRunTriggerIncludeParams(params []RunTriggerIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case RunTriggerWorkspace, RunTriggerSourceable:
-			// Do nothing
-		default:
-			return ErrInvalidIncludeValue
 		}
 	}
 

--- a/state_version.go
+++ b/state_version.go
@@ -443,35 +443,8 @@ func (o StateVersionUploadOptions) valid() error {
 }
 
 func (o *StateVersionReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateStateVerIncludeParams(o.Include); err != nil {
-		return err
-	}
 	return nil
 }
 func (o *StateVersionCurrentOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateStateVerIncludeParams(o.Include); err != nil {
-		return err
-	}
-	return nil
-}
-
-func validateStateVerIncludeParams(params []StateVersionIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case SVcreatedby, SVrun, SVrunCreatedBy, SVrunConfigurationVersion, SVoutputs:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/task_stages.go
+++ b/task_stages.go
@@ -191,28 +191,5 @@ func (s *taskStages) Override(ctx context.Context, taskStageID string, options T
 }
 
 func (o *TaskStageReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateTaskStageIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateTaskStageIncludeParams(params []TaskStageIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case TaskStageTaskResults:
-			// do nothing
-		case PolicyEvaluationsTaskResults:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }

--- a/team.go
+++ b/team.go
@@ -273,25 +273,8 @@ func (o *TeamListOptions) valid() error {
 		return nil // nothing to validate
 	}
 
-	if err := validateTeamIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	if err := validateTeamNames(o.Names); err != nil {
 		return err
-	}
-
-	return nil
-}
-
-func validateTeamIncludeParams(params []TeamIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case TeamUsers, TeamOrganizationMemberships:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
 	}
 
 	return nil

--- a/tfe.go
+++ b/tfe.go
@@ -887,6 +887,16 @@ func checkResponseCode(r *http.Response) error {
 	var err error
 
 	switch r.StatusCode {
+	case 400:
+		errs, err = decodeErrorPayload(r)
+		if err != nil {
+			return err
+		}
+
+		if errorPayloadContains(errs, "Invalid include parameter") {
+			return ErrInvalidIncludeValue
+		}
+		return errors.New(strings.Join(errs, "\n"))
 	case 401:
 		return ErrUnauthorized
 	case 404:

--- a/workspace.go
+++ b/workspace.go
@@ -1266,39 +1266,10 @@ func (o WorkspaceRemoveTagsOptions) valid() error {
 }
 
 func (o *WorkspaceListOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateWorkspaceIncludeParams(o.Include); err != nil {
-		return err
-	}
-
 	return nil
 }
 
 func (o *WorkspaceReadOptions) valid() error {
-	if o == nil {
-		return nil // nothing to validate
-	}
-
-	if err := validateWorkspaceIncludeParams(o.Include); err != nil {
-		return err
-	}
-
-	return nil
-}
-
-func validateWorkspaceIncludeParams(params []WSIncludeOpt) error {
-	for _, p := range params {
-		switch p {
-		case WSOrganization, WSCurrentConfigVer, WSCurrentConfigVerIngress, WSCurrentRun, WSCurrentRunPlan, WSCurrentRunConfigVer, WSCurrentrunConfigVerIngress, WSLockedBy, WSReadme, WSOutputs, WSCurrentStateVer:
-			// do nothing
-		default:
-			return ErrInvalidIncludeValue
-		}
-	}
-
 	return nil
 }
 


### PR DESCRIPTION
## Description

We have forgotten to add new ones to the validation, the server will validate them for us, and the string is already typed. Note that the API behavior is identical with the same error being returned but only after a round trip to the server.

Example server error response (400)

```
{
  "errors": [
    {
      "status": "400",
      "title": "bad request",
      "detail": "Invalid include parameter"
    }
  ]
}
```
