### PR TITLE
Allow organization invitation to add users to teams

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * Add `Stages` field to `WorkspaceRunTask`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
 * Changing BETA `OrganizationScoped` attribute of `OAuthClient` to be a pointer for bug fix by @netramali [884](https://github.com/hashicorp/go-tfe/pull/884)
 * Adds `Query` parameter to `VariableSetListOptions` to allow searching variable sets by name, by @JarrettSpiker[#877](https://github.com/hashicorp/go-tfe/pull/877)
-
+* Adds `Teams` field to `OrganizationMembershipCreateOptions` to allow users to be added to teams at the same time they are invited to an organization. @JarrettSpiker [#886](https://github.com/hashicorp/go-tfe/pull/886)
 
 ## Deprecations
 * The `Stage` field has been deprecated on `WorkspaceRunTask`. Instead, use `Stages`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -102,6 +102,9 @@ type OrganizationMembershipCreateOptions struct {
 
 	// Required: User's email address.
 	Email *string `jsonapi:"attr,email"`
+
+	// Optional: A list of teams in the organization to add the user to
+	Teams []*Team `jsonapi:"relation,teams,omitempty"`
 }
 
 // OrganizationMembershipReadOptions represents the options for reading organization memberships.


### PR DESCRIPTION
## Description

The Terraform Cloud API allows users to be added to teams at the same time as they are added to the organization. In the UI, we actually require that you add a user to at least one team when inviting them to an org.

This allows go-tfe organization membership creation to optionally include teams which the user should be added to as well.

## Testing plan

1. Test that org invitation still works without the new team parameter
2. Test that the user can be added to one team at membership creation
3. Test that the user can be added to multiple teams at membership creation

## External links

 - [JIRA](https://hashicorp.atlassian.net/browse/TF-14520)
 - [API Documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organization-memberships#request-body)

## Output from tests

```

go test -timeout 30s -run ^TestOrganizationMembershipsCreate$ github.com/hashicorp/go-tfe

=== RUN   TestOrganizationMembershipsCreate
=== RUN   TestOrganizationMembershipsCreate/with_valid_options
--- PASS: TestOrganizationMembershipsCreate/with_valid_options (1.00s)
=== RUN   TestOrganizationMembershipsCreate/when_options_is_missing_email
--- PASS: TestOrganizationMembershipsCreate/when_options_is_missing_email (0.00s)
=== RUN   TestOrganizationMembershipsCreate/with_an_invalid_organization
--- PASS: TestOrganizationMembershipsCreate/with_an_invalid_organization (0.00s)
=== RUN   TestOrganizationMembershipsCreate/when_an_error_is_returned_from_the_api
--- PASS: TestOrganizationMembershipsCreate/when_an_error_is_returned_from_the_api (0.15s)
=== RUN   TestOrganizationMembershipsCreate/with_initial_teams
--- PASS: TestOrganizationMembershipsCreate/with_initial_teams (1.88s)
--- PASS: TestOrganizationMembershipsCreate (4.24s)
PASS
ok      github.com/hashicorp/go-tfe     4.449s

```
