### PR TITLE
TF-9651 update varset enforced attribute to priority attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 ## Features
 * Add the tags attribute to VCSRepo to be used with registry modules by @hashimoon [#793](https://github.com/hashicorp/go-tfe/pull/793)
+* Added BETA support for including `priority` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
 
 # v.1.36.0
 
@@ -20,7 +21,6 @@
 * Added BETA support for private module registry tests by @hashimoon [#781](https://github.com/hashicorp/go-tfe/pull/781)
 
 ## Enhancements
-* Added BETA support for including `priority` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
 * Removed beta flags for `PolicySetProjects` and `PolicySetWorkspaceExclusions` by @Netra2104 [#770](https://github.com/hashicorp/go-tfe/pull/770)
 
 # v1.34.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+## Features
 * Added BETA support for including `priority` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
 
 # v.1.37.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 <!-- Please also include if this is a Bug Fix, Enhancement, or Feature -->
 
 ## Enhancements
-* Added BETA support for including `enforced` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
+* Added BETA support for including `priority` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
 
 # v1.34.0
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # UNRELEASED
+* Added BETA support for including `priority` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
 
 # v.1.37.0
 
 ## Features
 * Add the tags attribute to VCSRepo to be used with registry modules by @hashimoon [#793](https://github.com/hashicorp/go-tfe/pull/793)
-* Added BETA support for including `priority` attribute to variable_set on create and update by @Netra2104 [#778](https://github.com/hashicorp/go-tfe/pull/778)
 
 # v.1.36.0
 

--- a/variable_set.go
+++ b/variable_set.go
@@ -72,7 +72,7 @@ type VariableSet struct {
 	Description string `jsonapi:"attr,description"`
 	Global      bool   `jsonapi:"attr,global"`
 	// **Note: This field is still in BETA and subject to change.**
-	Enforced bool `jsonapi:"attr,enforced"`
+	Priority bool `jsonapi:"attr,priority"`
 
 	// Relations
 	Organization *Organization          `jsonapi:"relation,organization"`
@@ -118,7 +118,7 @@ type VariableSetCreateOptions struct {
 
 	// **Note: This field is still in BETA and subject to change.**
 	// If true the variables in the set cannot be overwritten and take precedence.
-	Enforced *bool `jsonapi:"attr,enforced,omitempty"`
+	Priority *bool `jsonapi:"attr,priority,omitempty"`
 }
 
 // VariableSetReadOptions represents the options for reading variable sets.
@@ -147,7 +147,7 @@ type VariableSetUpdateOptions struct {
 
 	// **Note: This field is still in BETA and subject to change.**
 	// If true the variables in the set cannot be overwritten and take precedence.
-	Enforced *bool `jsonapi:"attr,enforced,omitempty"`
+	Priority *bool `jsonapi:"attr,priority,omitempty"`
 }
 
 // VariableSetApplyToWorkspacesOptions represents the options for applying variable sets to workspaces.

--- a/variable_set.go
+++ b/variable_set.go
@@ -117,7 +117,8 @@ type VariableSetCreateOptions struct {
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
 	// **Note: This field is still in BETA and subject to change.**
-	// If true the variables in the set cannot be overwritten and take precedence.
+	// If true the variables in the set override any other variable values set
+	// in a more specific scope including values set on the command line.
 	Priority *bool `jsonapi:"attr,priority,omitempty"`
 }
 
@@ -146,7 +147,8 @@ type VariableSetUpdateOptions struct {
 	Global *bool `jsonapi:"attr,global,omitempty"`
 
 	// **Note: This field is still in BETA and subject to change.**
-	// If true the variables in the set cannot be overwritten and take precedence.
+	// If true the variables in the set override any other variable values set
+	// in a more specific scope including values set on the command line.
 	Priority *bool `jsonapi:"attr,priority,omitempty"`
 }
 

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -208,7 +208,7 @@ func TestVariableSetsCreate(t *testing.T) {
 	})
 }
 
-func TestVariableSetsWithEnforcedCreate(t *testing.T) {
+func TestVariableSetsWithPriorityCreate(t *testing.T) {
 	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
@@ -221,7 +221,7 @@ func TestVariableSetsWithEnforcedCreate(t *testing.T) {
 			Name:        String("varset"),
 			Description: String("a variable set"),
 			Global:      Bool(false),
-			Enforced:    Bool(false),
+			Priority:    Bool(false),
 		}
 
 		vs, err := client.VariableSets.Create(ctx, orgTest.Name, &options)
@@ -239,7 +239,7 @@ func TestVariableSetsWithEnforcedCreate(t *testing.T) {
 			assert.Equal(t, *options.Name, item.Name)
 			assert.Equal(t, *options.Description, item.Description)
 			assert.Equal(t, *options.Global, item.Global)
-			assert.Equal(t, *options.Enforced, item.Enforced)
+			assert.Equal(t, *options.Priority, item.Priority)
 		}
 	})
 
@@ -322,7 +322,7 @@ func TestVariableSetsUpdate(t *testing.T) {
 	})
 }
 
-func TestVariableSetsUpdateWithEnforced(t *testing.T) {
+func TestVariableSetsUpdateWithPriority(t *testing.T) {
 	skipUnlessBeta(t)
 	client := testClient(t)
 	ctx := context.Background()
@@ -334,7 +334,7 @@ func TestVariableSetsUpdateWithEnforced(t *testing.T) {
 		Name:        String("OriginalName"),
 		Description: String("Original Description"),
 		Global:      Bool(false),
-		Enforced:    Bool(false),
+		Priority:    Bool(false),
 	})
 
 	t.Run("when updating a subset of values", func(t *testing.T) {
@@ -342,7 +342,7 @@ func TestVariableSetsUpdateWithEnforced(t *testing.T) {
 			Name:        String("UpdatedName"),
 			Description: String("Updated Description"),
 			Global:      Bool(true),
-			Enforced:    Bool(true),
+			Priority:    Bool(true),
 		}
 
 		vsAfter, err := client.VariableSets.Update(ctx, vsTest.ID, &options)
@@ -351,7 +351,7 @@ func TestVariableSetsUpdateWithEnforced(t *testing.T) {
 		assert.Equal(t, *options.Name, vsAfter.Name)
 		assert.Equal(t, *options.Description, vsAfter.Description)
 		assert.Equal(t, *options.Global, vsAfter.Global)
-		assert.Equal(t, *options.Enforced, vsAfter.Enforced)
+		assert.Equal(t, *options.Priority, vsAfter.Priority)
 	})
 
 	t.Run("when options has an invalid variable set ID", func(t *testing.T) {
@@ -359,7 +359,7 @@ func TestVariableSetsUpdateWithEnforced(t *testing.T) {
 			Name:        String("UpdatedName"),
 			Description: String("Updated Description"),
 			Global:      Bool(true),
-			Enforced:    Bool(true),
+			Priority:    Bool(true),
 		})
 		assert.Nil(t, vsAfter)
 		assert.EqualError(t, err, ErrInvalidVariableSetID.Error())


### PR DESCRIPTION
## Description

Rename the enforced field on varsets to be priority instead. This feature has not been released yet anywhere, so there's no concern about breaking changes here.

This pr simply renames the field added in this PR by @Netra2104: https://github.com/hashicorp/go-tfe/pull/778

## External links

- [Related PR](https://github.com/hashicorp/atlas/pull/17301)
- [Related Docs PR](https://github.com/hashicorp/terraform-docs-common/pull/458)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
➜  go-tfe git:(TF-9651-update-varsets-enforced-field-to-priority-field) TFE_ADDRESS=http://localhost:21080/ TFE_TOKEN=<local token> go test -run TestVariableSetsWithPriorityCreate                              
PASS
ok      github.com/hashicorp/go-tfe     0.185s
➜  go-tfe git:(TF-9651-update-varsets-enforced-field-to-priority-field) TFE_ADDRESS=http://localhost:21080/ TFE_TOKEN=<local token> go test -run TestVariableSetsUpdateWithPriority                                  
PASS
ok      github.com/hashicorp/go-tfe     0.205s
```
