### PR TITLE
Await async state version processing in TestStateVersionsUpload

### DIFF
--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -146,16 +146,16 @@ func TestStateVersionsUpload(t *testing.T) {
 		require.NoError(t, err)
 
 		// TFC does some async processing on state versions, so we must await it
-		// lest we flake. Shouldn't take a whole minute tho.
-		timeout := 1 * time.Minute
+		// lest we flake. Should take well less than a minute tho.
+		timeout := time.Minute / 2
 
 		ctxPollSVReady, cancelPollSVReady := context.WithTimeout(ctx, timeout)
 		defer cancelPollSVReady()
 
-		pollStateVersionStatus(t, client, ctxPollSVReady, sv, []StateVersionStatus{StateVersionFinalized})
+		sv = pollStateVersionStatus(t, client, ctxPollSVReady, sv, []StateVersionStatus{StateVersionFinalized})
 
 		assert.NotEmpty(t, sv.DownloadURL)
-		assert.Equal(t, sv.Status, StateVersionFinalized)
+		assert.Equal(t, StateVersionFinalized, sv.Status)
 	})
 
 	t.Run("cannot provide base64 state parameter when uploading", func(t *testing.T) {


### PR DESCRIPTION
## Description

TFC does some async processing on uploaded state versions; they're not guaranteed to have `finalized` status by the time the upload call is acknowledged. That means this test flakes. (Though it wasn't flaking in CI until today, since it was previously being skipped as beta.)

This adds a state version clone of the run polling function. Yeah, it's copypasta code, but it seemed premature to try and come up with some kind of ReadWithStatus interface that could cope with all the distinct string types etc. Possibly worth revisiting later.

## Testing plan

1. the test stops flaking.

## Output from tests

see CI output