### PR TITLE
[WAYP-2819] Support creating no-code workspaces

### DIFF
--- a/.github/actions/test-go-tfe/action.yml
+++ b/.github/actions/test-go-tfe/action.yml
@@ -95,6 +95,7 @@ runs:
         TFC_RUN_TASK_URL: "http://testing-mocks.tfe:22180/runtasks/pass"
         GITHUB_POLICY_SET_IDENTIFIER: "hashicorp/test-policy-set"
         GITHUB_REGISTRY_MODULE_IDENTIFIER: "hashicorp/terraform-random-module"
+        GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER: "hashicorp/terraform-random-no-code-module"
         OAUTH_CLIENT_GITHUB_TOKEN: "${{ inputs.oauth-client-github-token }}"
         GO111MODULE: "on"
         ENABLE_TFE: ${{ inputs.enterprise }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,5 @@
 # UNRELEASED
 
-# v1.61.0
-
 ## Enhancements
 
 * Adds support for creating no-code workspaces by @paladin-devops [#927](https://github.com/hashicorp/go-tfe/pull/927)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # UNRELEASED
 
+# v1.61.0
+
+## Enhancements
+
+* Adds support for creating no-code workspaces by @paladin-devops [#927](https://github.com/hashicorp/go-tfe/pull/927)
+
 # v1.60.0
 
 ## Enhancements

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -20,7 +20,7 @@ There are instances where several new resources being added (i.e Workspace Run T
 
 After opening a PR, our CI system will perform a series of code checks, one of which is linting. Linting is not strictly required for a change to be merged, but it helps smooth the review process and catch common mistakes early. If you'd like to run the linters manually, follow these steps:
 
-1. Ensure you have [installed golangci-lint](https://golangci-lint.run/usage/install/#local-installation)
+1. Ensure you have [installed golangci-lint](https://golangci-lint.run/welcome/install/#local-installation)
 2. Format your code by running `make fmt`
 3. Run lint checks using `make lint`
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -55,6 +55,7 @@ Tests are run against an actual backend so they require a valid backend address 
     ```sh
       $ GITHUB_APP_INSTALLATION_ID=ghain-xxxx TFE_ADDRESS= https://tfe.local TFE_TOKEN=xxx GITHUB_POLICY_SET_IDENTIFIER=username/repository GITHUB_REGISTRY_MODULE_IDENTIFIER=username/repository go test -run "(GHA|GithubApp)" -v ./...
     ```
+8. `GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER` - Required for running tests for workspaces using no-code modules.
 
 ## 3. Make sure run queue settings are correct
 

--- a/mocks/registry_no_code_module_mocks.go
+++ b/mocks/registry_no_code_module_mocks.go
@@ -55,6 +55,21 @@ func (mr *MockRegistryNoCodeModulesMockRecorder) Create(ctx, organization, optio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockRegistryNoCodeModules)(nil).Create), ctx, organization, options)
 }
 
+// CreateWorkspace mocks base method.
+func (m *MockRegistryNoCodeModules) CreateWorkspace(ctx context.Context, noCodeModuleID string, options *tfe.RegistryNoCodeModuleCreateWorkspaceOptions) (*tfe.RegistryNoCodeModuleWorkspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "CreateWorkspace", ctx, noCodeModuleID, options)
+	ret0, _ := ret[0].(*tfe.RegistryNoCodeModuleWorkspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// CreateWorkspace indicates an expected call of CreateWorkspace.
+func (mr *MockRegistryNoCodeModulesMockRecorder) CreateWorkspace(ctx, noCodeModuleID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateWorkspace", reflect.TypeOf((*MockRegistryNoCodeModules)(nil).CreateWorkspace), ctx, noCodeModuleID, options)
+}
+
 // Delete mocks base method.
 func (m *MockRegistryNoCodeModules) Delete(ctx context.Context, ID string) error {
 	m.ctrl.T.Helper()

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -59,6 +59,12 @@ type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 	// Variables is the slice of variables to be configured for the no-code
 	// workspace.
 	Variables []*Variable `jsonapi:"relation,vars,omitempty"`
+
+	// SourceName is the name of the source of the workspace.
+	SourceName *string `jsonapi:"attr,source-name"`
+
+	// SourceUrl is the URL of the source of the workspace.
+	SourceURL *string `jsonapi:"attr,source-url"`
 }
 
 type RegistryNoCodeModuleWorkspace struct {

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -45,7 +45,7 @@ type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 	// Name is the name of the workspace, which can only include letters,
 	// numbers, and _. This will be used as an identifier and must be unique in
 	// the organization.
-	Name *string `jsonapi:"attr,name,omitempty"`
+	Name string `jsonapi:"attr,name"`
 
 	// Description is a description for the workspace.
 	Description *string `jsonapi:"attr,description,omitempty"`
@@ -61,10 +61,10 @@ type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 	Variables []*Variable `jsonapi:"relation,vars,omitempty"`
 
 	// SourceName is the name of the source of the workspace.
-	SourceName *string `jsonapi:"attr,source-name"`
+	SourceName *string `jsonapi:"attr,source-name,omitempty"`
 
 	// SourceUrl is the URL of the source of the workspace.
-	SourceURL *string `jsonapi:"attr,source-url"`
+	SourceURL *string `jsonapi:"attr,source-url,omitempty"`
 }
 
 type RegistryNoCodeModuleWorkspace struct {
@@ -309,11 +309,8 @@ func (o *RegistryNoCodeModuleReadOptions) valid() error {
 }
 
 func (o *RegistryNoCodeModuleCreateWorkspaceOptions) valid() error {
-	if !validString(o.Name) {
+	if !validString(&o.Name) {
 		return ErrRequiredName
-	}
-	if !validStringID(o.Name) {
-		return ErrInvalidName
 	}
 
 	return nil

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -33,6 +33,36 @@ type RegistryNoCodeModules interface {
 	// Delete a registry no-code module
 	// **Note: This API is still in BETA and subject to change.**
 	Delete(ctx context.Context, ID string) error
+
+	// CreateWorkspace creates a workspace using a no-code module.
+	CreateWorkspace(ctx context.Context, noCodeModuleID string, options *RegistryNoCodeModuleCreateWorkspaceOptions) (*RegistryNoCodeModuleWorkspace, error)
+}
+
+type RegistryNoCodeModuleCreateWorkspaceOptions struct {
+	Type string `jsonapi:"primary,no-code-module-workspace"`
+	// Add more create options here
+
+	// Name is the name of the workspace, which can only include letters,
+	// numbers, and _. This will be used as an identifier and must be unique in
+	// the organization.
+	Name *string `jsonapi:"attr,name,omitempty"`
+
+	// Description is a description for the workspace.
+	Description *string `jsonapi:"attr,description,omitempty"`
+
+	AutoApply *bool `jsonapi:"attr,auto-apply,omitempty"`
+
+	// Project is the associated project with the workspace. If not provided,
+	// default project of the organization will be assigned to the workspace.
+	Project *Project `jsonapi:"relation,project,omitempty"`
+
+	// Variables is the slice of variables to be configured for the no-code
+	// workspace.
+	Variables []*Variable `jsonapi:"relation,vars,omitempty"`
+}
+
+type RegistryNoCodeModuleWorkspace struct {
+	Workspace
 }
 
 // registryNoCodeModules implements RegistryNoCodeModules.
@@ -223,6 +253,31 @@ func (r *registryNoCodeModules) Delete(ctx context.Context, noCodeModuleID strin
 	return req.Do(ctx, nil)
 }
 
+// CreateWorkspace creates a no-code workspace using a no-code module.
+func (r *registryNoCodeModules) CreateWorkspace(
+	ctx context.Context,
+	noCodeModuleID string,
+	options *RegistryNoCodeModuleCreateWorkspaceOptions,
+) (*RegistryNoCodeModuleWorkspace, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	u := fmt.Sprintf("no-code-modules/%s/workspaces", url.QueryEscape(noCodeModuleID))
+	req, err := r.client.NewRequest("POST", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	w := &RegistryNoCodeModuleWorkspace{}
+	err = req.Do(ctx, w)
+	if err != nil {
+		return nil, err
+	}
+
+	return w, nil
+}
+
 func (o RegistryNoCodeModuleCreateOptions) valid() error {
 	if o.RegistryModule == nil || o.RegistryModule.ID == "" {
 		return ErrRequiredRegistryModule
@@ -244,5 +299,16 @@ func (o *RegistryNoCodeModuleUpdateOptions) valid() error {
 }
 
 func (o *RegistryNoCodeModuleReadOptions) valid() error {
+	return nil
+}
+
+func (o *RegistryNoCodeModuleCreateWorkspaceOptions) valid() error {
+	if !validString(o.Name) {
+		return ErrRequiredName
+	}
+	if !validStringID(o.Name) {
+		return ErrInvalidName
+	}
+
 	return nil
 }

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -353,11 +353,15 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 
 	t.Run("test creating a workspace via a no-code module", func(t *testing.T) {
 		wn := fmt.Sprintf("foo-%s", randomString(t))
+		sn := "my-app"
+		su := "http://my-app.com"
 		_, err = client.RegistryNoCodeModules.CreateWorkspace(
 			ctx,
 			ncm.ID,
 			&RegistryNoCodeModuleCreateWorkspaceOptions{
-				Name: String(wn),
+				Name:       String(wn),
+				SourceName: String(sn),
+				SourceURL:  String(su),
 			},
 		)
 		r.NoError(err)
@@ -365,6 +369,8 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		w, err := client.Workspaces.Read(ctx, org.Name, wn)
 		r.NoError(err)
 		r.Equal(wn, w.Name)
+		r.Equal(sn, w.SourceName)
+		r.Equal(su, w.SourceURL)
 	})
 
 	t.Run("fail to create a workspace with a bad module ID", func(t *testing.T) {

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -359,7 +359,7 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 			ctx,
 			ncm.ID,
 			&RegistryNoCodeModuleCreateWorkspaceOptions{
-				Name:       String(wn),
+				Name:       wn,
 				SourceName: String(sn),
 				SourceURL:  String(su),
 			},
@@ -379,7 +379,7 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 			ctx,
 			"codeno-abc123XYZ",
 			&RegistryNoCodeModuleCreateWorkspaceOptions{
-				Name: String(wn),
+				Name: wn,
 			},
 		)
 		r.Error(err)


### PR DESCRIPTION
The registry no-code module resource is updated with this commit to include an additional method which can be used to create workspaces using the registry no-code module.

<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

## Testing plan

Run `go-tfe go test -run TestRegistryNoCodeModule -v ./...` with the necessary environment variables.

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
