### PR TITLE
Add enforcement level to policies

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -243,7 +243,9 @@ var (
 
 	ErrRequiredEnabled = errors.New("enabled is required")
 
-	ErrRequiredEnforce = errors.New("enforce is required")
+	ErrRequiredEnforce = errors.New("enforce or enforcement-level is required")
+
+	ErrConflictingEnforceEnforcementLevel = errors.New("enforce and enforcement-level may not both be specified together")
 
 	ErrRequiredEnforcementPath = errors.New("enforcement path is required")
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -771,20 +771,24 @@ func createPolicyWithOptions(t *testing.T, client *Client, org *Organization, op
 	}
 
 	name := randomString(t)
-	path := name + ".sentinel"
-	if opts.Kind == OPA {
-		path = name + ".rego"
-	}
 	options := PolicyCreateOptions{
-		Name:  String(name),
-		Kind:  opts.Kind,
-		Query: opts.Query,
-		Enforce: []*EnforcementOptions{
+		Name:             String(name),
+		Kind:             opts.Kind,
+		Query:            opts.Query,
+		EnforcementLevel: opts.EnforcementLevel,
+	}
+
+	if len(opts.Enforce) > 0 {
+		path := name + ".sentinel"
+		if opts.Kind == OPA {
+			path = name + ".rego"
+		}
+		options.Enforce = []*EnforcementOptions{
 			{
 				Path: String(path),
 				Mode: opts.Enforce[0].Mode,
 			},
-		},
+		}
 	}
 
 	ctx := context.Background()

--- a/policy.go
+++ b/policy.go
@@ -65,14 +65,16 @@ type PolicyList struct {
 
 // Policy represents a Terraform Enterprise policy.
 type Policy struct {
-	ID             string         `jsonapi:"primary,policies"`
-	Name           string         `jsonapi:"attr,name"`
-	Kind           PolicyKind     `jsonapi:"attr,kind"`
-	Query          *string        `jsonapi:"attr,query"`
-	Description    string         `jsonapi:"attr,description"`
-	Enforce        []*Enforcement `jsonapi:"attr,enforce"`
-	PolicySetCount int            `jsonapi:"attr,policy-set-count"`
-	UpdatedAt      time.Time      `jsonapi:"attr,updated-at,iso8601"`
+	ID          string     `jsonapi:"primary,policies"`
+	Name        string     `jsonapi:"attr,name"`
+	Kind        PolicyKind `jsonapi:"attr,kind"`
+	Query       *string    `jsonapi:"attr,query"`
+	Description string     `jsonapi:"attr,description"`
+	// Deprecated: Use EnforcementLevel instead.
+	Enforce          []*Enforcement   `jsonapi:"attr,enforce"`
+	EnforcementLevel EnforcementLevel `jsonapi:"attr,enforcement-level"`
+	PolicySetCount   int              `jsonapi:"attr,policy-set-count"`
+	UpdatedAt        time.Time        `jsonapi:"attr,updated-at,iso8601"`
 
 	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`
@@ -121,8 +123,14 @@ type PolicyCreateOptions struct {
 	// Optional: A description of the policy's purpose.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
-	// Required: The enforcements of the policy.
-	Enforce []*EnforcementOptions `jsonapi:"attr,enforce"`
+	// The enforcements of the policy.
+	//
+	// Deprecated: Use EnforcementLevel instead.
+	Enforce []*EnforcementOptions `jsonapi:"attr,enforce,omitempty"`
+
+	// Required: The enforcement level of the policy.
+	// Either EnforcementLevel or Enforce must be set.
+	EnforcementLevel *EnforcementLevel `jsonapi:"attr,enforcement-level,omitempty"`
 }
 
 // PolicyUpdateOptions represents the options for updating a policy.
@@ -140,7 +148,12 @@ type PolicyUpdateOptions struct {
 	Query *string `jsonapi:"attr,query,omitempty"`
 
 	// Optional: The enforcements of the policy.
+	//
+	// Deprecated: Use EnforcementLevel instead.
 	Enforce []*EnforcementOptions `jsonapi:"attr,enforce,omitempty"`
+
+	// Optional: The enforcement level of the policy.
+	EnforcementLevel *EnforcementLevel `jsonapi:"attr,enforcement-level,omitempty"`
 }
 
 // List all the policies for a given organization
@@ -291,15 +304,20 @@ func (o PolicyCreateOptions) valid() error {
 	if o.Kind == OPA && !validString(o.Query) {
 		return ErrRequiredQuery
 	}
-	if o.Enforce == nil {
+	if o.Enforce == nil && o.EnforcementLevel == nil {
 		return ErrRequiredEnforce
 	}
-	for _, e := range o.Enforce {
-		if !validString(e.Path) {
-			return ErrRequiredEnforcementPath
-		}
-		if e.Mode == nil {
-			return ErrRequiredEnforcementMode
+	if o.Enforce != nil && o.EnforcementLevel != nil {
+		return ErrConflictingEnforceEnforcementLevel
+	}
+	if o.Enforce != nil {
+		for _, e := range o.Enforce {
+			if !validString(e.Path) {
+				return ErrRequiredEnforcementPath
+			}
+			if e.Mode == nil {
+				return ErrRequiredEnforcementMode
+			}
 		}
 	}
 	return nil

--- a/policy_integration_test.go
+++ b/policy_integration_test.go
@@ -207,6 +207,35 @@ func TestPoliciesCreate(t *testing.T) {
 		}
 	})
 
+	t.Run("with valid options - Enforcement Level", func(t *testing.T) {
+		name := randomString(t)
+		options := PolicyCreateOptions{
+			Name:             String(name),
+			Description:      String("A sample policy"),
+			Kind:             Sentinel,
+			EnforcementLevel: EnforcementMode(EnforcementHard),
+		}
+
+		p, err := client.Policies.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		// Get a refreshed view from the API.
+		refreshed, err := client.Policies.Read(ctx, p.ID)
+		require.NoError(t, err)
+
+		for _, item := range []*Policy{
+			p,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, options.Kind, item.Kind)
+			assert.Nil(t, options.Query)
+			assert.Equal(t, *options.Description, item.Description)
+			assert.Equal(t, *options.EnforcementLevel, item.EnforcementLevel)
+		}
+	})
+
 	t.Run("when options has an invalid name", func(t *testing.T) {
 		p, err := client.Policies.Create(ctx, orgTest.Name, PolicyCreateOptions{
 			Name: String(badIdentifier),
@@ -369,6 +398,24 @@ func TestPoliciesCreate(t *testing.T) {
 		assert.Equal(t, err, ErrRequiredEnforcementMode)
 	})
 
+	t.Run("when options is have both enforcement level and enforcement path", func(t *testing.T) {
+		name := randomString(t)
+		options := PolicyCreateOptions{
+			Name: String(name),
+			Enforce: []*EnforcementOptions{
+				{
+					Path: String(randomString(t) + ".sentinel"),
+					Mode: EnforcementMode(EnforcementSoft),
+				},
+			},
+			EnforcementLevel: EnforcementMode(EnforcementMandatory),
+		}
+
+		p, err := client.Policies.Create(ctx, orgTest.Name, options)
+		assert.Nil(t, p)
+		assert.Equal(t, err, ErrConflictingEnforceEnforcementLevel)
+	})
+
 	t.Run("when options has an invalid organization", func(t *testing.T) {
 		p, err := client.Policies.Create(ctx, badIdentifier, PolicyCreateOptions{
 			Name: String("foo"),
@@ -396,6 +443,7 @@ func TestPoliciesRead(t *testing.T) {
 		assert.Equal(t, pTest.Name, p.Name)
 		assert.Equal(t, pTest.PolicySetCount, p.PolicySetCount)
 		assert.Empty(t, p.Enforce)
+		assert.Equal(t, p.EnforcementLevel, pTest.EnforcementLevel)
 		assert.Equal(t, pTest.Organization.Name, p.Organization.Name)
 	})
 
@@ -413,6 +461,7 @@ func TestPoliciesRead(t *testing.T) {
 		assert.NotEmpty(t, p.Enforce)
 		assert.NotEmpty(t, p.Enforce[0].Path)
 		assert.NotEmpty(t, p.Enforce[0].Mode)
+		assert.Equal(t, p.EnforcementLevel, pTest.EnforcementLevel)
 		assert.Equal(t, pTest.Organization.Name, p.Organization.Name)
 	})
 
@@ -527,6 +576,27 @@ func TestPoliciesUpdate(t *testing.T) {
 		assert.Equal(t, pBefore.Enforce, pAfter.Enforce)
 		assert.NotEqual(t, *pBefore.Query, *pAfter.Query)
 		assert.Equal(t, "terraform.policy1.deny", *pAfter.Query)
+	})
+
+	t.Run("with a new enforcement level", func(t *testing.T) {
+		options := PolicyCreateOptions{
+			Description:      String("A sample OPA policy"),
+			Kind:             OPA,
+			Query:            String("data.example.rule"),
+			EnforcementLevel: EnforcementMode(EnforcementMandatory),
+		}
+		pBefore, pBeforeCleanup := createUploadedPolicyWithOptions(t, client, true, orgTest, options)
+		defer pBeforeCleanup()
+
+		pAfter, err := client.Policies.Update(ctx, pBefore.ID, PolicyUpdateOptions{
+			EnforcementLevel: EnforcementMode(EnforcementAdvisory),
+		})
+		require.NoError(t, err)
+
+		assert.Equal(t, pBefore.Name, pAfter.Name)
+		assert.Equal(t, pBefore.EnforcementLevel, EnforcementMandatory)
+		assert.Equal(t, pAfter.EnforcementLevel, EnforcementAdvisory)
+
 	})
 
 	t.Run("update query when kind is not OPA", func(t *testing.T) {


### PR DESCRIPTION
## Description

Adds support for the `EnforcementLevel` field for policies, and their create/update options.

The current method of adding enforcement to policies (the `Enforce` array) is deprecated.

## Testing plan

1. Policies can still be created with the existing enforce array
2. Policies can be created using the preferred enforcement level string
3. Either Enforce or EnforcementLevel must be set on policies during creation
4. Enforce and Enforcement level may not both be set on policy creation

## External links

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/policies#request-body)

## Output from tests

```
go test -timeout 30s -run ^TestPoliciesCreate$ github.com/hashicorp/go-tfe

=== RUN   TestPoliciesCreate
=== RUN   TestPoliciesCreate/with_no_kind
--- PASS: TestPoliciesCreate/with_no_kind (0.47s)
=== RUN   TestPoliciesCreate/with_valid_options_-_Sentinel
--- PASS: TestPoliciesCreate/with_valid_options_-_Sentinel (0.50s)
=== RUN   TestPoliciesCreate/with_valid_options_-_OPA
--- PASS: TestPoliciesCreate/with_valid_options_-_OPA (0.42s)
=== RUN   TestPoliciesCreate/with_valid_options_-_Enforcement_Level
--- PASS: TestPoliciesCreate/with_valid_options_-_Enforcement_Level (0.60s)
=== RUN   TestPoliciesCreate/when_options_has_an_invalid_name
--- PASS: TestPoliciesCreate/when_options_has_an_invalid_name (0.00s)
=== RUN   TestPoliciesCreate/when_options_has_an_invalid_name_-_OPA
--- PASS: TestPoliciesCreate/when_options_has_an_invalid_name_-_OPA (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_name
--- PASS: TestPoliciesCreate/when_options_is_missing_name (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_name_-_OPA
--- PASS: TestPoliciesCreate/when_options_is_missing_name_-_OPA (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_query_-_OPA
--- PASS: TestPoliciesCreate/when_options_is_missing_query_-_OPA (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_an_enforcement-OPA
--- PASS: TestPoliciesCreate/when_options_is_missing_an_enforcement-OPA (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_an_enforcement-Sentinel
--- PASS: TestPoliciesCreate/when_options_is_missing_an_enforcement-Sentinel (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_enforcement_path-Sentinel
--- PASS: TestPoliciesCreate/when_options_is_missing_enforcement_path-Sentinel (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_enforcement_path-OPA
--- PASS: TestPoliciesCreate/when_options_is_missing_enforcement_path-OPA (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_enforcement_path
--- PASS: TestPoliciesCreate/when_options_is_missing_enforcement_path (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_missing_enforcement_mode-OPA
--- PASS: TestPoliciesCreate/when_options_is_missing_enforcement_mode-OPA (0.00s)
=== RUN   TestPoliciesCreate/when_options_is_have_both_enforcement_level_and_enforcement_path
--- PASS: TestPoliciesCreate/when_options_is_have_both_enforcement_level_and_enforcement_path (0.00s)
=== RUN   TestPoliciesCreate/when_options_has_an_invalid_organization
--- PASS: TestPoliciesCreate/when_options_has_an_invalid_organization (0.00s)
--- PASS: TestPoliciesCreate (3.22s)
PASS
ok      github.com/hashicorp/go-tfe     3.413s

go test -timeout 30s -run ^TestPoliciesRead$ github.com/hashicorp/go-tfe

=== RUN   TestPoliciesRead
=== RUN   TestPoliciesRead/when_the_policy_exists_without_content
--- PASS: TestPoliciesRead/when_the_policy_exists_without_content (0.20s)
=== RUN   TestPoliciesRead/when_the_policy_exists_with_content
--- PASS: TestPoliciesRead/when_the_policy_exists_with_content (0.24s)
=== RUN   TestPoliciesRead/when_the_policy_does_not_exist
--- PASS: TestPoliciesRead/when_the_policy_does_not_exist (0.18s)
=== RUN   TestPoliciesRead/without_a_valid_policy_ID
--- PASS: TestPoliciesRead/without_a_valid_policy_ID (0.00s)
--- PASS: TestPoliciesRead (2.84s)
PASS
ok      github.com/hashicorp/go-tfe     3.041s

go test -timeout 30s -run ^TestPoliciesUpdate$ github.com/hashicorp/go-tfe

=== RUN   TestPoliciesUpdate
=== RUN   TestPoliciesUpdate/when_updating_with_an_existing_path
--- PASS: TestPoliciesUpdate/when_updating_with_an_existing_path (1.43s)
=== RUN   TestPoliciesUpdate/when_updating_with_a_nonexisting_path
    /Users/jarretspiker/go/src/github.com/hashicorp/go-tfe/policy_integration_test.go:516: see comment...
--- SKIP: TestPoliciesUpdate/when_updating_with_a_nonexisting_path (0.00s)
=== RUN   TestPoliciesUpdate/with_a_new_description
--- PASS: TestPoliciesUpdate/with_a_new_description (1.31s)
=== RUN   TestPoliciesUpdate/with_a_new_query
--- PASS: TestPoliciesUpdate/with_a_new_query (1.42s)
=== RUN   TestPoliciesUpdate/with_a_new_enforcement_level
--- PASS: TestPoliciesUpdate/with_a_new_enforcement_level (1.34s)
=== RUN   TestPoliciesUpdate/update_query_when_kind_is_not_OPA
--- PASS: TestPoliciesUpdate/update_query_when_kind_is_not_OPA (1.29s)
=== RUN   TestPoliciesUpdate/without_a_valid_policy_ID
--- PASS: TestPoliciesUpdate/without_a_valid_policy_ID (0.00s)
--- PASS: TestPoliciesUpdate (8.01s)
PASS
ok      github.com/hashicorp/go-tfe     8.209s

...
```
