### PR TITLE
fix: add missing AdminOrganization field (GlobalProviderSharing)

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -47,6 +47,7 @@ type AdminOrganization struct {
 	AccessBetaTools                  bool   `jsonapi:"attr,access-beta-tools"`
 	ExternalID                       string `jsonapi:"attr,external-id"`
 	GlobalModuleSharing              *bool  `jsonapi:"attr,global-module-sharing"`
+	GlobalProviderSharing            *bool  `jsonapi:"attr,global-provider-sharing"`
 	IsDisabled                       bool   `jsonapi:"attr,is-disabled"`
 	NotificationEmail                string `jsonapi:"attr,notification-email"`
 	SsoEnabled                       bool   `jsonapi:"attr,sso-enabled"`
@@ -64,6 +65,7 @@ type AdminOrganization struct {
 type AdminOrganizationUpdateOptions struct {
 	AccessBetaTools                  *bool   `jsonapi:"attr,access-beta-tools,omitempty"`
 	GlobalModuleSharing              *bool   `jsonapi:"attr,global-module-sharing,omitempty"`
+	GlobalProviderSharing            *bool   `jsonapi:"attr,global-provider-sharing,omitempty"`
 	IsDisabled                       *bool   `jsonapi:"attr,is-disabled,omitempty"`
 	TerraformBuildWorkerApplyTimeout *string `jsonapi:"attr,terraform-build-worker-apply-timeout,omitempty"`
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -220,6 +220,7 @@ func TestAdminOrganizations_Update(t *testing.T) {
 
 		accessBetaTools := true
 		globalModuleSharing := false
+		globalProviderSharing := false
 		isDisabled := false
 		terraformBuildWorkerApplyTimeout := "24h"
 		terraformBuildWorkerPlanTimeout := "24h"
@@ -228,6 +229,7 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		opts := AdminOrganizationUpdateOptions{
 			AccessBetaTools:                  &accessBetaTools,
 			GlobalModuleSharing:              &globalModuleSharing,
+			GlobalProviderSharing:            &globalProviderSharing,
 			IsDisabled:                       &isDisabled,
 			TerraformBuildWorkerApplyTimeout: &terraformBuildWorkerApplyTimeout,
 			TerraformBuildWorkerPlanTimeout:  &terraformBuildWorkerPlanTimeout,
@@ -240,6 +242,7 @@ func TestAdminOrganizations_Update(t *testing.T) {
 
 		assert.Equal(t, accessBetaTools, adminOrg.AccessBetaTools)
 		assert.Equal(t, adminOrg.GlobalModuleSharing, &globalModuleSharing)
+		assert.Equal(t, adminOrg.GlobalProviderSharing, &globalProviderSharing)
 		assert.Equal(t, isDisabled, adminOrg.IsDisabled)
 		assert.Equal(t, terraformBuildWorkerApplyTimeout, adminOrg.TerraformBuildWorkerApplyTimeout)
 		assert.Equal(t, terraformBuildWorkerPlanTimeout, adminOrg.TerraformBuildWorkerPlanTimeout)
@@ -248,11 +251,13 @@ func TestAdminOrganizations_Update(t *testing.T) {
 
 		isDisabled = true
 		globalModuleSharing = true
+		globalProviderSharing = true
 		workspaceLimit := 42
 		opts = AdminOrganizationUpdateOptions{
-			GlobalModuleSharing: &globalModuleSharing,
-			IsDisabled:          &isDisabled,
-			WorkspaceLimit:      &workspaceLimit,
+			GlobalModuleSharing:   &globalModuleSharing,
+			GlobalProviderSharing: &globalProviderSharing,
+			IsDisabled:            &isDisabled,
+			WorkspaceLimit:        &workspaceLimit,
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
@@ -260,16 +265,19 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		require.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
 
 		assert.Equal(t, adminOrg.GlobalModuleSharing, &globalModuleSharing)
+		assert.Equal(t, adminOrg.GlobalProviderSharing, &globalProviderSharing)
 		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
 		assert.Equal(t, &workspaceLimit, adminOrg.WorkspaceLimit)
 
 		globalModuleSharing = false
+		globalProviderSharing = false
 		isDisabled = false
 		workspaceLimit = 0
 		opts = AdminOrganizationUpdateOptions{
-			GlobalModuleSharing: &globalModuleSharing,
-			IsDisabled:          &isDisabled,
-			WorkspaceLimit:      &workspaceLimit,
+			GlobalModuleSharing:   &globalModuleSharing,
+			GlobalProviderSharing: &globalProviderSharing,
+			IsDisabled:            &isDisabled,
+			WorkspaceLimit:        &workspaceLimit,
 		}
 
 		adminOrg, err = client.Admin.Organizations.Update(ctx, org.Name, opts)
@@ -277,6 +285,7 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		require.NotNilf(t, adminOrg, "Org returned as nil when it shouldn't be.")
 
 		assert.Equal(t, &globalModuleSharing, adminOrg.GlobalModuleSharing)
+		assert.Equal(t, &globalProviderSharing, adminOrg.GlobalProviderSharing)
 		assert.Equal(t, adminOrg.IsDisabled, isDisabled)
 
 		assert.Equal(t, &workspaceLimit, adminOrg.WorkspaceLimit)


### PR DESCRIPTION
## Description

We need to set the global-provider-sharing attribute with the `tfe` provider. Sadly, this attributes is not managed by go-tfe right now.


## External links

- [API documentation](https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/organizations#update-an-organization)
