### PR TITLE
TF-9274 Remove beta flags for PolicySetProjects and PolicySetWorkspaceExclusions

### DIFF
--- a/policy_set.go
+++ b/policy_set.go
@@ -118,7 +118,6 @@ type PolicySet struct {
 	// **Note: This field is still in BETA and subject to change.**
 	// The workspace exclusions to which the policy set applies.
 	WorkspaceExclusions []*Workspace `jsonapi:"relation,workspace-exclusions"`
-	// **Note: This field is still in BETA and subject to change.**
 	// The projects to which the policy set applies.
 	Projects []*Project `jsonapi:"relation,projects"`
 }
@@ -132,9 +131,9 @@ const (
 	PolicySetWorkspaces     PolicySetIncludeOpt = "workspaces"
 	PolicySetCurrentVersion PolicySetIncludeOpt = "current_version"
 	PolicySetNewestVersion  PolicySetIncludeOpt = "newest_version"
+	PolicySetProjects       PolicySetIncludeOpt = "projects"
 	// **Note: This field is still in BETA and subject to change.**
 	PolicySetWorkspaceExclusions PolicySetIncludeOpt = "workspace_exclusions"
-	PolicySetProjects            PolicySetIncludeOpt = "projects"
 )
 
 // PolicySetListOptions represents the options for listing policy sets.
@@ -209,7 +208,6 @@ type PolicySetCreateOptions struct {
 	// Optional: The initial list of workspace exclusions for which the policy set should be enforced.
 	WorkspaceExclusions []*Workspace `jsonapi:"relation,workspace-exclusions,omitempty"`
 
-	// **Note: This field is still in BETA and subject to change.**
 	// Optional: The initial list of projects for which the policy set should be enforced.
 	Projects []*Project `jsonapi:"relation,projects,omitempty"`
 }

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -172,7 +172,6 @@ func TestPolicySetsCreate(t *testing.T) {
 	})
 
 	t.Run("with policies, workspaces and projects provided", func(t *testing.T) {
-		skipUnlessBeta(t)
 		pTest, pTestCleanup := createPolicy(t, client, orgTest)
 		defer pTestCleanup()
 		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
@@ -889,7 +888,6 @@ func TestPolicySetsRemoveWorkspaceExclusions(t *testing.T) {
 }
 
 func TestPolicySetsAddProjects(t *testing.T) {
-	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -959,7 +957,6 @@ func TestPolicySetsAddProjects(t *testing.T) {
 }
 
 func TestPolicySetsRemoveProjects(t *testing.T) {
-	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Removes skipping of Projects and Workspace Exclusions associated with a policy set now that the feature is fully GA. 

## Testing plan

CI should pass

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
