### PR TITLE
feat(notification): add auto destroy configuration triggers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 * Adds the `IsUnified` field to `Project`, `Organization` and `Team` by @roncodingenthusiast [#915](https://github.com/hashicorp/go-tfe/pull/915)
+* Adds Workspace auto-destroy notification types to `NotificationTriggerType` by @notchairmk [#918](https://github.com/hashicorp/go-tfe/pull/918)
 
 # v1.56.0
 

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -48,15 +48,17 @@ type notificationConfigurations struct {
 type NotificationTriggerType string
 
 const (
-	NotificationTriggerCreated               NotificationTriggerType = "run:created"
-	NotificationTriggerPlanning              NotificationTriggerType = "run:planning"
-	NotificationTriggerNeedsAttention        NotificationTriggerType = "run:needs_attention"
-	NotificationTriggerApplying              NotificationTriggerType = "run:applying"
-	NotificationTriggerCompleted             NotificationTriggerType = "run:completed"
-	NotificationTriggerErrored               NotificationTriggerType = "run:errored"
-	NotificationTriggerAssessmentDrifted     NotificationTriggerType = "assessment:drifted"
-	NotificationTriggerAssessmentFailed      NotificationTriggerType = "assessment:failed"
-	NotificationTriggerAssessmentCheckFailed NotificationTriggerType = "assessment:check_failure"
+	NotificationTriggerCreated                        NotificationTriggerType = "run:created"
+	NotificationTriggerPlanning                       NotificationTriggerType = "run:planning"
+	NotificationTriggerNeedsAttention                 NotificationTriggerType = "run:needs_attention"
+	NotificationTriggerApplying                       NotificationTriggerType = "run:applying"
+	NotificationTriggerCompleted                      NotificationTriggerType = "run:completed"
+	NotificationTriggerErrored                        NotificationTriggerType = "run:errored"
+	NotificationTriggerAssessmentDrifted              NotificationTriggerType = "assessment:drifted"
+	NotificationTriggerAssessmentFailed               NotificationTriggerType = "assessment:failed"
+	NotificationTriggerAssessmentCheckFailed          NotificationTriggerType = "assessment:check_failure"
+	NotificationTriggerWorkspaceAutoDestroyReminder   NotificationTriggerType = "workspace:auto_destroy_reminder"
+	NotificationTriggerWorkspaceAutoDestroyRunResults NotificationTriggerType = "workspace:auto_destroy_run_results"
 )
 
 // NotificationDestinationType represents the destination type of the
@@ -359,6 +361,8 @@ func validNotificationTriggerType(triggers []NotificationTriggerType) bool {
 			NotificationTriggerPlanning,
 			NotificationTriggerAssessmentDrifted,
 			NotificationTriggerAssessmentFailed,
+			NotificationTriggerWorkspaceAutoDestroyReminder,
+			NotificationTriggerWorkspaceAutoDestroyRunResults,
 			NotificationTriggerAssessmentCheckFailed:
 			continue
 		default:


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This change adds auto destroy configuration triggers for workspace notification configurations. Also adds a test to test creation of all notification configuration triggers.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
1. tests pass
2. (optionally) disable all cleanup steps in `TestNotificationConfigurationsCreate_byType` run tests and confirm that all notification trigger types look correct in the workspace notification settings

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)
-->

- [Jira](https://hashicorp.atlassian.net/browse/TF-16982)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ envchain go-tfe go test -run "TestNotificationConfigurationsCreate_byType"  -v ./...
?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestNotificationConfigurationsCreate_byType
=== PAUSE TestNotificationConfigurationsCreate_byType
=== CONT  TestNotificationConfigurationsCreate_byType
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_run:created_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_run:created_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_run:planning_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_run:planning_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_run:needs_attention_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_run:needs_attention_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_run:applying_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_run:applying_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_run:completed_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_run:completed_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_run:errored_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_run:errored_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_assessment:drifted_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_assessment:drifted_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_assessment:failed_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_assessment:failed_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_assessment:check_failure_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_assessment:check_failure_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_reminder_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_reminder_and_all_required_values
=== RUN   TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_run_results_and_all_required_values
=== PAUSE TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_run_results_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_run:created_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_run_results_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_reminder_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_assessment:check_failure_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_assessment:failed_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_run:completed_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_run:applying_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_assessment:drifted_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_run:needs_attention_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_run:errored_and_all_required_values
=== CONT  TestNotificationConfigurationsCreate_byType/with_trigger_run:planning_and_all_required_values
--- PASS: TestNotificationConfigurationsCreate_byType (3.73s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_assessment:failed_and_all_required_values (0.87s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_run:created_and_all_required_values (1.05s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_run_results_and_all_required_values (1.06s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_workspace:auto_destroy_reminder_and_all_required_values (1.57s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_run:applying_and_all_required_values (1.57s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_assessment:check_failure_and_all_required_values (1.69s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_assessment:drifted_and_all_required_values (1.79s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_run:errored_and_all_required_values (1.91s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_run:needs_attention_and_all_required_values (2.12s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_run:completed_and_all_required_values (2.16s)
    --- PASS: TestNotificationConfigurationsCreate_byType/with_trigger_run:planning_and_all_required_values (1.34s)
PASS
ok  	github.com/hashicorp/go-tfe	6.457s

```
