### PR TITLE
Remove BETA labelling for several features

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # UNRELEASED
 
+## Features
+* Removed BETA labels for StateVersion Upload method by @brandonc
+
 # v.1.38.0
 
 ## Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # UNRELEASED
 
 ## Features
-* Removed BETA labels for StateVersion Upload method by @brandonc
+* Removed BETA labels for StateVersion Upload method, ConfigurationVersion `provisional` field, and `save-plan` runs by @brandonc [#800](https://github.com/hashicorp/go-tfe/pull/800)
 
 # v.1.38.0
 

--- a/configuration_version_integration_test.go
+++ b/configuration_version_integration_test.go
@@ -116,8 +116,6 @@ func TestConfigurationVersionsCreate(t *testing.T) {
 	})
 
 	t.Run("provisional", func(t *testing.T) {
-		skipUnlessBeta(t)
-
 		cv, err := client.ConfigurationVersions.Create(ctx,
 			wTest.ID,
 			ConfigurationVersionCreateOptions{

--- a/run.go
+++ b/run.go
@@ -70,7 +70,7 @@ const (
 	RunPending                  RunStatus = "pending"
 	RunPlanned                  RunStatus = "planned"
 	RunPlannedAndFinished       RunStatus = "planned_and_finished"
-	RunPlannedAndSaved          RunStatus = "planned_and_saved" // Note: This status is in BETA.
+	RunPlannedAndSaved          RunStatus = "planned_and_saved"
 	RunPlanning                 RunStatus = "planning"
 	RunPlanQueued               RunStatus = "plan_queued"
 	RunPolicyChecked            RunStatus = "policy_checked"
@@ -108,8 +108,7 @@ const (
 	RunOperationRefreshOnly RunOperation = "refresh_only"
 	RunOperationDestroy     RunOperation = "destroy"
 	RunOperationEmptyApply  RunOperation = "empty_apply"
-	// **Note: This operation type is still in BETA and subject to change.**
-	RunOperationSavePlan RunOperation = "save_plan"
+	RunOperationSavePlan    RunOperation = "save_plan"
 )
 
 // RunList represents a list of runs.
@@ -120,30 +119,29 @@ type RunList struct {
 
 // Run represents a Terraform Enterprise run.
 type Run struct {
-	ID                     string          `jsonapi:"primary,runs"`
-	Actions                *RunActions     `jsonapi:"attr,actions"`
-	AutoApply              bool            `jsonapi:"attr,auto-apply,omitempty"`
-	AllowConfigGeneration  *bool           `jsonapi:"attr,allow-config-generation,omitempty"`
-	AllowEmptyApply        bool            `jsonapi:"attr,allow-empty-apply"`
-	CreatedAt              time.Time       `jsonapi:"attr,created-at,iso8601"`
-	ForceCancelAvailableAt time.Time       `jsonapi:"attr,force-cancel-available-at,iso8601"`
-	HasChanges             bool            `jsonapi:"attr,has-changes"`
-	IsDestroy              bool            `jsonapi:"attr,is-destroy"`
-	Message                string          `jsonapi:"attr,message"`
-	Permissions            *RunPermissions `jsonapi:"attr,permissions"`
-	PositionInQueue        int             `jsonapi:"attr,position-in-queue"`
-	PlanOnly               bool            `jsonapi:"attr,plan-only"`
-	Refresh                bool            `jsonapi:"attr,refresh"`
-	RefreshOnly            bool            `jsonapi:"attr,refresh-only"`
-	ReplaceAddrs           []string        `jsonapi:"attr,replace-addrs,omitempty"`
-	// **Note: This field is still in BETA and subject to change.**
-	SavePlan         bool                 `jsonapi:"attr,save-plan,omitempty"`
-	Source           RunSource            `jsonapi:"attr,source"`
-	Status           RunStatus            `jsonapi:"attr,status"`
-	StatusTimestamps *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
-	TargetAddrs      []string             `jsonapi:"attr,target-addrs,omitempty"`
-	TerraformVersion string               `jsonapi:"attr,terraform-version"`
-	Variables        []*RunVariableAttr   `jsonapi:"attr,variables"`
+	ID                     string               `jsonapi:"primary,runs"`
+	Actions                *RunActions          `jsonapi:"attr,actions"`
+	AutoApply              bool                 `jsonapi:"attr,auto-apply,omitempty"`
+	AllowConfigGeneration  *bool                `jsonapi:"attr,allow-config-generation,omitempty"`
+	AllowEmptyApply        bool                 `jsonapi:"attr,allow-empty-apply"`
+	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
+	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
+	HasChanges             bool                 `jsonapi:"attr,has-changes"`
+	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
+	Message                string               `jsonapi:"attr,message"`
+	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
+	PositionInQueue        int                  `jsonapi:"attr,position-in-queue"`
+	PlanOnly               bool                 `jsonapi:"attr,plan-only"`
+	Refresh                bool                 `jsonapi:"attr,refresh"`
+	RefreshOnly            bool                 `jsonapi:"attr,refresh-only"`
+	ReplaceAddrs           []string             `jsonapi:"attr,replace-addrs,omitempty"`
+	SavePlan               bool                 `jsonapi:"attr,save-plan,omitempty"`
+	Source                 RunSource            `jsonapi:"attr,source"`
+	Status                 RunStatus            `jsonapi:"attr,status"`
+	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	TargetAddrs            []string             `jsonapi:"attr,target-addrs,omitempty"`
+	TerraformVersion       string               `jsonapi:"attr,terraform-version"`
+	Variables              []*RunVariableAttr   `jsonapi:"attr,variables"`
 
 	// Relations
 	Apply                *Apply                `jsonapi:"relation,apply"`
@@ -189,19 +187,18 @@ type RunStatusTimestamps struct {
 	FetchingAt           time.Time `jsonapi:"attr,fetching-at,rfc3339"`
 	ForceCanceledAt      time.Time `jsonapi:"attr,force-canceled-at,rfc3339"`
 	PlannedAndFinishedAt time.Time `jsonapi:"attr,planned-and-finished-at,rfc3339"`
-	// **Note: This field is still in BETA and subject to change.**
-	PlannedAndSavedAt   time.Time `jsonapi:"attr,planned-and-saved-at,rfc3339"`
-	PlannedAt           time.Time `jsonapi:"attr,planned-at,rfc3339"`
-	PlanningAt          time.Time `jsonapi:"attr,planning-at,rfc3339"`
-	PlanQueueableAt     time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
-	PlanQueuedAt        time.Time `jsonapi:"attr,plan-queued-at,rfc3339"`
-	PolicyCheckedAt     time.Time `jsonapi:"attr,policy-checked-at,rfc3339"`
-	PolicySoftFailedAt  time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
-	PostPlanCompletedAt time.Time `jsonapi:"attr,post-plan-completed-at,rfc3339"`
-	PostPlanRunningAt   time.Time `jsonapi:"attr,post-plan-running-at,rfc3339"`
-	PrePlanCompletedAt  time.Time `jsonapi:"attr,pre-plan-completed-at,rfc3339"`
-	PrePlanRunningAt    time.Time `jsonapi:"attr,pre-plan-running-at,rfc3339"`
-	QueuingAt           time.Time `jsonapi:"attr,queuing-at,rfc3339"`
+	PlannedAndSavedAt    time.Time `jsonapi:"attr,planned-and-saved-at,rfc3339"`
+	PlannedAt            time.Time `jsonapi:"attr,planned-at,rfc3339"`
+	PlanningAt           time.Time `jsonapi:"attr,planning-at,rfc3339"`
+	PlanQueueableAt      time.Time `jsonapi:"attr,plan-queueable-at,rfc3339"`
+	PlanQueuedAt         time.Time `jsonapi:"attr,plan-queued-at,rfc3339"`
+	PolicyCheckedAt      time.Time `jsonapi:"attr,policy-checked-at,rfc3339"`
+	PolicySoftFailedAt   time.Time `jsonapi:"attr,policy-soft-failed-at,rfc3339"`
+	PostPlanCompletedAt  time.Time `jsonapi:"attr,post-plan-completed-at,rfc3339"`
+	PostPlanRunningAt    time.Time `jsonapi:"attr,post-plan-running-at,rfc3339"`
+	PrePlanCompletedAt   time.Time `jsonapi:"attr,pre-plan-completed-at,rfc3339"`
+	PrePlanRunningAt     time.Time `jsonapi:"attr,pre-plan-running-at,rfc3339"`
+	QueuingAt            time.Time `jsonapi:"attr,queuing-at,rfc3339"`
 }
 
 // RunIncludeOpt represents the available options for include query params.
@@ -300,7 +297,6 @@ type RunCreateOptions struct {
 	// SavePlan determines whether this should be a saved-plan run. Saved-plan
 	// runs perform their plan and checks immediately, but won't lock the
 	// workspace and become its current run until they are confirmed for apply.
-	// **Note: This field is still in BETA and subject to change.**
 	SavePlan *bool `jsonapi:"attr,save-plan,omitempty"`
 
 	// Specifies the message to be associated with this run.

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -147,9 +147,6 @@ func TestRunsListQueryParams(t *testing.T) {
 				assert.Equal(t, 0, len(rl.Items))
 			},
 		},
-	}
-
-	betaTestCases := []testCase{
 		{
 			description: "with operation of save_plan parameter",
 			options:     &RunListOptions{Operation: string(RunOperationSavePlan), Include: []RunIncludeOpt{RunWorkspace}},
@@ -159,6 +156,8 @@ func TestRunsListQueryParams(t *testing.T) {
 			},
 		},
 	}
+
+	betaTestCases := []testCase{}
 
 	for _, testCase := range testCases {
 		t.Run(testCase.description, func(t *testing.T) {
@@ -223,7 +222,6 @@ func TestRunsCreate(t *testing.T) {
 	})
 
 	t.Run("with save-plan", func(t *testing.T) {
-		skipUnlessBeta(t)
 		options := RunCreateOptions{
 			Workspace: wTest,
 			SavePlan:  Bool(true),

--- a/state_version.go
+++ b/state_version.go
@@ -41,8 +41,6 @@ type StateVersions interface {
 
 	// Upload creates a new state version but uploads the state content directly to the object store.
 	// This is a more resilient form of Create and is the recommended approach to creating state versions.
-	//
-	// **Note: This method is still in BETA and subject to change.**
 	Upload(ctx context.Context, workspaceID string, options StateVersionUploadOptions) (*StateVersion, error)
 
 	// Read a state version by its ID.
@@ -184,15 +182,11 @@ type StateVersionCreateOptions struct {
 	// https://developer.hashicorp.com/terraform/internals/json-format#state-representation
 	// Supplying this state representation can provide more details to the platform
 	// about the current terraform state.
-	//
-	// **Note**: This field is in BETA, subject to change and not widely available yet.
 	JSONState *string `jsonapi:"attr,json-state,omitempty"`
 	// Optional: The external, json representation of state outputs, base64 encoded. Supplying this field
 	// will provide more detailed output type information to TFE.
 	// For more information on the contents of this field: https://developer.hashicorp.com/terraform/internals/json-format#values-representation
 	// about the current terraform state.
-	//
-	// **Note**: This field is in BETA, subject to change and not widely available yet.
 	JSONStateOutputs *string `jsonapi:"attr,json-state-outputs,omitempty"`
 }
 

--- a/state_version.go
+++ b/state_version.go
@@ -275,8 +275,6 @@ func (s *stateVersions) Create(ctx context.Context, workspaceID string, options 
 
 // Upload creates a new state version but uploads the state content directly to the object store.
 // This is a more resilient form of Create and is the recommended approach to creating state versions.
-//
-// **Note: This method is still in BETA and subject to change.**
 func (s *stateVersions) Upload(ctx context.Context, workspaceID string, options StateVersionUploadOptions) (*StateVersion, error) {
 	if err := options.valid(); err != nil {
 		return nil, err

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -104,8 +104,6 @@ func TestStateVersionsList(t *testing.T) {
 }
 
 func TestStateVersionsUpload(t *testing.T) {
-	skipUnlessBeta(t)
-
 	client := testClient(t)
 
 	wTest, wTestCleanup := createWorkspace(t, client, nil)

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -202,8 +202,6 @@ func TestStateVersionsCreate(t *testing.T) {
 	}
 
 	t.Run("can create pending state versions", func(t *testing.T) {
-		skipUnlessBeta(t)
-
 		ctx := context.Background()
 		_, err := client.Workspaces.Lock(ctx, wTest.ID, WorkspaceLockOptions{})
 		if err != nil {


### PR DESCRIPTION
Removes BETA labels for several features that are now generally available:

1. save-plans for Runs
2. provisional Configuration Versions
3. StateVersion Upload