### PR TITLE
Go-Tfe support for creating test variables

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -1345,7 +1345,7 @@ func createTestVariable(t *testing.T, client *Client, rm *RegistryModule) (*Vari
 	if rm == nil {
 		rm, rmCleanup = createBranchBasedRegistryModule(t, client, nil)
 	}
-	rmId := RegistryModuleID{
+	rmID := RegistryModuleID{
 		Organization: rm.Organization.Name,
 		Name:         rm.Name,
 		Provider:     rm.Provider,
@@ -1354,7 +1354,7 @@ func createTestVariable(t *testing.T, client *Client, rm *RegistryModule) (*Vari
 	}
 
 	ctx := context.Background()
-	v, err := client.TestVariables.Create(ctx, rmId, VariableCreateOptions{
+	v, err := client.TestVariables.Create(ctx, rmID, VariableCreateOptions{
 		Key:         String(randomKeyValue(t)),
 		Value:       String(randomStringWithoutSpecialChar(t)),
 		Category:    Category(CategoryEnv),
@@ -1365,7 +1365,7 @@ func createTestVariable(t *testing.T, client *Client, rm *RegistryModule) (*Vari
 	}
 
 	return v, func() {
-		if err := client.TestVariables.Delete(ctx, rmId, v.ID); err != nil {
+		if err := client.TestVariables.Delete(ctx, rmID, v.ID); err != nil {
 			t.Errorf("Error destroying variable! WARNING: Dangling resources\n"+
 				"may exist! The full error is shown below.\n\n"+
 				"Variable: %s\nError: %s", v.Key, err)

--- a/helper_test.go
+++ b/helper_test.go
@@ -1355,10 +1355,10 @@ func createTestVariable(t *testing.T, client *Client, rm *RegistryModule) (*Vari
 
 	ctx := context.Background()
 	v, err := client.TestVariables.Create(ctx, rmId, VariableCreateOptions{
-		Key:         String(randomStringWithoutSpecialChar(t)),
+		Key:         String(randomKeyValue(t)),
 		Value:       String(randomStringWithoutSpecialChar(t)),
 		Category:    Category(CategoryEnv),
-		Description: String(randomString(t)),
+		Description: String(randomStringWithoutSpecialChar(t)),
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -2641,6 +2641,15 @@ func randomStringWithoutSpecialChar(t *testing.T) string {
 	}
 	uuidWithoutHyphens := strings.ReplaceAll(v, "-", "")
 	return uuidWithoutHyphens
+}
+
+func randomKeyValue(t *testing.T) string {
+	v, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+	uuidWithoutHyphens := strings.ReplaceAll(v, "-", "")
+	return "t" + uuidWithoutHyphens
 }
 
 func containsProject(pl []*Project, str string) bool {

--- a/organization.go
+++ b/organization.go
@@ -84,6 +84,7 @@ type Organization struct {
 	TrialExpiresAt                                    time.Time                `jsonapi:"attr,trial-expires-at,iso8601"`
 	TwoFactorConformant                               bool                     `jsonapi:"attr,two-factor-conformant"`
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
+	RemainingTestableCount                            int                      `jsonapi:"attr,remaining-testable-count"`
 	// Note: This will be false for TFE versions older than v202211, where the setting was introduced.
 	// On those TFE versions, safe delete does not exist, so ALL deletes will be force deletes.
 	AllowForceDeleteWorkspaces bool `jsonapi:"attr,allow-force-delete-workspaces"`

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -170,6 +170,7 @@ func TestOrganizationsRead(t *testing.T) {
 			assert.NotEmpty(t, org.CreatedAt)
 			// By default accounts are in the free tier and are not in a trial
 			assert.Empty(t, org.TrialExpiresAt)
+			assert.Equal(t, org.RemainingTestableCount, 5)
 		})
 	})
 

--- a/test_config.go
+++ b/test_config.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tfe
 
 type TestConfig struct {

--- a/test_variables.go
+++ b/test_variables.go
@@ -1,0 +1,130 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// Compile-time proof of interface implementation.
+var _ TestVariables = (*testVariables)(nil)
+
+// Variables describes all the variable related methods that the Terraform
+// Enterprise API supports.
+//
+// TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspace-variables
+type TestVariables interface {
+	// List all the variables associated with the given workspace.
+	List(ctx context.Context, moduleID RegistryModuleID, options *VariableListOptions) (*VariableList, error)
+
+	// Create is used to create a new variable.
+	Create(ctx context.Context, moduleID RegistryModuleID, options VariableCreateOptions) (*Variable, error)
+
+	// Update values of an existing variable.
+	Update(ctx context.Context, moduleID RegistryModuleID, variableID string, options VariableUpdateOptions) (*Variable, error)
+
+	// Delete a variable by its ID.
+	Delete(ctx context.Context, moduleID RegistryModuleID, variableID string) error
+}
+
+// variables implements Variables.
+type testVariables struct {
+	client *Client
+}
+
+// List all the variables associated with the given workspace.
+func (s *testVariables) List(ctx context.Context, moduleID RegistryModuleID, options *VariableListOptions) (*VariableList, error) {
+	if err := moduleID.valid(); err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", testVarsPath(moduleID), options)
+	if err != nil {
+		return nil, err
+	}
+
+	vl := &VariableList{}
+	err = req.Do(ctx, vl)
+	if err != nil {
+		return nil, err
+	}
+
+	return vl, nil
+}
+
+// Create is used to create a new variable.
+func (s *testVariables) Create(ctx context.Context, moduleID RegistryModuleID, options VariableCreateOptions) (*Variable, error) {
+	if err := moduleID.valid(); err != nil {
+		return nil, err
+	}
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest("POST", testVarsPath(moduleID), &options)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &Variable{}
+	err = req.Do(ctx, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Update values of an existing variable.
+func (s *testVariables) Update(ctx context.Context, moduleID RegistryModuleID, variableID string, options VariableUpdateOptions) (*Variable, error) {
+	if err := moduleID.valid(); err != nil {
+		return nil, err
+	}
+	if !validStringID(&variableID) {
+		return nil, ErrInvalidVariableID
+	}
+
+	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.QueryEscape(variableID))
+	req, err := s.client.NewRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	v := &Variable{}
+	err = req.Do(ctx, v)
+	if err != nil {
+		return nil, err
+	}
+
+	return v, nil
+}
+
+// Delete a variable by its ID.
+func (s *testVariables) Delete(ctx context.Context, moduleID RegistryModuleID, variableID string) error {
+	if err := moduleID.valid(); err != nil {
+		return err
+	}
+	if !validStringID(&variableID) {
+		return ErrInvalidVariableID
+	}
+
+	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.QueryEscape(variableID))
+	req, err := s.client.NewRequest("DELETE", u, nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+func testVarsPath(moduleID RegistryModuleID) string {
+	return fmt.Sprintf("organizations/%s/tests/registry-modules/%s/%s/%s/%s/vars",
+		url.QueryEscape(moduleID.Organization),
+		url.QueryEscape(string(moduleID.RegistryName)),
+		url.QueryEscape(moduleID.Namespace),
+		url.QueryEscape(moduleID.Name),
+		url.QueryEscape(moduleID.Provider))
+}

--- a/test_variables.go
+++ b/test_variables.go
@@ -15,9 +15,9 @@ var _ TestVariables = (*testVariables)(nil)
 // Variables describes all the variable related methods that the Terraform
 // Enterprise API supports.
 //
-// TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspace-variables
+// TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/tests
 type TestVariables interface {
-	// List all the variables associated with the given workspace.
+	// List all the test variables associated with the given module.
 	List(ctx context.Context, moduleID RegistryModuleID, options *VariableListOptions) (*VariableList, error)
 
 	// Create is used to create a new variable.
@@ -35,7 +35,7 @@ type testVariables struct {
 	client *Client
 }
 
-// List all the variables associated with the given workspace.
+// List all the variables associated with the given module.
 func (s *testVariables) List(ctx context.Context, moduleID RegistryModuleID, options *VariableListOptions) (*VariableList, error) {
 	if err := moduleID.valid(); err != nil {
 		return nil, err

--- a/test_variables_integration_test.go
+++ b/test_variables_integration_test.go
@@ -13,6 +13,7 @@ import (
 
 func TestTestConfigVarsList(t *testing.T) {
 	skipUnlessBeta(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -30,11 +31,45 @@ func TestTestConfigVarsList(t *testing.T) {
 		RegistryName: rmTest.RegistryName,
 	}
 
+	tv1, tvCleanup1 := createTestVariable(t, client, rmTest)
+	tv2, tvCleanup2 := createTestVariable(t, client, rmTest)
+
+	defer tvCleanup1()
+	defer tvCleanup2()
+
+	t.Run("without list options", func(t *testing.T) {
+		trl, err := client.TestVariables.List(ctx, id, nil)
+		var found []string
+		for _, r := range trl.Items {
+			found = append(found, r.ID)
+		}
+
+		require.NoError(t, err)
+		assert.Contains(t, found, tv1.ID)
+		assert.Contains(t, found, tv2.ID)
+		assert.Equal(t, 1, trl.CurrentPage)
+		assert.Equal(t, 2, trl.TotalCount)
+	})
+
+	t.Run("empty list options", func(t *testing.T) {
+		trl, err := client.TestVariables.List(ctx, id, &VariableListOptions{})
+		var found []string
+		for _, r := range trl.Items {
+			found = append(found, r.ID)
+		}
+
+		require.NoError(t, err)
+		assert.Contains(t, found, tv1.ID)
+		assert.Contains(t, found, tv2.ID)
+		assert.Equal(t, 1, trl.CurrentPage)
+		assert.Equal(t, 2, trl.TotalCount)
+	})
+
 	t.Run("with page size", func(t *testing.T) {
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
-		trl, err := client.TestVariables.List(ctx, id, &VariableListOptions{
+		tvl, err := client.TestVariables.List(ctx, id, &VariableListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 999,
 				PageSize:   100,
@@ -42,8 +77,8 @@ func TestTestConfigVarsList(t *testing.T) {
 		})
 
 		require.NoError(t, err)
-		assert.Empty(t, trl.Items)
-		assert.Equal(t, 999, trl.CurrentPage)
-		assert.Equal(t, 2, trl.TotalCount)
+		assert.Empty(t, tvl.Items)
+		assert.Equal(t, 999, tvl.CurrentPage)
+		assert.Equal(t, 2, tvl.TotalCount)
 	})
 }

--- a/test_variables_integration_test.go
+++ b/test_variables_integration_test.go
@@ -221,6 +221,7 @@ func TestTestVariablesCreate(t *testing.T) {
 }
 
 func TestTestVariablesUpdate(t *testing.T) {
+	skipUnlessBeta(t)
 
 	client := testClient(t)
 	ctx := context.Background()
@@ -310,6 +311,8 @@ func TestTestVariablesUpdate(t *testing.T) {
 }
 
 func TestTestVariablesDelete(t *testing.T) {
+	skipUnlessBeta(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/test_variables_integration_test.go
+++ b/test_variables_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestTestConfigVarsList(t *testing.T) {
+func TestTestVariablesList(t *testing.T) {
 	skipUnlessBeta(t)
 
 	client := testClient(t)
@@ -105,7 +105,7 @@ func TestTestVariablesCreate(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := VariableCreateOptions{
-			Key:         String(randomStringWithoutSpecialChar(t)),
+			Key:         String(randomKeyValue(t)),
 			Value:       String(randomStringWithoutSpecialChar(t)),
 			Category:    Category(CategoryEnv),
 			Description: String("testing"),
@@ -124,7 +124,7 @@ func TestTestVariablesCreate(t *testing.T) {
 
 	t.Run("when options has an empty string value", func(t *testing.T) {
 		options := VariableCreateOptions{
-			Key:         String(randomStringWithoutSpecialChar(t)),
+			Key:         String(randomKeyValue(t)),
 			Value:       String(""),
 			Description: String("testing"),
 			Category:    Category(CategoryEnv),
@@ -143,7 +143,7 @@ func TestTestVariablesCreate(t *testing.T) {
 
 	t.Run("when options has an empty string description", func(t *testing.T) {
 		options := VariableCreateOptions{
-			Key:         String(randomStringWithoutSpecialChar(t)),
+			Key:         String(randomKeyValue(t)),
 			Value:       String(randomStringWithoutSpecialChar(t)),
 			Description: String(""),
 			Category:    Category(CategoryEnv),
@@ -162,7 +162,7 @@ func TestTestVariablesCreate(t *testing.T) {
 
 	t.Run("when options has a too-long description", func(t *testing.T) {
 		options := VariableCreateOptions{
-			Key:         String(randomStringWithoutSpecialChar(t)),
+			Key:         String(randomKeyValue(t)),
 			Value:       String(randomStringWithoutSpecialChar(t)),
 			Description: String("tortor aliquam nulla go lint is fussy about spelling cras fermentum odio eu feugiat pretium nibh ipsum consequat nisl vel pretium lectus quam id leo in vitae turpis massa sed elementum tempus egestas sed sed risus pretium quam vulputate dignissim suspendisse in est ante in nibh mauris cursus mattis molestie a iaculis at erat pellentesque adipiscing commodo elit at imperdiet dui accumsan sit amet nulla redacted morbi tempus iaculis urna id volutpat lacus laoreet non curabitur gravida arcu ac tortor dignissim convallis aenean et tortor"),
 			Category:    Category(CategoryEnv),
@@ -174,7 +174,7 @@ func TestTestVariablesCreate(t *testing.T) {
 
 	t.Run("when options is missing value", func(t *testing.T) {
 		options := VariableCreateOptions{
-			Key:      String(randomStringWithoutSpecialChar(t)),
+			Key:      String(randomKeyValue(t)),
 			Category: Category(CategoryEnv),
 		}
 
@@ -211,7 +211,7 @@ func TestTestVariablesCreate(t *testing.T) {
 
 	t.Run("when options is missing category", func(t *testing.T) {
 		options := VariableCreateOptions{
-			Key:   String(randomStringWithoutSpecialChar(t)),
+			Key:   String(randomKeyValue(t)),
 			Value: String(randomStringWithoutSpecialChar(t)),
 		}
 

--- a/test_variables_integration_test.go
+++ b/test_variables_integration_test.go
@@ -1,0 +1,49 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestConfigVarsList(t *testing.T) {
+	skipUnlessBeta(t)
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	rmTest, registryModuleTestCleanup := createBranchBasedRegistryModule(t, client, orgTest)
+	defer registryModuleTestCleanup()
+
+	id := RegistryModuleID{
+		Organization: orgTest.Name,
+		Name:         rmTest.Name,
+		Provider:     rmTest.Provider,
+		Namespace:    rmTest.Namespace,
+		RegistryName: rmTest.RegistryName,
+	}
+
+	t.Run("with page size", func(t *testing.T) {
+		// Request a page number which is out of range. The result should
+		// be successful, but return no results if the paging options are
+		// properly passed along.
+		trl, err := client.TestVariables.List(ctx, id, &VariableListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 999,
+				PageSize:   100,
+			},
+		})
+
+		require.NoError(t, err)
+		assert.Empty(t, trl.Items)
+		assert.Equal(t, 999, trl.CurrentPage)
+		assert.Equal(t, 2, trl.TotalCount)
+	})
+}

--- a/tfe.go
+++ b/tfe.go
@@ -170,6 +170,7 @@ type Client struct {
 	TeamProjectAccess          TeamProjectAccesses
 	TeamTokens                 TeamTokens
 	TestRuns                   TestRuns
+	TestVariables              TestVariables
 	Users                      Users
 	UserTokens                 UserTokens
 	Variables                  Variables
@@ -464,6 +465,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Teams = &teams{client: client}
 	client.TeamTokens = &teamTokens{client: client}
 	client.TestRuns = &testRuns{client: client}
+	client.TestVariables = &testVariables{client: client}
 	client.Users = &users{client: client}
 	client.UserTokens = &userTokens{client: client}
 	client.Variables = &variables{client: client}


### PR DESCRIPTION
## Description

This PR adds support for consuming environment variables for remote terraform tests. It contains a full test suite.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
go test -run TestTestVariables -v
=== RUN   TestTestVariablesList
=== RUN   TestTestVariablesList/without_list_options
=== RUN   TestTestVariablesList/empty_list_options
=== RUN   TestTestVariablesList/with_page_size
--- PASS: TestTestVariablesList (6.52s)
    --- PASS: TestTestVariablesList/without_list_options (0.22s)
    --- PASS: TestTestVariablesList/empty_list_options (0.20s)
    --- PASS: TestTestVariablesList/with_page_size (0.30s)
=== RUN   TestTestVariablesCreate
=== RUN   TestTestVariablesCreate/with_valid_options
=== RUN   TestTestVariablesCreate/when_options_has_an_empty_string_value
=== RUN   TestTestVariablesCreate/when_options_has_an_empty_string_description
=== RUN   TestTestVariablesCreate/when_options_has_a_too-long_description
=== RUN   TestTestVariablesCreate/when_options_is_missing_value
=== RUN   TestTestVariablesCreate/when_options_is_missing_key
=== RUN   TestTestVariablesCreate/when_options_has_an_empty_key
=== RUN   TestTestVariablesCreate/when_options_is_missing_category
--- PASS: TestTestVariablesCreate (5.68s)
    --- PASS: TestTestVariablesCreate/with_valid_options (0.31s)
    --- PASS: TestTestVariablesCreate/when_options_has_an_empty_string_value (0.22s)
    --- PASS: TestTestVariablesCreate/when_options_has_an_empty_string_description (0.23s)
    --- PASS: TestTestVariablesCreate/when_options_has_a_too-long_description (0.18s)
    --- PASS: TestTestVariablesCreate/when_options_is_missing_value (0.20s)
    --- PASS: TestTestVariablesCreate/when_options_is_missing_key (0.00s)
    --- PASS: TestTestVariablesCreate/when_options_has_an_empty_key (0.00s)
    --- PASS: TestTestVariablesCreate/when_options_is_missing_category (0.00s)
=== RUN   TestTestVariablesUpdate
=== RUN   TestTestVariablesUpdate/with_valid_options
=== RUN   TestTestVariablesUpdate/when_updating_a_subset_of_values
=== RUN   TestTestVariablesUpdate/with_sensitive_set
=== RUN   TestTestVariablesUpdate/without_any_changes
=== RUN   TestTestVariablesUpdate/with_invalid_variable_ID
--- PASS: TestTestVariablesUpdate (9.16s)
    --- PASS: TestTestVariablesUpdate/with_valid_options (0.21s)
    --- PASS: TestTestVariablesUpdate/when_updating_a_subset_of_values (0.25s)
    --- PASS: TestTestVariablesUpdate/with_sensitive_set (0.21s)
    --- PASS: TestTestVariablesUpdate/without_any_changes (2.84s)
    --- PASS: TestTestVariablesUpdate/with_invalid_variable_ID (0.00s)
=== RUN   TestTestVariablesDelete
=== RUN   TestTestVariablesDelete/with_valid_options
=== RUN   TestTestVariablesDelete/with_non_existing_variable_ID
=== RUN   TestTestVariablesDelete/with_invalid_variable_ID
--- PASS: TestTestVariablesDelete (5.28s)
    --- PASS: TestTestVariablesDelete/with_valid_options (0.29s)
    --- PASS: TestTestVariablesDelete/with_non_existing_variable_ID (0.18s)
    --- PASS: TestTestVariablesDelete/with_invalid_variable_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	26.840s
```
