### PR TITLE
Bump nightly instance job timeout to 20m

### DIFF
--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   instance:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - name: terraform-cloud/apply
         uses: hashicorp-forge/terraform-cloud-action/apply@4adbe7eea886138ac10a4c09e63c5c568aaa6672


### PR DESCRIPTION
Timeouts are resulting workflow failures since runs are taking longer than 10m to complete. 
