### PR TITLE
[TF-9605] Add validation when configuring Registry Module Publishing

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -222,9 +222,10 @@ var (
 
 	ErrRequiredAgentPoolID = errors.New("'agent' execution mode requires an agent pool ID to be specified")
 
-	ErrRequiredAgentMode              = errors.New("specifying an agent pool ID requires 'agent' execution mode")
-	ErrRequiredBranchWhenTestsEnabled = errors.New("VCS branch is required when enabling tests")
-	ErrRequiredCategory               = errors.New("category is required")
+	ErrRequiredAgentMode                = errors.New("specifying an agent pool ID requires 'agent' execution mode")
+	ErrRequiredBranchWhenTestsEnabled   = errors.New("VCS branch is required when enabling tests")
+	ErrBranchMustBeEmptyWhenTagsEnabled = errors.New("VCS branch must be empty to enable tags")
+	ErrRequiredCategory                 = errors.New("category is required")
 
 	ErrRequiredDestinationType = errors.New("destination type is required")
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -289,6 +289,7 @@ type RegistryModuleVCSRepoOptions struct {
 	//
 	// **Note: This field is still in BETA and subject to change.**
 	Branch *string `json:"branch,omitempty"`
+	Tags   *bool   `json:"tags,omitempty"`
 }
 
 type RegistryModuleVCSRepoUpdateOptions struct {
@@ -424,6 +425,12 @@ func (r *registryModules) Update(ctx context.Context, moduleID RegistryModuleID,
 
 	if options.NoCode != nil {
 		log.Println("[WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.")
+	}
+
+	if options.VCSRepo != nil {
+		if options.VCSRepo.Tags != nil && *options.VCSRepo.Tags && validString(options.VCSRepo.Branch) {
+			return nil, ErrBranchMustBeEmptyWhenTagsEnabled
+		}
 	}
 
 	org := url.QueryEscape(moduleID.Organization)
@@ -735,6 +742,12 @@ func (o RegistryModuleCreateWithVCSConnectionOptions) valid() error {
 			if !validString(o.VCSRepo.Branch) {
 				return ErrRequiredBranchWhenTestsEnabled
 			}
+		}
+	}
+
+	if o.VCSRepo.Tags != nil && *o.VCSRepo.Tags {
+		if validString(o.VCSRepo.Branch) {
+			return ErrBranchMustBeEmptyWhenTagsEnabled
 		}
 	}
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

This change throws the exception when setting `tags` to `true` and a `branch` is present when configuring the `VCSRepo` for a `RegistryModule`.  Currently, if a `branch` is provided in the API request, the backend will give precedence to the `branch` value and return the value for `tags` as `false`, which can lead to user confusion.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

1. Create a `RegistryModule` with a VCS connection
1. Set `VCSRepo` `tags` to `true`
1. Set `VCSRepo` `branch` to `main`
1. Verify that an exception is thrown


## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestRegistryModule
?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestRegistryModulesList
=== RUN   TestRegistryModulesList/with_no_list_options
=== RUN   TestRegistryModulesList/with_list_options
--- PASS: TestRegistryModulesList (2.36s)
    --- PASS: TestRegistryModulesList/with_no_list_options (0.19s)
    --- PASS: TestRegistryModulesList/with_list_options (0.44s)
=== RUN   TestRegistryModulesCreate
=== RUN   TestRegistryModulesCreate/with_valid_options
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute
2023/11/06 12:11:52 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to create a no-code module is with the registryNoCodeModules.Create method.
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_invalid_options
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name
=== RUN   TestRegistryModulesCreate/without_a_valid_organization
--- PASS: TestRegistryModulesCreate (2.39s)
    --- PASS: TestRegistryModulesCreate/with_valid_options (0.81s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName (0.20s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName (0.18s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName (0.19s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute (0.25s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreate/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name (0.00s)
    --- PASS: TestRegistryModulesCreate/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/11/06 12:11:54 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/11/06 12:11:54 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (3.25s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.40s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (1.00s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/11/06 12:11:58 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/11/06 12:11:59 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/prevents_setting_the_branch_when_using_tag_based_publishing
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (7.23s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.31s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.20s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/prevents_setting_the_branch_when_using_tag_based_publishing (0.23s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.69s)
=== RUN   TestRegistryModulesCreateVersion
=== RUN   TestRegistryModulesCreateVersion/with_valid_options
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/without_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version
=== RUN   TestRegistryModulesCreateVersion/without_a_name
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_name
=== RUN   TestRegistryModulesCreateVersion/without_a_provider
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesCreateVersion/without_a_valid_organization
--- PASS: TestRegistryModulesCreateVersion (2.34s)
    --- PASS: TestRegistryModulesCreateVersion/with_valid_options (0.23s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version (0.32s)
    --- PASS: TestRegistryModulesCreateVersion/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/without_version (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesShowVersion
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/relationships_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/links_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_reading_a_version_that_does_not_exist
--- PASS: TestRegistryModulesShowVersion (2.73s)
    --- PASS: TestRegistryModulesShowVersion/when_the_version_exists (0.38s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/links_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesShowVersion/when_reading_a_version_that_does_not_exist (0.39s)
=== RUN   TestRegistryModulesListCommit
=== RUN   TestRegistryModulesListCommit/with_valid_options
=== RUN   TestRegistryModulesListCommit/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesListCommit/with_valid_options/listing_commits
=== RUN   TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present
=== RUN   TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present/listing_commits
--- PASS: TestRegistryModulesListCommit (7.46s)
    --- PASS: TestRegistryModulesListCommit/with_valid_options (3.01s)
        --- PASS: TestRegistryModulesListCommit/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesListCommit/with_valid_options/listing_commits (1.63s)
    --- PASS: TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present (0.65s)
        --- PASS: TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present/listing_commits (0.17s)
=== RUN   TestRegistryModulesCreateWithVCSConnection
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/when_tags_are_enabled_and_a_branch_is_provided
=== RUN   TestRegistryModulesCreateWithVCSConnection/without_options
--- PASS: TestRegistryModulesCreateWithVCSConnection (7.24s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options (1.31s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/when_tags_are_enabled_and_a_branch_is_provided (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/without_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection (5.22s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options (1.34s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting (5.21s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options (1.34s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled (0.00s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled (0.00s)
=== RUN   TestRegistryModulesCreateWithGithubApp
    registry_module_integration_test.go:1025: Export a valid GITHUB_APP_INSTALLATION_ID before running this test!
--- SKIP: TestRegistryModulesCreateWithGithubApp (0.00s)
=== RUN   TestRegistryModulesRead
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider
2023/11/06 12:12:35 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:35 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/without_a_name
=== RUN   TestRegistryModulesRead/with_an_invalid_name
=== RUN   TestRegistryModulesRead/without_a_provider
=== RUN   TestRegistryModulesRead/with_an_invalid_provider
=== RUN   TestRegistryModulesRead/with_an_invalid_registry_name
=== RUN   TestRegistryModulesRead/without_a_valid_organization
=== RUN   TestRegistryModulesRead/without_a_valid_namespace_for_public_registry_module
=== RUN   TestRegistryModulesRead/when_the_registry_module_does_not_exist
2023/11/06 12:12:35 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:35 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
--- PASS: TestRegistryModulesRead (3.08s)
    --- PASS: TestRegistryModulesRead/with_valid_name_and_provider (0.24s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module (0.16s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module (0.17s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_name (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_registry_name (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_valid_namespace_for_public_registry_module (0.00s)
    --- PASS: TestRegistryModulesRead/when_the_registry_module_does_not_exist (0.18s)
=== RUN   TestRegistryModulesDelete
=== RUN   TestRegistryModulesDelete/with_valid_name
2023/11/06 12:12:38 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:38 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDelete/without_a_name
=== RUN   TestRegistryModulesDelete/with_an_invalid_name
=== RUN   TestRegistryModulesDelete/without_a_valid_organization
=== RUN   TestRegistryModulesDelete/when_the_registry_module_does_not_exist
--- PASS: TestRegistryModulesDelete (2.14s)
    --- PASS: TestRegistryModulesDelete/with_valid_name (0.35s)
    --- PASS: TestRegistryModulesDelete/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDelete/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDelete/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDelete/when_the_registry_module_does_not_exist (0.14s)
=== RUN   TestRegistryModulesDeleteProvider
=== RUN   TestRegistryModulesDeleteProvider/with_valid_name_and_provider
2023/11/06 12:12:40 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:40 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteProvider/without_a_name
=== RUN   TestRegistryModulesDeleteProvider/with_an_invalid_name
=== RUN   TestRegistryModulesDeleteProvider/without_a_provider
=== RUN   TestRegistryModulesDeleteProvider/with_an_invalid_provider
=== RUN   TestRegistryModulesDeleteProvider/without_a_valid_organization
=== RUN   TestRegistryModulesDeleteProvider/when_the_registry_module_name_and_provider_do_not_exist
--- PASS: TestRegistryModulesDeleteProvider (2.00s)
    --- PASS: TestRegistryModulesDeleteProvider/with_valid_name_and_provider (0.32s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/when_the_registry_module_name_and_provider_do_not_exist (0.14s)
=== RUN   TestRegistryModulesDeleteVersion
2023/11/06 12:12:43 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:43 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteVersion/with_valid_name_and_provider
2023/11/06 12:12:44 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:44 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
2023/11/06 12:12:44 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:44 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteVersion/with_prerelease_and_metadata_version
2023/11/06 12:12:45 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:45 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
2023/11/06 12:12:45 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:12:45 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteVersion/without_a_name
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_name
=== RUN   TestRegistryModulesDeleteVersion/without_a_provider
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesDeleteVersion/without_a_version
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_version
=== RUN   TestRegistryModulesDeleteVersion/without_a_valid_organization
=== RUN   TestRegistryModulesDeleteVersion/when_the_registry_module_name,_provider,_and_version_do_not_exist
--- PASS: TestRegistryModulesDeleteVersion (5.70s)
    --- PASS: TestRegistryModulesDeleteVersion/with_valid_name_and_provider (0.93s)
    --- PASS: TestRegistryModulesDeleteVersion/with_prerelease_and_metadata_version (0.79s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_version (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_version (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/when_the_registry_module_name,_provider,_and_version_do_not_exist (0.13s)
=== RUN   TestRegistryModulesUpload
=== RUN   TestRegistryModulesUpload/with_valid_upload_URL
=== RUN   TestRegistryModulesUpload/with_missing_upload_URL
--- PASS: TestRegistryModulesUpload (1.98s)
    --- PASS: TestRegistryModulesUpload/with_valid_upload_URL (0.04s)
    --- PASS: TestRegistryModulesUpload/with_missing_upload_URL (0.00s)
=== RUN   TestRegistryModulesUploadTarGzip
=== RUN   TestRegistryModulesUploadTarGzip/with_custom_go-slug
=== RUN   TestRegistryModulesUploadTarGzip/with_custom_tar_archive
--- PASS: TestRegistryModulesUploadTarGzip (3.14s)
    --- PASS: TestRegistryModulesUploadTarGzip/with_custom_go-slug (0.03s)
    --- PASS: TestRegistryModulesUploadTarGzip/with_custom_tar_archive (0.04s)
=== RUN   TestRegistryModule_Unmarshal
--- PASS: TestRegistryModule_Unmarshal (0.00s)
=== RUN   TestRegistryModulesList
=== RUN   TestRegistryModulesList/with_no_list_options
=== RUN   TestRegistryModulesList/with_list_options
--- PASS: TestRegistryModulesList (4.73s)
    --- PASS: TestRegistryModulesList/with_no_list_options (0.26s)
    --- PASS: TestRegistryModulesList/with_list_options (2.28s)
=== RUN   TestRegistryModulesCreate
=== RUN   TestRegistryModulesCreate/with_valid_options
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute
2023/11/06 12:12:58 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to create a no-code module is with the registryNoCodeModules.Create method.
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreate/with_invalid_options
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name
=== RUN   TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name
=== RUN   TestRegistryModulesCreate/without_a_valid_organization
--- PASS: TestRegistryModulesCreate (2.35s)
    --- PASS: TestRegistryModulesCreate/with_valid_options (0.88s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName (0.21s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/without_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName (0.19s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_private_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName (0.29s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_public_RegistryName/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute (0.20s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/permissions_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/relationships_are_properly_decoded (0.00s)
            --- PASS: TestRegistryModulesCreate/with_valid_options/with_no-code_attribute/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreate/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_provider (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_an_invalid_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/without_a_namespace_for_public_registry_name (0.00s)
        --- PASS: TestRegistryModulesCreate/with_invalid_options/with_a_namespace_for_private_registry_name (0.00s)
    --- PASS: TestRegistryModulesCreate/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModuleUpdate
=== RUN   TestRegistryModuleUpdate/enable_no-code
2023/11/06 12:13:00 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdate/disable_no-code
2023/11/06 12:13:00 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
--- PASS: TestRegistryModuleUpdate (2.62s)
    --- PASS: TestRegistryModuleUpdate/enable_no-code (0.39s)
    --- PASS: TestRegistryModuleUpdate/disable_no-code (0.37s)
=== RUN   TestRegistryModuleUpdateWithVCSConnection
=== RUN   TestRegistryModuleUpdateWithVCSConnection/enable_no-code
2023/11/06 12:13:04 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/disable_no-code
2023/11/06 12:13:04 [WARN] Support for using the NoCode field is deprecated as of release 1.22.0 and may be removed in a future version. The preferred way to update a no-code module is with the registryNoCodeModules.Update method.
=== RUN   TestRegistryModuleUpdateWithVCSConnection/prevents_setting_the_branch_when_using_tag_based_publishing
=== RUN   TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing
--- PASS: TestRegistryModuleUpdateWithVCSConnection (6.69s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/enable_no-code (0.30s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/disable_no-code (0.19s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/prevents_setting_the_branch_when_using_tag_based_publishing (0.21s)
    --- PASS: TestRegistryModuleUpdateWithVCSConnection/toggle_between_git_tag-based_and_branch-based_publishing (0.78s)
=== RUN   TestRegistryModulesCreateVersion
=== RUN   TestRegistryModulesCreateVersion/with_valid_options
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded
=== RUN   TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/without_version
=== RUN   TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version
=== RUN   TestRegistryModulesCreateVersion/without_a_name
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_name
=== RUN   TestRegistryModulesCreateVersion/without_a_provider
=== RUN   TestRegistryModulesCreateVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesCreateVersion/without_a_valid_organization
--- PASS: TestRegistryModulesCreateVersion (2.29s)
    --- PASS: TestRegistryModulesCreateVersion/with_valid_options (0.21s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_valid_options/links_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_prerelease_and_metadata_version (0.19s)
    --- PASS: TestRegistryModulesCreateVersion/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/without_version (0.00s)
        --- PASS: TestRegistryModulesCreateVersion/with_invalid_options/with_invalid_version (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesCreateVersion/without_a_valid_organization (0.00s)
=== RUN   TestRegistryModulesShowVersion
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/relationships_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_the_version_exists/links_are_properly_decoded
=== RUN   TestRegistryModulesShowVersion/when_reading_a_version_that_does_not_exist
--- PASS: TestRegistryModulesShowVersion (2.58s)
    --- PASS: TestRegistryModulesShowVersion/when_the_version_exists (0.35s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/timestamps_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesShowVersion/when_the_version_exists/links_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesShowVersion/when_reading_a_version_that_does_not_exist (0.42s)
=== RUN   TestRegistryModulesListCommit
=== RUN   TestRegistryModulesListCommit/with_valid_options
=== RUN   TestRegistryModulesListCommit/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesListCommit/with_valid_options/listing_commits
=== RUN   TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present
=== RUN   TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present/listing_commits
--- PASS: TestRegistryModulesListCommit (6.25s)
    --- PASS: TestRegistryModulesListCommit/with_valid_options (1.97s)
        --- PASS: TestRegistryModulesListCommit/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesListCommit/with_valid_options/listing_commits (0.62s)
    --- PASS: TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present (0.47s)
        --- PASS: TestRegistryModulesListCommit/when_a_VCS_connection_is_not_present/listing_commits (0.15s)
=== RUN   TestRegistryModulesCreateWithVCSConnection
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier
=== RUN   TestRegistryModulesCreateWithVCSConnection/with_invalid_options/when_tags_are_enabled_and_a_branch_is_provided
=== RUN   TestRegistryModulesCreateWithVCSConnection/without_options
--- PASS: TestRegistryModulesCreateWithVCSConnection (6.10s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options (1.34s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/relationships_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_valid_options/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_an_oauth_token_ID (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/without_a_display_identifier (0.00s)
        --- PASS: TestRegistryModulesCreateWithVCSConnection/with_invalid_options/when_tags_are_enabled_and_a_branch_is_provided (0.00s)
    --- PASS: TestRegistryModulesCreateWithVCSConnection/without_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection (5.09s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options (1.28s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_invalid_options (0.00s)
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting (5.26s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options (1.36s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_valid_options/tests_are_enabled (0.00s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options (0.00s)
        --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnectionWithTesting/with_invalid_options/when_the_the_module_is_not_branch_based_and_test_are_enabled (0.00s)
=== RUN   TestRegistryModulesCreateWithGithubApp
    registry_module_integration_test.go:1025: Export a valid GITHUB_APP_INSTALLATION_ID before running this test!
--- SKIP: TestRegistryModulesCreateWithGithubApp (0.00s)
=== RUN   TestRegistryModulesRead
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider
2023/11/06 12:13:37 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:37 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/timestamps_are_properly_decoded
=== RUN   TestRegistryModulesRead/without_a_name
=== RUN   TestRegistryModulesRead/with_an_invalid_name
=== RUN   TestRegistryModulesRead/without_a_provider
=== RUN   TestRegistryModulesRead/with_an_invalid_provider
=== RUN   TestRegistryModulesRead/with_an_invalid_registry_name
=== RUN   TestRegistryModulesRead/without_a_valid_organization
=== RUN   TestRegistryModulesRead/without_a_valid_namespace_for_public_registry_module
=== RUN   TestRegistryModulesRead/when_the_registry_module_does_not_exist
2023/11/06 12:13:37 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:37 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
--- PASS: TestRegistryModulesRead (4.03s)
    --- PASS: TestRegistryModulesRead/with_valid_name_and_provider (0.17s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_valid_name_and_provider/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module (0.24s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_private_module/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module (0.17s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_complete_registry_module_ID_fields_for_public_module/timestamps_are_properly_decoded (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_name (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesRead/with_an_invalid_registry_name (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesRead/without_a_valid_namespace_for_public_registry_module (0.00s)
    --- PASS: TestRegistryModulesRead/when_the_registry_module_does_not_exist (0.14s)
=== RUN   TestRegistryModulesDelete
=== RUN   TestRegistryModulesDelete/with_valid_name
2023/11/06 12:13:41 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:41 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDelete/without_a_name
=== RUN   TestRegistryModulesDelete/with_an_invalid_name
=== RUN   TestRegistryModulesDelete/without_a_valid_organization
=== RUN   TestRegistryModulesDelete/when_the_registry_module_does_not_exist
--- PASS: TestRegistryModulesDelete (2.09s)
    --- PASS: TestRegistryModulesDelete/with_valid_name (0.32s)
    --- PASS: TestRegistryModulesDelete/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDelete/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDelete/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDelete/when_the_registry_module_does_not_exist (0.24s)
=== RUN   TestRegistryModulesDeleteProvider
=== RUN   TestRegistryModulesDeleteProvider/with_valid_name_and_provider
2023/11/06 12:13:43 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:43 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteProvider/without_a_name
=== RUN   TestRegistryModulesDeleteProvider/with_an_invalid_name
=== RUN   TestRegistryModulesDeleteProvider/without_a_provider
=== RUN   TestRegistryModulesDeleteProvider/with_an_invalid_provider
=== RUN   TestRegistryModulesDeleteProvider/without_a_valid_organization
=== RUN   TestRegistryModulesDeleteProvider/when_the_registry_module_name_and_provider_do_not_exist
--- PASS: TestRegistryModulesDeleteProvider (2.09s)
    --- PASS: TestRegistryModulesDeleteProvider/with_valid_name_and_provider (0.31s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDeleteProvider/when_the_registry_module_name_and_provider_do_not_exist (0.23s)
=== RUN   TestRegistryModulesDeleteVersion
2023/11/06 12:13:45 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:45 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteVersion/with_valid_name_and_provider
2023/11/06 12:13:45 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:45 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
2023/11/06 12:13:46 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:46 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteVersion/with_prerelease_and_metadata_version
2023/11/06 12:13:46 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:46 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
2023/11/06 12:13:46 [WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.
2023/11/06 12:13:46 [WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.
=== RUN   TestRegistryModulesDeleteVersion/without_a_name
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_name
=== RUN   TestRegistryModulesDeleteVersion/without_a_provider
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_provider
=== RUN   TestRegistryModulesDeleteVersion/without_a_version
=== RUN   TestRegistryModulesDeleteVersion/with_an_invalid_version
=== RUN   TestRegistryModulesDeleteVersion/without_a_valid_organization
=== RUN   TestRegistryModulesDeleteVersion/when_the_registry_module_name,_provider,_and_version_do_not_exist
--- PASS: TestRegistryModulesDeleteVersion (3.85s)
    --- PASS: TestRegistryModulesDeleteVersion/with_valid_name_and_provider (0.82s)
    --- PASS: TestRegistryModulesDeleteVersion/with_prerelease_and_metadata_version (0.79s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_name (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_name (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_provider (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_version (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/with_an_invalid_version (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/without_a_valid_organization (0.00s)
    --- PASS: TestRegistryModulesDeleteVersion/when_the_registry_module_name,_provider,_and_version_do_not_exist (0.14s)
=== RUN   TestRegistryModulesUpload
=== RUN   TestRegistryModulesUpload/with_valid_upload_URL
=== RUN   TestRegistryModulesUpload/with_missing_upload_URL
--- PASS: TestRegistryModulesUpload (2.00s)
    --- PASS: TestRegistryModulesUpload/with_valid_upload_URL (0.04s)
    --- PASS: TestRegistryModulesUpload/with_missing_upload_URL (0.00s)
=== RUN   TestRegistryModulesUploadTarGzip
=== RUN   TestRegistryModulesUploadTarGzip/with_custom_go-slug
=== RUN   TestRegistryModulesUploadTarGzip/with_custom_tar_archive
--- PASS: TestRegistryModulesUploadTarGzip (2.58s)
    --- PASS: TestRegistryModulesUploadTarGzip/with_custom_go-slug (0.04s)
    --- PASS: TestRegistryModulesUploadTarGzip/with_custom_tar_archive (0.05s)
=== RUN   TestRegistryModule_Unmarshal
--- PASS: TestRegistryModule_Unmarshal (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	124.460s
...
```
