### PR TITLE
[TF-9605] Add the tags attribute to VCSRepo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# UNRELEASED
+
+## Features
+* Add the tags attribute to VCSRepo to be used with registry modules by @hashimoon [#793](https://github.com/hashicorp/go-tfe/pull/793)
+
 # v.1.36.0
 
 ## Features

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -380,6 +380,8 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 		}, options)
 		require.NoError(t, err)
 		assert.Equal(t, rm.PublishingMechanism, PublishingMechanismBranch)
+		assert.Equal(t, false, rm.VCSRepo.Tags)
+		assert.Equal(t, githubBranch, rm.VCSRepo.Branch)
 
 		options = RegistryModuleUpdateOptions{
 			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
@@ -396,6 +398,8 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, rm.PublishingMechanism, PublishingMechanismTag)
+		assert.Equal(t, true, rm.VCSRepo.Tags)
+		assert.Equal(t, "", rm.VCSRepo.Branch)
 
 		options = RegistryModuleUpdateOptions{
 			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
@@ -411,6 +415,8 @@ func TestRegistryModuleUpdateWithVCSConnection(t *testing.T) {
 		}, options)
 		require.NoError(t, err)
 		assert.Equal(t, rm.PublishingMechanism, PublishingMechanismBranch)
+		assert.Equal(t, false, rm.VCSRepo.Tags)
+		assert.Equal(t, githubBranch, rm.VCSRepo.Branch)
 	})
 }
 
@@ -860,8 +866,8 @@ func TestRegistryModulesCreateBranchBasedWithVCSConnection(t *testing.T) {
 		assert.Equal(t, registryModuleName, rm.Name)
 		assert.Equal(t, registryModuleProvider, rm.Provider)
 		assert.Equal(t, githubBranch, rm.VCSRepo.Branch)
+		assert.Equal(t, false, rm.VCSRepo.Tags)
 	})
-
 	t.Run("with invalid options", func(t *testing.T) {
 		options := RegistryModuleCreateWithVCSConnectionOptions{
 			VCSRepo: &RegistryModuleVCSRepoOptions{
@@ -920,6 +926,7 @@ func TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting(t *testing
 		assert.Equal(t, registryModuleName, rm.Name)
 		assert.Equal(t, registryModuleProvider, rm.Provider)
 		assert.Equal(t, githubBranch, rm.VCSRepo.Branch)
+		assert.Equal(t, false, rm.VCSRepo.Tags)
 
 		t.Run("tests are enabled", func(t *testing.T) {
 			assert.NotEmpty(t, rm.TestConfig)

--- a/workspace.go
+++ b/workspace.go
@@ -198,6 +198,7 @@ type VCSRepo struct {
 	GHAInstallationID string `jsonapi:"attr,github-app-installation-id"`
 	RepositoryHTTPURL string `jsonapi:"attr,repository-http-url"`
 	ServiceProvider   string `jsonapi:"attr,service-provider"`
+	Tags              bool   `jsonapi:"attr,tags"`
 	TagsRegex         string `jsonapi:"attr,tags-regex"`
 	WebhookURL        string `jsonapi:"attr,webhook-url"`
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
This is required to prevent terraform always from always asserting new state changes when toggling between a branch and tag based publishing for RegistryModules


## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

1. Create a `RegistryModule`
1. Verify that `VCSRepo.Branch` and `VCSRepo.Tags` are returned in the response
1. Update a `RegistryModule`
1. Verify that `VCSRepo.Branch` and `VCSRepo.Tags` are returned in the response

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/modules#update-a-private-registry-module)
## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestRegistryModulesCreate
=== RUN   TestRegistryModulesCreate
=== RUN   TestRegistryModulesCreate/with_valid_options
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute
2023/10/12 20:54:43 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to create a no-code module is with the registryNoCodeModules.Create method.
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_invalid_options
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name
=== RUN   TestRegistryModulesCreate/without_a_valid_organization
--- PASS: TestRegistryModulesCreate (2.05s)
    --- PASS: TestRegistryModulesCreate/with_valid_options (0.83s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName (0.18s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName (0.17s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName (0.30s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute (0.18s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreate/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name (0.00s)
    --- PASS: TestRegistryModulesCreate/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesCreateVersion
=== RUN   TestRegistryModulesCreateVersion/with_valid_options
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/without_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version
=== RUN   TestRegistryModulesCreateVersion/without_a_name
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_name
=== RUN   TestRegistryModulesCreateVersion/without_a_provider
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesCreateVersion/without_a_valid_organization
--- PASS: TestRegistryModulesCreateVersion (2.28s)
    --- PASS: TestRegistryModulesCreateVersion/with_valid_options (0.22s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version (0.20s)
    --- PASS: TestRegistryModulesCreateVersion/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/without_version (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesCreateWithVCSConnection
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/without_options
--- PASS: TestRegistryModulesCreateWithVCSConnection (5.13s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options (1.32s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/without_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection (5.03s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options (1.33s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting (5.40s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options (1.39s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled (0.00s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled (0.00s)
=== RUN   TestRegistryModulesCreateWithGithubApp
    registry_module_integration_test.go:974: Export a valid GITHUB_APP_INSTALLATION_ID before running this test!
--- SKIP: TestRegistryModulesCreateWithGithubApp (0.00s)
=== RUN   TestRegistryModulesCreate
=== RUN   TestRegistryModulesCreate/with_valid_options
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute
2023/10/12 20:55:03 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to create a no-code module is with the registryNoCodeModules.Create method.
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_invalid_options
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name
=== RUN   TestRegistryModulesCreate/without_a_valid_organization
--- PASS: TestRegistryModulesCreate (2.34s)
    --- PASS: TestRegistryModulesCreate/with_valid_options (0.77s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName (0.19s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName (0.16s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName (0.17s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute (0.24s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreate/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name (0.00s)
    --- PASS: TestRegistryModulesCreate/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesCreateVersion
=== RUN   TestRegistryModulesCreateVersion/with_valid_options
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/without_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version
=== RUN   TestRegistryModulesCreateVersion/without_a_name
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_name
=== RUN   TestRegistryModulesCreateVersion/without_a_provider
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesCreateVersion/without_a_valid_organization
--- PASS: TestRegistryModulesCreateVersion (2.56s)
    --- PASS: TestRegistryModulesCreateVersion/with_valid_options (0.24s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version (0.31s)
    --- PASS: TestRegistryModulesCreateVersion/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/without_version (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesCreateWithVCSConnection
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/without_options
--- PASS: TestRegistryModulesCreateWithVCSConnection (5.03s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options (1.27s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/without_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection (5.18s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options (1.41s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting (5.13s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options (1.36s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled (0.00s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled (0.00s)
=== RUN   TestRegistryModulesCreateWithGithubApp
    registry_module_integration_test.go:974: Export a valid GITHUB_APP_INSTALLATION_ID before running this test!
--- SKIP: TestRegistryModulesCreateWithGithubApp (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	40.462s
...

$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/12 20:59:15 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/12 20:59:16 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.10s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.36s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.46s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/12 20:59:19 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/12 20:59:20 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.17s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.30s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.62s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/10/12 20:59:24 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/10/12 20:59:24 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.55s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.33s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.42s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/10/12 20:59:28 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/10/12 20:59:29 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.73s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.37s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.30s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.83s)
PASS
ok  	github.com/hashicorp/go-tfe	17.901s
```
