### PR TITLE
Add Query parameter to varset list options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 * Add `Global` field to `RunTask`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
 * Add `Stages` field to `WorkspaceRunTask`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
 * Changing BETA `OrganizationScoped` attribute of `OAuthClient` to be a pointer for bug fix by @netramali [884](https://github.com/hashicorp/go-tfe/pull/884)
+* Adds `Query` parameter to `VariableSetListOptions` to allow searching variable sets by name, by @JarrettSpiker[#877](https://github.com/hashicorp/go-tfe/pull/877)
+
 
 ## Deprecations
 * The `Stage` field has been deprecated on `WorkspaceRunTask`. Instead, use `Stages`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)

--- a/variable_set.go
+++ b/variable_set.go
@@ -94,6 +94,10 @@ const (
 type VariableSetListOptions struct {
 	ListOptions
 	Include string `url:"include"`
+
+	// Optional: A query string used to filter variable sets.
+	// Any variable sets with a name partially matching this value will be returned.
+	Query string `url:"q,omitempty"`
 }
 
 // VariableSetCreateOptions represents the options for creating a new variable set within in a organization.

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -30,13 +30,11 @@ func TestVariableSetsList(t *testing.T) {
 		assert.Contains(t, vsl.Items, vsTest1)
 		assert.Contains(t, vsl.Items, vsTest2)
 
-		t.Skip("paging not supported yet in API")
 		assert.Equal(t, 1, vsl.CurrentPage)
 		assert.Equal(t, 2, vsl.TotalCount)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		t.Skip("paging not supported yet in API")
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
@@ -56,6 +54,15 @@ func TestVariableSetsList(t *testing.T) {
 		vsl, err := client.VariableSets.List(ctx, badIdentifier, nil)
 		assert.Nil(t, vsl)
 		assert.EqualError(t, err, ErrInvalidOrg.Error())
+	})
+
+	t.Run("with query parameter", func(t *testing.T) {
+		vsl, err := client.VariableSets.List(ctx, orgTest.Name, &VariableSetListOptions{
+			Query: vsTest2.Name,
+		})
+		require.NoError(t, err)
+		assert.Len(t, vsl.Items, 1)
+		assert.Equal(t, vsTest2.ID, vsl.Items[0].ID)
 	})
 }
 
@@ -88,7 +95,6 @@ func TestVariableSetsListForWorkspace(t *testing.T) {
 	})
 
 	t.Run("with list options", func(t *testing.T) {
-		t.Skip("paging not supported yet in API")
 		// Request a page number which is out of range. The result should
 		// be successful, but return no results if the paging options are
 		// properly passed along.
@@ -108,6 +114,15 @@ func TestVariableSetsListForWorkspace(t *testing.T) {
 		vsl, err := client.VariableSets.ListForWorkspace(ctx, badIdentifier, nil)
 		assert.Nil(t, vsl)
 		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
+	})
+
+	t.Run("with query parameter", func(t *testing.T) {
+		vsl, err := client.VariableSets.List(ctx, orgTest.Name, &VariableSetListOptions{
+			Query: vsTest2.Name,
+		})
+		require.NoError(t, err)
+		assert.Len(t, vsl.Items, 1)
+		assert.Equal(t, vsTest2.ID, vsl.Items[0].ID)
 	})
 }
 
@@ -156,6 +171,15 @@ func TestVariableSetsListForProject(t *testing.T) {
 		vsl, err := client.VariableSets.ListForProject(ctx, badIdentifier, nil)
 		assert.Nil(t, vsl)
 		assert.EqualError(t, err, ErrInvalidProjectID.Error())
+	})
+
+	t.Run("with query parameter", func(t *testing.T) {
+		vsl, err := client.VariableSets.List(ctx, orgTest.Name, &VariableSetListOptions{
+			Query: vsTest2.Name,
+		})
+		require.NoError(t, err)
+		assert.Len(t, vsl.Items, 1)
+		assert.Equal(t, vsTest2.ID, vsl.Items[0].ID)
 	})
 }
 


### PR DESCRIPTION
## Description

I noticed that we were missing this bit of functionality in the [API docs ](https://github.com/hashicorp/terraform-docs-common/pull/589) and in go-tfe

Adds a `Query` parameter to variable set list options

## Testing plan

1. Test searching for organization varsets with a parameter that returns a subset of results
2. Test searching for organization varsets with a parameter that returns no results
1. Test searching for project varsets with a parameter that returns a subset of results
2. Test searching for project varsets with a parameter that returns no results
1. Test searching for workspace varsets with a parameter that returns a subset of results
2. Test searching for workspace varsets with a parameter that returns no results

## External links

- [API documentation](https://github.com/hashicorp/terraform-docs-common/pull/589)


## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
❯ go test -run TestVariableSetsList -v
=== RUN   TestVariableSetsList
=== RUN   TestVariableSetsList/without_list_options
=== RUN   TestVariableSetsList/with_list_options
=== RUN   TestVariableSetsList/when_Organization_name_is_an_invalid_ID
=== RUN   TestVariableSetsList/with_query_parameter
--- PASS: TestVariableSetsList (2.56s)
    --- PASS: TestVariableSetsList/without_list_options (0.22s)
    --- PASS: TestVariableSetsList/with_list_options (0.21s)
    --- PASS: TestVariableSetsList/when_Organization_name_is_an_invalid_ID (0.00s)
    --- PASS: TestVariableSetsList/with_query_parameter (0.21s)
=== RUN   TestVariableSetsListForWorkspace
=== RUN   TestVariableSetsListForWorkspace/without_list_options
=== RUN   TestVariableSetsListForWorkspace/with_list_options
=== RUN   TestVariableSetsListForWorkspace/when_Workspace_ID_is_an_invalid_ID
=== RUN   TestVariableSetsListForWorkspace/with_query_parameter
--- PASS: TestVariableSetsListForWorkspace (3.44s)
    --- PASS: TestVariableSetsListForWorkspace/without_list_options (0.24s)
    --- PASS: TestVariableSetsListForWorkspace/with_list_options (0.20s)
    --- PASS: TestVariableSetsListForWorkspace/when_Workspace_ID_is_an_invalid_ID (0.00s)
    --- PASS: TestVariableSetsListForWorkspace/with_query_parameter (0.20s)
=== RUN   TestVariableSetsListForProject
=== RUN   TestVariableSetsListForProject/without_list_options
=== RUN   TestVariableSetsListForProject/with_list_options
=== RUN   TestVariableSetsListForProject/when_Project_ID_is_an_invalid_ID
=== RUN   TestVariableSetsListForProject/with_query_parameter
--- PASS: TestVariableSetsListForProject (3.75s)
    --- PASS: TestVariableSetsListForProject/without_list_options (0.24s)
    --- PASS: TestVariableSetsListForProject/with_list_options (0.20s)
    --- PASS: TestVariableSetsListForProject/when_Project_ID_is_an_invalid_ID (0.00s)
    --- PASS: TestVariableSetsListForProject/with_query_parameter (0.20s)
PASS
ok      github.com/hashicorp/go-tfe     9.944s

...
```
