### PR TITLE
Add new notification trigger types for workspace auto destroy reminder and run results

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 * Adds the `IsUnified` field to `Project`, `Organization` and `Team` by @roncodingenthusiast [#915](https://github.com/hashicorp/go-tfe/pull/915)
-* Add `NotificationTriggerWorkspaceAutoDestroyReminder` and `NotificationTriggerWorkspaceAutoDestroyRunResults` notification trigger types by @sawyerward [#549](https://github.com/hashicorp/go-tfe/pull/919)
+* Add `NotificationTriggerWorkspaceAutoDestroyReminder` and `NotificationTriggerWorkspaceAutoDestroyRunResults` notification trigger types by @sawyerward [#919](https://github.com/hashicorp/go-tfe/pull/919)
 
 # v1.56.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 * Adds the `IsUnified` field to `Project`, `Organization` and `Team` by @roncodingenthusiast [#915](https://github.com/hashicorp/go-tfe/pull/915)
+* Add `NotificationTriggerWorkspaceAutoDestroyReminder` and `NotificationTriggerWorkspaceAutoDestroyRunResults` notification trigger types by @sawyerward [#549](https://github.com/hashicorp/go-tfe/pull/919)
 
 # v1.56.0
 

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -48,15 +48,17 @@ type notificationConfigurations struct {
 type NotificationTriggerType string
 
 const (
-	NotificationTriggerCreated               NotificationTriggerType = "run:created"
-	NotificationTriggerPlanning              NotificationTriggerType = "run:planning"
-	NotificationTriggerNeedsAttention        NotificationTriggerType = "run:needs_attention"
-	NotificationTriggerApplying              NotificationTriggerType = "run:applying"
-	NotificationTriggerCompleted             NotificationTriggerType = "run:completed"
-	NotificationTriggerErrored               NotificationTriggerType = "run:errored"
-	NotificationTriggerAssessmentDrifted     NotificationTriggerType = "assessment:drifted"
-	NotificationTriggerAssessmentFailed      NotificationTriggerType = "assessment:failed"
-	NotificationTriggerAssessmentCheckFailed NotificationTriggerType = "assessment:check_failure"
+	NotificationTriggerCreated                        NotificationTriggerType = "run:created"
+	NotificationTriggerPlanning                       NotificationTriggerType = "run:planning"
+	NotificationTriggerNeedsAttention                 NotificationTriggerType = "run:needs_attention"
+	NotificationTriggerApplying                       NotificationTriggerType = "run:applying"
+	NotificationTriggerCompleted                      NotificationTriggerType = "run:completed"
+	NotificationTriggerErrored                        NotificationTriggerType = "run:errored"
+	NotificationTriggerAssessmentDrifted              NotificationTriggerType = "assessment:drifted"
+	NotificationTriggerAssessmentFailed               NotificationTriggerType = "assessment:failed"
+	NotificationTriggerAssessmentCheckFailed          NotificationTriggerType = "assessment:check_failure"
+	NotificationTriggerWorkspaceAutoDestroyReminder   NotificationTriggerType = "workspace:auto_destroy_reminder"
+	NotificationTriggerWorkspaceAutoDestroyRunResults NotificationTriggerType = "workspace:auto_destroy_run_results"
 )
 
 // NotificationDestinationType represents the destination type of the
@@ -359,7 +361,9 @@ func validNotificationTriggerType(triggers []NotificationTriggerType) bool {
 			NotificationTriggerPlanning,
 			NotificationTriggerAssessmentDrifted,
 			NotificationTriggerAssessmentFailed,
-			NotificationTriggerAssessmentCheckFailed:
+			NotificationTriggerAssessmentCheckFailed,
+			NotificationTriggerWorkspaceAutoDestroyReminder,
+			NotificationTriggerWorkspaceAutoDestroyRunResults:
 			continue
 		default:
 			return false


### PR DESCRIPTION
## Description

- Add support for workspace auto-destroy triggers for notifications.

## Testing plan
- Run tests for `TestNotificationConfiguration.*`.

## Outputs from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

``` 
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run "TestNotificationConfiguration.*"
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestNotificationConfigurationList
=== RUN   TestNotificationConfigurationList/with_a_valid_workspace
    notification_configuration_integration_test.go:36: paging not supported yet in API
=== RUN   TestNotificationConfigurationList/with_list_options
    notification_configuration_integration_test.go:42: paging not supported yet in API
=== RUN   TestNotificationConfigurationList/without_a_valid_workspace
--- PASS: TestNotificationConfigurationList (2.80s)
    --- SKIP: TestNotificationConfigurationList/with_a_valid_workspace (0.17s)
    --- SKIP: TestNotificationConfigurationList/with_list_options (0.00s)
    --- PASS: TestNotificationConfigurationList/without_a_valid_workspace (0.00s)
=== RUN   TestNotificationConfigurationCreate
=== RUN   TestNotificationConfigurationCreate/with_all_required_values
=== RUN   TestNotificationConfigurationCreate/without_a_required_value
=== RUN   TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_generic
=== RUN   TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_slack
=== RUN   TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_MS_Teams
=== RUN   TestNotificationConfigurationCreate/without_a_valid_workspace
=== RUN   TestNotificationConfigurationCreate/with_an_invalid_notification_trigger
=== RUN   TestNotificationConfigurationCreate/with_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationCreate/without_email_users_when_destination_type_is_email
--- PASS: TestNotificationConfigurationCreate (4.20s)
    --- PASS: TestNotificationConfigurationCreate/with_all_required_values (0.14s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_generic (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_slack (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_required_value_URL_when_destination_type_is_MS_Teams (0.00s)
    --- PASS: TestNotificationConfigurationCreate/without_a_valid_workspace (0.00s)
    --- PASS: TestNotificationConfigurationCreate/with_an_invalid_notification_trigger (0.00s)
    --- PASS: TestNotificationConfigurationCreate/with_email_users_when_destination_type_is_email (0.17s)
    --- PASS: TestNotificationConfigurationCreate/without_email_users_when_destination_type_is_email (0.16s)
=== RUN   TestNotificationConfigurationRead
=== RUN   TestNotificationConfigurationRead/with_a_valid_ID
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationRead (2.57s)
    --- PASS: TestNotificationConfigurationRead/with_a_valid_ID (0.15s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_does_not_exist (0.12s)
    --- PASS: TestNotificationConfigurationRead/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationUpdate
=== RUN   TestNotificationConfigurationUpdate/with_options
=== RUN   TestNotificationConfigurationUpdate/with_invalid_notification_trigger
=== RUN   TestNotificationConfigurationUpdate/with_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationUpdate/without_email_users_when_destination_type_is_email
=== RUN   TestNotificationConfigurationUpdate/without_options
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationUpdate (6.41s)
    --- PASS: TestNotificationConfigurationUpdate/with_options (0.26s)
    --- PASS: TestNotificationConfigurationUpdate/with_invalid_notification_trigger (0.00s)
    --- PASS: TestNotificationConfigurationUpdate/with_email_users_when_destination_type_is_email (0.19s)
    --- PASS: TestNotificationConfigurationUpdate/without_email_users_when_destination_type_is_email (0.17s)
    --- PASS: TestNotificationConfigurationUpdate/without_options (0.22s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_does_not_exist (0.12s)
    --- PASS: TestNotificationConfigurationUpdate/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationDelete
=== RUN   TestNotificationConfigurationDelete/with_a_valid_ID
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist
=== RUN   TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationDelete (2.59s)
    --- PASS: TestNotificationConfigurationDelete/with_a_valid_ID (0.24s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_does_not_exist (0.11s)
    --- PASS: TestNotificationConfigurationDelete/when_the_notification_configuration_ID_is_invalid (0.00s)
=== RUN   TestNotificationConfigurationVerify
=== RUN   TestNotificationConfigurationVerify/with_a_valid_ID
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists
=== RUN   TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid
--- PASS: TestNotificationConfigurationVerify (2.65s)
    --- PASS: TestNotificationConfigurationVerify/with_a_valid_ID (0.27s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_does_not_exists (0.12s)
    --- PASS: TestNotificationConfigurationVerify/when_the_notification_configuration_ID_is_invalid (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     21.854s
```