### PR TITLE
chore: bump nightly run timeout to 59m

### DIFF
--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -21,7 +21,7 @@ jobs:
   tests:
     needs: instance
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 59
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
## Description

This PR bumps the go-tfe nightly test job timeout to 59m.
