### PR TITLE
feat: add workspace auto destroy duration field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Unreleased
+## Enhancements
+* Adds the `AutoDestroyActivityDuration` field to `Workspace` by @notchairmk [#902](https://github.com/hashicorp/go-tfe/pull/902)
+
 ## Deprecations
 * The `IsSiteAdmin` field on User has been deprecated. Use the `IsAdmin` field instead [#900](https://github.com/hashicorp/go-tfe/pull/900)
-
 
 # v1.53.0
 

--- a/workspace.go
+++ b/workspace.go
@@ -155,44 +155,45 @@ type LockedByChoice struct {
 
 // Workspace represents a Terraform Enterprise workspace.
 type Workspace struct {
-	ID                         string                          `jsonapi:"primary,workspaces"`
-	Actions                    *WorkspaceActions               `jsonapi:"attr,actions"`
-	AllowDestroyPlan           bool                            `jsonapi:"attr,allow-destroy-plan"`
-	AssessmentsEnabled         bool                            `jsonapi:"attr,assessments-enabled"`
-	AutoApply                  bool                            `jsonapi:"attr,auto-apply"`
-	AutoApplyRunTrigger        bool                            `jsonapi:"attr,auto-apply-run-trigger"`
-	AutoDestroyAt              jsonapi.NullableAttr[time.Time] `jsonapi:"attr,auto-destroy-at,iso8601,omitempty"`
-	CanQueueDestroyPlan        bool                            `jsonapi:"attr,can-queue-destroy-plan"`
-	CreatedAt                  time.Time                       `jsonapi:"attr,created-at,iso8601"`
-	Description                string                          `jsonapi:"attr,description"`
-	Environment                string                          `jsonapi:"attr,environment"`
-	ExecutionMode              string                          `jsonapi:"attr,execution-mode"`
-	FileTriggersEnabled        bool                            `jsonapi:"attr,file-triggers-enabled"`
-	GlobalRemoteState          bool                            `jsonapi:"attr,global-remote-state"`
-	Locked                     bool                            `jsonapi:"attr,locked"`
-	MigrationEnvironment       string                          `jsonapi:"attr,migration-environment"`
-	Name                       string                          `jsonapi:"attr,name"`
-	Operations                 bool                            `jsonapi:"attr,operations"`
-	Permissions                *WorkspacePermissions           `jsonapi:"attr,permissions"`
-	QueueAllRuns               bool                            `jsonapi:"attr,queue-all-runs"`
-	SpeculativeEnabled         bool                            `jsonapi:"attr,speculative-enabled"`
-	SourceName                 string                          `jsonapi:"attr,source-name"`
-	SourceURL                  string                          `jsonapi:"attr,source-url"`
-	StructuredRunOutputEnabled bool                            `jsonapi:"attr,structured-run-output-enabled"`
-	TerraformVersion           string                          `jsonapi:"attr,terraform-version"`
-	TriggerPrefixes            []string                        `jsonapi:"attr,trigger-prefixes"`
-	TriggerPatterns            []string                        `jsonapi:"attr,trigger-patterns"`
-	VCSRepo                    *VCSRepo                        `jsonapi:"attr,vcs-repo"`
-	WorkingDirectory           string                          `jsonapi:"attr,working-directory"`
-	UpdatedAt                  time.Time                       `jsonapi:"attr,updated-at,iso8601"`
-	ResourceCount              int                             `jsonapi:"attr,resource-count"`
-	ApplyDurationAverage       time.Duration                   `jsonapi:"attr,apply-duration-average"`
-	PlanDurationAverage        time.Duration                   `jsonapi:"attr,plan-duration-average"`
-	PolicyCheckFailures        int                             `jsonapi:"attr,policy-check-failures"`
-	RunFailures                int                             `jsonapi:"attr,run-failures"`
-	RunsCount                  int                             `jsonapi:"attr,workspace-kpis-runs-count"`
-	TagNames                   []string                        `jsonapi:"attr,tag-names"`
-	SettingOverwrites          *WorkspaceSettingOverwrites     `jsonapi:"attr,setting-overwrites"`
+	ID                          string                          `jsonapi:"primary,workspaces"`
+	Actions                     *WorkspaceActions               `jsonapi:"attr,actions"`
+	AllowDestroyPlan            bool                            `jsonapi:"attr,allow-destroy-plan"`
+	AssessmentsEnabled          bool                            `jsonapi:"attr,assessments-enabled"`
+	AutoApply                   bool                            `jsonapi:"attr,auto-apply"`
+	AutoApplyRunTrigger         bool                            `jsonapi:"attr,auto-apply-run-trigger"`
+	AutoDestroyAt               jsonapi.NullableAttr[time.Time] `jsonapi:"attr,auto-destroy-at,iso8601,omitempty"`
+	AutoDestroyActivityDuration jsonapi.NullableAttr[string]    `jsonapi:"attr,auto-destroy-activity-duration,omitempty"`
+	CanQueueDestroyPlan         bool                            `jsonapi:"attr,can-queue-destroy-plan"`
+	CreatedAt                   time.Time                       `jsonapi:"attr,created-at,iso8601"`
+	Description                 string                          `jsonapi:"attr,description"`
+	Environment                 string                          `jsonapi:"attr,environment"`
+	ExecutionMode               string                          `jsonapi:"attr,execution-mode"`
+	FileTriggersEnabled         bool                            `jsonapi:"attr,file-triggers-enabled"`
+	GlobalRemoteState           bool                            `jsonapi:"attr,global-remote-state"`
+	Locked                      bool                            `jsonapi:"attr,locked"`
+	MigrationEnvironment        string                          `jsonapi:"attr,migration-environment"`
+	Name                        string                          `jsonapi:"attr,name"`
+	Operations                  bool                            `jsonapi:"attr,operations"`
+	Permissions                 *WorkspacePermissions           `jsonapi:"attr,permissions"`
+	QueueAllRuns                bool                            `jsonapi:"attr,queue-all-runs"`
+	SpeculativeEnabled          bool                            `jsonapi:"attr,speculative-enabled"`
+	SourceName                  string                          `jsonapi:"attr,source-name"`
+	SourceURL                   string                          `jsonapi:"attr,source-url"`
+	StructuredRunOutputEnabled  bool                            `jsonapi:"attr,structured-run-output-enabled"`
+	TerraformVersion            string                          `jsonapi:"attr,terraform-version"`
+	TriggerPrefixes             []string                        `jsonapi:"attr,trigger-prefixes"`
+	TriggerPatterns             []string                        `jsonapi:"attr,trigger-patterns"`
+	VCSRepo                     *VCSRepo                        `jsonapi:"attr,vcs-repo"`
+	WorkingDirectory            string                          `jsonapi:"attr,working-directory"`
+	UpdatedAt                   time.Time                       `jsonapi:"attr,updated-at,iso8601"`
+	ResourceCount               int                             `jsonapi:"attr,resource-count"`
+	ApplyDurationAverage        time.Duration                   `jsonapi:"attr,apply-duration-average"`
+	PlanDurationAverage         time.Duration                   `jsonapi:"attr,plan-duration-average"`
+	PolicyCheckFailures         int                             `jsonapi:"attr,policy-check-failures"`
+	RunFailures                 int                             `jsonapi:"attr,run-failures"`
+	RunsCount                   int                             `jsonapi:"attr,workspace-kpis-runs-count"`
+	TagNames                    []string                        `jsonapi:"attr,tag-names"`
+	SettingOverwrites           *WorkspaceSettingOverwrites     `jsonapi:"attr,setting-overwrites"`
 
 	// Relations
 	AgentPool                   *AgentPool            `jsonapi:"relation,agent-pool"`
@@ -363,6 +364,10 @@ type WorkspaceCreateOptions struct {
 	// Optional: The time after which an automatic destroy run will be queued
 	AutoDestroyAt jsonapi.NullableAttr[time.Time] `jsonapi:"attr,auto-destroy-at,iso8601,omitempty"`
 
+	// Optional: The period of time to wait after workspace activity to trigger a destroy run. The format
+	// should roughly match a Go duration string limited to days and hours, e.g. "24h" or "1d".
+	AutoDestroyActivityDuration jsonapi.NullableAttr[string] `jsonapi:"attr,auto-destroy-activity-duration,omitempty"`
+
 	// Optional: A description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
 
@@ -512,6 +517,10 @@ type WorkspaceUpdateOptions struct {
 
 	// Optional: The time after which an automatic destroy run will be queued
 	AutoDestroyAt jsonapi.NullableAttr[time.Time] `jsonapi:"attr,auto-destroy-at,iso8601,omitempty"`
+
+	// Optional: The period of time to wait after workspace activity to trigger a destroy run. The format
+	// should roughly match a Go duration string limited to days and hours, e.g. "24h" or "1d".
+	AutoDestroyActivityDuration jsonapi.NullableAttr[string] `jsonapi:"attr,auto-destroy-activity-duration,omitempty"`
 
 	// Optional: A new name for the workspace, which can only include letters, numbers, -,
 	// and _. This will be used as an identifier and must be unique in the


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

Adds an `auto_destroy_activity_duration` field to Workspaces (see [API docs](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#create-a-workspace:~:text=auto-destroy-activity-duration)). Makes use of `jsonapi.NullableAttr` because this is an optional string field, but we will want to be able to send an explicit null to unset.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

1. Run auto destroy tests, confirm that they're valid `envchain go-tfe go test -run "TestWorkspacesAutoDestroy.*"  -v ./...`

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#create-a-workspace:~:text=auto-destroy-activity-duration)
- [Jira](https://hashicorp.atlassian.net/browse/TF-15075)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run "TestWorkspacesAutoDestroy.*"

?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestWorkspacesAutoDestroy
--- PASS: TestWorkspacesAutoDestroy (4.72s)
=== RUN   TestWorkspacesAutoDestroyDuration
--- PASS: TestWorkspacesAutoDestroyDuration (3.85s)
PASS
ok  	github.com/hashicorp/go-tfe	9.099s
...
```
