### PR TITLE
Fix Test Runs test suite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@
 ## Features
 * Add the tags attribute to VCSRepo to be used with registry modules by @hashimoon [#793](https://github.com/hashicorp/go-tfe/pull/793)
 
+## Bug Fixes
+* Fixed test run test suite by enabling tests on the branch based module helper function.
+
 # v.1.36.0
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,6 @@
 ## Features
 * Add the tags attribute to VCSRepo to be used with registry modules by @hashimoon [#793](https://github.com/hashicorp/go-tfe/pull/793)
 
-## Bug Fixes
-* Fixed test run test suite by enabling tests on the branch based module helper function.
-
 # v.1.36.0
 
 ## Features

--- a/test_run_integration_test.go
+++ b/test_run_integration_test.go
@@ -20,7 +20,7 @@ func TestTestRunsList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	rmTest, registryModuleTestCleanup := createBranchBasedRegistryModule(t, client, orgTest)
+	rmTest, registryModuleTestCleanup := createBranchBasedRegistryModuleWithTests(t, client, orgTest)
 	defer registryModuleTestCleanup()
 
 	id := RegistryModuleID{
@@ -91,7 +91,7 @@ func TestTestRunsRead(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	rmTest, registryModuleTestCleanup := createBranchBasedRegistryModule(t, client, orgTest)
+	rmTest, registryModuleTestCleanup := createBranchBasedRegistryModuleWithTests(t, client, orgTest)
 	defer registryModuleTestCleanup()
 
 	id := RegistryModuleID{
@@ -125,7 +125,7 @@ func TestTestRunsCreate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	rmTest, rmTestCleanup := createBranchBasedRegistryModule(t, client, orgTest)
+	rmTest, rmTestCleanup := createBranchBasedRegistryModuleWithTests(t, client, orgTest)
 	defer rmTestCleanup()
 
 	cvTest, cvTestCleanup := createUploadedTestRunConfigurationVersion(t, client, rmTest)
@@ -191,7 +191,7 @@ func TestTestRunsLogs(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	rmTest, rmTestCleanup := createBranchBasedRegistryModule(t, client, orgTest)
+	rmTest, rmTestCleanup := createBranchBasedRegistryModuleWithTests(t, client, orgTest)
 	defer rmTestCleanup()
 
 	id := RegistryModuleID{
@@ -232,7 +232,7 @@ func TestTestRunsCancel(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	rmTest, rmTestCleanup := createBranchBasedRegistryModule(t, client, orgTest)
+	rmTest, rmTestCleanup := createBranchBasedRegistryModuleWithTests(t, client, orgTest)
 	defer rmTestCleanup()
 
 	id := RegistryModuleID{


### PR DESCRIPTION
## Description

This PR fixes the test suite for test runs by enabling tests via the `TestConfig` object.

## External links

https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/modules#update-a-private-registry-module

## Output from tests
```
go test -run TestTestRun -v
=== RUN   TestTestRunsList
=== RUN   TestTestRunsList/without_list_options
=== RUN   TestTestRunsList/empty_list_options
=== RUN   TestTestRunsList/with_page_size
--- PASS: TestTestRunsList (12.42s)
    --- PASS: TestTestRunsList/without_list_options (0.34s)
    --- PASS: TestTestRunsList/empty_list_options (0.60s)
    --- PASS: TestTestRunsList/with_page_size (0.22s)
=== RUN   TestTestRunsRead
=== RUN   TestTestRunsRead/when_the_test_run_exists
=== RUN   TestTestRunsRead/when_the_test_run_does_not_exist
--- PASS: TestTestRunsRead (6.34s)
    --- PASS: TestTestRunsRead/when_the_test_run_exists (0.22s)
    --- PASS: TestTestRunsRead/when_the_test_run_does_not_exist (0.30s)
=== RUN   TestTestRunsCreate
=== RUN   TestTestRunsCreate/with_a_configuration_version
=== RUN   TestTestRunsCreate/without_a_configuration_version
=== RUN   TestTestRunsCreate/without_a_module
=== RUN   TestTestRunsCreate/without_an_organisation
--- PASS: TestTestRunsCreate (6.35s)
    --- PASS: TestTestRunsCreate/with_a_configuration_version (0.34s)
    --- PASS: TestTestRunsCreate/without_a_configuration_version (0.00s)
    --- PASS: TestTestRunsCreate/without_a_module (0.00s)
    --- PASS: TestTestRunsCreate/without_an_organisation (0.00s)
=== RUN   TestTestRunsLogs
=== RUN   TestTestRunsLogs/when_the_log_exists
=== RUN   TestTestRunsLogs/when_the_log_does_not_exist
--- PASS: TestTestRunsLogs (28.55s)
    --- PASS: TestTestRunsLogs/when_the_log_exists (22.74s)
    --- PASS: TestTestRunsLogs/when_the_log_does_not_exist (0.17s)
=== RUN   TestTestRunsCancel
=== RUN   TestTestRunsCancel/when_the_run_exists
=== RUN   TestTestRunsCancel/when_the_run_does_not_exist
--- PASS: TestTestRunsCancel (6.04s)
    --- PASS: TestTestRunsCancel/when_the_run_exists (0.24s)
    --- PASS: TestTestRunsCancel/when_the_run_does_not_exist (0.29s)
PASS
ok  	github.com/hashicorp/go-tfe	59.888s
```
