### PR TITLE
Remove unused agent-pool-id field from Workspace model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # UNRELEASED
-<!-- Add CHANGELOG entry to this section for any PR awaiting the next release -->
-<!-- Please also include if this is a Bug Fix, Enhancement, or Feature -->
+
+## Bug Fixes
+* Removed unused field `AgentPoolID` from the Workspace model. (Callers should be using the `AgentPool` relation instead) by @brandonc [#815](https://github.com/hashicorp/go-tfe/pull/815)
 
 # v1.39.2
 

--- a/workspace.go
+++ b/workspace.go
@@ -118,7 +118,6 @@ type WorkspaceList struct {
 type Workspace struct {
 	ID                         string                      `jsonapi:"primary,workspaces"`
 	Actions                    *WorkspaceActions           `jsonapi:"attr,actions"`
-	AgentPoolID                string                      `jsonapi:"attr,agent-pool-id"`
 	AllowDestroyPlan           bool                        `jsonapi:"attr,allow-destroy-plan"`
 	AssessmentsEnabled         bool                        `jsonapi:"attr,assessments-enabled"`
 	AutoApply                  bool                        `jsonapi:"attr,auto-apply"`


### PR DESCRIPTION
This is not a response attribute in the API and should never be populated or used.