### PR TITLE
Allow searching by name on team and project list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Enhancements
+* Adds `Query` field to `Project` and `Team` list options, to allow projects and teams to be searched by name by @JarrettSpiker [#849](https://github.com/hashicorp/go-tfe/pull/849)
+
 # v1.45.0
 
 ## Enhancements

--- a/project.go
+++ b/project.go
@@ -57,10 +57,13 @@ type Project struct {
 type ProjectListOptions struct {
 	ListOptions
 
-	// Optional: String (partial project name) used to filter the results.
+	// Optional: String (complete project name) used to filter the results.
 	// If multiple, comma separated values are specified, projects matching
 	// any of the names are returned.
 	Name string `url:"filter[names],omitempty"`
+
+	// Optional: A query string to search projects by names.
+	Query string `url:"q,omitempty"`
 }
 
 // ProjectCreateOptions represents the options for creating a project

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -34,7 +34,7 @@ func TestProjectsList(t *testing.T) {
 		assert.Equal(t, 3, pl.TotalCount)
 	})
 
-	t.Run("with list options", func(t *testing.T) {
+	t.Run("with pagination list options", func(t *testing.T) {
 		pl, err := client.Projects.List(ctx, orgTest.Name, &ProjectListOptions{
 			ListOptions: ListOptions{
 				PageNumber: 1,
@@ -46,6 +46,15 @@ func TestProjectsList(t *testing.T) {
 		assert.Contains(t, pl.Items, pTest2)
 		assert.Equal(t, true, containsProject(pl.Items, "Default Project"))
 		assert.Equal(t, 3, len(pl.Items))
+	})
+
+	t.Run("with query list option", func(t *testing.T) {
+		pl, err := client.Projects.List(ctx, orgTest.Name, &ProjectListOptions{
+			Query: "Default",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, true, containsProject(pl.Items, "Default Project"))
+		assert.Equal(t, 1, len(pl.Items))
 	})
 
 	t.Run("without a valid organization", func(t *testing.T) {

--- a/team.go
+++ b/team.go
@@ -98,6 +98,9 @@ type TeamListOptions struct {
 
 	// Optional: A list of team names to filter by.
 	Names []string `url:"filter[names],omitempty"`
+
+	// Optional: A query string to search teams by names.
+	Query string `url:"q,omitempty"`
 }
 
 // TeamCreateOptions represents the options for creating a team.

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -33,9 +33,10 @@ func TestTeamsList(t *testing.T) {
 		require.NoError(t, err)
 		assert.Contains(t, tl.Items, tmTest1)
 		assert.Contains(t, tl.Items, tmTest2)
+		assert.Contains(t, tl.Items, tmTest3)
 
 		assert.Equal(t, 1, tl.CurrentPage)
-		assert.Equal(t, 2, tl.TotalCount)
+		assert.Equal(t, 4, tl.TotalCount)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
@@ -51,13 +52,13 @@ func TestTeamsList(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, tl.Items)
 		assert.Equal(t, 999, tl.CurrentPage)
-		assert.Equal(t, 2, tl.TotalCount)
+		assert.Equal(t, 4, tl.TotalCount)
 
 		tl, err = client.Teams.List(ctx, orgTest.Name, &TeamListOptions{
 			Names: []string{tmTest2.Name, tmTest3.Name},
 		})
-
-		assert.Equal(t, tl.Items, 2)
+		require.NoError(t, err)
+		assert.Equal(t, len(tl.Items), 2)
 		assert.Contains(t, tl.Items, tmTest2)
 		assert.Contains(t, tl.Items, tmTest3)
 

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -34,13 +34,11 @@ func TestTeamsList(t *testing.T) {
 		assert.Contains(t, tl.Items, tmTest1)
 		assert.Contains(t, tl.Items, tmTest2)
 
-		t.Skip("paging not supported yet in API")
 		assert.Equal(t, 1, tl.CurrentPage)
 		assert.Equal(t, 2, tl.TotalCount)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		t.Skip("paging not supported yet in API")
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
@@ -62,6 +60,14 @@ func TestTeamsList(t *testing.T) {
 		assert.Equal(t, tl.Items, 2)
 		assert.Contains(t, tl.Items, tmTest2)
 		assert.Contains(t, tl.Items, tmTest3)
+
+		tl, err = client.Teams.List(ctx, orgTest.Name, &TeamListOptions{
+			Query: tmTest1.Name[:len(tmTest1.Name)-2],
+		})
+		require.NoError(t, err)
+		assert.Equal(t, len(tl.Items), 1)
+		assert.Equal(t, 1, tl.TotalCount)
+		assert.Contains(t, tl.Items, tmTest1)
 
 		t.Run("with invalid names query param", func(t *testing.T) {
 			// should return an error because we've included an empty string


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds `Query` parameter to team and project list options. This allows teams and projects to be searched by name through go-tfe.

## Testing plan

1. Teams.List can now accept a query parameter which filters results by name
1.  Projects.List can now accept a query parameter which filters results by name

## External links

- [Teams API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/teams#list-teams)
- [Projects API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/projects#list-projects)

## Output from tests

```
go test -timeout 30s -run ^TestProjectsList$ github.com/hashicorp/go-tfe

=== RUN   TestProjectsList
=== RUN   TestProjectsList/without_list_options
--- PASS: TestProjectsList/without_list_options (0.16s)
=== RUN   TestProjectsList/with_pagination_list_options
--- PASS: TestProjectsList/with_pagination_list_options (0.16s)
=== RUN   TestProjectsList/with_query_list_option
--- PASS: TestProjectsList/with_query_list_option (0.17s)
=== RUN   TestProjectsList/without_a_valid_organization
--- PASS: TestProjectsList/without_a_valid_organization (0.00s)
--- PASS: TestProjectsList (2.10s)
PASS
ok      github.com/hashicorp/go-tfe     2.732s


go test -timeout 30s -run ^TestTeamsList$ github.com/hashicorp/go-tfe

=== RUN   TestTeamsList
=== RUN   TestTeamsList/without_list_options
--- PASS: TestTeamsList/without_list_options (0.34s)
=== RUN   TestTeamsList/with_list_options
=== RUN   TestTeamsList/with_list_options/with_invalid_names_query_param
--- PASS: TestTeamsList/with_list_options/with_invalid_names_query_param (0.00s)
--- PASS: TestTeamsList/with_list_options (0.64s)
=== RUN   TestTeamsList/without_a_valid_organization
--- PASS: TestTeamsList/without_a_valid_organization (0.00s)
--- PASS: TestTeamsList (3.29s)
PASS
ok      github.com/hashicorp/go-tfe     3.780s

...
```
