### PR TITLE
[TF-18071] Handle unified id for unified resources: project, workspace, org & teams

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -128,7 +128,7 @@ func (s *adminOrganizations) List(ctx context.Context, options *AdminOrganizatio
 
 // ListModuleConsumers lists specific organizations in the Terraform Enterprise installation that have permission to use an organization's modules.
 func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organization string, options *AdminOrganizationListModuleConsumersOptions) (*AdminOrganizationList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -150,7 +150,7 @@ func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organizati
 
 // Read an organization by its name.
 func (s *adminOrganizations) Read(ctx context.Context, organization string) (*AdminOrganization, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -171,7 +171,7 @@ func (s *adminOrganizations) Read(ctx context.Context, organization string) (*Ad
 
 // Update an organization by its name.
 func (s *adminOrganizations) Update(ctx context.Context, organization string, options AdminOrganizationUpdateOptions) (*AdminOrganization, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -192,7 +192,7 @@ func (s *adminOrganizations) Update(ctx context.Context, organization string, op
 
 // UpdateModuleConsumers updates an organization to specify a list of organizations that can use modules from the sharing organization's private registry.
 func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organization string, consumerOrganizationIDs []string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 
@@ -200,7 +200,7 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 
 	var organizations []*AdminOrganizationID
 	for _, id := range consumerOrganizationIDs {
-		if !validStringID(&id) {
+		if !validUnifiedID(&id) {
 			return ErrInvalidOrg
 		}
 		organizations = append(organizations, &AdminOrganizationID{ID: id})
@@ -221,7 +221,7 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 
 // Delete an organization by its name.
 func (s *adminOrganizations) Delete(ctx context.Context, organization string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -109,7 +109,7 @@ func (s *adminWorkspaces) List(ctx context.Context, options *AdminWorkspaceListO
 
 // Read a workspace by its ID.
 func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminWorkspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceValue
 	}
 
@@ -130,7 +130,7 @@ func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminW
 
 // Delete a workspace by its ID.
 func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceValue
 	}
 

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -107,7 +107,7 @@ type AgentPoolCreateOptions struct {
 
 // List all the agent pools of the given organization.
 func (s *agentPools) List(ctx context.Context, organization string, options *AgentPoolListOptions) (*AgentPoolList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -131,7 +131,7 @@ func (s *agentPools) List(ctx context.Context, organization string, options *Age
 
 // Create a new agent pool with the given options.
 func (s *agentPools) Create(ctx context.Context, organization string, options AgentPoolCreateOptions) (*AgentPool, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -207,7 +207,7 @@ type IngressAttributes struct {
 
 // List returns all configuration versions of a workspace.
 func (s *configurationVersions) List(ctx context.Context, workspaceID string, options *ConfigurationVersionListOptions) (*ConfigurationVersionList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -232,7 +232,7 @@ func (s *configurationVersions) List(ctx context.Context, workspaceID string, op
 // Create is used to create a new configuration version. The created
 // configuration version will be usable once data is uploaded to it.
 func (s *configurationVersions) Create(ctx context.Context, workspaceID string, options ConfigurationVersionCreateOptions) (*ConfigurationVersion, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -227,7 +227,7 @@ type ExampleUpdateOptions struct {
 
 // Create is used to create a new example for an organization
 func (s *example) Create(ctx context.Context, organization string, options ExampleCreateOptions) (*Example, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization){
 		return nil, ErrInvalidOrg
 	}
 
@@ -252,7 +252,7 @@ func (s *example) Create(ctx context.Context, organization string, options Examp
 
 // List all the examples for an organization
 func (s *example) List(ctx context.Context, organization string, options *ExampleListOptions) (*ExampleList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization){
 		return nil, ErrInvalidOrg
 	}
 

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -186,7 +186,7 @@ type NotificationConfigurationUpdateOptions struct {
 
 // List all the notification configurations associated with a workspace.
 func (s *notificationConfigurations) List(ctx context.Context, workspaceID string, options *NotificationConfigurationListOptions) (*NotificationConfigurationList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -207,7 +207,7 @@ func (s *notificationConfigurations) List(ctx context.Context, workspaceID strin
 
 // Create a notification configuration with the given options.
 func (s *notificationConfigurations) Create(ctx context.Context, workspaceID string, options NotificationConfigurationCreateOptions) (*NotificationConfiguration, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -217,7 +217,7 @@ type OAuthClientRemoveProjectsOptions struct {
 
 // List all the OAuth clients for a given organization.
 func (s *oAuthClients) List(ctx context.Context, organization string, options *OAuthClientListOptions) (*OAuthClientList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -241,7 +241,7 @@ func (s *oAuthClients) List(ctx context.Context, organization string, options *O
 
 // Create an OAuth client to connect an organization and a VCS provider.
 func (s *oAuthClients) Create(ctx context.Context, organization string, options OAuthClientCreateOptions) (*OAuthClient, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -75,7 +75,7 @@ type OAuthTokenUpdateOptions struct {
 
 // List all the OAuth tokens for a given organization.
 func (s *oAuthTokens) List(ctx context.Context, organization string, options *OAuthTokenListOptions) (*OAuthTokenList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 

--- a/organization.go
+++ b/organization.go
@@ -342,7 +342,7 @@ func (s *organizations) Read(ctx context.Context, organization string) (*Organiz
 
 // Read an organization by its name with options
 func (s *organizations) ReadWithOptions(ctx context.Context, organization string, options OrganizationReadOptions) (*Organization, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -366,7 +366,7 @@ func (s *organizations) ReadWithOptions(ctx context.Context, organization string
 
 // Update attributes of an existing organization.
 func (s *organizations) Update(ctx context.Context, organization string, options OrganizationUpdateOptions) (*Organization, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -387,7 +387,7 @@ func (s *organizations) Update(ctx context.Context, organization string, options
 
 // Delete an organization by its name.
 func (s *organizations) Delete(ctx context.Context, organization string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 
@@ -402,7 +402,7 @@ func (s *organizations) Delete(ctx context.Context, organization string) error {
 
 // ReadCapacity shows the currently used capacity of an organization.
 func (s *organizations) ReadCapacity(ctx context.Context, organization string) (*Capacity, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -423,7 +423,7 @@ func (s *organizations) ReadCapacity(ctx context.Context, organization string) (
 
 // ReadEntitlements shows the entitlements of an organization.
 func (s *organizations) ReadEntitlements(ctx context.Context, organization string) (*Entitlements, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -444,7 +444,7 @@ func (s *organizations) ReadEntitlements(ctx context.Context, organization strin
 
 // ReadRunQueue shows the current run queue of an organization.
 func (s *organizations) ReadRunQueue(ctx context.Context, organization string, options ReadRunQueueOptions) (*RunQueue, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -464,7 +464,7 @@ func (s *organizations) ReadRunQueue(ctx context.Context, organization string, o
 }
 
 func (s *organizations) ReadDataRetentionPolicy(ctx context.Context, organization string) (*DataRetentionPolicy, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -490,7 +490,7 @@ func (s *organizations) ReadDataRetentionPolicy(ctx context.Context, organizatio
 }
 
 func (s *organizations) ReadDataRetentionPolicyChoice(ctx context.Context, organization string) (*DataRetentionPolicyChoice, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -546,7 +546,7 @@ func (s *organizations) ReadDataRetentionPolicyChoice(ctx context.Context, organ
 // Deprecated: Use SetDataRetentionPolicyDeleteOlder instead
 // **Note: This functionality is only available in Terraform Enterprise versions v202311-1 and v202312-1.**
 func (s *organizations) SetDataRetentionPolicy(ctx context.Context, organization string, options DataRetentionPolicySetOptions) (*DataRetentionPolicy, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -567,7 +567,7 @@ func (s *organizations) SetDataRetentionPolicy(ctx context.Context, organization
 }
 
 func (s *organizations) SetDataRetentionPolicyDeleteOlder(ctx context.Context, organization string, options DataRetentionPolicyDeleteOlderSetOptions) (*DataRetentionPolicyDeleteOlder, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -588,7 +588,7 @@ func (s *organizations) SetDataRetentionPolicyDeleteOlder(ctx context.Context, o
 }
 
 func (s *organizations) SetDataRetentionPolicyDontDelete(ctx context.Context, organization string, options DataRetentionPolicyDontDeleteSetOptions) (*DataRetentionPolicyDontDelete, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -609,7 +609,7 @@ func (s *organizations) SetDataRetentionPolicyDontDelete(ctx context.Context, or
 }
 
 func (s *organizations) DeleteDataRetentionPolicy(ctx context.Context, organization string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -116,7 +116,7 @@ type OrganizationMembershipReadOptions struct {
 
 // List all the organization memberships of the given organization.
 func (s *organizationMemberships) List(ctx context.Context, organization string, options *OrganizationMembershipListOptions) (*OrganizationMembershipList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -140,7 +140,7 @@ func (s *organizationMemberships) List(ctx context.Context, organization string,
 
 // Create an organization membership with the given options.
 func (s *organizationMemberships) Create(ctx context.Context, organization string, options OrganizationMembershipCreateOptions) (*OrganizationMembership, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {

--- a/organization_tags.go
+++ b/organization_tags.go
@@ -83,7 +83,7 @@ type workspaceID struct {
 
 // List all the tags in an organization. You can provide query params through OrganizationTagsListOptions
 func (s *organizationTags) List(ctx context.Context, organization string, options *OrganizationTagsListOptions) (*OrganizationTagsList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -104,7 +104,7 @@ func (s *organizationTags) List(ctx context.Context, organization string, option
 
 // Delete tags from a Terraform Enterprise organization
 func (s *organizationTags) Delete(ctx context.Context, organization string, options OrganizationTagsDeleteOptions) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 

--- a/organization_token.go
+++ b/organization_token.go
@@ -62,7 +62,7 @@ func (s *organizationTokens) Create(ctx context.Context, organization string) (*
 
 // CreateWithOptions a new organization token with options, replacing any existing token.
 func (s *organizationTokens) CreateWithOptions(ctx context.Context, organization string, options OrganizationTokenCreateOptions) (*OrganizationToken, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -83,7 +83,7 @@ func (s *organizationTokens) CreateWithOptions(ctx context.Context, organization
 
 // Read an organization token.
 func (s *organizationTokens) Read(ctx context.Context, organization string) (*OrganizationToken, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -104,7 +104,7 @@ func (s *organizationTokens) Read(ctx context.Context, organization string) (*Or
 
 // Delete an organization token.
 func (s *organizationTokens) Delete(ctx context.Context, organization string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 

--- a/policy.go
+++ b/policy.go
@@ -158,7 +158,7 @@ type PolicyUpdateOptions struct {
 
 // List all the policies for a given organization
 func (s *policies) List(ctx context.Context, organization string, options *PolicyListOptions) (*PolicyList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -179,7 +179,7 @@ func (s *policies) List(ctx context.Context, organization string, options *Polic
 
 // Create a policy and associate it with an organization.
 func (s *policies) Create(ctx context.Context, organization string, options PolicyCreateOptions) (*Policy, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {

--- a/policy_set.go
+++ b/policy_set.go
@@ -310,7 +310,7 @@ type PolicySetRemoveProjectsOptions struct {
 
 // List all the policies for a given organization.
 func (s *policySets) List(ctx context.Context, organization string, options *PolicySetListOptions) (*PolicySetList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -331,7 +331,7 @@ func (s *policySets) List(ctx context.Context, organization string, options *Pol
 
 // Create a policy set and associate it with an organization.
 func (s *policySets) Create(ctx context.Context, organization string, options PolicySetCreateOptions) (*PolicySet, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {

--- a/project.go
+++ b/project.go
@@ -101,7 +101,7 @@ type ProjectUpdateOptions struct {
 
 // List all projects.
 func (s *projects) List(ctx context.Context, organization string, options *ProjectListOptions) (*ProjectList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -122,7 +122,7 @@ func (s *projects) List(ctx context.Context, organization string, options *Proje
 
 // Create a project with the given options
 func (s *projects) Create(ctx context.Context, organization string, options ProjectCreateOptions) (*Project, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -147,7 +147,7 @@ func (s *projects) Create(ctx context.Context, organization string, options Proj
 
 // Read a single project by its ID.
 func (s *projects) Read(ctx context.Context, projectID string) (*Project, error) {
-	if !validStringID(&projectID) {
+	if !validUnifiedID(&projectID) {
 		return nil, ErrInvalidProjectID
 	}
 
@@ -168,7 +168,7 @@ func (s *projects) Read(ctx context.Context, projectID string) (*Project, error)
 
 // Update a project by its ID
 func (s *projects) Update(ctx context.Context, projectID string, options ProjectUpdateOptions) (*Project, error) {
-	if !validStringID(&projectID) {
+	if !validUnifiedID(&projectID) {
 		return nil, ErrInvalidProjectID
 	}
 
@@ -193,7 +193,7 @@ func (s *projects) Update(ctx context.Context, projectID string, options Project
 
 // Delete a project by its ID
 func (s *projects) Delete(ctx context.Context, projectID string) error {
-	if !validStringID(&projectID) {
+	if !validUnifiedID(&projectID) {
 		return ErrInvalidProjectID
 	}
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -310,7 +310,7 @@ type RegistryModuleVCSRepoUpdateOptions struct {
 
 // List all the registory modules within an organization.
 func (r *registryModules) List(ctx context.Context, organization string, options *RegistryModuleListOptions) (*RegistryModuleList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -385,7 +385,7 @@ func (r *registryModules) UploadTarGzip(ctx context.Context, uploadURL string, a
 
 // Create a new registry module without a VCS repo
 func (r *registryModules) Create(ctx context.Context, organization string, options RegistryModuleCreateOptions) (*RegistryModule, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -591,7 +591,7 @@ func (r *registryModules) ReadVersion(ctx context.Context, moduleID RegistryModu
 // Warning: This method is deprecated and will be removed from a future version of go-tfe. Use DeleteByName instead.
 // See API Docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/modules#delete-a-module
 func (r *registryModules) Delete(ctx context.Context, organization, name string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 	if !validString(&name) {

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -133,7 +133,7 @@ type RegistryNoCodeModuleUpdateOptions struct {
 
 // Create a new registry no-code module
 func (r *registryNoCodeModules) Create(ctx context.Context, organization string, options RegistryNoCodeModuleCreateOptions) (*RegistryNoCodeModule, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {

--- a/registry_provider.go
+++ b/registry_provider.go
@@ -127,7 +127,7 @@ type RegistryProviderReadOptions struct {
 }
 
 func (r *registryProviders) List(ctx context.Context, organization string, options *RegistryProviderListOptions) (*RegistryProviderList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -150,7 +150,7 @@ func (r *registryProviders) List(ctx context.Context, organization string, optio
 }
 
 func (r *registryProviders) Create(ctx context.Context, organization string, options RegistryProviderCreateOptions) (*RegistryProvider, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 

--- a/run.go
+++ b/run.go
@@ -376,7 +376,7 @@ type RunDiscardOptions struct {
 
 // List all the runs of the given workspace.
 func (s *runs) List(ctx context.Context, workspaceID string, options *RunListOptions) (*RunList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {

--- a/run_task.go
+++ b/run_task.go
@@ -164,7 +164,7 @@ type RunTaskUpdateOptions struct {
 
 // Create is used to create a new run task for an organization
 func (s *runTasks) Create(ctx context.Context, organization string, options RunTaskCreateOptions) (*RunTask, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -189,7 +189,7 @@ func (s *runTasks) Create(ctx context.Context, organization string, options RunT
 
 // List all the run tasks for an organization
 func (s *runTasks) List(ctx context.Context, organization string, options *RunTaskListOptions) (*RunTaskList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -102,7 +102,7 @@ type RunTriggerCreateOptions struct {
 
 // List all the run triggers associated with a workspace.
 func (s *runTriggers) List(ctx context.Context, workspaceID string, options *RunTriggerListOptions) (*RunTriggerList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -126,7 +126,7 @@ func (s *runTriggers) List(ctx context.Context, workspaceID string, options *Run
 
 // Create a run trigger with the given options.
 func (s *runTriggers) Create(ctx context.Context, workspaceID string, options RunTriggerCreateOptions) (*RunTrigger, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -82,7 +82,7 @@ type SSHKeyUpdateOptions struct {
 
 // List all the SSH keys for a given organization
 func (s *sshKeys) List(ctx context.Context, organization string, options *SSHKeyListOptions) (*SSHKeyList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 
@@ -103,7 +103,7 @@ func (s *sshKeys) List(ctx context.Context, organization string, options *SSHKey
 
 // Create an SSH key and associate it with an organization.
 func (s *sshKeys) Create(ctx context.Context, organization string, options SSHKeyCreateOptions) (*SSHKey, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 

--- a/state_version.go
+++ b/state_version.go
@@ -257,7 +257,7 @@ func (s *stateVersions) List(ctx context.Context, options *StateVersionListOptio
 
 // Create a new state version for the given workspace.
 func (s *stateVersions) Create(ctx context.Context, workspaceID string, options StateVersionCreateOptions) (*StateVersion, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -343,7 +343,7 @@ func (s *stateVersions) Read(ctx context.Context, svID string) (*StateVersion, e
 
 // ReadCurrentWithOptions reads the latest available state from the given workspace using the options supplied.
 func (s *stateVersions) ReadCurrentWithOptions(ctx context.Context, workspaceID string, options *StateVersionCurrentOptions) (*StateVersion, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {

--- a/state_version_output.go
+++ b/state_version_output.go
@@ -40,7 +40,7 @@ type StateVersionOutput struct {
 
 // ReadCurrent reads the current state version outputs for the specified workspace
 func (s *stateVersionOutputs) ReadCurrent(ctx context.Context, workspaceID string) (*StateVersionOutputsList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 

--- a/team.go
+++ b/team.go
@@ -171,7 +171,7 @@ type OrganizationAccessOptions struct {
 
 // List all the teams of the given organization.
 func (s *teams) List(ctx context.Context, organization string, options *TeamListOptions) (*TeamList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -194,7 +194,7 @@ func (s *teams) List(ctx context.Context, organization string, options *TeamList
 
 // Create a new team with the given options.
 func (s *teams) Create(ctx context.Context, organization string, options TeamCreateOptions) (*Team, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -218,7 +218,7 @@ func (s *teams) Create(ctx context.Context, organization string, options TeamCre
 
 // Read a single team by its ID.
 func (s *teams) Read(ctx context.Context, teamID string) (*Team, error) {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}
 
@@ -239,7 +239,7 @@ func (s *teams) Read(ctx context.Context, teamID string) (*Team, error) {
 
 // Update a team by its ID.
 func (s *teams) Update(ctx context.Context, teamID string, options TeamUpdateOptions) (*Team, error) {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}
 
@@ -260,7 +260,7 @@ func (s *teams) Update(ctx context.Context, teamID string, options TeamUpdateOpt
 
 // Delete a team by its ID.
 func (s *teams) Delete(ctx context.Context, teamID string) error {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return ErrInvalidTeamID
 	}
 

--- a/team_member.go
+++ b/team_member.go
@@ -70,7 +70,7 @@ func (s *teamMembers) List(ctx context.Context, teamID string) ([]*User, error) 
 
 // ListUsers returns the Users of this team.
 func (s *teamMembers) ListUsers(ctx context.Context, teamID string) ([]*User, error) {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}
 
@@ -97,7 +97,7 @@ func (s *teamMembers) ListUsers(ctx context.Context, teamID string) ([]*User, er
 
 // ListOrganizationMemberships returns the OrganizationMemberships of this team.
 func (s *teamMembers) ListOrganizationMemberships(ctx context.Context, teamID string) ([]*OrganizationMembership, error) {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}
 
@@ -124,7 +124,7 @@ func (s *teamMembers) ListOrganizationMemberships(ctx context.Context, teamID st
 
 // Add multiple users to a team.
 func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMemberAddOptions) error {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return ErrInvalidTeamID
 	}
 	if err := options.valid(); err != nil {
@@ -163,7 +163,7 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 
 // Remove multiple users from a team.
 func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMemberRemoveOptions) error {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return ErrInvalidTeamID
 	}
 	if err := options.valid(); err != nil {

--- a/team_project_access.go
+++ b/team_project_access.go
@@ -300,7 +300,7 @@ func (s *teamProjectAccesses) Remove(ctx context.Context, teamProjectAccessID st
 }
 
 func (o TeamProjectAccessListOptions) valid() error {
-	if !validStringID(&o.ProjectID) {
+	if !validUnifiedID(&o.ProjectID) {
 		return ErrInvalidProjectID
 	}
 

--- a/team_token.go
+++ b/team_token.go
@@ -62,7 +62,7 @@ func (s *teamTokens) Create(ctx context.Context, teamID string) (*TeamToken, err
 
 // CreateWithOptions a new team token, with options, replacing any existing token.
 func (s *teamTokens) CreateWithOptions(ctx context.Context, teamID string, options TeamTokenCreateOptions) (*TeamToken, error) {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}
 
@@ -83,7 +83,7 @@ func (s *teamTokens) CreateWithOptions(ctx context.Context, teamID string, optio
 
 // Read a team token by its ID.
 func (s *teamTokens) Read(ctx context.Context, teamID string) (*TeamToken, error) {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return nil, ErrInvalidTeamID
 	}
 
@@ -104,7 +104,7 @@ func (s *teamTokens) Read(ctx context.Context, teamID string) (*TeamToken, error
 
 // Delete a team token by its ID.
 func (s *teamTokens) Delete(ctx context.Context, teamID string) error {
-	if !validStringID(&teamID) {
+	if !validUnifiedID(&teamID) {
 		return ErrInvalidTeamID
 	}
 

--- a/validations.go
+++ b/validations.go
@@ -13,6 +13,10 @@ import (
 // A regular expression used to validate common string ID patterns.
 var reStringID = regexp.MustCompile(`^[a-zA-Z0-9\-._]+$`)
 
+// A regular expression used to validate a unified string ID pattern.
+// It validates that string doesn't have slashes and is not empty.
+var unifiedStringRegex = regexp.MustCompile(`^[^/]+$`)
+
 // validEmail checks if the given input is a correct email
 func validEmail(v string) bool {
 	_, err := mail.ParseAddress(v)
@@ -28,6 +32,12 @@ func validString(v *string) bool {
 // contains a typical string identifier.
 func validStringID(v *string) bool {
 	return v != nil && reStringID.MatchString(*v)
+}
+
+// validUnifiedID checks if the given string pointer is non-nil and
+// contains a unified string identifier.
+func validUnifiedID(v *string) bool {
+	return v != nil && unifiedStringRegex.MatchString(*v)
 }
 
 // validVersion checks if the given input is a valid version.

--- a/validations_test.go
+++ b/validations_test.go
@@ -1,0 +1,38 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidUnifiedID(t *testing.T) {
+	type testCase struct {
+		externalID    *string
+		expectedValue bool
+	}
+
+	unifiedTeamID := "iam.group:kmpwhkwf6tkgWzgJKPcP"
+	unifiedProjectID := "616f63c1-3ef5-46a5-b5e8-6d1d86c3f93f"
+	nonUnifiedID := "prj-AywVvpbtLQTcwf8K"
+	invalidID := "test/with-a-slash"
+
+	cases := map[string]testCase{
+		"external-id-is-nil":                {externalID: nil, expectedValue: false},
+		"external-id-is-empty-string":       {externalID: new(string), expectedValue: false},
+		"external-id-is-invalid-with-slash": {externalID: &invalidID, expectedValue: false},
+		"external-id-is-unified-team-id":    {externalID: &unifiedTeamID, expectedValue: true},
+		"external-id-is-unified-project-id": {externalID: &unifiedProjectID, expectedValue: true},
+		"external-id-is-non-unified":        {externalID: &nonUnifiedID, expectedValue: true},
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(tt *testing.T) {
+			actual := validUnifiedID(tcase.externalID)
+			assert.Equal(tt, tcase.expectedValue, actual)
+		})
+	}
+}

--- a/variable.go
+++ b/variable.go
@@ -130,7 +130,7 @@ type VariableUpdateOptions struct {
 
 // List all the variables associated with the given workspace.
 func (s *variables) List(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -151,7 +151,7 @@ func (s *variables) List(ctx context.Context, workspaceID string, options *Varia
 
 // Create is used to create a new variable.
 func (s *variables) Create(ctx context.Context, workspaceID string, options VariableCreateOptions) (*Variable, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -175,7 +175,7 @@ func (s *variables) Create(ctx context.Context, workspaceID string, options Vari
 
 // Read a variable by its ID.
 func (s *variables) Read(ctx context.Context, workspaceID, variableID string) (*Variable, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if !validStringID(&variableID) {
@@ -199,7 +199,7 @@ func (s *variables) Read(ctx context.Context, workspaceID, variableID string) (*
 
 // Update values of an existing variable.
 func (s *variables) Update(ctx context.Context, workspaceID, variableID string, options VariableUpdateOptions) (*Variable, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if !validStringID(&variableID) {
@@ -223,7 +223,7 @@ func (s *variables) Update(ctx context.Context, workspaceID, variableID string, 
 
 // Delete a variable by its ID.
 func (s *variables) Delete(ctx context.Context, workspaceID, variableID string) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 	if !validStringID(&variableID) {

--- a/variable_set.go
+++ b/variable_set.go
@@ -197,7 +197,7 @@ type privateVariableSetUpdateWorkspacesOptions struct {
 
 // List all Variable Sets in the organization
 func (s *variableSets) List(ctx context.Context, organization string, options *VariableSetListOptions) (*VariableSetList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if options != nil {
@@ -223,7 +223,7 @@ func (s *variableSets) List(ctx context.Context, organization string, options *V
 
 // ListForWorkspace gets the associated variable sets for a workspace.
 func (s *variableSets) ListForWorkspace(ctx context.Context, workspaceID string, options *VariableSetListOptions) (*VariableSetList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if options != nil {
@@ -249,7 +249,7 @@ func (s *variableSets) ListForWorkspace(ctx context.Context, workspaceID string,
 
 // ListForProject gets the associated variable sets for a project.
 func (s *variableSets) ListForProject(ctx context.Context, projectID string, options *VariableSetListOptions) (*VariableSetList, error) {
-	if !validStringID(&projectID) {
+	if !validUnifiedID(&projectID) {
 		return nil, ErrInvalidProjectID
 	}
 	if options != nil {
@@ -275,7 +275,7 @@ func (s *variableSets) ListForProject(ctx context.Context, projectID string, opt
 
 // Create is used to create a new variable set.
 func (s *variableSets) Create(ctx context.Context, organization string, options *VariableSetCreateOptions) (*VariableSet, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {

--- a/workspace.go
+++ b/workspace.go
@@ -692,7 +692,7 @@ type WorkspaceRemoveTagsOptions struct {
 
 // List all the workspaces within an organization.
 func (s *workspaces) List(ctx context.Context, organization string, options *WorkspaceListOptions) (*WorkspaceList, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -716,7 +716,7 @@ func (s *workspaces) List(ctx context.Context, organization string, options *Wor
 
 // Create is used to create a new workspace.
 func (s *workspaces) Create(ctx context.Context, organization string, options WorkspaceCreateOptions) (*Workspace, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if err := options.valid(); err != nil {
@@ -745,7 +745,7 @@ func (s *workspaces) Read(ctx context.Context, organization, workspace string) (
 
 // ReadWithOptions reads a workspace by name and organization name with given options.
 func (s *workspaces) ReadWithOptions(ctx context.Context, organization, workspace string, options *WorkspaceReadOptions) (*Workspace, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
@@ -788,7 +788,7 @@ func (s *workspaces) ReadByID(ctx context.Context, workspaceID string) (*Workspa
 
 // ReadByIDWithOptions reads a workspace by its ID with the given options.
 func (s *workspaces) ReadByIDWithOptions(ctx context.Context, workspaceID string, options *WorkspaceReadOptions) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -818,7 +818,7 @@ func (s *workspaces) ReadByIDWithOptions(ctx context.Context, workspaceID string
 
 // Readme gets the readme of a workspace by its ID.
 func (s *workspaces) Readme(ctx context.Context, workspaceID string) (io.Reader, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -842,7 +842,7 @@ func (s *workspaces) Readme(ctx context.Context, workspaceID string) (io.Reader,
 
 // Update settings of an existing workspace.
 func (s *workspaces) Update(ctx context.Context, organization, workspace string, options WorkspaceUpdateOptions) (*Workspace, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
@@ -873,7 +873,7 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 
 // UpdateByID updates the settings of an existing workspace.
 func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options WorkspaceUpdateOptions) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -894,7 +894,7 @@ func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options
 
 // Delete a workspace by its name.
 func (s *workspaces) Delete(ctx context.Context, organization, workspace string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
@@ -916,7 +916,7 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 
 // DeleteByID deletes a workspace by its ID.
 func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 
@@ -931,7 +931,7 @@ func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
 
 // SafeDelete a workspace by its name.
 func (s *workspaces) SafeDelete(ctx context.Context, organization, workspace string) error {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
@@ -953,7 +953,7 @@ func (s *workspaces) SafeDelete(ctx context.Context, organization, workspace str
 
 // SafeDeleteByID safely deletes a workspace by its ID.
 func (s *workspaces) SafeDeleteByID(ctx context.Context, workspaceID string) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 
@@ -968,7 +968,7 @@ func (s *workspaces) SafeDeleteByID(ctx context.Context, workspaceID string) err
 
 // RemoveVCSConnection from a workspace.
 func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, workspace string) (*Workspace, error) {
-	if !validStringID(&organization) {
+	if !validUnifiedID(&organization) {
 		return nil, ErrInvalidOrg
 	}
 	if !validStringID(&workspace) {
@@ -997,7 +997,7 @@ func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, work
 
 // RemoveVCSConnectionByID removes a VCS connection from a workspace.
 func (s *workspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceID string) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1019,7 +1019,7 @@ func (s *workspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceID st
 
 // Lock a workspace by its ID.
 func (s *workspaces) Lock(ctx context.Context, workspaceID string, options WorkspaceLockOptions) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1040,7 +1040,7 @@ func (s *workspaces) Lock(ctx context.Context, workspaceID string, options Works
 
 // Unlock a workspace by its ID.
 func (s *workspaces) Unlock(ctx context.Context, workspaceID string) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1061,7 +1061,7 @@ func (s *workspaces) Unlock(ctx context.Context, workspaceID string) (*Workspace
 
 // ForceUnlock a workspace by its ID.
 func (s *workspaces) ForceUnlock(ctx context.Context, workspaceID string) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1082,7 +1082,7 @@ func (s *workspaces) ForceUnlock(ctx context.Context, workspaceID string) (*Work
 
 // AssignSSHKey to a workspace.
 func (s *workspaces) AssignSSHKey(ctx context.Context, workspaceID string, options WorkspaceAssignSSHKeyOptions) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -1106,7 +1106,7 @@ func (s *workspaces) AssignSSHKey(ctx context.Context, workspaceID string, optio
 
 // UnassignSSHKey from a workspace.
 func (s *workspaces) UnassignSSHKey(ctx context.Context, workspaceID string) (*Workspace, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1127,7 +1127,7 @@ func (s *workspaces) UnassignSSHKey(ctx context.Context, workspaceID string) (*W
 
 // RemoteStateConsumers returns the remote state consumers for a given workspace.
 func (s *workspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID string, options *RemoteStateConsumersListOptions) (*WorkspaceList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1149,7 +1149,7 @@ func (s *workspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID s
 
 // AddRemoteStateConsumere adds the remote state consumers to a given workspace.
 func (s *workspaces) AddRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceAddRemoteStateConsumersOptions) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -1167,7 +1167,7 @@ func (s *workspaces) AddRemoteStateConsumers(ctx context.Context, workspaceID st
 
 // RemoveRemoteStateConsumers removes the remote state consumers for a given workspace.
 func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceRemoveRemoteStateConsumersOptions) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -1185,7 +1185,7 @@ func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID
 
 // UpdateRemoteStateConsumers removes the remote state consumers for a given workspace.
 func (s *workspaces) UpdateRemoteStateConsumers(ctx context.Context, workspaceID string, options WorkspaceUpdateRemoteStateConsumersOptions) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -1203,7 +1203,7 @@ func (s *workspaces) UpdateRemoteStateConsumers(ctx context.Context, workspaceID
 
 // ListTags returns the tags for a given workspace.
 func (s *workspaces) ListTags(ctx context.Context, workspaceID string, options *WorkspaceTagListOptions) (*TagList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1225,7 +1225,7 @@ func (s *workspaces) ListTags(ctx context.Context, workspaceID string, options *
 
 // AddTags adds a list of tags to a workspace.
 func (s *workspaces) AddTags(ctx context.Context, workspaceID string, options WorkspaceAddTagsOptions) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -1243,7 +1243,7 @@ func (s *workspaces) AddTags(ctx context.Context, workspaceID string, options Wo
 
 // RemoveTags removes a list of tags from a workspace.
 func (s *workspaces) RemoveTags(ctx context.Context, workspaceID string, options WorkspaceRemoveTagsOptions) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {
@@ -1260,7 +1260,7 @@ func (s *workspaces) RemoveTags(ctx context.Context, workspaceID string, options
 }
 
 func (s *workspaces) ReadDataRetentionPolicy(ctx context.Context, workspaceID string) (*DataRetentionPolicy, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1286,7 +1286,7 @@ func (s *workspaces) ReadDataRetentionPolicy(ctx context.Context, workspaceID st
 }
 
 func (s *workspaces) ReadDataRetentionPolicyChoice(ctx context.Context, workspaceID string) (*DataRetentionPolicyChoice, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1340,7 +1340,7 @@ func (s *workspaces) ReadDataRetentionPolicyChoice(ctx context.Context, workspac
 }
 
 func (s *workspaces) SetDataRetentionPolicy(ctx context.Context, workspaceID string, options DataRetentionPolicySetOptions) (*DataRetentionPolicy, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1361,7 +1361,7 @@ func (s *workspaces) SetDataRetentionPolicy(ctx context.Context, workspaceID str
 }
 
 func (s *workspaces) SetDataRetentionPolicyDeleteOlder(ctx context.Context, workspaceID string, options DataRetentionPolicyDeleteOlderSetOptions) (*DataRetentionPolicyDeleteOlder, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1382,7 +1382,7 @@ func (s *workspaces) SetDataRetentionPolicyDeleteOlder(ctx context.Context, work
 }
 
 func (s *workspaces) SetDataRetentionPolicyDontDelete(ctx context.Context, workspaceID string, options DataRetentionPolicyDontDeleteSetOptions) (*DataRetentionPolicyDontDelete, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -1403,7 +1403,7 @@ func (s *workspaces) SetDataRetentionPolicyDontDelete(ctx context.Context, works
 }
 
 func (s *workspaces) DeleteDataRetentionPolicy(ctx context.Context, workspaceID string) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 

--- a/workspace_resources.go
+++ b/workspace_resources.go
@@ -53,7 +53,7 @@ type WorkspaceResourceListOptions struct {
 
 // List all the workspaces resources within a workspace
 func (s *workspaceResources) List(ctx context.Context, workspaceID string, options *WorkspaceResourceListOptions) (*WorkspaceResourcesList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 	if err := options.valid(); err != nil {

--- a/workspace_run_task.go
+++ b/workspace_run_task.go
@@ -83,7 +83,7 @@ type WorkspaceRunTaskUpdateOptions struct {
 
 // List all run tasks attached to a workspace
 func (s *workspaceRunTasks) List(ctx context.Context, workspaceID string, options *WorkspaceRunTaskListOptions) (*WorkspaceRunTaskList, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -104,7 +104,7 @@ func (s *workspaceRunTasks) List(ctx context.Context, workspaceID string, option
 
 // Read a workspace run task by ID
 func (s *workspaceRunTasks) Read(ctx context.Context, workspaceID, workspaceTaskID string) (*WorkspaceRunTask, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -133,7 +133,7 @@ func (s *workspaceRunTasks) Read(ctx context.Context, workspaceID, workspaceTask
 
 // Create is used to attach a run task to a workspace, or in other words: create a workspace run task. The run task must exist in the workspace's organization.
 func (s *workspaceRunTasks) Create(ctx context.Context, workspaceID string, options WorkspaceRunTaskCreateOptions) (*WorkspaceRunTask, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -158,7 +158,7 @@ func (s *workspaceRunTasks) Create(ctx context.Context, workspaceID string, opti
 
 // Update an existing workspace run task by ID
 func (s *workspaceRunTasks) Update(ctx context.Context, workspaceID, workspaceTaskID string, options WorkspaceRunTaskUpdateOptions) (*WorkspaceRunTask, error) {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return nil, ErrInvalidWorkspaceID
 	}
 
@@ -187,7 +187,7 @@ func (s *workspaceRunTasks) Update(ctx context.Context, workspaceID, workspaceTa
 
 // Delete a workspace run task by ID
 func (s *workspaceRunTasks) Delete(ctx context.Context, workspaceID, workspaceTaskID string) error {
-	if !validStringID(&workspaceID) {
+	if !validUnifiedID(&workspaceID) {
 		return ErrInvalidWorkspaceID
 	}
 


### PR DESCRIPTION
## Description

- Resources managed by HCP (synced to terraform) do not use the same external ID style as traditional Terraform resources (these resources are known as unified resources)
- This PR adds support for unified resources support 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
