### PR TITLE
Add AllowMemberTokenManagement to Team

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # UNRELEASED
+* Adds `AllowMemberTokenManagement` permission to `Team` by @juliannatetreault []()
 
 ## Enhancements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 # UNRELEASED
-* Adds `AllowMemberTokenManagement` permission to `Team` by @juliannatetreault []()
+* Adds `AllowMemberTokenManagement` permission to `Team` by @juliannatetreault [#922](https://github.com/hashicorp/go-tfe/pull/922)
 
 ## Enhancements
 

--- a/team.go
+++ b/team.go
@@ -54,7 +54,8 @@ type Team struct {
 	Permissions        *TeamPermissions    `jsonapi:"attr,permissions"`
 	UserCount          int                 `jsonapi:"attr,users-count"`
 	SSOTeamID          string              `jsonapi:"attr,sso-team-id"`
-	AllowMemberTokenManagement bool        `jsonapi:"attr,allow-member-token-management"`
+	// AllowMemberTokenManagement is false for TFE versions older than v202408
+	AllowMemberTokenManagement bool `jsonapi:"attr,allow-member-token-management"`
 
 	// Relations
 	Users                   []*User                   `jsonapi:"relation,users"`
@@ -129,8 +130,8 @@ type TeamCreateOptions struct {
 	// The team's visibility ("secret", "organization")
 	Visibility *string `jsonapi:"attr,visibility,omitempty"`
 
-    // Used by Owners and users with "Manage Teams" permissions to control team tokens
-	AllowMemberTokenManagement *bool    `jsonapi:"attr,allow-member-token-management,omitempty"`
+	// Optional: Used by Owners and users with "Manage Teams" permissions to control whether team members can manage team tokens
+	AllowMemberTokenManagement *bool `jsonapi:"attr,allow-member-token-management,omitempty"`
 }
 
 // TeamUpdateOptions represents the options for updating a team.
@@ -153,8 +154,8 @@ type TeamUpdateOptions struct {
 	// Optional: The team's visibility ("secret", "organization")
 	Visibility *string `jsonapi:"attr,visibility,omitempty"`
 
-	// Optional: Used by Owners and users with "Manage Teams" permissions to control team tokens
-    AllowMemberTokenManagement *bool    `jsonapi:"attr,allow-member-token-management,omitempty"`
+	// Optional: Used by Owners and users with "Manage Teams" permissions to control whether team members can manage team tokens
+	AllowMemberTokenManagement *bool `jsonapi:"attr,allow-member-token-management,omitempty"`
 }
 
 // OrganizationAccessOptions represents the organization access options of a team.

--- a/team.go
+++ b/team.go
@@ -54,6 +54,7 @@ type Team struct {
 	Permissions        *TeamPermissions    `jsonapi:"attr,permissions"`
 	UserCount          int                 `jsonapi:"attr,users-count"`
 	SSOTeamID          string              `jsonapi:"attr,sso-team-id"`
+	AllowMemberTokenManagement bool        `jsonapi:"attr,allow-member-token-management"`
 
 	// Relations
 	Users                   []*User                   `jsonapi:"relation,users"`
@@ -127,6 +128,9 @@ type TeamCreateOptions struct {
 
 	// The team's visibility ("secret", "organization")
 	Visibility *string `jsonapi:"attr,visibility,omitempty"`
+
+    // Used by Owners and users with "Manage Teams" permissions to control team tokens
+	AllowMemberTokenManagement *bool    `jsonapi:"attr,allow-member-token-management,omitempty"`
 }
 
 // TeamUpdateOptions represents the options for updating a team.
@@ -148,6 +152,9 @@ type TeamUpdateOptions struct {
 
 	// Optional: The team's visibility ("secret", "organization")
 	Visibility *string `jsonapi:"attr,visibility,omitempty"`
+
+	// Optional: Used by Owners and users with "Manage Teams" permissions to control team tokens
+    AllowMemberTokenManagement *bool    `jsonapi:"attr,allow-member-token-management,omitempty"`
 }
 
 // OrganizationAccessOptions represents the organization access options of a team.

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -159,6 +159,7 @@ func TestTeamsRead(t *testing.T) {
 		OrganizationAccess: &OrganizationAccessOptions{
 			ManagePolicies: Bool(true),
 		},
+		AllowMemberTokenManagement: Bool(true),
 	}
 	ssoTeam, err := client.Teams.Create(ctx, orgTest.Name, opts)
 	require.NoError(t, err)
@@ -188,6 +189,10 @@ func TestTeamsRead(t *testing.T) {
 			assert.NotNil(t, ssoTeam.SSOTeamID)
 			assert.Equal(t, *opts.SSOTeamID, ssoTeam.SSOTeamID)
 		})
+
+        t.Run("allow member token management is returned", func(t *testing.T) {
+                assert.Equal(t, *opts.AllowMemberTokenManagement, tm.AllowMemberTokenManagement)
+            })
 	})
 
 	t.Run("when the team does not exist", func(t *testing.T) {
@@ -224,6 +229,7 @@ func TestTeamsUpdate(t *testing.T) {
 				ManageModules:         Bool(false),
 			},
 			Visibility: String("organization"),
+			AllowMemberTokenManagement: Bool(true),
 		}
 
 		tm, err := client.Teams.Update(ctx, tmTest.ID, options)
@@ -241,6 +247,10 @@ func TestTeamsUpdate(t *testing.T) {
 				*options.Visibility,
 				item.Visibility,
 			)
+            assert.Equal(t,
+                *options.AllowMemberTokenManagement,
+                item.AllowMemberTokenManagement,
+            )
 			assert.Equal(t,
 				*options.OrganizationAccess.ManagePolicies,
 				item.OrganizationAccess.ManagePolicies,
@@ -344,12 +354,14 @@ func TestTeam_Unmarshal(t *testing.T) {
 	assert.Equal(t, team.OrganizationAccess.ReadProjects, true)
 	assert.Equal(t, team.Permissions.CanDestroy, true)
 	assert.Equal(t, team.Permissions.CanUpdateMembership, true)
+	assert.Equal(t, team.AllowMemberTokenManagement, true)
 }
 
 func TestTeamCreateOptions_Marshal(t *testing.T) {
 	opts := TeamCreateOptions{
 		Name:       String("team name"),
 		Visibility: String("organization"),
+		AllowMemberTokenManagement: Bool(true),
 		OrganizationAccess: &OrganizationAccessOptions{
 			ManagePolicies: Bool(true),
 		},
@@ -362,7 +374,7 @@ func TestTeamCreateOptions_Marshal(t *testing.T) {
 	bodyBytes, err := req.BodyBytes()
 	require.NoError(t, err)
 
-	expectedBody := `{"data":{"type":"teams","attributes":{"name":"team name","organization-access":{"manage-policies":true},"visibility":"organization"}}}
+	expectedBody := `{"data":{"type":"teams","attributes":{"name":"team name","organization-access":{"manage-policies":true},"visibility":"organization","allow-member-token-management":true}}}
 `
 	assert.Equal(t, expectedBody, string(bodyBytes))
 }

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -190,9 +190,9 @@ func TestTeamsRead(t *testing.T) {
 			assert.Equal(t, *opts.SSOTeamID, ssoTeam.SSOTeamID)
 		})
 
-        t.Run("allow member token management is returned", func(t *testing.T) {
-                assert.Equal(t, *opts.AllowMemberTokenManagement, tm.AllowMemberTokenManagement)
-            })
+		t.Run("allow member token management is returned", func(t *testing.T) {
+			assert.Equal(t, *opts.AllowMemberTokenManagement, tm.AllowMemberTokenManagement)
+		})
 	})
 
 	t.Run("when the team does not exist", func(t *testing.T) {
@@ -228,7 +228,7 @@ func TestTeamsUpdate(t *testing.T) {
 				ManageProviders:       Bool(true),
 				ManageModules:         Bool(false),
 			},
-			Visibility: String("organization"),
+			Visibility:                 String("organization"),
 			AllowMemberTokenManagement: Bool(true),
 		}
 
@@ -247,10 +247,10 @@ func TestTeamsUpdate(t *testing.T) {
 				*options.Visibility,
 				item.Visibility,
 			)
-            assert.Equal(t,
-                *options.AllowMemberTokenManagement,
-                item.AllowMemberTokenManagement,
-            )
+			assert.Equal(t,
+				*options.AllowMemberTokenManagement,
+				item.AllowMemberTokenManagement,
+			)
 			assert.Equal(t,
 				*options.OrganizationAccess.ManagePolicies,
 				item.OrganizationAccess.ManagePolicies,
@@ -359,8 +359,8 @@ func TestTeam_Unmarshal(t *testing.T) {
 
 func TestTeamCreateOptions_Marshal(t *testing.T) {
 	opts := TeamCreateOptions{
-		Name:       String("team name"),
-		Visibility: String("organization"),
+		Name:                       String("team name"),
+		Visibility:                 String("organization"),
 		AllowMemberTokenManagement: Bool(true),
 		OrganizationAccess: &OrganizationAccessOptions{
 			ManagePolicies: Bool(true),

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -354,7 +354,6 @@ func TestTeam_Unmarshal(t *testing.T) {
 	assert.Equal(t, team.OrganizationAccess.ReadProjects, true)
 	assert.Equal(t, team.Permissions.CanDestroy, true)
 	assert.Equal(t, team.Permissions.CanUpdateMembership, true)
-	assert.Equal(t, team.AllowMemberTokenManagement, true)
 }
 
 func TestTeamCreateOptions_Marshal(t *testing.T) {
@@ -374,7 +373,7 @@ func TestTeamCreateOptions_Marshal(t *testing.T) {
 	bodyBytes, err := req.BodyBytes()
 	require.NoError(t, err)
 
-	expectedBody := `{"data":{"type":"teams","attributes":{"name":"team name","organization-access":{"manage-policies":true},"visibility":"organization","allow-member-token-management":true}}}
+	expectedBody := `{"data":{"type":"teams","attributes":{"allow-member-token-management":true,"name":"team name","organization-access":{"manage-policies":true},"visibility":"organization"}}}
 `
 	assert.Equal(t, expectedBody, string(bodyBytes))
 }


### PR DESCRIPTION
## Description

This PR adds a new team permission - `AllowMemberTokenManagement` - to the `Team` block. `AllowMemberTokenManagement` is  `true` by default and can only be managed by Owners or users with "Manage Teams" permissions. 

Additionally, this PR adds tests for the new permission.

## Testing plan

1. `AllowMemberTokenManagement` is  `true` by default when Teams are created.
2. `AllowMemberTokenManagement` is read for Teams.
3. `AllowMemberTokenManagement` is updatable for Teams.

## External links
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)


## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
