### PR TITLE
Add sort field to workspace list options

### DIFF
--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -93,7 +93,7 @@ func TestAdminWorkspaces_ListWithSort(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, wl.Items)
 		require.GreaterOrEqual(t, len(wl.Items), 2)
-		require.Equal(t, wl.Items[1].CurrentRun.CreatedAt.After(wl.Items[0].CurrentRun.CreatedAt), true)
+		assert.True(t, wl.Items[1].CurrentRun.CreatedAt.After(wl.Items[0].CurrentRun.CreatedAt))
 	})
 }
 

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -87,7 +87,8 @@ func TestAdminWorkspaces_ListWithSort(t *testing.T) {
 		t.Cleanup(unappliedCleanup2)
 
 		wl, err := client.Admin.Workspaces.List(ctx, &AdminWorkspaceListOptions{
-			Sort: "current-run.created-at",
+			Include: []AdminWorkspaceIncludeOpt{AdminWorkspaceCurrentRun},
+			Sort:    "current-run.created-at",
 		})
 
 		require.NoError(t, err)

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -93,6 +93,7 @@ func TestAdminWorkspaces_ListWithSort(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, wl.Items)
 		require.GreaterOrEqual(t, len(wl.Items), 2)
+		require.Equal(t, wl.Items[1].CurrentRun.CreatedAt.After(wl.Items[0].CurrentRun.CreatedAt), true)
 	})
 }
 

--- a/workspace.go
+++ b/workspace.go
@@ -307,6 +307,10 @@ type WorkspaceListOptions struct {
 
 	// Optional: A list of relations to include. See available resources https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#available-related-resources
 	Include []WSIncludeOpt `url:"include,omitempty"`
+
+	// Optional: May sort on "name" (the default) and "current-run.created-at" (which sorts by the time of the current run)
+	// Prepending a hyphen to the sort parameter will reverse the order (e.g. "-name" to reverse the default order)
+	Sort string `url:"sort,omitempty"`
 }
 
 // WorkspaceCreateOptions represents the options for creating a new workspace.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -44,6 +44,8 @@ func TestWorkspacesList(t *testing.T) {
 	t.Cleanup(wTest1Cleanup)
 	wTest2, wTest2Cleanup := createWorkspace(t, client, orgTest)
 	t.Cleanup(wTest2Cleanup)
+	wTest3, wTest3Cleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wTest3Cleanup)
 
 	t.Run("without list options", func(t *testing.T) {
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, nil)
@@ -51,7 +53,7 @@ func TestWorkspacesList(t *testing.T) {
 		assert.Contains(t, wl.Items, wTest1)
 		assert.Contains(t, wl.Items, wTest2)
 		assert.Equal(t, 1, wl.CurrentPage)
-		assert.Equal(t, 2, wl.TotalCount)
+		assert.Equal(t, 3, wl.TotalCount)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
@@ -67,7 +69,7 @@ func TestWorkspacesList(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, wl.Items)
 		assert.Equal(t, 999, wl.CurrentPage)
-		assert.Equal(t, 2, wl.TotalCount)
+		assert.Equal(t, 3, wl.TotalCount)
 	})
 
 	t.Run("when sorting by workspace names", func(t *testing.T) {
@@ -81,10 +83,10 @@ func TestWorkspacesList(t *testing.T) {
 	})
 
 	t.Run("when sorting workspaces on current-run.created-at", func(t *testing.T) {
-		_, unappliedCleanup1 := createRunUnapplied(t, client, wTest1)
+		_, unappliedCleanup1 := createRunUnapplied(t, client, wTest2)
 		t.Cleanup(unappliedCleanup1)
 
-		_, unappliedCleanup2 := createRunUnapplied(t, client, wTest2)
+		_, unappliedCleanup2 := createRunUnapplied(t, client, wTest3)
 		t.Cleanup(unappliedCleanup2)
 
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
@@ -94,7 +96,7 @@ func TestWorkspacesList(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, wl.Items)
 		require.GreaterOrEqual(t, len(wl.Items), 2)
-		require.Equal(t, wl.Items[1].CreatedAt.After(wl.Items[0].CreatedAt), true)
+		assert.True(t, wl.Items[1].CreatedAt.After(wl.Items[0].CreatedAt))
 	})
 
 	t.Run("when searching a known workspace", func(t *testing.T) {
@@ -135,7 +137,7 @@ func TestWorkspacesList(t *testing.T) {
 	})
 
 	t.Run("when searching using exclude-tags", func(t *testing.T) {
-		for wsID, tag := range map[string]string{wTest1.ID: "foo", wTest2.ID: "bar"} {
+		for wsID, tag := range map[string]string{wTest1.ID: "foo", wTest2.ID: "bar", wTest3.ID: "foo"} {
 			err := client.Workspaces.AddTags(ctx, wsID, WorkspaceAddTagsOptions{
 				Tags: []*Tag{
 					{

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -90,13 +90,14 @@ func TestWorkspacesList(t *testing.T) {
 		t.Cleanup(unappliedCleanup2)
 
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
-			Sort: "current-run.created-at",
+			Include: []WSIncludeOpt{WSCurrentRun},
+			Sort:    "current-run.created-at",
 		})
 
 		require.NoError(t, err)
 		require.NotEmpty(t, wl.Items)
 		require.GreaterOrEqual(t, len(wl.Items), 2)
-		assert.True(t, wl.Items[1].CreatedAt.After(wl.Items[0].CreatedAt))
+		assert.True(t, wl.Items[1].CurrentRun.CreatedAt.After(wl.Items[0].CurrentRun.CreatedAt))
 	})
 
 	t.Run("when searching a known workspace", func(t *testing.T) {


### PR DESCRIPTION
## Description

Adds the `Sort` query parameter to `WorkspaceListOptions`. Was previously present in `AdminWorkspaceListOptions` but was missing in `WorkspaceListOptions` despite the two endpoints having an identical sort behavior, implemented by the same service object class in atlas. 

OTHER NOTE: Added a greater degree of specificity to the test covering `Sort`'s `created-at` behavior for the admin side of things.

## Testing plan

Tests covering this `Sort` behavior have been added to `workspace_integration_test.go`. 

## External links

[Jira Ticket](https://hashicorp.atlassian.net/jira/software/c/projects/TF/boards/605?selectedIssue=TF-5421)

## Output from tests

![Screenshot 2024-02-23 at 11 33 03 AM](https://github.com/hashicorp/go-tfe/assets/72527044/8b85336a-6b8b-42fc-8db3-ff19b3642343)

