### PR TITLE
[TF-10829] add new organization setting option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Features
+* Adds `AggregatedCommitStatusEnabled` field to `Organization` by @mjyocca [#829](https://github.com/hashicorp/go-tfe/pull/829)
+
 # v1.42.0
 
 ## Deprecations

--- a/organization.go
+++ b/organization.go
@@ -99,7 +99,7 @@ type Organization struct {
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
 	RemainingTestableCount                            int                      `jsonapi:"attr,remaining-testable-count"`
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
-	AggregatedCommitStatusEnabled bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
+	AggregatedCommitStatusEnabled bool `jsonapi:"attr,aggregated-commit-status-enabled"`
 	// Note: This will be false for TFE versions older than v202211, where the setting was introduced.
 	// On those TFE versions, safe delete does not exist, so ALL deletes will be force deletes.
 	AllowForceDeleteWorkspaces bool `jsonapi:"attr,allow-force-delete-workspaces"`
@@ -216,7 +216,7 @@ type OrganizationCreateOptions struct {
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
-	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
+	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`
@@ -261,7 +261,7 @@ type OrganizationUpdateOptions struct {
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
-	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
+	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`

--- a/organization.go
+++ b/organization.go
@@ -98,8 +98,7 @@ type Organization struct {
 	TwoFactorConformant                               bool                     `jsonapi:"attr,two-factor-conformant"`
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
 	RemainingTestableCount                            int                      `jsonapi:"attr,remaining-testable-count"`
-	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans is ignored.
-	// **Note: This field is still in BETA and subject to change.**
+	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
 	AggregatedCommitStatusEnabled bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 	// Note: This will be false for TFE versions older than v202211, where the setting was introduced.
 	// On those TFE versions, safe delete does not exist, so ALL deletes will be force deletes.
@@ -216,8 +215,7 @@ type OrganizationCreateOptions struct {
 	// Optional: SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
-	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans is ignored.
-	// **Note: This field is still in BETA and subject to change.**
+	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
 	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
@@ -262,8 +260,7 @@ type OrganizationUpdateOptions struct {
 	// SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
-	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans is ignored.
-	// **Note: This field is still in BETA and subject to change.**
+	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
 	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.

--- a/organization.go
+++ b/organization.go
@@ -98,6 +98,9 @@ type Organization struct {
 	TwoFactorConformant                               bool                     `jsonapi:"attr,two-factor-conformant"`
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
 	RemainingTestableCount                            int                      `jsonapi:"attr,remaining-testable-count"`
+	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans is ignored.
+	// **Note: This field is still in BETA and subject to change.**
+	AggregatedCommitStatusEnabled bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 	// Note: This will be false for TFE versions older than v202211, where the setting was introduced.
 	// On those TFE versions, safe delete does not exist, so ALL deletes will be force deletes.
 	AllowForceDeleteWorkspaces bool `jsonapi:"attr,allow-force-delete-workspaces"`
@@ -213,6 +216,10 @@ type OrganizationCreateOptions struct {
 	// Optional: SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
+	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans is ignored.
+	// **Note: This field is still in BETA and subject to change.**
+	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
+
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`
 
@@ -254,6 +261,10 @@ type OrganizationUpdateOptions struct {
 
 	// SendPassingStatusesForUntriggeredSpeculativePlans toggles behavior of untriggered speculative plans to send status updates to version control systems like GitHub.
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
+
+	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans is ignored.
+	// **Note: This field is still in BETA and subject to change.**
+	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`

--- a/organization.go
+++ b/organization.go
@@ -99,7 +99,7 @@ type Organization struct {
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
 	RemainingTestableCount                            int                      `jsonapi:"attr,remaining-testable-count"`
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
-	AggregatedCommitStatusEnabled bool `jsonapi:"attr,aggregated-commit-status-enabled"`
+	AggregatedCommitStatusEnabled bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 	// Note: This will be false for TFE versions older than v202211, where the setting was introduced.
 	// On those TFE versions, safe delete does not exist, so ALL deletes will be force deletes.
 	AllowForceDeleteWorkspaces bool `jsonapi:"attr,allow-force-delete-workspaces"`
@@ -216,7 +216,7 @@ type OrganizationCreateOptions struct {
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
-	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled"`
+	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`
@@ -261,7 +261,7 @@ type OrganizationUpdateOptions struct {
 	SendPassingStatusesForUntriggeredSpeculativePlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
 
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
-	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled"`
+	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -236,6 +236,7 @@ func TestOrganizationsUpdate(t *testing.T) {
 	t.Run("with new AggregatedCommitStatusEnabled option", func(t *testing.T) {
 		skipIfEnterprise(t)
 
+		// verify both test cases
 		for _, testCase := range []bool{true, false} {
 			orgTest, orgTestCleanup := createOrganization(t, client)
 			t.Cleanup(orgTestCleanup)

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -236,7 +236,6 @@ func TestOrganizationsUpdate(t *testing.T) {
 	t.Run("with new AggregatedCommitStatusEnabled option", func(t *testing.T) {
 		skipIfEnterprise(t)
 
-		// verify both test cases
 		for _, testCase := range []bool{true, false} {
 			orgTest, orgTestCleanup := createOrganization(t, client)
 			t.Cleanup(orgTestCleanup)

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -233,6 +233,24 @@ func TestOrganizationsUpdate(t *testing.T) {
 		assert.Equal(t, false, org.SendPassingStatusesForUntriggeredSpeculativePlans)
 	})
 
+	t.Run("with new AggregatedCommitStatusEnabled option", func(t *testing.T) {
+		skipIfEnterprise(t)
+
+		for _, testCase := range []bool{true, false} {
+			orgTest, orgTestCleanup := createOrganization(t, client)
+			t.Cleanup(orgTestCleanup)
+
+			options := OrganizationUpdateOptions{
+				AggregatedCommitStatusEnabled: Bool(testCase),
+			}
+
+			org, err := client.Organizations.Update(ctx, orgTest.Name, options)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase, org.AggregatedCommitStatusEnabled)
+		}
+	})
+
 	t.Run("with valid options", func(t *testing.T) {
 		orgTest, orgTestCleanup := createOrganization(t, client)
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds new Organization field to expose enablement/disablement of the new VCS status check setting. 

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organizations)
- [Organization Setting Documentation](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/organizations#aggregated-status-checks)


## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
