### PR TITLE
Rebrand Terraform Cloud to HCP Terrraform

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -9,7 +9,7 @@ Hi there,
 
 Thank you for opening an issue! Please note that we try to keep the this issue
 tracker reserved for bug reports and feature requests related to the go-tfe API
-wrapper. If you know your issue relates to the Terraform Cloud/Enterprise
+wrapper. If you know your issue relates to the HCP Terraform and Terraform Enterprise
 platform itself, please contact tf-cloud@hashicorp.support. For general usage
 questions, please post to our community forum: https://discuss.hashicorp.com.
 -->

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -3,9 +3,9 @@
 
 blank_issues_enabled: false
 contact_links:
-  - name: Terraform Cloud/Enterprise Troubleshooting and Feature Requests
+  - name: HCP Terraform and Terraform Enterprise Troubleshooting and Feature Requests
     url: https://support.hashicorp.com/hc/en-us/requests/new
-    about: For issues and feature requests concerning the Terraform Cloud/Enterprise platform itself, please submit a HashiCorp support request or email tf-cloud@hashicorp.support
+    about: For issues and feature requests concerning the HCP Terraform and Terraform Enterprise platform itself, please submit a HashiCorp support request or email tf-cloud@hashicorp.support
   - name: Terraform Language or Workflow Questions
     url: https://discuss.hashicorp.com
     about: Please ask Terraform language or workflow related questions through the HashiCorp Discuss forum

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -9,7 +9,7 @@ Hi there,
 
 Thank you for opening an issue! Please note that we try to keep the this issue tracker reserved for
 bug reports and feature requests related to the go-tfe API wrapper. If you know
-your issue relates to the Terraform Cloud/Enterprise platform itself, please contact
+your issue relates to the HCP Terraform and Terraform Enterprise platform itself, please contact
 tf-cloud@hashicorp.support. For general usage questions, please post to our community forum:
 https://discuss.hashicorp.com.
 -->

--- a/.github/actions/test-go-tfe/action.yml
+++ b/.github/actions/test-go-tfe/action.yml
@@ -11,31 +11,31 @@ inputs:
     description: Total number of matrix strategy runners
     required: true
   address:
-    description: Address of the Terraform Cloud instance to test against
+    description: Address of the HCP Terraform instance to test against
     required: true
   admin_configuration_token:
-    description: TFC Admin API Configuration role token
+    description: HCP Terraform Admin API Configuration role token
     required: true
   admin_provision_licenses_token:
-    description: TFC Admin API Provision Licenses role token
+    description: HCP Terraform Admin API Provision Licenses role token
     required: true
   admin_security_maintenance_token:
-    description: TFC Admin API Security Maintenance role token
+    description: HCP Terraform Admin API Security Maintenance role token
     required: true
   admin_site_admin_token:
-    description: TFC Admin API Site Admin role token
+    description: HCP Terraform Admin API Site Admin role token
     required: true
   admin_subscription_token:
-    description: TFC Admin API Subscription role token
+    description: HCP Terraform Admin API Subscription role token
     required: true
   admin_support_token:
-    description: TFC Admin API Support role token
+    description: HCP Terraform Admin API Support role token
     required: true
   admin_version_maintenance_token:
-    description: TFC Admin API Version Maintenance role token
+    description: HCP Terraform Admin API Version Maintenance role token
     required: true
   token:
-    description: Terraform Cloud token
+    description: HCP Terraform token
     required: true
   oauth-client-github-token:
     description: The GitHub token used for testing OAuth scenarios for VCS workspaces

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -3,7 +3,7 @@ Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md
 
 Here's what to expect after the pull request is opened:
 
-The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.
+The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.
 
 Your change, depending on its impact, may be released in the following ways:
 

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -6,5 +6,5 @@ category: library
 
 summary:
   owner: team-tf-cli
-  description: Terraform Cloud/Enterprise API Client/SDK in Golang
+  description: HCP Terraform and Terraform Enterprise API Client/SDK in Golang
   visibility: external

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Terraform Cloud/Enterprise Go Client
+HCP Terraform and Terraform Enterprise Go Client
 ==============================
 
 [![Tests](https://github.com/hashicorp/go-tfe/actions/workflows/ci.yml/badge.svg)](https://github.com/hashicorp/go-tfe/actions/workflows/ci.yml)
@@ -7,11 +7,11 @@ Terraform Cloud/Enterprise Go Client
 [![Go Report Card](https://goreportcard.com/badge/github.com/hashicorp/go-tfe)](https://goreportcard.com/report/github.com/hashicorp/go-tfe)
 [![GitHub issues](https://img.shields.io/github/issues/hashicorp/go-tfe.svg)](https://github.com/hashicorp/go-tfe/issues)
 
-The official Go API client for [Terraform Cloud/Enterprise](https://www.hashicorp.com/products/terraform).
+The official Go API client for [HCP Terraform and Terraform Enterprise](https://www.hashicorp.com/products/terraform).
 
-This client supports the [Terraform Cloud V2 API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs).
-As Terraform Enterprise is a self-hosted distribution of Terraform Cloud, this
-client supports both Cloud and Enterprise use cases. In all package
+This client supports the [HCP Terraform V2 API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs).
+As Terraform Enterprise is a self-hosted distribution of HCP Terraform, this
+client supports both HCP Terraform and Terraform Enterprise use cases. In all package
 documentation and API, the platform will always be stated as 'Terraform
 Enterprise' - but a feature will be explicitly noted as only supported in one or
 the other, if applicable (rare).
@@ -56,8 +56,8 @@ if err != nil {
 ### Using the default config with env vars
 The default configuration makes use of the `TFE_ADDRESS` and `TFE_TOKEN` environment variables.
 
-1. `TFE_ADDRESS` - URL of a Terraform Cloud or Terraform Enterprise instance. Example: `https://tfe.local`
-1. `TFE_TOKEN` - An [API token](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens) for the Terraform Cloud or Terraform Enterprise instance.
+1. `TFE_ADDRESS` - URL of a HCP Terraform or Terraform Enterprise instance. Example: `https://tfe.local`
+1. `TFE_TOKEN` - An [API token](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/api-tokens) for the HCP Terraform or Terraform Enterprise instance.
 
 **Note:** Alternatively, you can set `TFE_HOSTNAME` which serves as a fallback for `TFE_ADDRESS`. It will only be used if `TFE_ADDRESS` is not set and will resolve the host to an `https` scheme. Example: `tfe.local` => resolves to `https://tfe.local`
 
@@ -115,7 +115,7 @@ For complete usage of the API client, see the [full package docs](https://pkg.go
 
 ## API Coverage
 
-This API client covers most of the existing Terraform Cloud API calls and is updated regularly to add new or missing endpoints.
+This API client covers most of the existing HCP Terraform API calls and is updated regularly to add new or missing endpoints.
 
 - [x] Account
 - [x] Agents

--- a/admin_workspace_integration_test.go
+++ b/admin_workspace_integration_test.go
@@ -16,7 +16,7 @@ import (
 
 // BEWARE: The admin workspaces API can view all of the workspaces created by
 // EVERY test organization in EVERY concurrent test run (or other usage) for the
-// current TFC instance. It's generally not safe to assume that the workspaces
+// current HCP Terraform instance. It's generally not safe to assume that the workspaces
 // you create in a given test will be within the first page of list results, so
 // you might have to get creative and/or settle for less when testing the
 // behavior of these endpoints.

--- a/agent.go
+++ b/agent.go
@@ -14,7 +14,7 @@ import (
 var _ Agents = (*agents)(nil)
 
 // Agents describes all the agent-related methods that the
-// Terraform Cloud API supports.
+// HCP Terraform API supports.
 // TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/agents
 type Agents interface {
 	// Read an agent by its ID.
@@ -35,7 +35,7 @@ type AgentList struct {
 	Items []*Agent
 }
 
-// Agent represents a Terraform Cloud agent.
+// Agent represents a HCP Terraform agent.
 type Agent struct {
 	ID         string `jsonapi:"primary,agents"`
 	Name       string `jsonapi:"attr,name"`

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -12,8 +12,8 @@ import (
 // Compile-time proof of interface implementation.
 var _ AgentPools = (*agentPools)(nil)
 
-// AgentPools describes all the agent pool related methods that the Terraform
-// Cloud API supports. Note that agents are not available in Terraform Enterprise.
+// AgentPools describes all the agent pool related methods that the HCP Terraform
+// API supports. Note that agents are not available in Terraform Enterprise.
 //
 // TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/agents
 type AgentPools interface {
@@ -50,7 +50,7 @@ type AgentPoolList struct {
 	Items []*AgentPool
 }
 
-// AgentPool represents a Terraform Cloud agent pool.
+// AgentPool represents a HCP Terraform agent pool.
 type AgentPool struct {
 	ID                 string `jsonapi:"primary,agent-pools"`
 	Name               string `jsonapi:"attr,name"`

--- a/agent_token.go
+++ b/agent_token.go
@@ -14,7 +14,7 @@ import (
 var _ AgentTokens = (*agentTokens)(nil)
 
 // AgentTokens describes all the agent token related methods that the
-// Terraform Cloud API supports.
+// HCP Terraform API supports.
 //
 // TFE API docs:
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/agent-tokens
@@ -37,7 +37,7 @@ type agentTokens struct {
 	client *Client
 }
 
-// AgentToken represents a Terraform Cloud agent token.
+// AgentToken represents a HCP Terraform agent token.
 type AgentToken struct {
 	ID          string    `jsonapi:"primary,authentication-tokens"`
 	CreatedAt   time.Time `jsonapi:"attr,created-at,iso8601"`

--- a/audit_trail.go
+++ b/audit_trail.go
@@ -17,12 +17,12 @@ import (
 // Compile-time proof of interface implementation
 var _ AuditTrails = (*auditTrails)(nil)
 
-// AuditTrails describes all the audit event related methods that the Terraform
-// Cloud API supports.
+// AuditTrails describes all the audit event related methods that the HCP Terraform
+// API supports.
 // **Note:** These methods require the client to be configured with an organization token for
-// an organization in the Business tier. Furthermore, these methods are only available in Terraform Cloud.
+// an organization in the Business tier. Furthermore, these methods are only available in HCP Terraform.
 //
-// TFC API Docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/audit-trails
+// HCP Terraform API Docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/audit-trails
 type AuditTrails interface {
 	// Read all the audit events in an organization.
 	List(ctx context.Context, options *AuditTrailListOptions) (*AuditTrailList, error)
@@ -63,7 +63,7 @@ type AuditTrailPagination struct {
 	TotalCount   int `json:"total_count"`
 }
 
-// AuditTrail represents an event in the TFC audit log.
+// AuditTrail represents an event in the HCP Terraform audit log.
 type AuditTrail struct {
 	ID        string    `json:"id"`
 	Version   string    `json:"version"`

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -4,7 +4,7 @@ If you find an issue with this package, please create an issue in GitHub. If you
 
 ## Adding new functionality or fixing relevant bugs
 
-If you are adding a new endpoint, make sure to update the [coverage list in README.md](../README.md#API-Coverage) where we keep a list of the TFC APIs that this SDK supports.
+If you are adding a new endpoint, make sure to update the [coverage list in README.md](../README.md#API-Coverage) where we keep a list of the HCP Terraform APIs that this SDK supports.
 
 If you are making relevant changes that is worth communicating to our users, please include a note about it in our CHANGELOG.md. You can include it as part of the PR where you are submitting your changes.
 
@@ -121,7 +121,7 @@ var ErrInvalidExampleID = errors.New("invalid value for example ID") // move thi
 var _ ExampleResource = (*example)(nil)
 
 // Example represents all the example methods in the context of an organization
-// that the Terraform Cloud/Enterprise API supports.
+// that the HCP Terraform and Terraform Enterprise API supports.
 // If this API is in beta or pre-release state, include that warning here.
 type ExampleResource interface {
 	// Create an example for an organization
@@ -148,7 +148,7 @@ type example struct {
 	client *Client
 }
 
-// Example represents a TFC/E example resource
+// Example represents a HCP Terraform and Terraform Enterprise example resource
 type Example struct {
 	ID            string  `jsonapi:"primary,examples"`
 	Name          string  `jsonapi:"attr,name"`

--- a/docs/RELEASES.md
+++ b/docs/RELEASES.md
@@ -8,7 +8,7 @@ Start by comparing the main branch with the last release in order to fully under
 
 1. Is the change added to CHANGELOG.md?
 2. Does the public package API follow all endpoint conventions, such as naming, pointer usage, and options availability? Once these are released, they are permanent in the current major release version.
-3. Are new features generally available in the Terraform Cloud API? Or is there another considered reason to release them?
+3. Are new features generally available in the HCP Terraform API? Or is there another considered reason to release them?
 
 Steps to prepare the changelog for a new release:
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -1,6 +1,6 @@
 # Running tests
 
-go-tfe relies on acceptance tests against either the Terraform Cloud and Terraform Enterprise APIs. go-tfe is tested against Terraform Cloud by our CI environment, and against Terraform Enterprise prior to release or otherwise as needed.
+go-tfe relies on acceptance tests against either the HCP Terraform and Terraform Enterprise APIs. go-tfe is tested against HCP Terraform by our CI environment, and against Terraform Enterprise prior to release or otherwise as needed.
 
 ## 1. (Optional) Create repositories for policy sets and registry modules
 
@@ -38,8 +38,8 @@ You'll need to have environment variables setup in your environment to run the t
 
 Tests are run against an actual backend so they require a valid backend address and token:
 
-1. `TFE_ADDRESS` - URL of a Terraform Cloud or Terraform Enterprise instance to be used for testing, including scheme. Example: `https://tfe.local`
-1. `TFE_TOKEN` - A [user API token](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/users#tokens) for the Terraform Cloud or Terraform Enterprise instance being used for testing.
+1. `TFE_ADDRESS` - URL of a HCP Terraform or Terraform Enterprise instance to be used for testing, including scheme. Example: `https://tfe.local`
+1. `TFE_TOKEN` - A [user API token](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/users#tokens) for the HCP Terraform or Terraform Enterprise instance being used for testing.
 
 **Note:** Alternatively, you can set `TFE_HOSTNAME` which serves as a fallback for `TFE_ADDRESS`. It will only be used if `TFE_ADDRESS` is not set and will resolve the host to an `https` scheme. Example: `tfe.local` => resolves to `https://tfe.local`
 
@@ -48,10 +48,10 @@ Tests are run against an actual backend so they require a valid backend address 
 1. `OAUTH_CLIENT_GITHUB_TOKEN` - [GitHub personal access token](https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line). Required for running any tests that use VCS (OAuth clients, policy sets, etc).
 2. `GITHUB_POLICY_SET_IDENTIFIER` - GitHub policy set repository identifier in the format `username/repository`. Required for running policy set tests.
 3. `GITHUB_REGISTRY_MODULE_IDENTIFIER` - GitHub registry module repository identifier in the format `username/repository`. Required for running registry module tests.
-4. `ENABLE_TFE` - Some tests are only applicable to Terraform Enterprise or Terraform Cloud. By setting `ENABLE_TFE=1` you will enable enterprise only tests and disable cloud only tests. In CI `ENABLE_TFE` is not set so if you are writing enterprise only features you should manually test with `ENABLE_TFE=1` against a Terraform Enterprise instance.
+4. `ENABLE_TFE` - Some tests are only applicable to Terraform Enterprise or HCP Terraforrm. By setting `ENABLE_TFE=1` you will enable Terraform Enterprise only tests and disable HCP Terraform only tests. In CI `ENABLE_TFE` is not set so if you are writing enterprise only features you should manually test with `ENABLE_TFE=1` against a Terraform Enterprise instance.
 5. `ENABLE_BETA` - Some tests require access to beta features. By setting `ENABLE_BETA=1` you will enable tests that require access to beta features. IN CI `ENABLE_BETA` is not set so if you are writing beta only features you should manually test with `ENABLE_BETA=1` against a Terraform Enterprise instance with those features enabled.
 6. `TFC_RUN_TASK_URL` - Run task integration tests require a URL to use when creating run tasks. To learn more about the Run Task API, [read here](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run-tasks/run-tasks)
-7. `GITHUB_APP_INSTALLATION_ID` - Required for running any tests that use GitHub App as the VCS provider (workspace, policy sets, registry module). These tests are skipped in the automated CI pipeline because in order to use this variable, the user has to have a GitHub App Installation setup done using the [TFC UI](https://developer.hashicorp.com/terraform/enterprise/admin/application/github-app-integration). And then the value can be fetched either from the UI or from the `GET /github-app/installations` API. The test command is listed below.
+7. `GITHUB_APP_INSTALLATION_ID` - Required for running any tests that use GitHub App as the VCS provider (workspace, policy sets, registry module). These tests are skipped in the automated CI pipeline because in order to use this variable, the user has to have a GitHub App Installation setup done using the [HCP Terraform UI](https://developer.hashicorp.com/terraform/enterprise/admin/application/github-app-integration). And then the value can be fetched either from the UI or from the `GET /github-app/installations` API. The test command is listed below.
     ```sh
       $ GITHUB_APP_INSTALLATION_ID=ghain-xxxx TFE_ADDRESS= https://tfe.local TFE_TOKEN=xxx GITHUB_POLICY_SET_IDENTIFIER=username/repository GITHUB_REGISTRY_MODULE_IDENTIFIER=username/repository go test -run "(GHA|GithubApp)" -v ./...
     ```
@@ -59,7 +59,7 @@ Tests are run against an actual backend so they require a valid backend address 
 ## 3. Make sure run queue settings are correct
 
 In order for the tests relating to queuing and capacity to pass, FRQ (fair run queuing) should be
-enabled with a limit of 2 concurrent runs per organization on the Terraform Cloud or Terraform Enterprise instance you are using for testing.
+enabled with a limit of 2 concurrent runs per organization on the HCP Terraform or Terraform Enterprise instance you are using for testing.
 
 ## 4. Run tests
 
@@ -108,6 +108,6 @@ $ TFE_TOKEN=xyz TFE_HOSTNAME=tfe.local ENABLE_TFE=1 go test ./... -timeout=30m
 ```
 
 
-### Running tests for TFC features that require paid plans (HashiCorp Employees)
+### Running tests for HCP Terraform features that require paid plans (HashiCorp Employees)
 
-You can use the test helper `upgradeOrganizationSubscription()` to upgrade your test organization to a Business Plan, giving the organization access to all features in Terraform Cloud. This method requires `TFE_TOKEN` to be a user token with administrator access in the target test environment. Furthermore, you **can not** have enterprise features enabled (`ENABLE_TFE=1`) in order to use this method since the API call fails against TFE test environments.
+You can use the test helper `upgradeOrganizationSubscription()` to upgrade your test organization to a Business Plan, giving the organization access to all features in HCP Terraform. This method requires `TFE_TOKEN` to be a user token with administrator access in the target test environment. Furthermore, you **can not** have enterprise features enabled (`ENABLE_TFE=1`) in order to use this method since the API call fails against Terraform Enterprise test environments.

--- a/examples/run_errors/README.md
+++ b/examples/run_errors/README.md
@@ -1,6 +1,6 @@
 ## Example: Parsing Run Errors
 
-In this example, you'll use terraform to create a run with errors on Terraform Cloud, then
+In this example, you'll use terraform to create a run with errors on HCP Terraform, then
 execute the command to read the plan log and filter it for errors. It's important to use
 Terraform to create the run, otherwise you will not get the structured log that this code
 example requires.

--- a/gpg_key.go
+++ b/gpg_key.go
@@ -45,7 +45,7 @@ type GPGKeyList struct {
 	Items []*GPGKey
 }
 
-// GPGKey represents a signed GPG key for a TFC/E private provider.
+// GPGKey represents a signed GPG key for a HCP Terraform or Terraform Enterprise private provider.
 type GPGKey struct {
 	ID             string    `jsonapi:"primary,gpg-keys"`
 	AsciiArmor     string    `jsonapi:"attr,ascii-armor"`
@@ -69,7 +69,7 @@ type GPGKeyID struct {
 type GPGKeyListOptions struct {
 	ListOptions
 
-	// Required: A list of one or more namespaces. Must be authorized TFC/E organization names.
+	// Required: A list of one or more namespaces. Must be authorized HCP Terraform or Terraform Enterprise organization names.
 	Namespaces []string `url:"filter[namespace]"`
 }
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -117,7 +117,7 @@ func testAuditTrailClient(t *testing.T, userClient *Client, org *Organization) *
 }
 
 // TestAccountDetails represents the basic account information
-// of a TFE/TFC user.
+// of a Terraform Enterprise or HCP Terraform user.
 //
 // See FetchTestAccountDetails for more information.
 type TestAccountDetails struct {
@@ -2671,8 +2671,8 @@ func genSha(t *testing.T) string {
 }
 
 // genSafeRandomTerraformVersion returns a random version number of the form
-// `1.0.<RANDOM>`, which TFC won't ever select as the latest available
-// Terraform. (At the time of writing, a fresh TFC instance will include
+// `1.0.<RANDOM>`, which HCP Terraform won't ever select as the latest available
+// Terraform. (At the time of writing, a fresh HCP Terraform instance will include
 // official Terraforms 1.2 and higher.) This is necessary because newly created
 // workspaces default to the latest available version, and there's nothing
 // preventing unrelated processes from creating workspaces during these tests.
@@ -2740,11 +2740,11 @@ func randomSemver(t *testing.T) string {
 	return fmt.Sprintf("%d.%d.%d", rand.Intn(99)+3, rand.Intn(99)+1, rand.Intn(99)+1)
 }
 
-// skips a test if the environment is for Terraform Cloud.
+// skips a test if the environment is for HCP Terraform.
 func skipUnlessEnterprise(t *testing.T) {
 	t.Helper()
 	if !enterpriseEnabled() {
-		t.Skip("Skipping test related to Terraform Cloud. Set ENABLE_TFE=1 to run.")
+		t.Skip("Skipping test related to HCP Terraform. Set ENABLE_TFE=1 to run.")
 	}
 }
 
@@ -2766,7 +2766,7 @@ func skipIfEnterprise(t *testing.T) {
 func skipUnlessBeta(t *testing.T) {
 	t.Helper()
 	if !betaFeaturesEnabled() {
-		t.Skip("Skipping test related to a Terraform Cloud beta feature. Set ENABLE_BETA=1 to run.")
+		t.Skip("Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.")
 	}
 }
 

--- a/ip_ranges.go
+++ b/ip_ranges.go
@@ -10,11 +10,11 @@ import (
 // Compile-time proof of interface implementation.
 var _ IPRanges = (*ipRanges)(nil)
 
-// IP Ranges provides a list of Terraform Cloud and Enterprise's IP ranges.
+// IP Ranges provides a list of HCP Terraform or Terraform Enterprise's IP ranges.
 //
 // TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/ip-ranges
 type IPRanges interface {
-	// Retrieve TFC IP ranges. If `modifiedSince` is not an empty string
+	// Retrieve HCP Terraform IP ranges. If `modifiedSince` is not an empty string
 	// then it will only return the IP ranges changes since that date.
 	// The format for `modifiedSince` can be found here:
 	// https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-Modified-Since
@@ -26,9 +26,9 @@ type ipRanges struct {
 	client *Client
 }
 
-// IPRange represents a list of Terraform Cloud's IP ranges
+// IPRange represents a list of HCP Terraform's IP ranges
 type IPRange struct {
-	// List of IP ranges in CIDR notation used for connections from user site to Terraform Cloud APIs
+	// List of IP ranges in CIDR notation used for connections from user site to HCP Terraform APIs
 	API []string `json:"api"`
 	// List of IP ranges in CIDR notation used for notifications
 	Notifications []string `json:"notifications"`

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -91,7 +91,7 @@ type NotificationConfiguration struct {
 	UpdatedAt         time.Time                   `jsonapi:"attr,updated-at,iso8601"`
 	URL               string                      `jsonapi:"attr,url"`
 
-	// EmailAddresses is only available for TFE users. It is not available in TFC.
+	// EmailAddresses is only available for TFE users. It is not available in HCP Terraform.
 	EmailAddresses []string `jsonapi:"attr,email-addresses"`
 
 	// Relations
@@ -143,7 +143,7 @@ type NotificationConfigurationCreateOptions struct {
 	URL *string `jsonapi:"attr,url,omitempty"`
 
 	// Optional: The list of email addresses that will receive notification emails.
-	// EmailAddresses is only available for TFE users. It is not available in TFC.
+	// EmailAddresses is only available for TFE users. It is not available in HCP Terraform.
 	EmailAddresses []string `jsonapi:"attr,email-addresses,omitempty"`
 
 	// Optional: The list of users belonging to the organization that will receive notification emails.
@@ -175,7 +175,7 @@ type NotificationConfigurationUpdateOptions struct {
 	URL *string `jsonapi:"attr,url,omitempty"`
 
 	// Optional: The list of email addresses that will receive notification emails.
-	// EmailAddresses is only available for TFE users. It is not available in TFC.
+	// EmailAddresses is only available for TFE users. It is not available in HCP Terraform.
 	EmailAddresses []string `jsonapi:"attr,email-addresses,omitempty"`
 
 	// Optional: The list of users belonging to the organization that will receive notification emails.

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -217,7 +217,7 @@ func TestOrganizationsUpdate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	t.Run("with TFC-only options", func(t *testing.T) {
+	t.Run("with HCP Terraform-only options", func(t *testing.T) {
 		skipIfEnterprise(t)
 
 		orgTest, orgTestCleanup := createOrganization(t, client)

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -395,7 +395,7 @@ func TestPolicySetsCreate(t *testing.T) {
 		}
 
 		// We are deliberately ignoring the cleanup func here, because there's a potential race condition
-		// against the subsequent subtest -- TFC performs some async cleanup on VCS repos when deleting an
+		// against the subsequent subtest -- HCP Terraform performs some async cleanup on VCS repos when deleting an
 		// OAuthClient, and we've seen evidence that it will zero out the next test's NEW VCSRepo values if
 		// they manage to slip in before the async stuff completes, even though the new values link it to a
 		// new OAuthToken. Anyway, there's a deferred cleanup for orgTest in the outer scope, so the org's
@@ -628,7 +628,7 @@ func TestPolicySetsRead(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// give TFC some time to process uploading the
+		// give HCP Terraform some time to process uploading the
 		// policy set version before reading.
 		time.Sleep(waitForPolicySetVersionUpload)
 

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -79,7 +79,7 @@ func TestPolicySetVersionsUpload(t *testing.T) {
 		)
 		require.NoError(t, err)
 
-		// give TFC some time to process uploading the
+		// give HCP Terraform some time to process uploading the
 		// policy set version before reading.
 		time.Sleep(waitForPolicySetVersionUpload)
 

--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -347,7 +347,7 @@ func TestRegistryProvidersRead(t *testing.T) {
 				}
 				_, err := client.RegistryProviders.Read(ctx, id, nil)
 				assert.Error(t, err)
-				// Local TFC/E will return a forbidden here when TFC/E is in development mode
+				// Local HCP Terraform or Terraform Enterprise will return a forbidden here when HCP Terraform or Terraform Enterprise is in development mode
 				// In non development mode this returns a 404
 				assert.Equal(t, ErrResourceNotFound, err)
 			})
@@ -448,7 +448,7 @@ func TestRegistryProvidersDelete(t *testing.T) {
 				}
 				err := client.RegistryProviders.Delete(ctx, id)
 				assert.Error(t, err)
-				// Local TFC/E will return a forbidden here when TFC/E is in development mode
+				// Local HCP Terraform or Terraform Enterprise will return a forbidden here when HCP Terraform or Terraform Enterprise is in development mode
 				// In non development mode this returns a 404
 				assert.Equal(t, ErrResourceNotFound, err)
 			})

--- a/run.go
+++ b/run.go
@@ -495,7 +495,7 @@ func (s *runs) ForceCancel(ctx context.Context, runID string, options RunForceCa
 // ForceExecute is used to forcefully execute a run by its ID.
 //
 // Note: While useful at times, force-executing a run circumvents the typical
-// workflow of applying runs using Terraform Cloud. It is not intended for
+// workflow of applying runs using HCP Terraform. It is not intended for
 // regular use. If you find yourself using it frequently, please reach out to
 // HashiCorp Support for help in developing an alternative approach.
 func (s *runs) ForceExecute(ctx context.Context, runID string) error {

--- a/run_task.go
+++ b/run_task.go
@@ -13,7 +13,7 @@ import (
 var _ RunTasks = (*runTasks)(nil)
 
 // RunTasks represents all the run task related methods in the context of an organization
-// that the Terraform Cloud/Enterprise API supports.
+// that the HCP Terraform and Terraform Enterprise API supports.
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run-tasks/run-tasks#run-tasks-api
 type RunTasks interface {
 	// Create a run task for an organization
@@ -43,7 +43,7 @@ type runTasks struct {
 	client *Client
 }
 
-// RunTask represents a TFC/E run task
+// RunTask represents a HCP Terraform or Terraform Enterprise run task
 type RunTask struct {
 	ID          string         `jsonapi:"primary,tasks"`
 	Name        string         `jsonapi:"attr,name"`
@@ -58,7 +58,7 @@ type RunTask struct {
 	WorkspaceRunTasks []*WorkspaceRunTask `jsonapi:"relation,workspace-tasks"`
 }
 
-// GlobalRunTask represents the global configuration of a TFC/E run task
+// GlobalRunTask represents the global configuration of a HCP Terraform or Terraform Enterprise run task
 type GlobalRunTask struct {
 	Enabled          bool                 `jsonapi:"attr,enabled"`
 	Stages           []Stage              `jsonapi:"attr,stages"`
@@ -95,7 +95,7 @@ type RunTaskReadOptions struct {
 	Include []RunTaskIncludeOpt `url:"include,omitempty"`
 }
 
-// GlobalRunTask represents the optional global configuration of a TFC/E run task
+// GlobalRunTask represents the optional global configuration of a HCP Terraform or Terraform Enterprise run task
 type GlobalRunTaskOptions struct {
 	Enabled          *bool                 `jsonapi:"attr,enabled,omitempty"`
 	Stages           *[]Stage              `jsonapi:"attr,stages,omitempty"`

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -14,7 +14,7 @@ import (
 var _ RunTriggers = (*runTriggers)(nil)
 
 // RunTriggers describes all the Run Trigger
-// related methods that the Terraform Cloud API supports.
+// related methods that the HCP Terraform API supports.
 //
 // TFE API docs:
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run-triggers

--- a/state_version.go
+++ b/state_version.go
@@ -58,7 +58,7 @@ type StateVersions interface {
 	// Download retrieves the actual stored state of a state version
 	Download(ctx context.Context, url string) ([]byte, error)
 
-	// ListOutputs retrieves all the outputs of a state version by its ID. IMPORTANT: Terraform Cloud might
+	// ListOutputs retrieves all the outputs of a state version by its ID. IMPORTANT: HCP Terraform might
 	// process outputs asynchronously. When consuming outputs or other async StateVersion fields, be sure to
 	// wait for ResourcesProcessed to become `true` before assuming they are empty.
 	ListOutputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error)
@@ -99,7 +99,7 @@ type StateVersion struct {
 	Serial          int64              `jsonapi:"attr,serial"`
 	VCSCommitSHA    string             `jsonapi:"attr,vcs-commit-sha"`
 	VCSCommitURL    string             `jsonapi:"attr,vcs-commit-url"`
-	// Whether Terraform Cloud has finished populating any StateVersion fields that required async processing.
+	// Whether HCP Terraform has finished populating any StateVersion fields that required async processing.
 	// If `false`, some fields may appear empty even if they should actually contain data; see comments on
 	// individual fields for details.
 	ResourcesProcessed bool `jsonapi:"attr,resources-processed"`
@@ -387,7 +387,7 @@ func (s *stateVersions) Download(ctx context.Context, u string) ([]byte, error) 
 	return buf.Bytes(), nil
 }
 
-// ListOutputs retrieves all the outputs of a state version by its ID. IMPORTANT: Terraform Cloud might
+// ListOutputs retrieves all the outputs of a state version by its ID. IMPORTANT: HCP Terraform might
 // process outputs asynchronously. When consuming outputs or other async StateVersion fields, be sure to
 // wait for ResourcesProcessed to become `true` before assuming they are empty.
 func (s *stateVersions) ListOutputs(ctx context.Context, svID string, options *StateVersionOutputsListOptions) (*StateVersionOutputsList, error) {

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -145,7 +145,7 @@ func TestStateVersionsUpload(t *testing.T) {
 		_, err = client.Workspaces.Unlock(ctx, wTest.ID)
 		require.NoError(t, err)
 
-		// TFC does some async processing on state versions, so we must await it
+		// HCP Terraform does some async processing on state versions, so we must await it
 		// lest we flake. Should take well less than a minute tho.
 		timeout := time.Minute / 2
 
@@ -469,7 +469,7 @@ func TestStateVersionsReadWithOptions(t *testing.T) {
 	svTest, svTestCleanup := createStateVersion(t, client, 0, nil)
 	t.Cleanup(svTestCleanup)
 
-	// give TFC some time to process the statefile and extract the outputs.
+	// give HCP Terraform some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
 
 	t.Run("when the state version exists", func(t *testing.T) {
@@ -507,7 +507,7 @@ func TestStateVersionsCurrent(t *testing.T) {
 			// again during the GET.
 			stateVersion.DownloadURL = ""
 
-			// outputs, providers are populated only once the state has been parsed by TFC
+			// outputs, providers are populated only once the state has been parsed by HCP Terraform
 			// which can cause the tests to fail if it doesn't happen fast enough.
 			stateVersion.Outputs = nil
 			stateVersion.Providers = nil
@@ -539,7 +539,7 @@ func TestStateVersionsCurrentWithOptions(t *testing.T) {
 	svTest, svTestCleanup := createStateVersion(t, client, 0, wTest1)
 	t.Cleanup(svTestCleanup)
 
-	// give TFC some time to process the statefile and extract the outputs.
+	// give HCP Terraform some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
 
 	t.Run("when the state version exists", func(t *testing.T) {
@@ -587,7 +587,7 @@ func TestStateVersionOutputs(t *testing.T) {
 	sv, svTestCleanup := createStateVersion(t, client, 0, wTest1)
 	t.Cleanup(svTestCleanup)
 
-	// give TFC some time to process the statefile and extract the outputs.
+	// give HCP Terraform some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, sv.ID)
 
 	t.Run("when the state version exists", func(t *testing.T) {

--- a/state_version_output_integration_test.go
+++ b/state_version_output_integration_test.go
@@ -21,7 +21,7 @@ func TestStateVersionOutputsRead(t *testing.T) {
 	svTest, svTestCleanup := createStateVersion(t, client, 0, wTest1)
 	defer svTestCleanup()
 
-	// give TFC some time to process the statefile and extract the outputs.
+	// give HCP Terraform some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
 
 	curOpts := &StateVersionCurrentOptions{

--- a/task_result.go
+++ b/task_result.go
@@ -12,7 +12,7 @@ import (
 // Compile-time proof of interface implementation
 var _ TaskResults = (*taskResults)(nil)
 
-// TaskResults describes all the task result related methods that the TFC/E API supports.
+// TaskResults describes all the task result related methods that the HCP Terraform or Terraform Enterprise API supports.
 type TaskResults interface {
 	// Read a task result by ID
 	Read(ctx context.Context, taskResultID string) (*TaskResult, error)
@@ -52,7 +52,7 @@ type TaskResultStatusTimestamps struct {
 	PassedAt   time.Time `jsonapi:"attr,passed-at,rfc3339"`
 }
 
-// TaskResult represents the result of a TFC/E run task
+// TaskResult represents the result of a HCP Terraform or Terraform Enterprise run task
 type TaskResult struct {
 	ID                            string                     `jsonapi:"primary,task-results"`
 	Status                        TaskResultStatus           `jsonapi:"attr,status"`

--- a/task_stages.go
+++ b/task_stages.go
@@ -12,7 +12,7 @@ import (
 // Compile-time proof of interface  implementation
 var _ TaskStages = (*taskStages)(nil)
 
-// TaskStages describes all the task stage related methods that the TFC/E API
+// TaskStages describes all the task stage related methods that the HCP Terraform and Terraform Enterprise API
 // supports.
 type TaskStages interface {
 	// Read a task stage by ID
@@ -67,7 +67,7 @@ type Actions struct {
 	IsOverridable *bool `jsonapi:"attr,is-overridable"`
 }
 
-// TaskStage represents a TFC/E run's stage where run tasks can occur
+// TaskStage represents a HCP Terraform or Terraform Enterprise run's stage where run tasks can occur
 type TaskStage struct {
 	ID               string                    `jsonapi:"primary,task-stages"`
 	Stage            Stage                     `jsonapi:"attr,stage"`

--- a/tfe.go
+++ b/tfe.go
@@ -186,7 +186,7 @@ type Client struct {
 
 // Admin is the the Terraform Enterprise Admin API. It provides access to site
 // wide admin settings. These are only available for Terraform Enterprise and
-// do not function against Terraform Cloud
+// do not function against HCP Terraform
 type Admin struct {
 	Organizations     AdminOrganizations
 	Workspaces        AdminWorkspaces
@@ -198,7 +198,7 @@ type Admin struct {
 	Settings          *AdminSettings
 }
 
-// Meta contains any Terraform Cloud APIs which provide data about the API itself.
+// Meta contains any HCP Terraform APIs which provide data about the API itself.
 type Meta struct {
 	IPRanges IPRanges
 }
@@ -492,18 +492,18 @@ func (c Client) AppName() string {
 	return c.appName
 }
 
-// IsCloud returns true if the client is configured against a Terraform Cloud
+// IsCloud returns true if the client is configured against a HCP Terraform
 // instance.
 //
-// Whether an instance is TFC or TFE is derived from the TFP-AppName header.
+// Whether an instance is HCP Terraform or Terraform Enterprise is derived from the TFP-AppName header.
 func (c Client) IsCloud() bool {
-	return c.appName == "Terraform Cloud"
+	return c.appName == "HCP Terraform"
 }
 
 // IsEnterprise returns true if the client is configured against a Terraform
 // Enterprise instance.
 //
-// Whether an instance is TFC or TFE is derived from the TFP-AppName header. Note:
+// Whether an instance is HCP Terraform or TFE is derived from the TFP-AppName header. Note:
 // not all TFE releases include this header in API responses.
 func (c Client) IsEnterprise() bool {
 	return !c.IsCloud()
@@ -511,7 +511,7 @@ func (c Client) IsEnterprise() bool {
 
 // RemoteAPIVersion returns the server's declared API version string.
 //
-// A Terraform Cloud or Enterprise API server returns its API version in an
+// A HCP Terraform or Enterprise API server returns its API version in an
 // HTTP header field in all responses. The NewClient function saves the
 // version number returned in its initial setup request and RemoteAPIVersion
 // returns that cached value.
@@ -521,7 +521,7 @@ func (c Client) IsEnterprise() bool {
 // second indicates a minor version which may have introduced some
 // backward-compatible additional features compared to its predecessor.
 //
-// Explicit API versioning was added to the Terraform Cloud and Enterprise
+// Explicit API versioning was added to the HCP Terraform and Enterprise
 // APIs as a later addition, so older servers will not return version
 // information. In that case, this function returns an empty string as the
 // version.
@@ -554,7 +554,7 @@ func (c *Client) SetFakeRemoteAPIVersion(fakeAPIVersion string) {
 // HTTP header field in all responses. This value is saved by the client
 // during the initial setup request and RemoteTFEVersion returns that cached
 // value. This function returns an empty string for any Terraform Enterprise version
-// earlier than v202208-3 and for Terraform Cloud.
+// earlier than v202208-3 and for HCP Terraform.
 func (c Client) RemoteTFEVersion() string {
 	return c.remoteTFEVersion
 }
@@ -644,7 +644,7 @@ type rawAPIMetadata struct {
 	// field was not included in the response.
 	RateLimit string
 
-	// AppName is either 'Terraform Cloud' or 'Terraform Enterprise'
+	// AppName is either 'HCP Terraform' or 'Terraform Enterprise'
 	AppName string
 }
 

--- a/tfe_integration_test.go
+++ b/tfe_integration_test.go
@@ -28,7 +28,7 @@ func TestClient_newClient(t *testing.T) {
 		if enterpriseEnabled() {
 			w.Header().Set("TFP-AppName", "Terraform Enterprise")
 		} else {
-			w.Header().Set("TFP-AppName", "Terraform Cloud")
+			w.Header().Set("TFP-AppName", "HCP Terraform")
 		}
 		w.WriteHeader(204) // We query the configured ping URL which should return a 204.
 	}))

--- a/user_token.go
+++ b/user_token.go
@@ -14,7 +14,7 @@ import (
 var _ UserTokens = (*userTokens)(nil)
 
 // UserTokens describes all the user token related methods that the
-// Terraform Cloud/Enterprise API supports.
+// HCP Terraform and Terraform Enterprise API supports.
 //
 // TFE API docs:
 // https://developer.hashicorp.com/terraform/cloud-docs/api-docs/user-tokens

--- a/workspace.go
+++ b/workspace.go
@@ -350,7 +350,7 @@ type WorkspaceCreateOptions struct {
 
 	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
 	// Reference: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#create-a-workspace
-	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
+	// Requires remote execution mode, HCP Terraform Business entitlement, and a valid agent pool to work
 	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
 
 	// Optional: Whether to automatically apply changes when a Terraform plan is successful.
@@ -399,7 +399,7 @@ type WorkspaceCreateOptions struct {
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
 
 	// Whether this workspace allows speculative plans. Setting this to false
-	// prevents Terraform Cloud or the Terraform Enterprise instance from
+	// prevents HCP Terraform or the Terraform Enterprise instance from
 	// running plans on pull requests, which can improve security if the VCS
 	// repository is public or includes untrusted contributors.
 	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
@@ -453,7 +453,7 @@ type WorkspaceCreateOptions struct {
 	// organization provides.
 	//
 	// In general, it's not necessary to mark a setting as `true` in this
-	// struct; if you provide a literal value for a setting, Terraform Cloud will
+	// struct; if you provide a literal value for a setting, HCP Terraform will
 	// automatically update its overwrites field to `true`. If you do choose to
 	// manually mark a setting as overwritten, you must provide a value for that
 	// setting at the same time.
@@ -500,7 +500,7 @@ type WorkspaceUpdateOptions struct {
 
 	// Optional: Whether to enable health assessments (drift detection etc.) for the workspace.
 	// Reference: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#update-a-workspace
-	// Requires remote execution mode, Terraform Cloud Business entitlement, and a valid agent pool to work
+	// Requires remote execution mode, HCP Terraform Business entitlement, and a valid agent pool to work
 	AssessmentsEnabled *bool `jsonapi:"attr,assessments-enabled,omitempty"`
 
 	// Optional: Whether to automatically apply changes when a Terraform plan is successful.
@@ -546,7 +546,7 @@ type WorkspaceUpdateOptions struct {
 	QueueAllRuns *bool `jsonapi:"attr,queue-all-runs,omitempty"`
 
 	// Optional: Whether this workspace allows speculative plans. Setting this to false
-	// prevents Terraform Cloud or the Terraform Enterprise instance from
+	// prevents HCP Terraform or the Terraform Enterprise instance from
 	// running plans on pull requests, which can improve security if the VCS
 	// repository is public or includes untrusted contributors.
 	SpeculativeEnabled *bool `jsonapi:"attr,speculative-enabled,omitempty"`
@@ -588,7 +588,7 @@ type WorkspaceUpdateOptions struct {
 	// organization provides.
 	//
 	// In general, it's not necessary to mark a setting as `true` in this
-	// struct; if you provide a literal value for a setting, Terraform Cloud will
+	// struct; if you provide a literal value for a setting, HCP Terraform will
 	// automatically update its overwrites field to `true`. If you do choose to
 	// manually mark a setting as overwritten, you must provide a value for that
 	// setting at the same time.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -923,7 +923,7 @@ func TestWorkspacesReadWithOptions(t *testing.T) {
 	svTest, svTestCleanup := createStateVersion(t, client, 0, wTest)
 	t.Cleanup(svTestCleanup)
 
-	// give TFC some time to process the statefile and extract the outputs.
+	// give HCP Terraform some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
 
 	t.Run("when options to include resource", func(t *testing.T) {

--- a/workspace_resources_integration_test.go
+++ b/workspace_resources_integration_test.go
@@ -5,9 +5,10 @@ package tfe
 
 import (
 	"context"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"testing"
 )
 
 func TestWorkspaceResourcesList(t *testing.T) {
@@ -23,7 +24,7 @@ func TestWorkspaceResourcesList(t *testing.T) {
 	svTest, svTestCleanup := createStateVersion(t, client, 0, wTest)
 	t.Cleanup(svTestCleanup)
 
-	// give TFC some time to process the statefile and extract the outputs.
+	// give HCP Terraform some time to process the statefile and extract the outputs.
 	waitForSVOutputs(t, client, svTest.ID)
 
 	t.Run("without list options", func(t *testing.T) {

--- a/workspace_run_task.go
+++ b/workspace_run_task.go
@@ -12,7 +12,7 @@ import (
 // Compile-time proof of interface implementation
 var _ WorkspaceRunTasks = (*workspaceRunTasks)(nil)
 
-// WorkspaceRunTasks represent all the run task related methods in the context of a workspace that the Terraform Cloud/Enterprise API supports.
+// WorkspaceRunTasks represent all the run task related methods in the context of a workspace that the HCP Terraform and Terraform Enterprise API supports.
 type WorkspaceRunTasks interface {
 	// Add a run task to a workspace
 	Create(ctx context.Context, workspaceID string, options WorkspaceRunTaskCreateOptions) (*WorkspaceRunTask, error)
@@ -35,7 +35,7 @@ type workspaceRunTasks struct {
 	client *Client
 }
 
-// WorkspaceRunTask represents a TFC/E run task that belongs to a workspace
+// WorkspaceRunTask represents a HCP Terraform or Terraform Enterprise run task that belongs to a workspace
 type WorkspaceRunTask struct {
 	ID               string               `jsonapi:"primary,workspace-tasks"`
 	EnforcementLevel TaskEnforcementLevel `jsonapi:"attr,enforcement-level"`


### PR DESCRIPTION
Apply the new branding to go-tfe documentation. 