### PR TITLE
[TF-7737] Fix broken BETA tests related to RegistryModule changes

### DIFF
--- a/registry_module.go
+++ b/registry_module.go
@@ -270,7 +270,7 @@ type RegistryModuleUpdateOptions struct {
 	// **Note: This field is still in BETA and subject to change.**
 	TestConfig *RegistryModuleTestConfigOptions `jsonapi:"attr,test-config,omitempty"`
 
-	VCSRepo *RegistryModuleVCSRepoUpdateOptions `jsonapi:"attr-vcs-repo,omitempty"`
+	VCSRepo *RegistryModuleVCSRepoUpdateOptions `jsonapi:"attr,vcs-repo,omitempty"`
 }
 
 type RegistryModuleTestConfigOptions struct {

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -364,7 +364,7 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 	})
 
 	t.Run("toggle between git tag-based and branch-based publishing", func(t *testing.T) {
-		assert.Equal(t, "git_tag", rm.PublishingMechanism)
+		assert.Equal(t, rm.PublishingMechanism, PublishingMechanismTag)
 
 		options := RegistryModuleUpdateOptions{
 			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
@@ -379,7 +379,7 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 			RegistryName: rm.RegistryName,
 		}, options)
 		require.NoError(t, err)
-		assert.Equal(t, "branch", rm.PublishingMechanism)
+		assert.Equal(t, rm.PublishingMechanism, PublishingMechanismBranch)
 
 		options = RegistryModuleUpdateOptions{
 			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
@@ -395,7 +395,7 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 		}, options)
 		require.NoError(t, err)
 
-		assert.Equal(t, "git_tag", rm.PublishingMechanism)
+		assert.Equal(t, rm.PublishingMechanism, PublishingMechanismTag)
 
 		options = RegistryModuleUpdateOptions{
 			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
@@ -410,7 +410,7 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 			RegistryName: rm.RegistryName,
 		}, options)
 		require.NoError(t, err)
-		assert.Equal(t, "branch", rm.PublishingMechanism)
+		assert.Equal(t, rm.PublishingMechanism, PublishingMechanismBranch)
 	})
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Fix broken BETA tests related to `RegistryModule` testing changes

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
➜  go-tfe git:(main) ✗ ENABLE_BETA=1 TFE_ADDRESS="https://tfcdev-ad663984.ngrok.io/"  go test ./... -v -count=5 -run TestRegistryModuleUpdate
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/06 14:28:49 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/06 14:28:49 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.64s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.53s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.43s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/06 14:28:53 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/06 14:28:53 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.50s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.32s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.89s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/06 14:28:58 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/06 14:28:58 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.51s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.35s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.43s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/06 14:29:02 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/06 14:29:02 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.25s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.27s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.67s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/06 14:29:07 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/06 14:29:07 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.53s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.35s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.41s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/06 14:29:11 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/06 14:29:11 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.06s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.30s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.62s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/06 14:29:15 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/06 14:29:15 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.41s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.33s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.41s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/06 14:29:19 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/06 14:29:19 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.13s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.31s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.62s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/06 14:29:24 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/06 14:29:24 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.54s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.35s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.44s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/06 14:29:28 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/06 14:29:28 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.03s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.30s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.62s)
PASS
ok  	github.com/hashicorp/go-tfe	43.992s


...
```
