### PR TITLE
Add Variables to the Workspace relations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds `Variables` relationship field to `Workspace` by @arybolovlev [#872](https://github.com/hashicorp/go-tfe/pull/872)
+
 # v1.47.1
 
 ## Bug fixes

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -79,6 +79,10 @@ func TestVariablesCreate(t *testing.T) {
 		v, err := client.Variables.Create(ctx, wTest.ID, options)
 		require.NoError(t, err)
 
+		// Refresh workspace once the variable is created.
+		reWorkspace, err := client.Workspaces.ReadByID(ctx, wTest.ID)
+		require.NoError(t, err)
+
 		assert.NotEmpty(t, v.ID)
 		assert.Equal(t, *options.Key, v.Key)
 		assert.Equal(t, *options.Value, v.Value)
@@ -87,6 +91,9 @@ func TestVariablesCreate(t *testing.T) {
 		// The workspace isn't returned correcly by the API.
 		// assert.Equal(t, *options.Workspace, v.Workspace)
 		assert.NotEmpty(t, v.VersionID)
+		// Validate that the same Variable is now listed in Workspace relations.
+		assert.NotEmpty(t, reWorkspace.Variables)
+		assert.Equal(t, reWorkspace.Variables[0].ID, v.ID)
 	})
 
 	t.Run("when options has an empty string value", func(t *testing.T) {

--- a/workspace.go
+++ b/workspace.go
@@ -205,6 +205,7 @@ type Workspace struct {
 	Tags                        []*Tag                `jsonapi:"relation,tags"`
 	CurrentConfigurationVersion *ConfigurationVersion `jsonapi:"relation,current-configuration-version,omitempty"`
 	LockedBy                    *LockedByChoice       `jsonapi:"polyrelation,locked-by"`
+	Variables                   []*Variable           `jsonapi:"relation,vars"`
 
 	// Deprecated: Use DataRetentionPolicyChoice instead.
 	DataRetentionPolicy *DataRetentionPolicy


### PR DESCRIPTION
## Description

This PR adds Variables to the Workspace relations.

```console
$ curl -s \
  --header "Authorization: Bearer $TFE_TOKEN" \
  --header "Content-Type: application/vnd.api+json" \
  --request GET \
"https://app.terraform.io/api/v2/workspaces/ws-XXX" | jq
```

```json
    "relationships": {
      ...
      "vars": {
        "data": [
          {
            "id": "var-xh8w2W4bZJ3X4HH9",
            "type": "vars"
          },
          {
            "id": "var-PStyaxTNYWszMBoy",
            "type": "vars"
          }
        ]
      }
      ...
    }
```

## Testing plan

N/A.

## External links

Relations are purely documented in the [API doc](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces), however, `vars` are mentioned there one. 

## Output from tests

Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
$ TFE_ADDRESS="https://app.terraform.io/" TFE_TOKEN="X.atlasv1.X" go test ./... -v -run TestVariablesCreate$

PASS
ok  	github.com/hashicorp/go-tfe	5.293s
```
