### PR TITLE
[TF-18071] Handle unified id for unified resources: project, workspace, org & teams

### DIFF
--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -485,7 +485,7 @@ func TestPolicySetsCreate(t *testing.T) {
 
 	t.Run("with an invalid name provided", func(t *testing.T) {
 		ps, err := client.PolicySets.Create(ctx, orgTest.Name, PolicySetCreateOptions{
-			Name: String("nope!"),
+			Name: String("nope/nope!"),
 		})
 		assert.Nil(t, ps)
 		assert.EqualError(t, err, ErrInvalidName.Error())
@@ -728,7 +728,7 @@ func TestPolicySetsUpdate(t *testing.T) {
 
 	t.Run("with invalid attributes", func(t *testing.T) {
 		ps, err := client.PolicySets.Update(ctx, psTest.ID, PolicySetUpdateOptions{
-			Name: String("nope!"),
+			Name: String("nope/nope!"),
 		})
 		assert.Nil(t, ps)
 		assert.EqualError(t, err, ErrInvalidName.Error())

--- a/validations.go
+++ b/validations.go
@@ -11,7 +11,7 @@ import (
 )
 
 // A regular expression used to validate common string ID patterns.
-var reStringID = regexp.MustCompile(`^[a-zA-Z0-9\-._]+$`)
+var reStringID = regexp.MustCompile(`^[^/\s]+$`)
 
 // validEmail checks if the given input is a correct email
 func validEmail(v string) bool {

--- a/validations_test.go
+++ b/validations_test.go
@@ -1,0 +1,40 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidStringID(t *testing.T) {
+	type testCase struct {
+		externalID    *string
+		expectedValue bool
+	}
+
+	unifiedTeamID := "iam.group:kmpwhkwf6tkgWzgJKPcP"
+	unifiedProjectID := "616f63c1-3ef5-46a5-b5e8-6d1d86c3f93f"
+	nonUnifiedID := "prj-AywVvpbtLQTcwf8K"
+	invalidID := "test/with-a-slash"
+	invalidIDWithSpace := "test with-space"
+
+	cases := map[string]testCase{
+		"external-id-is-nil":                {externalID: nil, expectedValue: false},
+		"external-id-is-empty-string":       {externalID: new(string), expectedValue: false},
+		"external-id-is-invalid-with-slash": {externalID: &invalidID, expectedValue: false},
+		"external-id-is-invalid-with-space": {externalID: &invalidIDWithSpace, expectedValue: false},
+		"external-id-is-unified-team-id":    {externalID: &unifiedTeamID, expectedValue: true},
+		"external-id-is-unified-project-id": {externalID: &unifiedProjectID, expectedValue: true},
+		"external-id-is-non-unified":        {externalID: &nonUnifiedID, expectedValue: true},
+	}
+
+	for name, tcase := range cases {
+		t.Run(name, func(tt *testing.T) {
+			actual := validStringID(tcase.externalID)
+			assert.Equal(tt, tcase.expectedValue, actual)
+		})
+	}
+}


### PR DESCRIPTION
## Description

- Resources managed by HCP (synced to terraform) do not use the same external ID style as traditional Terraform resources (these resources are known as unified resources). This PR relaxes validation on external ID
- This PR adds support for unified resources support 