### PR TITLE
TF-9286 Add the enforced attribute to variable_set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 <!-- Add CHANGELOG entry to this section for any PR awaiting the next release -->
 <!-- Please also include if this is a Bug Fix, Enhancement, or Feature -->
 
+## Enhancements
+* Added BETA support for including `enforced` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
 
 # v1.34.0
 ## Features

--- a/variable_set.go
+++ b/variable_set.go
@@ -71,6 +71,7 @@ type VariableSet struct {
 	Name        string `jsonapi:"attr,name"`
 	Description string `jsonapi:"attr,description"`
 	Global      bool   `jsonapi:"attr,global"`
+	Enforced    bool   `jsonapi:"attr,enforced"`
 
 	// Relations
 	Organization *Organization          `jsonapi:"relation,organization"`
@@ -113,6 +114,9 @@ type VariableSetCreateOptions struct {
 
 	// If true the variable set is considered in all runs in the organization.
 	Global *bool `jsonapi:"attr,global,omitempty"`
+
+	// If true the variables in the set cannot be overwritten and take precedence.
+	Enforced *bool `jsonapi:"attr,enforced,omitempty"`
 }
 
 // VariableSetReadOptions represents the options for reading variable sets.
@@ -138,6 +142,9 @@ type VariableSetUpdateOptions struct {
 
 	// If true the variable set is considered in all runs in the organization.
 	Global *bool `jsonapi:"attr,global,omitempty"`
+
+	// If true the variables in the set cannot be overwritten and take precedence.
+	Enforced *bool `jsonapi:"attr,enforced,omitempty"`
 }
 
 // VariableSetApplyToWorkspacesOptions represents the options for applying variable sets to workspaces.

--- a/variable_set.go
+++ b/variable_set.go
@@ -71,7 +71,8 @@ type VariableSet struct {
 	Name        string `jsonapi:"attr,name"`
 	Description string `jsonapi:"attr,description"`
 	Global      bool   `jsonapi:"attr,global"`
-	Enforced    bool   `jsonapi:"attr,enforced"`
+	// **Note: This field is still in BETA and subject to change.**
+	Enforced bool `jsonapi:"attr,enforced"`
 
 	// Relations
 	Organization *Organization          `jsonapi:"relation,organization"`
@@ -115,6 +116,7 @@ type VariableSetCreateOptions struct {
 	// If true the variable set is considered in all runs in the organization.
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
+	// **Note: This field is still in BETA and subject to change.**
 	// If true the variables in the set cannot be overwritten and take precedence.
 	Enforced *bool `jsonapi:"attr,enforced,omitempty"`
 }
@@ -143,6 +145,7 @@ type VariableSetUpdateOptions struct {
 	// If true the variable set is considered in all runs in the organization.
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
+	// **Note: This field is still in BETA and subject to change.**
 	// If true the variables in the set cannot be overwritten and take precedence.
 	Enforced *bool `jsonapi:"attr,enforced,omitempty"`
 }

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -171,6 +171,7 @@ func TestVariableSetsCreate(t *testing.T) {
 			Name:        String("varset"),
 			Description: String("a variable set"),
 			Global:      Bool(false),
+			Enforced:    Bool(false),
 		}
 
 		vs, err := client.VariableSets.Create(ctx, orgTest.Name, &options)
@@ -188,6 +189,7 @@ func TestVariableSetsCreate(t *testing.T) {
 			assert.Equal(t, *options.Name, item.Name)
 			assert.Equal(t, *options.Description, item.Description)
 			assert.Equal(t, *options.Global, item.Global)
+			assert.Equal(t, *options.Enforced, item.Enforced)
 		}
 	})
 
@@ -242,6 +244,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 		Name:        String("OriginalName"),
 		Description: String("Original Description"),
 		Global:      Bool(false),
+		Enforced:    Bool(false),
 	})
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
@@ -249,6 +252,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 			Name:        String("UpdatedName"),
 			Description: String("Updated Description"),
 			Global:      Bool(true),
+			Enforced:    Bool(true),
 		}
 
 		vsAfter, err := client.VariableSets.Update(ctx, vsTest.ID, &options)
@@ -257,6 +261,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 		assert.Equal(t, *options.Name, vsAfter.Name)
 		assert.Equal(t, *options.Description, vsAfter.Description)
 		assert.Equal(t, *options.Global, vsAfter.Global)
+		assert.Equal(t, *options.Enforced, vsAfter.Enforced)
 	})
 
 	t.Run("when options has an invalid variable set ID", func(t *testing.T) {
@@ -264,6 +269,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 			Name:        String("UpdatedName"),
 			Description: String("Updated Description"),
 			Global:      Bool(true),
+			Enforced:    Bool(true),
 		})
 		assert.Nil(t, vsAfter)
 		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -160,6 +160,7 @@ func TestVariableSetsListForProject(t *testing.T) {
 }
 
 func TestVariableSetsCreate(t *testing.T) {
+	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -234,6 +235,7 @@ func TestVariableSetsRead(t *testing.T) {
 }
 
 func TestVariableSetsUpdate(t *testing.T) {
+	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -160,6 +160,55 @@ func TestVariableSetsListForProject(t *testing.T) {
 }
 
 func TestVariableSetsCreate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	t.Run("with valid options", func(t *testing.T) {
+		options := VariableSetCreateOptions{
+			Name:        String("varset"),
+			Description: String("a variable set"),
+			Global:      Bool(false),
+		}
+
+		vs, err := client.VariableSets.Create(ctx, orgTest.Name, &options)
+		require.NoError(t, err)
+
+		// Get refreshed view from the API
+		refreshed, err := client.VariableSets.Read(ctx, vs.ID, nil)
+		require.NoError(t, err)
+
+		for _, item := range []*VariableSet{
+			vs,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.Description, item.Description)
+			assert.Equal(t, *options.Global, item.Global)
+		}
+	})
+
+	t.Run("when options is missing name", func(t *testing.T) {
+		vs, err := client.VariableSets.Create(ctx, "foo", &VariableSetCreateOptions{
+			Global: Bool(true),
+		})
+		assert.Nil(t, vs)
+		assert.EqualError(t, err, ErrRequiredName.Error())
+	})
+
+	t.Run("when options is missing global flag", func(t *testing.T) {
+		vs, err := client.VariableSets.Create(ctx, "foo", &VariableSetCreateOptions{
+			Name: String("foo"),
+		})
+		assert.Nil(t, vs)
+		assert.EqualError(t, err, ErrRequiredGlobalFlag.Error())
+	})
+}
+
+func TestVariableSetsWithEnforcedCreate(t *testing.T) {
 	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
@@ -235,6 +284,45 @@ func TestVariableSetsRead(t *testing.T) {
 }
 
 func TestVariableSetsUpdate(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	vsTest, _ := createVariableSet(t, client, orgTest, VariableSetCreateOptions{
+		Name:        String("OriginalName"),
+		Description: String("Original Description"),
+		Global:      Bool(false),
+	})
+
+	t.Run("when updating a subset of values", func(t *testing.T) {
+		options := VariableSetUpdateOptions{
+			Name:        String("UpdatedName"),
+			Description: String("Updated Description"),
+			Global:      Bool(true),
+		}
+
+		vsAfter, err := client.VariableSets.Update(ctx, vsTest.ID, &options)
+		require.NoError(t, err)
+
+		assert.Equal(t, *options.Name, vsAfter.Name)
+		assert.Equal(t, *options.Description, vsAfter.Description)
+		assert.Equal(t, *options.Global, vsAfter.Global)
+	})
+
+	t.Run("when options has an invalid variable set ID", func(t *testing.T) {
+		vsAfter, err := client.VariableSets.Update(ctx, badIdentifier, &VariableSetUpdateOptions{
+			Name:        String("UpdatedName"),
+			Description: String("Updated Description"),
+			Global:      Bool(true),
+		})
+		assert.Nil(t, vsAfter)
+		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())
+	})
+}
+
+func TestVariableSetsUpdateWithEnforced(t *testing.T) {
 	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

The variable sets has a new attribute called enforced to disable overwrites and hence go-tfe needs to be updated to accommodate the new attribute as well for POST and PATCH.

## Testing plan

Integration tests.

## External links

- [RFC](https://hermes.hashicorp.services/document/1l13bdkwiPAqMLMUYYjPTPwD1ipcVTMhIMkDT-KDQwhk?draft=true)
- [PRD](https://docs.google.com/document/d/1GU-o1QiNxCzCqVAvyfj1FUzPrU1YWfoUIA9QKHHMFZw/edit)
- [Jira](https://hashicorp.atlassian.net/browse/TF-9286)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
=== RUN   TestVariableSetsCreate
--- PASS: TestVariableSetsCreate (1.45s)
=== RUN   TestVariableSetsCreate/with_valid_options
    --- PASS: TestVariableSetsCreate/with_valid_options (0.36s)
PASS


=== RUN   TestVariableSetsUpdate
--- PASS: TestVariableSetsUpdate (1.61s)
=== RUN   TestVariableSetsUpdate/when_updating_a_subset_of_values
    --- PASS: TestVariableSetsUpdate/when_updating_a_subset_of_values (0.18s)
=== RUN   TestVariableSetsUpdate/when_options_has_an_invalid_variable_set_ID
    --- PASS: TestVariableSetsUpdate/when_options_has_an_invalid_variable_set_ID (0.00s)
PASS
```
