### PR TITLE
Fixes panic during state version upload after some create errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,11 @@
-# UNRELEASED
-<!-- Add CHANGELOG entry to this section for any PR awaiting the next release -->
-<!-- Please also include if this is a Bug Fix, Enhancement, or Feature -->
+# v.1.36.0
 
 ## Features
 * Added BETA support for private module registry test variables by @aaabdelgany [#787](https://github.com/hashicorp/go-tfe/pull/787)
 
 ## Bug Fixes
 * Fix incorrect attribute type for `RegistryModule.VCSRepo.Tags` by @hashimoon [#789](https://github.com/hashicorp/go-tfe/pull/789)
+* Fix nil dereference panic within `StateVersions` `upload` after not handling certain state version create errors by @brandonc [#792](https://github.com/hashicorp/go-tfe/pull/792)
 
 # v.1.35.0
 ## Features

--- a/state_version.go
+++ b/state_version.go
@@ -287,6 +287,7 @@ func (s *stateVersions) Upload(ctx context.Context, workspaceID string, options 
 		if strings.Contains(err.Error(), "param is missing or the value is empty: state") {
 			return nil, ErrStateVersionUploadNotSupported
 		}
+		return nil, err
 	}
 
 	g, _ := errgroup.WithContext(ctx)


### PR DESCRIPTION
## Description

This error was being ignored if it didn't match a certain criteria. Tests will be added in a separate PR in order to release the obvious fix a little faster.

Closes #791