### PR TITLE
Fix changelog merge error for 1.50.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Enhancements
+* Adds `Teams` field to `OrganizationMembershipCreateOptions` to allow users to be added to teams at the same time they are invited to an organization. @JarrettSpiker [#886](https://github.com/hashicorp/go-tfe/pull/886)
+
 # v1.50.0
 
 ## Enhancements
@@ -9,7 +12,6 @@
 * Add `Stages` field to `WorkspaceRunTask`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)
 * Changing BETA `OrganizationScoped` attribute of `OAuthClient` to be a pointer for bug fix by @netramali [884](https://github.com/hashicorp/go-tfe/pull/884)
 * Adds `Query` parameter to `VariableSetListOptions` to allow searching variable sets by name, by @JarrettSpiker[#877](https://github.com/hashicorp/go-tfe/pull/877)
-* Adds `Teams` field to `OrganizationMembershipCreateOptions` to allow users to be added to teams at the same time they are invited to an organization. @JarrettSpiker [#886](https://github.com/hashicorp/go-tfe/pull/886)
 
 ## Deprecations
 * The `Stage` field has been deprecated on `WorkspaceRunTask`. Instead, use `Stages`. by @glennsarti [#865](https://github.com/hashicorp/go-tfe/pull/865)


### PR DESCRIPTION
## Description

Merging #886 inserted the changelog entry into the 1.50.0 release, which is incorrect. Moving that entry back into unreleased.
