### PR TITLE
[TF-7737] Add fields for Registry Module Testing

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -222,9 +222,9 @@ var (
 
 	ErrRequiredAgentPoolID = errors.New("'agent' execution mode requires an agent pool ID to be specified")
 
-	ErrRequiredAgentMode = errors.New("specifying an agent pool ID requires 'agent' execution mode")
-
-	ErrRequiredCategory = errors.New("category is required")
+	ErrRequiredAgentMode              = errors.New("specifying an agent pool ID requires 'agent' execution mode")
+	ErrRequiredBranchWhenTestsEnabled = errors.New("VCS branch is required when enabling tests")
+	ErrRequiredCategory               = errors.New("category is required")
 
 	ErrRequiredDestinationType = errors.New("destination type is required")
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -270,6 +270,11 @@ type RegistryModuleUpdateOptions struct {
 	// **Note: This field is still in BETA and subject to change.**
 	TestConfig *RegistryModuleTestConfigOptions `jsonapi:"attr,test-config,omitempty"`
 
+	// The Branch and Tag fields are used to determine
+	// the PublishingMechanism for a RegistryModule that has a VCS a connection.
+	// When a value for Branch is provided, the Tags field is removed on the server
+	// When a value for Tags is provided, the Branch field is removed on the server
+	// **Note: This field is still in BETA and subject to change.**
 	Branch string `jsonapi:"attr,branch,omitempty"`
 	Tags   string `jsonapi:"attr,tags,omitempty"`
 }

--- a/registry_module.go
+++ b/registry_module.go
@@ -726,7 +726,7 @@ func (o RegistryModuleCreateWithVCSConnectionOptions) valid() error {
 		return ErrRequiredVCSRepo
 	}
 
-	if o.TestConfig != nil {
+	if o.TestConfig != nil && o.TestConfig.TestsEnabled != nil {
 		if *o.TestConfig.TestsEnabled {
 			if !validString(o.VCSRepo.Branch) {
 				return ErrRequiredBranchWhenTestsEnabled

--- a/registry_module.go
+++ b/registry_module.go
@@ -95,6 +95,13 @@ const (
 	RegistryModuleVersionStatusOk                  RegistryModuleVersionStatus = "ok"
 )
 
+type PublishingMechanism string
+
+const (
+	PublishingMechanismBranch PublishingMechanism = "branch"
+	PublishingMechanismTag    PublishingMechanism = "git_tag"
+)
+
 // RegistryModuleID represents the set of IDs that identify a RegistryModule
 type RegistryModuleID struct {
 	// The organization the module belongs to, see RegistryModule.Organization.Name
@@ -131,7 +138,7 @@ type RegistryModule struct {
 	Namespace           string                          `jsonapi:"attr,namespace"`
 	NoCode              bool                            `jsonapi:"attr,no-code"`
 	Permissions         *RegistryModulePermissions      `jsonapi:"attr,permissions"`
-	PublishingMechanism string                          `jsonapi:"attr,publishing-mechanism"`
+	PublishingMechanism PublishingMechanism             `jsonapi:"attr,publishing-mechanism"`
 	Status              RegistryModuleStatus            `jsonapi:"attr,status"`
 	TestConfig          *TestConfig                     `jsonapi:"attr,test-config"`
 	VCSRepo             *VCSRepo                        `jsonapi:"attr,vcs-repo"`

--- a/registry_module.go
+++ b/registry_module.go
@@ -124,18 +124,20 @@ type CommitList struct {
 
 // RegistryModule represents a registry module
 type RegistryModule struct {
-	ID              string                          `jsonapi:"primary,registry-modules"`
-	Name            string                          `jsonapi:"attr,name"`
-	Provider        string                          `jsonapi:"attr,provider"`
-	RegistryName    RegistryName                    `jsonapi:"attr,registry-name"`
-	Namespace       string                          `jsonapi:"attr,namespace"`
-	NoCode          bool                            `jsonapi:"attr,no-code"`
-	Permissions     *RegistryModulePermissions      `jsonapi:"attr,permissions"`
-	Status          RegistryModuleStatus            `jsonapi:"attr,status"`
-	VCSRepo         *VCSRepo                        `jsonapi:"attr,vcs-repo"`
-	VersionStatuses []RegistryModuleVersionStatuses `jsonapi:"attr,version-statuses"`
-	CreatedAt       string                          `jsonapi:"attr,created-at"`
-	UpdatedAt       string                          `jsonapi:"attr,updated-at"`
+	ID                  string                          `jsonapi:"primary,registry-modules"`
+	Name                string                          `jsonapi:"attr,name"`
+	Provider            string                          `jsonapi:"attr,provider"`
+	RegistryName        RegistryName                    `jsonapi:"attr,registry-name"`
+	Namespace           string                          `jsonapi:"attr,namespace"`
+	NoCode              bool                            `jsonapi:"attr,no-code"`
+	Permissions         *RegistryModulePermissions      `jsonapi:"attr,permissions"`
+	PublishingMechanism string                          `jsonapi:"attr,publishing-mechanism"`
+	Status              RegistryModuleStatus            `jsonapi:"attr,status"`
+	TestConfig          *TestConfig                     `jsonapi:"attr,test-config"`
+	VCSRepo             *VCSRepo                        `jsonapi:"attr,vcs-repo"`
+	VersionStatuses     []RegistryModuleVersionStatuses `jsonapi:"attr,version-statuses"`
+	CreatedAt           string                          `jsonapi:"attr,created-at"`
+	UpdatedAt           string                          `jsonapi:"attr,updated-at"`
 
 	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`
@@ -239,6 +241,10 @@ type RegistryModuleCreateWithVCSConnectionOptions struct {
 	//
 	// **Note: This field is still in BETA and subject to change.**
 	InitialVersion *string `jsonapi:"attr,initial-version,omitempty"`
+
+	// Optional: Flag to enable tests for the module
+	// **Note: This field is still in BETA and subject to change.**
+	TestConfig *RegistryModuleTestConfigOptions `jsonapi:"attr,test-config,omitempty"`
 }
 
 // RegistryModuleCreateVersionOptions is used when updating a registry module
@@ -252,6 +258,17 @@ type RegistryModuleUpdateOptions struct {
 	// Optional: Flag to enable no-code provisioning for the whole module.
 	// **Note: This field is still in BETA and subject to change.**
 	NoCode *bool `jsonapi:"attr,no-code,omitempty"`
+
+	// Optional: Flag to enable tests for the module
+	// **Note: This field is still in BETA and subject to change.**
+	TestConfig *RegistryModuleTestConfigOptions `jsonapi:"attr,test-config,omitempty"`
+
+	Branch string `jsonapi:"attr,branch,omitempty"`
+	Tags   string `jsonapi:"attr,tags,omitempty"`
+}
+
+type RegistryModuleTestConfigOptions struct {
+	TestsEnabled *bool `jsonapi:"attr,tests-enabled,omitempty"`
 }
 
 type RegistryModuleVCSRepoOptions struct {
@@ -696,6 +713,15 @@ func (o RegistryModuleCreateWithVCSConnectionOptions) valid() error {
 	if o.VCSRepo == nil {
 		return ErrRequiredVCSRepo
 	}
+
+	if o.TestConfig != nil {
+		if *o.TestConfig.TestsEnabled {
+			if !validString(o.VCSRepo.Branch) {
+				return ErrRequiredBranchWhenTestsEnabled
+			}
+		}
+	}
+
 	return o.VCSRepo.valid()
 }
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -270,13 +270,7 @@ type RegistryModuleUpdateOptions struct {
 	// **Note: This field is still in BETA and subject to change.**
 	TestConfig *RegistryModuleTestConfigOptions `jsonapi:"attr,test-config,omitempty"`
 
-	// The Branch and Tag fields are used to determine
-	// the PublishingMechanism for a RegistryModule that has a VCS a connection.
-	// When a value for Branch is provided, the Tags field is removed on the server
-	// When a value for Tags is provided, the Branch field is removed on the server
-	// **Note: This field is still in BETA and subject to change.**
-	Branch string `jsonapi:"attr,branch,omitempty"`
-	Tags   string `jsonapi:"attr,tags,omitempty"`
+	VCSRepo *RegistryModuleVCSRepoUpdateOptions `jsonapi:"attr-vcs-repo,omitempty"`
 }
 
 type RegistryModuleTestConfigOptions struct {
@@ -295,6 +289,16 @@ type RegistryModuleVCSRepoOptions struct {
 	//
 	// **Note: This field is still in BETA and subject to change.**
 	Branch *string `json:"branch,omitempty"`
+}
+
+type RegistryModuleVCSRepoUpdateOptions struct {
+	// The Branch and Tag fields are used to determine
+	// the PublishingMechanism for a RegistryModule that has a VCS a connection.
+	// When a value for Branch is provided, the Tags field is removed on the server
+	// When a value for Tags is provided, the Branch field is removed on the server
+	// **Note: This field is still in BETA and subject to change.**
+	Branch *string `json:"branch,omitempty"`
+	Tags   *string `json:"tags,omitempty"`
 }
 
 // List all the registory modules within an organization.

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -367,7 +367,9 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 		assert.Equal(t, "git_tag", rm.PublishingMechanism)
 
 		options := RegistryModuleUpdateOptions{
-			Branch: githubBranch,
+			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
+				Branch: String(githubBranch),
+			},
 		}
 		rm, err := client.RegistryModules.Update(ctx, RegistryModuleID{
 			Organization: orgTest.Name,
@@ -380,7 +382,9 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 		assert.Equal(t, "branch", rm.PublishingMechanism)
 
 		options = RegistryModuleUpdateOptions{
-			Tags: "1.0.0",
+			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
+				Tags: String("1.0.0"),
+			},
 		}
 		rm, err = client.RegistryModules.Update(ctx, RegistryModuleID{
 			Organization: orgTest.Name,
@@ -394,7 +398,9 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 		assert.Equal(t, "git_tag", rm.PublishingMechanism)
 
 		options = RegistryModuleUpdateOptions{
-			Branch: githubBranch,
+			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
+				Branch: String(githubBranch),
+			},
 		}
 		rm, err = client.RegistryModules.Update(ctx, RegistryModuleID{
 			Organization: orgTest.Name,

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -300,6 +300,114 @@ func TestRegistryModuleUpdate(t *testing.T) {
 	})
 }
 
+func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
+	skipUnlessBeta(t)
+	githubBranch := os.Getenv("GITHUB_REGISTRY_MODULE_BRANCH")
+	if githubBranch == "" {
+		githubBranch = "main"
+	}
+
+	githubIdentifier := os.Getenv("GITHUB_REGISTRY_MODULE_IDENTIFIER")
+	if githubIdentifier == "" {
+		t.Skip("Export a valid GITHUB_REGISTRY_MODULE_IDENTIFIER before running this test")
+	}
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	oauthTokenTest, oauthTokenTestCleanup := createOAuthToken(t, client, orgTest)
+	defer oauthTokenTestCleanup()
+
+	options := RegistryModuleCreateWithVCSConnectionOptions{
+		VCSRepo: &RegistryModuleVCSRepoOptions{
+			OrganizationName:  String(orgTest.Name),
+			Identifier:        String(githubIdentifier),
+			OAuthTokenID:      String(oauthTokenTest.ID),
+			DisplayIdentifier: String(githubIdentifier),
+		},
+	}
+	rm, err := client.RegistryModules.CreateWithVCSConnection(ctx, options)
+	require.NoError(t, err)
+	assert.NotEmpty(t, rm.ID)
+
+	t.Run("enable no-code", func(t *testing.T) {
+		options := RegistryModuleUpdateOptions{
+			NoCode: Bool(true),
+		}
+		rm, err := client.RegistryModules.Update(ctx, RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         rm.Name,
+			Provider:     rm.Provider,
+			Namespace:    rm.Namespace,
+			RegistryName: rm.RegistryName,
+		}, options)
+		require.NoError(t, err)
+		assert.True(t, rm.NoCode)
+	})
+
+	t.Run("disable no-code", func(t *testing.T) {
+		options := RegistryModuleUpdateOptions{
+			NoCode: Bool(false),
+		}
+		rm, err := client.RegistryModules.Update(ctx, RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         rm.Name,
+			Provider:     rm.Provider,
+			Namespace:    rm.Namespace,
+			RegistryName: rm.RegistryName,
+		}, options)
+		require.NoError(t, err)
+		assert.False(t, rm.NoCode)
+	})
+
+	t.Run("toggle between git tag-based and branch-based publishing", func(t *testing.T) {
+		assert.Equal(t, "git_tag", rm.PublishingMechanism)
+
+		options := RegistryModuleUpdateOptions{
+			Branch: githubBranch,
+		}
+		rm, err := client.RegistryModules.Update(ctx, RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         rm.Name,
+			Provider:     rm.Provider,
+			Namespace:    rm.Namespace,
+			RegistryName: rm.RegistryName,
+		}, options)
+		require.NoError(t, err)
+		assert.Equal(t, "branch", rm.PublishingMechanism)
+
+		options = RegistryModuleUpdateOptions{
+			Tags: "1.0.0",
+		}
+		rm, err = client.RegistryModules.Update(ctx, RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         rm.Name,
+			Provider:     rm.Provider,
+			Namespace:    rm.Namespace,
+			RegistryName: rm.RegistryName,
+		}, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, "git_tag", rm.PublishingMechanism)
+
+		options = RegistryModuleUpdateOptions{
+			Branch: githubBranch,
+		}
+		rm, err = client.RegistryModules.Update(ctx, RegistryModuleID{
+			Organization: orgTest.Name,
+			Name:         rm.Name,
+			Provider:     rm.Provider,
+			Namespace:    rm.Namespace,
+			RegistryName: rm.RegistryName,
+		}, options)
+		require.NoError(t, err)
+		assert.Equal(t, "branch", rm.PublishingMechanism)
+	})
+}
+
 func TestRegistryModulesCreateVersion(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
@@ -759,6 +867,86 @@ func TestRegistryModulesCreateBranchBasedWithVCSConnection(t *testing.T) {
 		}
 		_, err := client.RegistryModules.CreateWithVCSConnection(ctx, options)
 		require.Equal(t, err, ErrInvalidOrg)
+	})
+}
+
+func TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting(t *testing.T) {
+	skipUnlessBeta(t)
+
+	githubIdentifier := os.Getenv("GITHUB_REGISTRY_MODULE_IDENTIFIER")
+	if githubIdentifier == "" {
+		t.Skip("Export a valid GITHUB_REGISTRY_MODULE_IDENTIFIER before running this test")
+	}
+	repositoryName := strings.Split(githubIdentifier, "/")[1]
+	registryModuleProvider := strings.SplitN(repositoryName, "-", 3)[1]
+	registryModuleName := strings.SplitN(repositoryName, "-", 3)[2]
+
+	githubBranch := os.Getenv("GITHUB_REGISTRY_MODULE_BRANCH")
+	if githubBranch == "" {
+		githubBranch = "main"
+	}
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	oauthTokenTest, oauthTokenTestCleanup := createOAuthToken(t, client, orgTest)
+	defer oauthTokenTestCleanup()
+
+	t.Run("with valid options", func(t *testing.T) {
+		options := RegistryModuleCreateWithVCSConnectionOptions{
+			VCSRepo: &RegistryModuleVCSRepoOptions{
+				OrganizationName:  String(orgTest.Name),
+				Identifier:        String(githubIdentifier),
+				OAuthTokenID:      String(oauthTokenTest.ID),
+				DisplayIdentifier: String(githubIdentifier),
+				Branch:            String(githubBranch),
+			},
+			TestConfig: &RegistryModuleTestConfigOptions{
+				TestsEnabled: Bool(true),
+			},
+		}
+		rm, err := client.RegistryModules.CreateWithVCSConnection(ctx, options)
+		require.NoError(t, err)
+		assert.NotEmpty(t, rm.ID)
+		assert.Equal(t, registryModuleName, rm.Name)
+		assert.Equal(t, registryModuleProvider, rm.Provider)
+		assert.Equal(t, githubBranch, rm.VCSRepo.Branch)
+
+		t.Run("tests are enabled", func(t *testing.T) {
+			assert.NotEmpty(t, rm.TestConfig)
+			assert.True(t, rm.TestConfig.TestsEnabled)
+		})
+	})
+
+	t.Run("with invalid options", func(t *testing.T) {
+		options := RegistryModuleCreateWithVCSConnectionOptions{
+			VCSRepo: &RegistryModuleVCSRepoOptions{
+				Identifier:        String(githubIdentifier),
+				OAuthTokenID:      String(oauthTokenTest.ID),
+				DisplayIdentifier: String(githubIdentifier),
+				Branch:            String(githubBranch),
+			},
+		}
+		_, err := client.RegistryModules.CreateWithVCSConnection(ctx, options)
+		require.Equal(t, err, ErrInvalidOrg)
+
+		t.Run("when the the module is not branch based and test are enabled", func(t *testing.T) {
+			options := RegistryModuleCreateWithVCSConnectionOptions{
+				VCSRepo: &RegistryModuleVCSRepoOptions{
+					Identifier:        String(githubIdentifier),
+					OAuthTokenID:      String(oauthTokenTest.ID),
+					DisplayIdentifier: String(githubIdentifier),
+				},
+				TestConfig: &RegistryModuleTestConfigOptions{
+					TestsEnabled: Bool(true),
+				},
+			}
+			_, err := client.RegistryModules.CreateWithVCSConnection(ctx, options)
+			require.Equal(t, err, ErrRequiredBranchWhenTestsEnabled)
+		})
 	})
 }
 

--- a/test_config.go
+++ b/test_config.go
@@ -1,0 +1,5 @@
+package tfe
+
+type TestConfig struct {
+	TestsEnabled bool `jsonapi:"attr,tests-enabled"`
+}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

These changes are to support testing functionality for the Private Module Registry. 
- Receive the `TestConfig` object on the `RegistryModule`
- Enable tests for a new `RegistryModule` by passing a `TestConfig` object with `TestsEnabled` set to `true`
- Enable tests for an existing `RegistryModule` by passing a `TestConfig` object with `TestsEnabled` set to `true`
- Enable switching a `RegistryModule` between `git_tag` and `branch` based publishing

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange


=== RUN   TestRegistryModuleUpdatePrivateRegistry
=== RUN   TestRegistryModuleUpdatePrivateRegistry/enable_no-code
2023/09/29 12:39:31 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdatePrivateRegistry/disable_no-code
2023/09/29 12:39:31 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdatePrivateRegistry/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdatePrivateRegistry (5.97s)
    --- PASS: TestRegistryModuleUpdatePrivateRegistry/enable_no-code (0.30s)
    --- PASS: TestRegistryModuleUpdatePrivateRegistry/disable_no-code (0.25s)
    --- PASS: TestRegistryModuleUpdatePrivateRegistry/toggle_between_git_tag-based_and_branch-based_publishing (0.84s)
PASS
ok  	github.com/hashicorp/go-tfe	6.419s

=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting (5.88s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options (2.51s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled (0.00s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	6.233s
...
```
