### PR TITLE
Allow managing StateVersion and ConfigurationVersion backing data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Features
 * Removed BETA labels for StateVersion Upload method, ConfigurationVersion `provisional` field, and `save-plan` runs by @brandonc [#800](https://github.com/hashicorp/go-tfe/pull/800)
+* Allow soft deleting, restoring, and permanently deleting StateVersion and ConfigurationVersion backing data by @mwudka [#801](https://github.com/hashicorp/go-tfe/pull/801)
 
 # v.1.38.0
 

--- a/examples/backing_data/main.go
+++ b/examples/backing_data/main.go
@@ -1,0 +1,72 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	tfe "github.com/hashicorp/go-tfe"
+	"log"
+	"strings"
+)
+
+func main() {
+	action := flag.String("action", "", "Action (soft-delete|restore|permanently-delete")
+	externalId := flag.String("external-id", "", "External ID of StateVersion or ConfigurationVersion")
+
+	flag.Parse()
+
+	if action == nil || *action == "" {
+		log.Fatal("No Action provided")
+	}
+
+	if externalId == nil || *externalId == "" {
+		log.Fatal("No external ID provided")
+	}
+
+	ctx := context.Background()
+	client, err := tfe.NewClient(&tfe.Config{
+		RetryServerErrors: true,
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	err = performAction(ctx, client, *action, *externalId)
+	if err != nil {
+		log.Fatalf("Error performing action: %v", err)
+	}
+}
+
+func performAction(ctx context.Context, client *tfe.Client, action string, id string) error {
+	externalIdParts := strings.Split(id, "-")
+	switch externalIdParts[0] {
+	case "cv":
+		switch action {
+		case "soft-delete":
+			return client.ConfigurationVersions.SoftDeleteBackingData(ctx, id)
+		case "restore":
+			return client.ConfigurationVersions.RestoreBackingData(ctx, id)
+		case "permanently-delete":
+			return client.ConfigurationVersions.PermanentlyDeleteBackingData(ctx, id)
+		default:
+			return fmt.Errorf("unsupported action: %s", action)
+		}
+	case "sv":
+		switch action {
+		case "soft-delete":
+			return client.StateVersions.SoftDeleteBackingData(ctx, id)
+		case "restore":
+			return client.StateVersions.RestoreBackingData(ctx, id)
+		case "permanently-delete":
+			return client.StateVersions.PermanentlyDeleteBackingData(ctx, id)
+		default:
+			return fmt.Errorf("unsupported action: %s", action)
+		}
+	default:
+		return fmt.Errorf("unsupported external ID: %s", id)
+	}
+	return nil
+}

--- a/mocks/configuration_version_mocks.go
+++ b/mocks/configuration_version_mocks.go
@@ -110,6 +110,20 @@ func (mr *MockConfigurationVersionsMockRecorder) List(ctx, workspaceID, options 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockConfigurationVersions)(nil).List), ctx, workspaceID, options)
 }
 
+// PermanentlyDeleteBackingData mocks base method.
+func (m *MockConfigurationVersions) PermanentlyDeleteBackingData(ctx context.Context, svID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PermanentlyDeleteBackingData", ctx, svID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PermanentlyDeleteBackingData indicates an expected call of PermanentlyDeleteBackingData.
+func (mr *MockConfigurationVersionsMockRecorder) PermanentlyDeleteBackingData(ctx, svID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PermanentlyDeleteBackingData", reflect.TypeOf((*MockConfigurationVersions)(nil).PermanentlyDeleteBackingData), ctx, svID)
+}
+
 // Read mocks base method.
 func (m *MockConfigurationVersions) Read(ctx context.Context, cvID string) (*tfe.ConfigurationVersion, error) {
 	m.ctrl.T.Helper()
@@ -138,6 +152,34 @@ func (m *MockConfigurationVersions) ReadWithOptions(ctx context.Context, cvID st
 func (mr *MockConfigurationVersionsMockRecorder) ReadWithOptions(ctx, cvID, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWithOptions", reflect.TypeOf((*MockConfigurationVersions)(nil).ReadWithOptions), ctx, cvID, options)
+}
+
+// RestoreBackingData mocks base method.
+func (m *MockConfigurationVersions) RestoreBackingData(ctx context.Context, svID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreBackingData", ctx, svID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreBackingData indicates an expected call of RestoreBackingData.
+func (mr *MockConfigurationVersionsMockRecorder) RestoreBackingData(ctx, svID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreBackingData", reflect.TypeOf((*MockConfigurationVersions)(nil).RestoreBackingData), ctx, svID)
+}
+
+// SoftDeleteBackingData mocks base method.
+func (m *MockConfigurationVersions) SoftDeleteBackingData(ctx context.Context, svID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SoftDeleteBackingData", ctx, svID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SoftDeleteBackingData indicates an expected call of SoftDeleteBackingData.
+func (mr *MockConfigurationVersionsMockRecorder) SoftDeleteBackingData(ctx, svID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SoftDeleteBackingData", reflect.TypeOf((*MockConfigurationVersions)(nil).SoftDeleteBackingData), ctx, svID)
 }
 
 // Upload mocks base method.

--- a/mocks/state_version_mocks.go
+++ b/mocks/state_version_mocks.go
@@ -95,6 +95,20 @@ func (mr *MockStateVersionsMockRecorder) ListOutputs(ctx, svID, options interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListOutputs", reflect.TypeOf((*MockStateVersions)(nil).ListOutputs), ctx, svID, options)
 }
 
+// PermanentlyDeleteBackingData mocks base method.
+func (m *MockStateVersions) PermanentlyDeleteBackingData(ctx context.Context, svID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "PermanentlyDeleteBackingData", ctx, svID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// PermanentlyDeleteBackingData indicates an expected call of PermanentlyDeleteBackingData.
+func (mr *MockStateVersionsMockRecorder) PermanentlyDeleteBackingData(ctx, svID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "PermanentlyDeleteBackingData", reflect.TypeOf((*MockStateVersions)(nil).PermanentlyDeleteBackingData), ctx, svID)
+}
+
 // Read mocks base method.
 func (m *MockStateVersions) Read(ctx context.Context, svID string) (*tfe.StateVersion, error) {
 	m.ctrl.T.Helper()
@@ -153,6 +167,34 @@ func (m *MockStateVersions) ReadWithOptions(ctx context.Context, svID string, op
 func (mr *MockStateVersionsMockRecorder) ReadWithOptions(ctx, svID, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWithOptions", reflect.TypeOf((*MockStateVersions)(nil).ReadWithOptions), ctx, svID, options)
+}
+
+// RestoreBackingData mocks base method.
+func (m *MockStateVersions) RestoreBackingData(ctx context.Context, svID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestoreBackingData", ctx, svID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RestoreBackingData indicates an expected call of RestoreBackingData.
+func (mr *MockStateVersionsMockRecorder) RestoreBackingData(ctx, svID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestoreBackingData", reflect.TypeOf((*MockStateVersions)(nil).RestoreBackingData), ctx, svID)
+}
+
+// SoftDeleteBackingData mocks base method.
+func (m *MockStateVersions) SoftDeleteBackingData(ctx context.Context, svID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SoftDeleteBackingData", ctx, svID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// SoftDeleteBackingData indicates an expected call of SoftDeleteBackingData.
+func (mr *MockStateVersionsMockRecorder) SoftDeleteBackingData(ctx, svID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SoftDeleteBackingData", reflect.TypeOf((*MockStateVersions)(nil).SoftDeleteBackingData), ctx, svID)
 }
 
 // Upload mocks base method.


### PR DESCRIPTION
## Description

Adds support for managing the backing data for state versions and configuration versions. 

## Testing plan

1. Ensure tests pass
2. Write a simple go program that soft deletes, permanently deletes, or restores a state version or configuration version.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ go test ./... -v -run TestStateVersions
=== RUN   TestStateVersionsList
=== RUN   TestStateVersionsList/without_StateVersionListOptions
=== RUN   TestStateVersionsList/without_list_options
=== RUN   TestStateVersionsList/with_list_options
=== RUN   TestStateVersionsList/without_an_organization
=== RUN   TestStateVersionsList/without_a_workspace
--- PASS: TestStateVersionsList (3.82s)
    --- PASS: TestStateVersionsList/without_StateVersionListOptions (0.00s)
    --- PASS: TestStateVersionsList/without_list_options (0.40s)
    --- PASS: TestStateVersionsList/with_list_options (0.34s)
    --- PASS: TestStateVersionsList/without_an_organization (0.00s)
    --- PASS: TestStateVersionsList/without_a_workspace (0.00s)
=== RUN   TestStateVersionsUpload
=== RUN   TestStateVersionsUpload/can_create_finalized_state_versions
    helper_test.go:1234: Polling state version "sv-3peL2Vh1YwsZmYzj" for status included in ["finalized"] with deadline of 2023-11-02 16:08:41.408598 -0700 PDT m=+36.319620418
    helper_test.go:1241: ...
    helper_test.go:1250: State version "sv-3peL2Vh1YwsZmYzj" had status "finalized"
=== RUN   TestStateVersionsUpload/cannot_provide_base64_state_parameter_when_uploading
=== RUN   TestStateVersionsUpload/RawState_parameter_is_required_when_uploading
--- PASS: TestStateVersionsUpload (5.29s)
    --- PASS: TestStateVersionsUpload/can_create_finalized_state_versions (3.01s)
    --- PASS: TestStateVersionsUpload/cannot_provide_base64_state_parameter_when_uploading (0.00s)
    --- PASS: TestStateVersionsUpload/RawState_parameter_is_required_when_uploading (0.00s)
=== RUN   TestStateVersionsCreate
=== RUN   TestStateVersionsCreate/can_create_pending_state_versions
=== RUN   TestStateVersionsCreate/with_valid_options
=== RUN   TestStateVersionsCreate/with_external_state_representation
=== RUN   TestStateVersionsCreate/with_the_force_flag_set
=== RUN   TestStateVersionsCreate/with_a_run_to_associate_with
    state_version_integration_test.go:354: This can only be tested with the run specific token
=== RUN   TestStateVersionsCreate/without_md5_hash
=== RUN   TestStateVersionsCreate/without_serial
=== RUN   TestStateVersionsCreate/with_invalid_workspace_id
--- PASS: TestStateVersionsCreate (6.33s)
    --- PASS: TestStateVersionsCreate/can_create_pending_state_versions (0.68s)
    --- PASS: TestStateVersionsCreate/with_valid_options (1.04s)
    --- PASS: TestStateVersionsCreate/with_external_state_representation (1.14s)
    --- PASS: TestStateVersionsCreate/with_the_force_flag_set (1.14s)
    --- SKIP: TestStateVersionsCreate/with_a_run_to_associate_with (0.00s)
    --- PASS: TestStateVersionsCreate/without_md5_hash (0.00s)
    --- PASS: TestStateVersionsCreate/without_serial (0.00s)
    --- PASS: TestStateVersionsCreate/with_invalid_workspace_id (0.00s)
=== RUN   TestStateVersionsRead
=== RUN   TestStateVersionsRead/when_the_state_version_exists
=== RUN   TestStateVersionsRead/when_the_state_version_does_not_exist
=== RUN   TestStateVersionsRead/with_invalid_state_version_id
--- PASS: TestStateVersionsRead (5.80s)
    --- PASS: TestStateVersionsRead/when_the_state_version_exists (3.26s)
    --- PASS: TestStateVersionsRead/when_the_state_version_does_not_exist (0.08s)
    --- PASS: TestStateVersionsRead/with_invalid_state_version_id (0.00s)
=== RUN   TestStateVersionsReadWithOptions
=== RUN   TestStateVersionsReadWithOptions/when_the_state_version_exists
--- PASS: TestStateVersionsReadWithOptions (6.21s)
    --- PASS: TestStateVersionsReadWithOptions/when_the_state_version_exists (0.18s)
=== RUN   TestStateVersionsCurrent
=== RUN   TestStateVersionsCurrent/when_a_state_version_exists
=== RUN   TestStateVersionsCurrent/when_a_state_version_does_not_exist
=== RUN   TestStateVersionsCurrent/with_invalid_workspace_id
--- PASS: TestStateVersionsCurrent (4.70s)
    --- PASS: TestStateVersionsCurrent/when_a_state_version_exists (0.13s)
    --- PASS: TestStateVersionsCurrent/when_a_state_version_does_not_exist (0.10s)
    --- PASS: TestStateVersionsCurrent/with_invalid_workspace_id (0.00s)
=== RUN   TestStateVersionsCurrentWithOptions
=== RUN   TestStateVersionsCurrentWithOptions/when_the_state_version_exists
--- PASS: TestStateVersionsCurrentWithOptions (5.82s)
    --- PASS: TestStateVersionsCurrentWithOptions/when_the_state_version_exists (0.17s)
=== RUN   TestStateVersionsDownload
=== RUN   TestStateVersionsDownload/when_the_state_version_exists
=== RUN   TestStateVersionsDownload/with_an_invalid_url
--- PASS: TestStateVersionsDownload (2.68s)
    --- PASS: TestStateVersionsDownload/when_the_state_version_exists (0.19s)
    --- PASS: TestStateVersionsDownload/with_an_invalid_url (0.08s)
=== RUN   TestStateVersions_ManageBackingData
    state_version_integration_test.go:639: Skipping test related to Terraform Cloud. Set ENABLE_TFE=1 to run.
--- SKIP: TestStateVersions_ManageBackingData (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]

$ go test ./... -v -run TestConfigurationVersions
=== RUN   TestConfigurationVersionsList
=== RUN   TestConfigurationVersionsList/without_list_options
=== RUN   TestConfigurationVersionsList/with_list_options
=== RUN   TestConfigurationVersionsList/without_a_valid_organization
--- PASS: TestConfigurationVersionsList (2.35s)
    --- PASS: TestConfigurationVersionsList/without_list_options (0.30s)
    --- PASS: TestConfigurationVersionsList/with_list_options (0.32s)
    --- PASS: TestConfigurationVersionsList/without_a_valid_organization (0.00s)
=== RUN   TestConfigurationVersionsCreate
=== RUN   TestConfigurationVersionsCreate/with_valid_options
=== RUN   TestConfigurationVersionsCreate/with_invalid_workspace_id
=== RUN   TestConfigurationVersionsCreate/provisional
    configuration_version_integration_test.go:127: 
                Error Trace:    /Users/mwudka/hashicorp/go-tfe/configuration_version_integration_test.go:127
                Error:          Should be true
                Test:           TestConfigurationVersionsCreate/provisional
    configuration_version_integration_test.go:136: 
                Error Trace:    /Users/mwudka/hashicorp/go-tfe/configuration_version_integration_test.go:136
                Error:          Should not be: "cv-vBoMNnwHyTJpspTp"
                Test:           TestConfigurationVersionsCreate/provisional
--- FAIL: TestConfigurationVersionsCreate (2.48s)
    --- PASS: TestConfigurationVersionsCreate/with_valid_options (0.35s)
    --- PASS: TestConfigurationVersionsCreate/with_invalid_workspace_id (0.00s)
    --- FAIL: TestConfigurationVersionsCreate/provisional (0.34s)
=== RUN   TestConfigurationVersionsCreateForRegistryModule
    configuration_version_integration_test.go:141: Skipping test related to a Terraform Cloud beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestConfigurationVersionsCreateForRegistryModule (0.00s)
=== RUN   TestConfigurationVersionsRead
=== RUN   TestConfigurationVersionsRead/when_the_configuration_version_exists
=== RUN   TestConfigurationVersionsRead/when_the_configuration_version_does_not_exist
=== RUN   TestConfigurationVersionsRead/with_invalid_configuration_version_id
--- PASS: TestConfigurationVersionsRead (2.58s)
    --- PASS: TestConfigurationVersionsRead/when_the_configuration_version_exists (0.12s)
    --- PASS: TestConfigurationVersionsRead/when_the_configuration_version_does_not_exist (0.07s)
    --- PASS: TestConfigurationVersionsRead/with_invalid_configuration_version_id (0.00s)
=== RUN   TestConfigurationVersionsReadWithOptions
    helper_test.go:904: Export a valid OAUTH_CLIENT_GITHUB_TOKEN before running this test!
--- SKIP: TestConfigurationVersionsReadWithOptions (1.30s)
=== RUN   TestConfigurationVersionsUpload
=== RUN   TestConfigurationVersionsUpload/with_valid_options
=== RUN   TestConfigurationVersionsUpload/without_a_valid_upload_URL
=== RUN   TestConfigurationVersionsUpload/without_a_valid_path
--- PASS: TestConfigurationVersionsUpload (1.94s)
    --- PASS: TestConfigurationVersionsUpload/with_valid_options (0.20s)
    --- PASS: TestConfigurationVersionsUpload/without_a_valid_upload_URL (0.06s)
    --- PASS: TestConfigurationVersionsUpload/without_a_valid_path (0.00s)
=== RUN   TestConfigurationVersionsUploadTarGzip
=== RUN   TestConfigurationVersionsUploadTarGzip/with_custom_go-slug
=== RUN   TestConfigurationVersionsUploadTarGzip/with_custom_tar_archive
--- PASS: TestConfigurationVersionsUploadTarGzip (2.19s)
    --- PASS: TestConfigurationVersionsUploadTarGzip/with_custom_go-slug (0.09s)
    --- PASS: TestConfigurationVersionsUploadTarGzip/with_custom_tar_archive (0.08s)
=== RUN   TestConfigurationVersionsArchive
=== RUN   TestConfigurationVersionsArchive/when_the_configuration_version_exists_and_has_been_uploaded
=== RUN   TestConfigurationVersionsArchive/when_the_configuration_version_does_not_exist
=== RUN   TestConfigurationVersionsArchive/with_invalid_configuration_version_id
--- PASS: TestConfigurationVersionsArchive (3.18s)
    --- PASS: TestConfigurationVersionsArchive/when_the_configuration_version_exists_and_has_been_uploaded (1.08s)
    --- PASS: TestConfigurationVersionsArchive/when_the_configuration_version_does_not_exist (0.08s)
    --- PASS: TestConfigurationVersionsArchive/with_invalid_configuration_version_id (0.00s)
=== RUN   TestConfigurationVersionsDownload
=== RUN   TestConfigurationVersionsDownload/with_a_valid_ID_for_downloadable_configuration_version
=== RUN   TestConfigurationVersionsDownload/with_a_valid_ID_for_a_non_downloadable_configuration_version
=== RUN   TestConfigurationVersionsDownload/with_an_invalid_ID
--- PASS: TestConfigurationVersionsDownload (4.13s)
    --- PASS: TestConfigurationVersionsDownload/with_a_valid_ID_for_downloadable_configuration_version (2.37s)
    --- PASS: TestConfigurationVersionsDownload/with_a_valid_ID_for_a_non_downloadable_configuration_version (1.44s)
    --- PASS: TestConfigurationVersionsDownload/with_an_invalid_ID (0.08s)
=== RUN   TestConfigurationVersions_Unmarshal
--- PASS: TestConfigurationVersions_Unmarshal (0.00s)
=== RUN   TestConfigurationVersions_ManageBackingData
    configuration_version_integration_test.go:477: Skipping test related to Terraform Cloud. Set ENABLE_TFE=1 to run.
--- SKIP: TestConfigurationVersions_ManageBackingData (0.00s)
FAIL
FAIL    github.com/hashicorp/go-tfe     20.798s
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
FAIL

```
**Note**: The failing test (`TestConfigurationVersionsCreate/provisional`) also consistently fails on production, so I don't think it's related to these changes.