### PR TITLE
Updating CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+.github/ @hashicorp/tf-cli
+Makefile @hashicorp/tf-cli

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,0 @@
-* @hashicorp/tf-cli


### PR DESCRIPTION
Update CODEOWNERS to allow other internal employees to approve PRs. We do not have a GitHub team for TFC App Eng Leads, so terraform-enterprise is the general group that was chosen.

TF-CLI still owns approval on general repo things.