### PR TITLE
Add AutoApplyRunTrigger attribute to workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,10 +5,9 @@
 ## Features
 * New WorkspaceSettingOverwritesOptions field for allowing workspaces to defer some settings to a default from their organization or project by @SwiftEngineer [#762](https://github.com/hashicorp/go-tfe/pull/762)
 * Added support for setting a default execution mode and agent pool at the organization level by @SwiftEngineer [#762](https://github.com/hashicorp/go-tfe/pull/762)
-
-## Features
 * Removed BETA labels for StateVersion Upload method, ConfigurationVersion `provisional` field, and `save-plan` runs by @brandonc [#800](https://github.com/hashicorp/go-tfe/pull/800)
 * Allow soft deleting, restoring, and permanently deleting StateVersion and ConfigurationVersion backing data by @mwudka [#801](https://github.com/hashicorp/go-tfe/pull/801)
+* Added the `AutoApplyRunTrigger` attribute to Workspaces by @nfagerlund [#798](https://github.com/hashicorp/go-tfe/pull/798)
 
 # v.1.38.0
 

--- a/workspace.go
+++ b/workspace.go
@@ -122,6 +122,7 @@ type Workspace struct {
 	AllowDestroyPlan           bool                        `jsonapi:"attr,allow-destroy-plan"`
 	AssessmentsEnabled         bool                        `jsonapi:"attr,assessments-enabled"`
 	AutoApply                  bool                        `jsonapi:"attr,auto-apply"`
+	AutoApplyRunTrigger        bool                        `jsonapi:"attr,auto-apply-run-trigger"`
 	CanQueueDestroyPlan        bool                        `jsonapi:"attr,can-queue-destroy-plan"`
 	CreatedAt                  time.Time                   `jsonapi:"attr,created-at,iso8601"`
 	Description                string                      `jsonapi:"attr,description"`
@@ -305,6 +306,10 @@ type WorkspaceCreateOptions struct {
 	// Optional: Whether to automatically apply changes when a Terraform plan is successful.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
 
+	// Optional: Whether to automatically apply changes for runs that are created by run triggers
+	// from another workspace.
+	AutoApplyRunTrigger *bool `jsonapi:"attr,auto-apply-run-trigger,omitempty"`
+
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
@@ -447,6 +452,10 @@ type WorkspaceUpdateOptions struct {
 
 	// Optional: Whether to automatically apply changes when a Terraform plan is successful.
 	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
+
+	// Optional: Whether to automatically apply changes for runs that are created by run triggers
+	// from another workspace.
+	AutoApplyRunTrigger *bool `jsonapi:"attr,auto-apply-run-trigger,omitempty"`
 
 	// Optional: A new name for the workspace, which can only include letters, numbers, -,
 	// and _. This will be used as an identifier and must be unique in the

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -506,6 +506,34 @@ func TestWorkspacesCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("with valid auto-apply-run-trigger option", func(t *testing.T) {
+		skipIfEnterprise(t)
+		// FEATURE FLAG: auto-apply-run-trigger
+		// Once un-flagged, delete this test and add an AutoApplyRunTrigger field
+		// to the basic "with valid options" test below.
+
+		options := WorkspaceCreateOptions{
+			Name:                String("foo"),
+			AutoApplyRunTrigger: Bool(true),
+		}
+
+		w, err := client.Workspaces.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		// Get a refreshed view from the API.
+		refreshed, err := client.Workspaces.Read(ctx, orgTest.Name, *options.Name)
+		require.NoError(t, err)
+
+		for _, item := range []*Workspace{
+			w,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.AutoApplyRunTrigger, item.AutoApplyRunTrigger)
+		}
+	})
+
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceCreateOptions{
 			Name:                       String("foo"),
@@ -1041,6 +1069,21 @@ func TestWorkspacesUpdate(t *testing.T) {
 		assert.NotEqual(t, wTest.AssessmentsEnabled, wAfter.AssessmentsEnabled)
 		assert.NotEqual(t, wTest.TerraformVersion, wAfter.TerraformVersion)
 		assert.Equal(t, wTest.WorkingDirectory, wAfter.WorkingDirectory)
+	})
+
+	t.Run("when updating auto-apply-run-trigger", func(t *testing.T) {
+		skipIfEnterprise(t)
+		// Feature flag: auto-apply-run-trigger. Once flag is removed, delete
+		// this test and add the attribute to one generic update test.
+		options := WorkspaceUpdateOptions{
+			AutoApplyRunTrigger: Bool(true),
+		}
+
+		wAfter, err := client.Workspaces.Update(ctx, orgTest.Name, wTest.Name, options)
+		require.NoError(t, err)
+
+		assert.Equal(t, wTest.Name, wAfter.Name)
+		assert.NotEqual(t, wTest.AutoApplyRunTrigger, wAfter.AutoApplyRunTrigger)
 	})
 
 	t.Run("when updating project", func(t *testing.T) {

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -513,7 +513,7 @@ func TestWorkspacesCreate(t *testing.T) {
 		// to the basic "with valid options" test below.
 
 		options := WorkspaceCreateOptions{
-			Name:                String("foo"),
+			Name:                String(fmt.Sprintf("foo-%s", randomString(t))),
 			AutoApplyRunTrigger: Bool(true),
 		}
 
@@ -536,7 +536,7 @@ func TestWorkspacesCreate(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		options := WorkspaceCreateOptions{
-			Name:                       String("foo"),
+			Name:                       String(fmt.Sprintf("foo-%s", randomString(t))),
 			AllowDestroyPlan:           Bool(false),
 			AutoApply:                  Bool(true),
 			Description:                String("qux"),
@@ -609,7 +609,7 @@ func TestWorkspacesCreate(t *testing.T) {
 
 	t.Run("when options has an invalid organization", func(t *testing.T) {
 		w, err := client.Workspaces.Create(ctx, badIdentifier, WorkspaceCreateOptions{
-			Name: String("foo"),
+			Name: String(fmt.Sprintf("foo-%s", randomString(t))),
 		})
 		assert.Nil(t, w)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())


### PR DESCRIPTION
## Description

Support the new auto-apply-run-trigger workspace attribute, which is exactly like auto-apply except it has to be a new attribute to avoid surprising anyone accustomed to the prior behavior of hard-denying auto-apply for run triggers. 

This feature is shipped to TFC prod, but not yet available in TFE. 

## Testing plan

- Set the new attribute on a workspace.
- It worked, yey. 

## External links

- [tfe provider PR](https://github.com/hashicorp/terraform-provider-tfe/pull/1123)

## Output from tests

I'm internal, check CI.