### PR TITLE
[TF-7737] Fix incorrect attribute type for `RegistryModule.VCSRepo.Tags`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 <!-- Add CHANGELOG entry to this section for any PR awaiting the next release -->
 <!-- Please also include if this is a Bug Fix, Enhancement, or Feature -->
 
+## Bug Fixes
+* Fix incorrect attribute type for `RegistryModule.VCSRepo.Tags` by @hashimoon [#789](https://github.com/hashicorp/go-tfe/pull/789)
+
 # v.1.35.0
 ## Features
 * Added BETA support for private module registry tests by @hashimoon [#781](https://github.com/hashicorp/go-tfe/pull/781)

--- a/registry_module.go
+++ b/registry_module.go
@@ -298,7 +298,7 @@ type RegistryModuleVCSRepoUpdateOptions struct {
 	// When a value for Tags is provided, the Branch field is removed on the server
 	// **Note: This field is still in BETA and subject to change.**
 	Branch *string `json:"branch,omitempty"`
-	Tags   *string `json:"tags,omitempty"`
+	Tags   *bool   `json:"tags,omitempty"`
 }
 
 // List all the registory modules within an organization.

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -383,7 +383,7 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 
 		options = RegistryModuleUpdateOptions{
 			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
-				Tags: String("1.0.0"),
+				Tags: Bool(true),
 			},
 		}
 		rm, err = client.RegistryModules.Update(ctx, RegistryModuleID{


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Fix incorrect attribute type for `RegistryModule.VCSRepo.Tags`. The attribute was declared as a `string`, when it should be a `boolean`. This feature is currently still in BETA. 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ 
ENABLE_BETA=1 TFE_ADDRESS="xxx" TFE_TOKEN="xxx" go test ./... -v -count=5 -run TestRegistryModuleUpdate
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/10 15:17:55 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/10 15:17:55 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.57s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.48s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.35s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/10 15:17:59 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/10 15:17:59 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.20s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.33s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.20s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.61s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/10 15:18:04 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/10 15:18:04 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.42s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.35s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.44s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/10 15:18:08 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/10 15:18:08 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.05s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.30s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.17s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.60s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/10 15:18:12 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/10 15:18:13 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.40s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.34s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.40s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/10 15:18:16 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/10 15:18:16 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.67s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.28s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.17s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.60s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/10 15:18:21 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/10 15:18:22 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (3.98s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.53s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (1.51s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/10 15:18:28 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/10 15:18:28 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (7.31s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.35s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.20s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.78s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/10 15:18:33 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/10 15:18:33 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.47s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.34s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.43s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/10 15:18:37 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/10 15:18:37 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.36s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.29s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.63s)
PASS
ok  	github.com/hashicorp/go-tfe	47.794s
...
```
