### PR TITLE
Add Manage Permissions to Team Organization Access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Adds `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` permissions to team `OrganizationAccess` by @juliannatetreault [#874](https://github.com/hashicorp/go-tfe/pull/874)
 
 # v1.52.0
 
@@ -24,7 +25,6 @@
 * Add `Stages` field to `WorkspaceRunTask`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
 * Changing BETA `OrganizationScoped` attribute of `OAuthClient` to be a pointer for bug fix by @netramali [884](https://github.com/hashicorp/go-tfe/pull/884)
 * Adds `Query` parameter to `VariableSetListOptions` to allow searching variable sets by name, by @JarrettSpiker[#877](https://github.com/hashicorp/go-tfe/pull/877)
-* Adds `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` permissions to team `OrganizationAccess` by @juliannatetreault [#874](https://github.com/hashicorp/go-tfe/pull/874)
 
 ## Deprecations
 * The `Stage` field has been deprecated on `WorkspaceRunTask`. Instead, use `Stages`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
@@ -51,14 +51,6 @@
 
 ## Bug fixes
 * Change the error message for `ErrWorkspaceStillProcessing` to be the same error message returned by the API by @uturunku1 [#864](https://github.com/hashicorp/go-tfe/pull/864)
-
-## Features
-*For Terraform Enterprise users who have data retention policies defined on Organizations or Workspaces: A new DataRetentionPolicyChoice relation has been added to reflect that [data retention policies are polymorphic](https://developer.hashicorp.com/terraform/enterprise/api-docs/data-retention-policies#data-retention-policy-types). Organizations and workspaces may be related to a `DataRetentionPolicyDeleteOlder` or `DataRetentionPolicyDontDelete` record through the `DataRetentionPolicyChoice` struct. Data retention policies can be read using `ReadDataRetentionPolicyChoice`, and set or updated (including changing their type) using `SetDataRetentionPolicyDeleteOlder` or `SetDataRetentionPolicyDontDelete` by  @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
-
-## Deprecations
-* The `DataRetentionPolicy` type, and the `DataRetentionPolicy` relationship on `Organization` and `Workspace`s have been deprecated. The `DataRetentionPolicy` type is equivalent to the new `DataRetentionPolicyDeleteOlder`. The Data retention policy relationships on `Organization` and `Workspace`s are now [polymorphic](https://developer.hashicorp.com/terraform/enterprise/api-docs/data-retention-policies#data-retention-policy-types), and are represented by the `DataRetentionPolicyChoice` relationship. The existing `DataRetentionPolicy` relationship will continue to be populated when reading an `Organization` or `Workspace`, but it may be removed in a future release. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
-* The `SetDataRetentionPolicy` function on `Organizations` and `Workspaces` is now deprecated in favour of `SetDataRetentionPolicyDeleteOlder` or `SetDataRetentionPolicyDontDelete`. `SetDataRetentionPolicy` will only update the data retention policy when communicating with TFE versions v202311 and v202312. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
-* The `ReadDataRetentionPolicy` function on `Organizations` and `Workspaces` is now deprecated in favour of `ReadDataRetentionPolicyChoice`. `ReadDataRetentionPolicyChoice` may return the different multiple data retention policy types added in TFE 202401-1. `SetDataRetentionPolicy` will only update the data retention policy when communicating with TFE versions v202311 and v202312. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
 
 # v1.47.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 * Add `Stages` field to `WorkspaceRunTask`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
 * Changing BETA `OrganizationScoped` attribute of `OAuthClient` to be a pointer for bug fix by @netramali [884](https://github.com/hashicorp/go-tfe/pull/884)
 * Adds `Query` parameter to `VariableSetListOptions` to allow searching variable sets by name, by @JarrettSpiker[#877](https://github.com/hashicorp/go-tfe/pull/877)
+* Adds `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` permissions to team `OrganizationAccess` by @juliannatetreault []()
 
 ## Deprecations
 * The `Stage` field has been deprecated on `WorkspaceRunTask`. Instead, use `Stages`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
@@ -51,7 +52,13 @@
 ## Bug fixes
 * Change the error message for `ErrWorkspaceStillProcessing` to be the same error message returned by the API by @uturunku1 [#864](https://github.com/hashicorp/go-tfe/pull/864)
 
-# v1.47.0
+## Features
+*For Terraform Enterprise users who have data retention policies defined on Organizations or Workspaces: A new DataRetentionPolicyChoice relation has been added to reflect that [data retention policies are polymorphic](https://developer.hashicorp.com/terraform/enterprise/api-docs/data-retention-policies#data-retention-policy-types). Organizations and workspaces may be related to a `DataRetentionPolicyDeleteOlder` or `DataRetentionPolicyDontDelete` record through the `DataRetentionPolicyChoice` struct. Data retention policies can be read using `ReadDataRetentionPolicyChoice`, and set or updated (including changing their type) using `SetDataRetentionPolicyDeleteOlder` or `SetDataRetentionPolicyDontDelete` by  @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
+
+## Deprecations
+* The `DataRetentionPolicy` type, and the `DataRetentionPolicy` relationship on `Organization` and `Workspace`s have been deprecated. The `DataRetentionPolicy` type is equivalent to the new `DataRetentionPolicyDeleteOlder`. The Data retention policy relationships on `Organization` and `Workspace`s are now [polymorphic](https://developer.hashicorp.com/terraform/enterprise/api-docs/data-retention-policies#data-retention-policy-types), and are represented by the `DataRetentionPolicyChoice` relationship. The existing `DataRetentionPolicy` relationship will continue to be populated when reading an `Organization` or `Workspace`, but it may be removed in a future release. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
+* The `SetDataRetentionPolicy` function on `Organizations` and `Workspaces` is now deprecated in favour of `SetDataRetentionPolicyDeleteOlder` or `SetDataRetentionPolicyDontDelete`. `SetDataRetentionPolicy` will only update the data retention policy when communicating with TFE versions v202311 and v202312. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
+* The `ReadDataRetentionPolicy` function on `Organizations` and `Workspaces` is now deprecated in favour of `ReadDataRetentionPolicyChoice`. `ReadDataRetentionPolicyChoice` may return the different multiple data retention policy types added in TFE 202401-1. `SetDataRetentionPolicy` will only update the data retention policy when communicating with TFE versions v202311 and v202312. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
 
 ## Enhancements
 * Adds BETA `description` attribute to `Project` by @netramali [#861](https://github.com/hashicorp/go-tfe/pull/861)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,7 @@
 * Add `Stages` field to `WorkspaceRunTask`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
 * Changing BETA `OrganizationScoped` attribute of `OAuthClient` to be a pointer for bug fix by @netramali [884](https://github.com/hashicorp/go-tfe/pull/884)
 * Adds `Query` parameter to `VariableSetListOptions` to allow searching variable sets by name, by @JarrettSpiker[#877](https://github.com/hashicorp/go-tfe/pull/877)
-* Adds `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` permissions to team `OrganizationAccess` by @juliannatetreault []()
+* Adds `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` permissions to team `OrganizationAccess` by @juliannatetreault [#874](https://github.com/hashicorp/go-tfe/pull/874)
 
 ## Deprecations
 * The `Stage` field has been deprecated on `WorkspaceRunTask`. Instead, use `Stages`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
@@ -46,7 +46,6 @@
 
 ## Enhancements
 * Adds `Variables` relationship field to `Workspace` by @arybolovlev [#872](https://github.com/hashicorp/go-tfe/pull/872)
-* Adds `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` permissions to team `OrganizationAccess` by @juliannatetreault [#874](https://github.com/hashicorp/go-tfe/pull/874)
 
 # v1.47.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@
 
 ## Enhancements
 * Adds `Variables` relationship field to `Workspace` by @arybolovlev [#872](https://github.com/hashicorp/go-tfe/pull/872)
+* Adds `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` permissions to team `OrganizationAccess` by @juliannatetreault [#874](https://github.com/hashicorp/go-tfe/pull/874)
 
 # v1.47.1
 
@@ -59,6 +60,8 @@
 * The `DataRetentionPolicy` type, and the `DataRetentionPolicy` relationship on `Organization` and `Workspace`s have been deprecated. The `DataRetentionPolicy` type is equivalent to the new `DataRetentionPolicyDeleteOlder`. The Data retention policy relationships on `Organization` and `Workspace`s are now [polymorphic](https://developer.hashicorp.com/terraform/enterprise/api-docs/data-retention-policies#data-retention-policy-types), and are represented by the `DataRetentionPolicyChoice` relationship. The existing `DataRetentionPolicy` relationship will continue to be populated when reading an `Organization` or `Workspace`, but it may be removed in a future release. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
 * The `SetDataRetentionPolicy` function on `Organizations` and `Workspaces` is now deprecated in favour of `SetDataRetentionPolicyDeleteOlder` or `SetDataRetentionPolicyDontDelete`. `SetDataRetentionPolicy` will only update the data retention policy when communicating with TFE versions v202311 and v202312. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
 * The `ReadDataRetentionPolicy` function on `Organizations` and `Workspaces` is now deprecated in favour of `ReadDataRetentionPolicyChoice`. `ReadDataRetentionPolicyChoice` may return the different multiple data retention policy types added in TFE 202401-1. `SetDataRetentionPolicy` will only update the data retention policy when communicating with TFE versions v202311 and v202312. @JarrettSpiker [#652](https://github.com/hashicorp/go-tfe/pull/844)
+
+# v1.47.0
 
 ## Enhancements
 * Adds BETA `description` attribute to `Project` by @netramali [#861](https://github.com/hashicorp/go-tfe/pull/861)

--- a/team.go
+++ b/team.go
@@ -161,9 +161,9 @@ type OrganizationAccessOptions struct {
 	ReadWorkspaces           *bool `json:"read-workspaces,omitempty"`
 	ReadProjects             *bool `json:"read-projects,omitempty"`
 	ManageMembership         *bool `json:"manage-membership,omitempty"`
-	ManageTeams              *bool `jsonapi:"attr,manage-teams,omitempty"`
-	ManageOrganizationAccess *bool `jsonapi:"attr,manage-organization-access,omitempty"`
-	AccessSecretTeams        *bool `jsonapi:"attr,access-secret-teams,omitempty"`
+	ManageTeams              *bool `json:"manage-teams,omitempty"`
+	ManageOrganizationAccess *bool `json:"manage-organization-access,omitempty"`
+	AccessSecretTeams        *bool `json:"access-secret-teams,omitempty"`
 }
 
 // List all the teams of the given organization.

--- a/team.go
+++ b/team.go
@@ -61,17 +61,20 @@ type Team struct {
 
 // OrganizationAccess represents the team's permissions on its organization
 type OrganizationAccess struct {
-	ManagePolicies        bool `jsonapi:"attr,manage-policies"`
-	ManagePolicyOverrides bool `jsonapi:"attr,manage-policy-overrides"`
-	ManageWorkspaces      bool `jsonapi:"attr,manage-workspaces"`
-	ManageVCSSettings     bool `jsonapi:"attr,manage-vcs-settings"`
-	ManageProviders       bool `jsonapi:"attr,manage-providers"`
-	ManageModules         bool `jsonapi:"attr,manage-modules"`
-	ManageRunTasks        bool `jsonapi:"attr,manage-run-tasks"`
-	ManageProjects        bool `jsonapi:"attr,manage-projects"`
-	ReadWorkspaces        bool `jsonapi:"attr,read-workspaces"`
-	ReadProjects          bool `jsonapi:"attr,read-projects"`
-	ManageMembership      bool `jsonapi:"attr,manage-membership"`
+	ManagePolicies           bool `jsonapi:"attr,manage-policies"`
+	ManagePolicyOverrides    bool `jsonapi:"attr,manage-policy-overrides"`
+	ManageWorkspaces         bool `jsonapi:"attr,manage-workspaces"`
+	ManageVCSSettings        bool `jsonapi:"attr,manage-vcs-settings"`
+	ManageProviders          bool `jsonapi:"attr,manage-providers"`
+	ManageModules            bool `jsonapi:"attr,manage-modules"`
+	ManageRunTasks           bool `jsonapi:"attr,manage-run-tasks"`
+	ManageProjects           bool `jsonapi:"attr,manage-projects"`
+	ReadWorkspaces           bool `jsonapi:"attr,read-workspaces"`
+	ReadProjects             bool `jsonapi:"attr,read-projects"`
+	ManageMembership         bool `jsonapi:"attr,manage-membership"`
+	ManageTeams              bool `jsonapi:"attr,manage-teams"`
+	ManageOrganizationAccess bool `jsonapi:"attr,manage-organization-access"`
+	AccessSecretTeams        bool `jsonapi:"attr,access-secret-teams"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -147,17 +150,20 @@ type TeamUpdateOptions struct {
 
 // OrganizationAccessOptions represents the organization access options of a team.
 type OrganizationAccessOptions struct {
-	ManagePolicies        *bool `json:"manage-policies,omitempty"`
-	ManagePolicyOverrides *bool `json:"manage-policy-overrides,omitempty"`
-	ManageWorkspaces      *bool `json:"manage-workspaces,omitempty"`
-	ManageVCSSettings     *bool `json:"manage-vcs-settings,omitempty"`
-	ManageProviders       *bool `json:"manage-providers,omitempty"`
-	ManageModules         *bool `json:"manage-modules,omitempty"`
-	ManageRunTasks        *bool `json:"manage-run-tasks,omitempty"`
-	ManageProjects        *bool `json:"manage-projects,omitempty"`
-	ReadWorkspaces        *bool `json:"read-workspaces,omitempty"`
-	ReadProjects          *bool `json:"read-projects,omitempty"`
-	ManageMembership      *bool `json:"manage-membership,omitempty"`
+	ManagePolicies           *bool `json:"manage-policies,omitempty"`
+	ManagePolicyOverrides    *bool `json:"manage-policy-overrides,omitempty"`
+	ManageWorkspaces         *bool `json:"manage-workspaces,omitempty"`
+	ManageVCSSettings        *bool `json:"manage-vcs-settings,omitempty"`
+	ManageProviders          *bool `json:"manage-providers,omitempty"`
+	ManageModules            *bool `json:"manage-modules,omitempty"`
+	ManageRunTasks           *bool `json:"manage-run-tasks,omitempty"`
+	ManageProjects           *bool `json:"manage-projects,omitempty"`
+	ReadWorkspaces           *bool `json:"read-workspaces,omitempty"`
+	ReadProjects             *bool `json:"read-projects,omitempty"`
+	ManageMembership         *bool `json:"manage-membership,omitempty"`
+	ManageTeams              *bool `jsonapi:"attr,manage-teams,omitempty"`
+	ManageOrganizationAccess *bool `jsonapi:"attr,manage-organization-access,omitempty"`
+	AccessSecretTeams        *bool `jsonapi:"attr,access-secret-teams,omitempty"`
 }
 
 // List all the teams of the given organization.

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -482,3 +482,108 @@ func TestTeamsUpdateManageManageMembership(t *testing.T) {
 	originalTeamAccess.ManageMembership = true
 	assert.Equal(t, originalTeamAccess, refreshed.OrganizationAccess)
 }
+
+func TestTeamsUpdateManageOrganizationAccess(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
+	defer tmTestCleanup()
+
+	teamRead, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.False(t, teamRead.OrganizationAccess.ManageOrganizationAccess, "manage organization access is false by default")
+
+	originalTeamAccess := teamRead.OrganizationAccess
+
+	options := TeamUpdateOptions{
+		OrganizationAccess: &OrganizationAccessOptions{
+			ManageOrganizationAccess: Bool(true),
+		},
+	}
+
+	tm, err := client.Teams.Update(ctx, tmTest.ID, options)
+	require.NoError(t, err)
+	assert.True(t, tm.OrganizationAccess.ManageOrganizationAccess)
+
+	refreshed, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.True(t, refreshed.OrganizationAccess.ManageOrganizationAccess)
+
+	// Check that other org access fields are not updated
+	originalTeamAccess.ManageOrganizationAccess = true
+	assert.Equal(t, originalTeamAccess, refreshed.OrganizationAccess)
+}
+
+func TestTeamsUpdateAccessSecretTeams(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
+	defer tmTestCleanup()
+
+	teamRead, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.False(t, teamRead.OrganizationAccess.AccessSecretTeams, "access secret teams is false by default")
+
+	originalTeamAccess := teamRead.OrganizationAccess
+
+	options := TeamUpdateOptions{
+		OrganizationAccess: &OrganizationAccessOptions{
+			AccessSecretTeams: Bool(true),
+		},
+	}
+
+	tm, err := client.Teams.Update(ctx, tmTest.ID, options)
+	require.NoError(t, err)
+	assert.True(t, tm.OrganizationAccess.AccessSecretTeams)
+
+	refreshed, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.True(t, refreshed.OrganizationAccess.AccessSecretTeams)
+
+	// Check that other org access fields are not updated
+	originalTeamAccess.AccessSecretTeams = true
+	assert.Equal(t, originalTeamAccess, refreshed.OrganizationAccess)
+}
+
+func TestTeamsUpdateManageTeams(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
+	defer tmTestCleanup()
+
+	teamRead, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.False(t, teamRead.OrganizationAccess.ManageTeams, "manage teams is false by default")
+
+	originalTeamAccess := teamRead.OrganizationAccess
+
+	options := TeamUpdateOptions{
+		OrganizationAccess: &OrganizationAccessOptions{
+			ManageTeams: Bool(true),
+		},
+	}
+
+	tm, err := client.Teams.Update(ctx, tmTest.ID, options)
+	require.NoError(t, err)
+	assert.True(t, tm.OrganizationAccess.ManageTeams)
+
+	refreshed, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.True(t, refreshed.OrganizationAccess.ManageTeams)
+
+	// Check that other org access fields are not updated
+	originalTeamAccess.ManageTeams = true
+	assert.Equal(t, originalTeamAccess, refreshed.OrganizationAccess)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds new manage permissions - `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` - to team organization access. Additionally, this PR adds tests for the new permissions.

## Testing plan

- `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` are `false` by default when Teams are created.
- `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` is read for Teams.
- `ManageTeams`, `ManageOrganizationAccess`, and `AccessSecretTeams` should be updatable through the `OrganizationAccessOptions`.

## External links

<!--
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
