### PR TITLE
Expose AppName header

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Enhancements
+* Updates go-tfe client to export the instance name using `AppName()`
+
 # v1.44.0
 
 ## Enhancements

--- a/tfe.go
+++ b/tfe.go
@@ -487,6 +487,11 @@ func NewClient(cfg *Config) (*Client, error) {
 	return client, nil
 }
 
+// AppName returns the name of the instance.
+func (c Client) AppName() string {
+	return c.appName
+}
+
 // IsCloud returns true if the client is configured against a Terraform Cloud
 // instance.
 //


### PR DESCRIPTION

## Description

This is a helper method that can be used to populate output that describes the instance you're currently running against. Rather than relying on `client.IsCloud()` (or IsEnterprise) checks, we can directly embed the app name value: "Terraform Cloud", "Terraform Enterprise". 

So example output can look like:

```go
fmt.Sprintf("%s is currently executing run with id: %s", client.AppName(), "foo-bar")
```

instead of:

```go
if client.IsCloud() {
  fmt.Println("Terraform Cloud is currently executing run with id foo-bar")
} else {
  fmt.Println("Terraform Enterprise is currently executing run with id foo-bar")
}
```
