### PR TITLE
Add workspace list filter by current run status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Unreleased
 
+## Enhancements
+* Adds the `CurrentRunStatus` filter to allow filtering workspaces by their current run status by @arybolovlev [#899](https://github.com/hashicorp/go-tfe/pull/899)
+
 # v1.54.0
 
 ## Enhancements
-* Adds the `CurrentRunStatus` filter to allow filtering workspaces by their current run status by @arybolovlev [#899](https://github.com/hashicorp/go-tfe/pull/899)
 * Adds the `AutoDestroyActivityDuration` field to `Workspace` by @notchairmk [#902](https://github.com/hashicorp/go-tfe/pull/902)
 
 ## Deprecations

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@
 ## Deprecations
 * The `IsSiteAdmin` field on User has been deprecated. Use the `IsAdmin` field instead [#900](https://github.com/hashicorp/go-tfe/pull/900)
 
+## Enhancements
+
+* Adds the `CurrentRunStatus` filter to allow filtering workspaces by their current run status by @arybolovlev [#899](https://github.com/hashicorp/go-tfe/pull/899)
+
 # v1.53.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,14 +3,11 @@
 # v1.54.0
 
 ## Enhancements
+* Adds the `CurrentRunStatus` filter to allow filtering workspaces by their current run status by @arybolovlev [#899](https://github.com/hashicorp/go-tfe/pull/899)
 * Adds the `AutoDestroyActivityDuration` field to `Workspace` by @notchairmk [#902](https://github.com/hashicorp/go-tfe/pull/902)
 
 ## Deprecations
 * The `IsSiteAdmin` field on User has been deprecated. Use the `IsAdmin` field instead [#900](https://github.com/hashicorp/go-tfe/pull/900)
-
-## Enhancements
-
-* Adds the `CurrentRunStatus` filter to allow filtering workspaces by their current run status by @arybolovlev [#899](https://github.com/hashicorp/go-tfe/pull/899)
 
 # v1.53.0
 

--- a/workspace.go
+++ b/workspace.go
@@ -325,6 +325,9 @@ type WorkspaceListOptions struct {
 	// Optional: A filter string to list all the workspaces linked to a given project id in the organization.
 	ProjectID string `url:"filter[project][id],omitempty"`
 
+	// Optional: A filter string to list all the workspaces filtered by current run status.
+	CurrentRunStatus string `url:"filter[current-run][status],omitempty"`
+
 	// Optional: A list of relations to include. See available resources https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#available-related-resources
 	Include []WSIncludeOpt `url:"include,omitempty"`
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -281,6 +281,33 @@ func TestWorkspacesList(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, wl.Items)
 	})
+
+	t.Run("when filter workspaces by current run status", func(t *testing.T) {
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		t.Cleanup(wTestCleanup)
+
+		rn, unappliedCleanup := createRunUnapplied(t, client, wTest)
+		t.Cleanup(unappliedCleanup)
+
+		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
+			CurrentRunStatus: string(RunPlanned),
+		})
+
+		require.NoError(t, err)
+		require.NotEmpty(t, wl.Items)
+		require.GreaterOrEqual(t, len(wl.Items), 1)
+
+		found := false
+		for _, ws := range wl.Items {
+			if ws.ID != wTest.ID {
+				continue
+			}
+			assert.Equal(t, ws.CurrentRun.ID, rn.ID)
+			found = true
+		}
+
+		assert.True(t, found)
+	})
 }
 
 func TestWorkspacesCreateTableDriven(t *testing.T) {

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -286,11 +286,11 @@ func TestWorkspacesList(t *testing.T) {
 		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
 		t.Cleanup(wTestCleanup)
 
-		rn, unappliedCleanup := createRunUnapplied(t, client, wTest)
-		t.Cleanup(unappliedCleanup)
+		rn, appliedCleanup := createRunApply(t, client, wTest)
+		t.Cleanup(appliedCleanup)
 
 		wl, err := client.Workspaces.List(ctx, orgTest.Name, &WorkspaceListOptions{
-			CurrentRunStatus: string(RunPlanned),
+			CurrentRunStatus: string(RunApplied),
 		})
 
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

This PR adds a new filter option `CurrentRunStatus` to `WorkspaceListOptions`, allowing a list of Workspaces to be filtered by current run status.

Here is an example of listing workspaces with the current run status set to `planned`.

```console
$ curl -s \
  --header "Authorization: Bearer $TFE_TOKEN" \
  --header "Content-Type: application/vnd.api+json" \
  --request GET \
"https://app.terraform.io/api/v2/organizations/XXX/workspaces?filter%5Bcurrent-run%5D%5Bstatus%5D=planned"
```

If this change is accepted, then I will raise a new PR to update the docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#query-parameters.

## Testing plan

N/A.

## External links

N/A.

## Output from tests

Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
$ TFE_ADDRESS="https://app.terraform.io/" TFE_TOKEN="X.atlasv1.X" go test ./... -v -run TestWorkspacesList
...
--- PASS: TestWorkspacesList (69.91s)
    --- PASS: TestWorkspacesList/without_list_options (0.21s)
    --- PASS: TestWorkspacesList/with_list_options (0.43s)
    --- PASS: TestWorkspacesList/when_sorting_by_workspace_names (0.34s)
    --- PASS: TestWorkspacesList/when_sorting_workspaces_on_current-run.created-at (26.03s)
    --- PASS: TestWorkspacesList/when_searching_a_known_workspace (0.20s)
    --- PASS: TestWorkspacesList/when_searching_using_a_tag (0.47s)
    --- PASS: TestWorkspacesList/when_searching_using_exclude-tags (0.73s)
    --- PASS: TestWorkspacesList/when_searching_an_unknown_workspace (0.17s)
    --- PASS: TestWorkspacesList/without_a_valid_organization (0.00s)
    --- PASS: TestWorkspacesList/with_organization_included (0.45s)
    --- PASS: TestWorkspacesList/with_current-state-version,current-run_included (18.81s)
    --- PASS: TestWorkspacesList/when_searching_a_known_substring (0.59s)
    --- PASS: TestWorkspacesList/when_wildcard_match_does_not_exist (0.57s)
    --- PASS: TestWorkspacesList/when_using_project_id_filter_and_project_contains_workspaces (1.12s)
    --- PASS: TestWorkspacesList/when_using_project_id_filter_but_project_contains_no_workspaces (0.46s)
    --- PASS: TestWorkspacesList/when_filter_workspaces_by_current_run_status (12.65s)
PASS
ok  	github.com/hashicorp/go-tfe	70.207s
```
