### PR TITLE
fix: adding missing sentinel field to PolicyCheck

### DIFF
--- a/policy_check.go
+++ b/policy_check.go
@@ -101,6 +101,7 @@ type PolicyResult struct {
 	Result         bool `jsonapi:"attr,result"`
 	SoftFailed     int  `jsonapi:"attr,soft-failed"`
 	TotalFailed    int  `jsonapi:"attr,total-failed"`
+	Sentinel       any  `jsonapi:"attr,sentinel"`
 }
 
 // PolicyStatusTimestamps holds the timestamps for individual policy check

--- a/policy_check_integration_test.go
+++ b/policy_check_integration_test.go
@@ -106,6 +106,7 @@ func TestPolicyChecksRead(t *testing.T) {
 		assert.NotEmpty(t, pc.StatusTimestamps)
 		assert.Equal(t, 1, pc.Result.Passed)
 		assert.NotEmpty(t, pc.Run)
+		assert.NotEmpty(t, pc.Result.Sentinel)
 	})
 
 	t.Run("when the policy check does not exist", func(t *testing.T) {


### PR DESCRIPTION
## Description

PolicyResult structure is missing an additional field returned by the api

## Testing plan

## External links

https://developer.hashicorp.com/terraform/cloud-docs/api-docs/policy-checks#sample-response
https://github.com/hashicorp/go-tfe/issues/790


## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.


```
/usr/local/opt/go/libexec/bin/go tool test2json -t /Users/skiss/Library/Caches/JetBrains/GoLand2023.2/tmp/GoLand/___TestPolicyChecksRead_in_github_com_hashicorp_go_tfe.test -test.v -test.paniconexit0 -test.run ^\QTestPolicyChecksRead\E$
=== RUN   TestPolicyChecksRead
    helper_test.go:1226: Polling run "run-hGVffWH2vb8cEWp1" for status included in ["policy_checked" "policy_override" "errored"] with deadline of 2023-11-25 20:40:20.339614 +0200 EET m=+124.232394161
    helper_test.go:1232: ...
    helper_test.go:1290: Reading run "run-hGVffWH2vb8cEWp1"
    helper_test.go:1238: Run "run-hGVffWH2vb8cEWp1" had status "plan_queued"
    helper_test.go:1232: ...
    helper_test.go:1290: Reading run "run-hGVffWH2vb8cEWp1"
    helper_test.go:1238: Run "run-hGVffWH2vb8cEWp1" had status "planning"
    helper_test.go:1232: ...
    helper_test.go:1290: Reading run "run-hGVffWH2vb8cEWp1"
    helper_test.go:1238: Run "run-hGVffWH2vb8cEWp1" had status "planning"
    helper_test.go:1232: ...
    helper_test.go:1290: Reading run "run-hGVffWH2vb8cEWp1"
    helper_test.go:1238: Run "run-hGVffWH2vb8cEWp1" had status "policy_checking"
    helper_test.go:1232: ...
    helper_test.go:1290: Reading run "run-hGVffWH2vb8cEWp1"
    helper_test.go:1238: Run "run-hGVffWH2vb8cEWp1" had status "policy_checked"
--- PASS: TestPolicyChecksRead (15.74s)
=== RUN   TestPolicyChecksRead/when_the_policy_check_exists
    --- PASS: TestPolicyChecksRead/when_the_policy_check_exists (0.18s)
=== RUN   TestPolicyChecksRead/when_the_policy_check_does_not_exist
    --- PASS: TestPolicyChecksRead/when_the_policy_check_does_not_exist (0.16s)
=== RUN   TestPolicyChecksRead/without_a_valid_policy_check_ID
    --- PASS: TestPolicyChecksRead/without_a_valid_policy_check_ID (0.00s)
PASS

Process finished with the exit code 0

```
