### PR TITLE
Allow managing data retention policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+* Allow managing workspace and organization data retention policies by @mwudka [#801](https://github.com/hashicorp/go-tfe/pull/817)
 
 ## Bug Fixes
 * Removed unused field `AgentPoolID` from the Workspace model. (Callers should be using the `AgentPool` relation instead) by @brandonc [#815](https://github.com/hashicorp/go-tfe/pull/815)

--- a/data_retention_policy.go
+++ b/data_retention_policy.go
@@ -1,0 +1,19 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+type DataRetentionPolicy struct {
+	ID                   string `jsonapi:"primary,data-retention-policies"`
+	DeleteOlderThanNDays int    `jsonapi:"attr,delete-older-than-n-days"`
+}
+
+type DataRetentionPolicySetOptions struct {
+	// Type is a public field utilized by JSON:API to
+	// set the resource type via the field tag.
+	// It is not a user-defined value and does not need to be set.
+	// https://jsonapi.org/format/#crud-creating
+	Type string `jsonapi:"primary,data-retention-policies"`
+
+	DeleteOlderThanNDays int `jsonapi:"attr,delete-older-than-n-days"`
+}

--- a/mocks/organization_mocks.go
+++ b/mocks/organization_mocks.go
@@ -64,6 +64,20 @@ func (mr *MockOrganizationsMockRecorder) Delete(ctx, organization interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockOrganizations)(nil).Delete), ctx, organization)
 }
 
+// DeleteDataRetentionPolicy mocks base method.
+func (m *MockOrganizations) DeleteDataRetentionPolicy(ctx context.Context, organization string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDataRetentionPolicy", ctx, organization)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDataRetentionPolicy indicates an expected call of DeleteDataRetentionPolicy.
+func (mr *MockOrganizationsMockRecorder) DeleteDataRetentionPolicy(ctx, organization interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDataRetentionPolicy", reflect.TypeOf((*MockOrganizations)(nil).DeleteDataRetentionPolicy), ctx, organization)
+}
+
 // List mocks base method.
 func (m *MockOrganizations) List(ctx context.Context, options *tfe.OrganizationListOptions) (*tfe.OrganizationList, error) {
 	m.ctrl.T.Helper()
@@ -109,6 +123,21 @@ func (mr *MockOrganizationsMockRecorder) ReadCapacity(ctx, organization interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadCapacity", reflect.TypeOf((*MockOrganizations)(nil).ReadCapacity), ctx, organization)
 }
 
+// ReadDataRetentionPolicy mocks base method.
+func (m *MockOrganizations) ReadDataRetentionPolicy(ctx context.Context, organization string) (*tfe.DataRetentionPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDataRetentionPolicy", ctx, organization)
+	ret0, _ := ret[0].(*tfe.DataRetentionPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDataRetentionPolicy indicates an expected call of ReadDataRetentionPolicy.
+func (mr *MockOrganizationsMockRecorder) ReadDataRetentionPolicy(ctx, organization interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDataRetentionPolicy", reflect.TypeOf((*MockOrganizations)(nil).ReadDataRetentionPolicy), ctx, organization)
+}
+
 // ReadEntitlements mocks base method.
 func (m *MockOrganizations) ReadEntitlements(ctx context.Context, organization string) (*tfe.Entitlements, error) {
 	m.ctrl.T.Helper()
@@ -152,6 +181,21 @@ func (m *MockOrganizations) ReadWithOptions(ctx context.Context, organization st
 func (mr *MockOrganizationsMockRecorder) ReadWithOptions(ctx, organization, options interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadWithOptions", reflect.TypeOf((*MockOrganizations)(nil).ReadWithOptions), ctx, organization, options)
+}
+
+// SetDataRetentionPolicy mocks base method.
+func (m *MockOrganizations) SetDataRetentionPolicy(ctx context.Context, organization string, options tfe.DataRetentionPolicySetOptions) (*tfe.DataRetentionPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDataRetentionPolicy", ctx, organization, options)
+	ret0, _ := ret[0].(*tfe.DataRetentionPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetDataRetentionPolicy indicates an expected call of SetDataRetentionPolicy.
+func (mr *MockOrganizationsMockRecorder) SetDataRetentionPolicy(ctx, organization, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataRetentionPolicy", reflect.TypeOf((*MockOrganizations)(nil).SetDataRetentionPolicy), ctx, organization, options)
 }
 
 // Update mocks base method.

--- a/mocks/workspace_mocks.go
+++ b/mocks/workspace_mocks.go
@@ -122,6 +122,20 @@ func (mr *MockWorkspacesMockRecorder) DeleteByID(ctx, workspaceID interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteByID", reflect.TypeOf((*MockWorkspaces)(nil).DeleteByID), ctx, workspaceID)
 }
 
+// DeleteDataRetentionPolicy mocks base method.
+func (m *MockWorkspaces) DeleteDataRetentionPolicy(ctx context.Context, workspaceID string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteDataRetentionPolicy", ctx, workspaceID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteDataRetentionPolicy indicates an expected call of DeleteDataRetentionPolicy.
+func (mr *MockWorkspacesMockRecorder) DeleteDataRetentionPolicy(ctx, workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteDataRetentionPolicy", reflect.TypeOf((*MockWorkspaces)(nil).DeleteDataRetentionPolicy), ctx, workspaceID)
+}
+
 // ForceUnlock mocks base method.
 func (m *MockWorkspaces) ForceUnlock(ctx context.Context, workspaceID string) (*tfe.Workspace, error) {
 	m.ctrl.T.Helper()
@@ -242,6 +256,21 @@ func (mr *MockWorkspacesMockRecorder) ReadByIDWithOptions(ctx, workspaceID, opti
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadByIDWithOptions", reflect.TypeOf((*MockWorkspaces)(nil).ReadByIDWithOptions), ctx, workspaceID, options)
 }
 
+// ReadDataRetentionPolicy mocks base method.
+func (m *MockWorkspaces) ReadDataRetentionPolicy(ctx context.Context, workspaceID string) (*tfe.DataRetentionPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadDataRetentionPolicy", ctx, workspaceID)
+	ret0, _ := ret[0].(*tfe.DataRetentionPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadDataRetentionPolicy indicates an expected call of ReadDataRetentionPolicy.
+func (mr *MockWorkspacesMockRecorder) ReadDataRetentionPolicy(ctx, workspaceID interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadDataRetentionPolicy", reflect.TypeOf((*MockWorkspaces)(nil).ReadDataRetentionPolicy), ctx, workspaceID)
+}
+
 // ReadWithOptions mocks base method.
 func (m *MockWorkspaces) ReadWithOptions(ctx context.Context, organization, workspace string, options *tfe.WorkspaceReadOptions) (*tfe.Workspace, error) {
 	m.ctrl.T.Helper()
@@ -356,6 +385,21 @@ func (m *MockWorkspaces) SafeDeleteByID(ctx context.Context, workspaceID string)
 func (mr *MockWorkspacesMockRecorder) SafeDeleteByID(ctx, workspaceID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SafeDeleteByID", reflect.TypeOf((*MockWorkspaces)(nil).SafeDeleteByID), ctx, workspaceID)
+}
+
+// SetDataRetentionPolicy mocks base method.
+func (m *MockWorkspaces) SetDataRetentionPolicy(ctx context.Context, workspaceID string, options tfe.DataRetentionPolicySetOptions) (*tfe.DataRetentionPolicy, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "SetDataRetentionPolicy", ctx, workspaceID, options)
+	ret0, _ := ret[0].(*tfe.DataRetentionPolicy)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// SetDataRetentionPolicy indicates an expected call of SetDataRetentionPolicy.
+func (mr *MockWorkspacesMockRecorder) SetDataRetentionPolicy(ctx, workspaceID, options interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SetDataRetentionPolicy", reflect.TypeOf((*MockWorkspaces)(nil).SetDataRetentionPolicy), ctx, workspaceID, options)
 }
 
 // UnassignSSHKey mocks base method.


### PR DESCRIPTION
## Description

Allows reading, setting, and clearing data retention policies on organizations and workspaces.

## Testing plan

Run tests and make a test build of TFE provider that uses this branch.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" ENABLE_TFE=1 go test ./... -v -run _DataRetentionPolicy

=== RUN   TestOrganization_DataRetentionPolicy
=== RUN   TestOrganization_DataRetentionPolicy/set_data_retention_policy
=== RUN   TestOrganization_DataRetentionPolicy/update_data_retention_policy
=== RUN   TestOrganization_DataRetentionPolicy/delete_data_retention_policy
--- PASS: TestOrganization_DataRetentionPolicy (6.16s)
    --- PASS: TestOrganization_DataRetentionPolicy/set_data_retention_policy (1.52s)
    --- PASS: TestOrganization_DataRetentionPolicy/update_data_retention_policy (0.73s)
    --- PASS: TestOrganization_DataRetentionPolicy/delete_data_retention_policy (0.69s)
=== RUN   TestWorkspace_DataRetentionPolicy
=== RUN   TestWorkspace_DataRetentionPolicy/set_data_retention_policy
=== RUN   TestWorkspace_DataRetentionPolicy/update_data_retention_policy
=== RUN   TestWorkspace_DataRetentionPolicy/delete_data_retention_policy
--- PASS: TestWorkspace_DataRetentionPolicy (5.82s)
    --- PASS: TestWorkspace_DataRetentionPolicy/set_data_retention_policy (1.02s)
    --- PASS: TestWorkspace_DataRetentionPolicy/update_data_retention_policy (0.72s)
    --- PASS: TestWorkspace_DataRetentionPolicy/delete_data_retention_policy (0.69s)
PASS
ok      github.com/hashicorp/go-tfe     12.285s

```
