### PR TITLE
[#TF-15258] add manage-agent-pools to team organization access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+* Adds `ManageAgentPools` permission to team `OrganizationAccess` by @emlanctot [#901](https://github.com/hashicorp/go-tfe/pull/901)
 
 ## Enhancements
 

--- a/team.go
+++ b/team.go
@@ -75,6 +75,7 @@ type OrganizationAccess struct {
 	ManageTeams              bool `jsonapi:"attr,manage-teams"`
 	ManageOrganizationAccess bool `jsonapi:"attr,manage-organization-access"`
 	AccessSecretTeams        bool `jsonapi:"attr,access-secret-teams"`
+	ManageAgentPools         bool `jsonapi:"attr,manage-agent-pools"`
 }
 
 // TeamPermissions represents the current user's permissions on the team.
@@ -164,6 +165,7 @@ type OrganizationAccessOptions struct {
 	ManageTeams              *bool `json:"manage-teams,omitempty"`
 	ManageOrganizationAccess *bool `json:"manage-organization-access,omitempty"`
 	AccessSecretTeams        *bool `json:"access-secret-teams,omitempty"`
+	ManageAgentPools         *bool `json:"manage-agent-pools,omitempty"`
 }
 
 // List all the teams of the given organization.

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -611,3 +611,38 @@ func TestTeamsUpdateAccessSecretTeams(t *testing.T) {
 	originalTeamAccess.AccessSecretTeams = true
 	assert.Equal(t, originalTeamAccess, refreshed.OrganizationAccess)
 }
+
+func TestTeamsUpdateManageAgentPools(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
+	defer tmTestCleanup()
+
+	teamRead, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.False(t, teamRead.OrganizationAccess.ManageAgentPools, "manage agent pools is false by default")
+
+	originalTeamAccess := teamRead.OrganizationAccess
+
+	options := TeamUpdateOptions{
+		OrganizationAccess: &OrganizationAccessOptions{
+			ManageAgentPools: Bool(true),
+		},
+	}
+
+	tm, err := client.Teams.Update(ctx, tmTest.ID, options)
+	require.NoError(t, err)
+	assert.True(t, tm.OrganizationAccess.ManageAgentPools)
+
+	refreshed, err := client.Teams.Read(ctx, tmTest.ID)
+	require.NoError(t, err)
+	assert.True(t, refreshed.OrganizationAccess.ManageAgentPools)
+
+	// Check that other org access fields are not updated
+	originalTeamAccess.ManageAgentPools = true
+	assert.Equal(t, originalTeamAccess, refreshed.OrganizationAccess)
+}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of Terraform Cloud, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds new `ManageAgentPools` permission to team organization access.

## Testing plan

- `ManageAgentPools` is `false` by default when Teams are created.
- `ManageAgentPools` is read for Teams.
- `ManageAgentPools` should be updatable through the `OrganizationAccessOptions`.

## External links

<!--
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
