### PR TITLE
Adding bitbucket data center support and using data center in tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Enhancements
+* Adds Bitbucket Data Center as a new `ServiceProviderType` and ensures similar validation as Bitbucket Server by @zainq11 [#879](https://github.com/hashicorp/go-tfe/pull/879)
+
 # v1.49.0
 
 ## Enhancements

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -344,8 +344,8 @@ func (o OAuthClientCreateOptions) valid() error {
 		return ErrRequiredServiceProvider
 	}
 	if !validString(o.OAuthToken) &&
-		*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketServer) &&
-		*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketDataCenter) {
+		(*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketServer) ||
+			*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketDataCenter)) {
 		return ErrRequiredOauthToken
 	}
 	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -344,8 +344,8 @@ func (o OAuthClientCreateOptions) valid() error {
 		return ErrRequiredServiceProvider
 	}
 	if !validString(o.OAuthToken) &&
-		(*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketServer) ||
-			*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketDataCenter)) {
+		*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketServer) &&
+		*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketDataCenter) {
 		return ErrRequiredOauthToken
 	}
 	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -56,6 +56,7 @@ type ServiceProviderType string
 const (
 	ServiceProviderAzureDevOpsServer   ServiceProviderType = "ado_server"
 	ServiceProviderAzureDevOpsServices ServiceProviderType = "ado_services"
+	ServiceProviderBitbucketDataCenter ServiceProviderType = "bitbucket_data_center"
 	ServiceProviderBitbucket           ServiceProviderType = "bitbucket_hosted"
 	// Bitbucket Server v5.4.0 and above
 	ServiceProviderBitbucketServer ServiceProviderType = "bitbucket_server"
@@ -160,8 +161,8 @@ type OAuthClientCreateOptions struct {
 	// Optional: Secret key associated with this vcs provider - only available for ado_server
 	Secret *string `jsonapi:"attr,secret,omitempty"`
 
-	// Optional: RSAPublicKey the text of the SSH public key associated with your BitBucket
-	// Server Application Link.
+	// Optional: RSAPublicKey the text of the SSH public key associated with your
+	// BitBucket Data Center Application Link.
 	RSAPublicKey *string `jsonapi:"attr,rsa-public-key,omitempty"`
 
 	// Required: The VCS provider being connected with.
@@ -342,7 +343,9 @@ func (o OAuthClientCreateOptions) valid() error {
 	if o.ServiceProvider == nil {
 		return ErrRequiredServiceProvider
 	}
-	if !validString(o.OAuthToken) && *o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketServer) {
+	if !validString(o.OAuthToken) &&
+		*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketServer) &&
+		*o.ServiceProvider != *ServiceProvider(ServiceProviderBitbucketDataCenter) {
 		return ErrRequiredOauthToken
 	}
 	if validString(o.PrivateKey) && *o.ServiceProvider != *ServiceProvider(ServiceProviderAzureDevOpsServer) {

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -205,9 +205,9 @@ func TestOAuthClientsCreate_rsaKeyPair(t *testing.T) {
 	t.Run("with key, rsa public/private key options", func(t *testing.T) {
 		key := randomString(t)
 		options := OAuthClientCreateOptions{
-			APIURL:          String("https://bbs.com"),
-			HTTPURL:         String("https://bbs.com"),
-			ServiceProvider: ServiceProvider(ServiceProviderBitbucketServer),
+			APIURL:          String("https://bbdc.com"),
+			HTTPURL:         String("https://bbdc.com"),
+			ServiceProvider: ServiceProvider(ServiceProviderBitbucketDataCenter),
 			Key:             String(key),
 			Secret:          String(privateKey),
 			RSAPublicKey:    String(publicKey),
@@ -216,9 +216,9 @@ func TestOAuthClientsCreate_rsaKeyPair(t *testing.T) {
 		oc, err := client.OAuthClients.Create(ctx, orgTest.Name, options)
 		require.NoError(t, err)
 		assert.NotEmpty(t, oc.ID)
-		assert.Equal(t, "https://bbs.com", oc.APIURL)
-		assert.Equal(t, "https://bbs.com", oc.HTTPURL)
-		assert.Equal(t, ServiceProviderBitbucketServer, oc.ServiceProvider)
+		assert.Equal(t, "https://bbdc.com", oc.APIURL)
+		assert.Equal(t, "https://bbdc.com", oc.HTTPURL)
+		assert.Equal(t, ServiceProviderBitbucketDataCenter, oc.ServiceProvider)
 		assert.Equal(t, publicKey, oc.RSAPublicKey)
 		assert.Equal(t, key, oc.Key)
 	})
@@ -644,9 +644,9 @@ func TestOAuthClientsUpdate(t *testing.T) {
 		organizationScoped := false
 		organizationScopedTrue := true
 		options := OAuthClientCreateOptions{
-			APIURL:             String("https://bbs.com"),
-			HTTPURL:            String("https://bbs.com"),
-			ServiceProvider:    ServiceProvider(ServiceProviderBitbucketServer),
+			APIURL:             String("https://bbdc.com"),
+			HTTPURL:            String("https://bbdc.com"),
+			ServiceProvider:    ServiceProvider(ServiceProviderBitbucketDataCenter),
 			OrganizationScoped: &organizationScopedTrue,
 		}
 
@@ -686,9 +686,9 @@ func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
 	t.Run("updates a new key", func(t *testing.T) {
 		originalKey := randomString(t)
 		options := OAuthClientCreateOptions{
-			APIURL:          String("https://bbs.com"),
-			HTTPURL:         String("https://bbs.com"),
-			ServiceProvider: ServiceProvider(ServiceProviderBitbucketServer),
+			APIURL:          String("https://bbdc.com"),
+			HTTPURL:         String("https://bbdc.com"),
+			ServiceProvider: ServiceProvider(ServiceProviderBitbucketDataCenter),
 			Key:             String(originalKey),
 			Secret:          String(privateKey),
 			RSAPublicKey:    String(publicKey),
@@ -705,7 +705,7 @@ func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
 		oc, err := client.OAuthClients.Update(ctx, origOC.ID, updateOpts)
 		require.NoError(t, err)
 		assert.NotEmpty(t, oc.ID)
-		assert.Equal(t, ServiceProviderBitbucketServer, oc.ServiceProvider)
+		assert.Equal(t, ServiceProviderBitbucketDataCenter, oc.ServiceProvider)
 		assert.Equal(t, oc.RSAPublicKey, origOC.RSAPublicKey)
 		assert.Equal(t, newKey, oc.Key)
 	})
@@ -713,9 +713,9 @@ func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
 	t.Run("errors when missing key", func(t *testing.T) {
 		originalKey := randomString(t)
 		options := OAuthClientCreateOptions{
-			APIURL:          String("https://bbs.com"),
-			HTTPURL:         String("https://bbs.com"),
-			ServiceProvider: ServiceProvider(ServiceProviderBitbucketServer),
+			APIURL:          String("https://bbdc.com"),
+			HTTPURL:         String("https://bbdc.com"),
+			ServiceProvider: ServiceProvider(ServiceProviderBitbucketDataCenter),
 			Key:             String(originalKey),
 			Secret:          String(privateKey),
 			RSAPublicKey:    String(publicKey),
@@ -729,6 +729,6 @@ func TestOAuthClientsUpdate_rsaKeyPair(t *testing.T) {
 			Key: String(""),
 		}
 		_, err = client.OAuthClients.Update(ctx, origOC.ID, updateOpts)
-		assert.Error(t, err, "The Consumer Key for BitBucket Server must be present. Please add a value for `key`.")
+		assert.Error(t, err, "The Consumer Key for Bitbucket Data Center must be present. Please add a value for `key`.")
 	})
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

On Feb 15, 2024, Atlassian stopped [support](https://bitbucket.org/blog/cloud-migration-benefits) for Bitbucket Server. This PR introduces changes in `go-tfe` so that we can support Bitbucket Data Center while keeping Bitbucket Server.

- A new `ServiceProviderType` has been added for Bitbucket Data Center.
- Validations specific to Bitbucket Server have been updated to also consider Bitbucket Data Center.
- String literals in tests have been updated to reference Bitbucket "Data Center" instead of "Server" to align with Bitbucket.
 
Bitbucket Data Center and Server are interoperable and have the same UX/API. So, no changes to options/config are needed.
Once these changes have been merged, we also intend to add Bitbucket Data Center support in the TFE [provider](https://github.com/hashicorp/terraform-provider-tfe). A draft PR for that is in the works. 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

- [Bitbucket blog post](https://bitbucket.org/blog/cloud-migration-benefits)
- [TFC VCS provider documentation](https://developer.hashicorp.com/terraform/cloud-docs/vcs/bitbucket-data-center)


## Output from tests

```bash
❯ go test -run TestOAuthClientsCreate -v ./...
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestOAuthClientsCreate
=== RUN   TestOAuthClientsCreate/with_valid_options
=== RUN   TestOAuthClientsCreate/with_valid_options/the_organization_relationship_is_decoded_correctly
=== RUN   TestOAuthClientsCreate/without_an_valid_organization
=== RUN   TestOAuthClientsCreate/without_an_API_URL
=== RUN   TestOAuthClientsCreate/without_a_HTTP_URL
=== RUN   TestOAuthClientsCreate/without_an_OAuth_token
=== RUN   TestOAuthClientsCreate/without_a_service_provider
=== RUN   TestOAuthClientsCreate/with_projects_provided
    oauth_client_integration_test.go:180: Skipping test related to a Terraform Cloud beta feature. Set ENABLE_BETA=1 to run.
--- PASS: TestOAuthClientsCreate (2.37s)
    --- PASS: TestOAuthClientsCreate/with_valid_options (0.50s)
        --- PASS: TestOAuthClientsCreate/with_valid_options/the_organization_relationship_is_decoded_correctly (0.00s)
    --- PASS: TestOAuthClientsCreate/without_an_valid_organization (0.00s)
    --- PASS: TestOAuthClientsCreate/without_an_API_URL (0.00s)
    --- PASS: TestOAuthClientsCreate/without_a_HTTP_URL (0.00s)
    --- PASS: TestOAuthClientsCreate/without_an_OAuth_token (0.00s)
    --- PASS: TestOAuthClientsCreate/without_a_service_provider (0.00s)
    --- SKIP: TestOAuthClientsCreate/with_projects_provided (0.00s)
=== RUN   TestOAuthClientsCreate_rsaKeyPair
=== RUN   TestOAuthClientsCreate_rsaKeyPair/with_key,_rsa_public/private_key_options
--- PASS: TestOAuthClientsCreate_rsaKeyPair (0.83s)
    --- PASS: TestOAuthClientsCreate_rsaKeyPair/with_key,_rsa_public/private_key_options (0.13s)
=== RUN   TestOAuthClientsCreate_agentPool
=== RUN   TestOAuthClientsCreate_agentPool/with_valid_agent_pool_external_id
    oauth_client_integration_test.go:238:
=== RUN   TestOAuthClientsCreate_agentPool/with_an_invalid_agent_pool
=== RUN   TestOAuthClientsCreate_agentPool/with_no_agents_connected
--- PASS: TestOAuthClientsCreate_agentPool (2.09s)
    --- SKIP: TestOAuthClientsCreate_agentPool/with_valid_agent_pool_external_id (0.00s)
    --- PASS: TestOAuthClientsCreate_agentPool/with_an_invalid_agent_pool (0.92s)
    --- PASS: TestOAuthClientsCreate_agentPool/with_no_agents_connected (0.94s)
=== RUN   TestOAuthClientsCreateOptionsValid
=== RUN   TestOAuthClientsCreateOptionsValid/with_valid_options
=== RUN   TestOAuthClientsCreateOptionsValid/without_an_API_URL
=== RUN   TestOAuthClientsCreateOptionsValid/without_a_HTTP_URL
=== RUN   TestOAuthClientsCreateOptionsValid/without_an_OAuth_token
=== RUN   TestOAuthClientsCreateOptionsValid/without_a_service_provider
=== RUN   TestOAuthClientsCreateOptionsValid/without_private_key_and_not_ado_server_options
=== RUN   TestOAuthClientsCreateOptionsValid/with_empty_private_key_and_not_ado_server_options
=== RUN   TestOAuthClientsCreateOptionsValid/with_private_key_and_not_ado_server_options
=== RUN   TestOAuthClientsCreateOptionsValid/with_valid_options_including_private_key
--- PASS: TestOAuthClientsCreateOptionsValid (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_valid_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_an_API_URL (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_a_HTTP_URL (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_an_OAuth_token (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_a_service_provider (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/without_private_key_and_not_ado_server_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_empty_private_key_and_not_ado_server_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_private_key_and_not_ado_server_options (0.00s)
    --- PASS: TestOAuthClientsCreateOptionsValid/with_valid_options_including_private_key (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     5.626s
```

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
