### PR TITLE
Adds AgentsCeilingOverride and RunsCeilingOverride fields in AdminOrganization and AdminOrganizationUpdateOptions structs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 # v1.43.0
 
 ## Features
+* Adds `AgentsCeilingOverride` and `RunsCeilingOverride` fields in `AdminOrganization` and `AdminOrganizationUpdateOptions` structs
 * Adds `AggregatedCommitStatusEnabled` field to `Organization` by @mjyocca [#829](https://github.com/hashicorp/go-tfe/pull/829)
 
 ## Enhancements

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -55,7 +55,8 @@ type AdminOrganization struct {
 	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
 	TerraformWorkerSudoEnabled       bool   `jsonapi:"attr,terraform-worker-sudo-enabled"`
 	WorkspaceLimit                   *int   `jsonapi:"attr,workspace-limit"`
-
+	AgentsCeilingOverride            *int   `jsonapi:"attr,agents-ceiling-override,omitempty"`
+	RunsCeilingOverride              *int   `jsonapi:"attr,runs-ceiling-override,omitempty"`
 	// Relations
 	Owners []*User `jsonapi:"relation,owners"`
 }
@@ -71,6 +72,8 @@ type AdminOrganizationUpdateOptions struct {
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
 	TerraformWorkerSudoEnabled       bool    `jsonapi:"attr,terraform-worker-sudo-enabled,omitempty"`
 	WorkspaceLimit                   *int    `jsonapi:"attr,workspace-limit,omitempty"`
+	AgentsCeilingOverride            *int    `jsonapi:"attr,agents-ceiling-override,omitempty"`
+	RunsCeilingOverride              *int    `jsonapi:"attr,runs-ceiling-override,omitempty"`
 }
 
 // AdminOrganizationList represents a list of organizations via Admin API.


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Add undocumented `agents-ceiling-override` and `runs-ceiling-override` attributes to Organization admin.

## Testing plan

Used in a modified version of the [tfe provider](https://github.com/alex-ikse/terraform-provider-tfe).

## External links

- [API documentation](https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/organizations#update-an-organization)
