### PR TITLE
[WAYP-2742] Support no-code workspace upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 ## Enhancements
 
 * Adds support for creating no-code workspaces by @paladin-devops [#927](https://github.com/hashicorp/go-tfe/pull/927)
+* Adds support for upgrading no-code workspaces by @paladin-devops [#935](https://github.com/hashicorp/go-tfe/pull/935)
 
 # v1.60.0
 

--- a/mocks/registry_no_code_module_mocks.go
+++ b/mocks/registry_no_code_module_mocks.go
@@ -113,3 +113,18 @@ func (mr *MockRegistryNoCodeModulesMockRecorder) Update(ctx, noCodeModuleID, opt
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockRegistryNoCodeModules)(nil).Update), ctx, noCodeModuleID, options)
 }
+
+// UpgradeWorkspace mocks base method.
+func (m *MockRegistryNoCodeModules) UpgradeWorkspace(ctx context.Context, noCodeModuleID, workspaceID string, options *tfe.RegistryNoCodeModuleUpgradeWorkspaceOptions) (*tfe.RegistryNoCodeModuleWorkspace, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpgradeWorkspace", ctx, noCodeModuleID, workspaceID, options)
+	ret0, _ := ret[0].(*tfe.RegistryNoCodeModuleWorkspace)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpgradeWorkspace indicates an expected call of UpgradeWorkspace.
+func (mr *MockRegistryNoCodeModulesMockRecorder) UpgradeWorkspace(ctx, noCodeModuleID, workspaceID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpgradeWorkspace", reflect.TypeOf((*MockRegistryNoCodeModules)(nil).UpgradeWorkspace), ctx, noCodeModuleID, workspaceID, options)
+}

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -295,6 +295,7 @@ func (r *registryNoCodeModules) CreateWorkspace(
 	return w, nil
 }
 
+// UpgradeWorkspace initiates an upgrade of an existing no-code module workspace.
 func (r *registryNoCodeModules) UpgradeWorkspace(
 	ctx context.Context,
 	noCodeModuleID string,

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -386,4 +386,117 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 	})
 }
 
-// TODO: Add workspace upgrade test
+func TestRegistryNoCodeModuleWorkspaceUpgrade(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+	r := require.New(t)
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	org, err := client.Organizations.Read(ctx, orgTest.Name)
+	r.NoError(err)
+	r.NotNil(org)
+
+	githubIdentifier := os.Getenv("GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER")
+	if githubIdentifier == "" {
+		t.Skip("Export a valid GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER before running this test")
+	}
+
+	token, cleanupToken := createOAuthToken(t, client, org)
+	defer cleanupToken()
+
+	rmOpts := RegistryModuleCreateWithVCSConnectionOptions{
+		VCSRepo: &RegistryModuleVCSRepoOptions{
+			OrganizationName:  String(org.Name),
+			Identifier:        String(githubIdentifier),
+			Tags:              Bool(true),
+			OAuthTokenID:      String(token.ID),
+			DisplayIdentifier: String(githubIdentifier),
+		},
+		InitialVersion: String("1.0.0"),
+	}
+
+	// create the module
+	rm, err := client.RegistryModules.CreateWithVCSConnection(ctx, rmOpts)
+	r.NoError(err)
+
+	// create the no-code module
+	ncm, err := client.RegistryNoCodeModules.Create(ctx, org.Name, RegistryNoCodeModuleCreateOptions{
+		RegistryModule:  rm,
+		Enabled:         Bool(true),
+		VariableOptions: nil,
+	})
+	r.NoError(err)
+	r.NotNil(ncm)
+
+	// We sleep for 10 seconds to let the module finish getting ready
+	time.Sleep(time.Second * 10)
+
+	// update the module's pinned version to be 1.0.0
+	// NOTE: This is done here as an update instead of at create time, because
+	// that results in the following error:
+	// Validation failed: Provided version pin is not equal to latest or provided
+	// string does not represent an existing version of the module.
+	uncm, err := client.RegistryNoCodeModules.Update(ctx, ncm.ID, RegistryNoCodeModuleUpdateOptions{
+		RegistryModule: rm,
+		VersionPin:     "1.0.0",
+	})
+	r.NoError(err)
+	r.NotNil(uncm)
+
+	// create a workspace, which will be attempted to be updated during the test
+	wn := fmt.Sprintf("foo-%s", randomString(t))
+	sn := "my-app"
+	su := "http://my-app.com"
+	w, err := client.RegistryNoCodeModules.CreateWorkspace(
+		ctx,
+		uncm.ID,
+		&RegistryNoCodeModuleCreateWorkspaceOptions{
+			Name:       wn,
+			SourceName: String(sn),
+			SourceURL:  String(su),
+		},
+	)
+	r.NoError(err)
+	r.NotNil(w)
+
+	// update the module's pinned version
+	uncm, err = client.RegistryNoCodeModules.Update(ctx, ncm.ID, RegistryNoCodeModuleUpdateOptions{
+		VersionPin: "1.0.1",
+	})
+	r.NoError(err)
+	r.NotNil(uncm)
+
+	t.Run("test upgrading a workspace via a no-code module", func(t *testing.T) {
+		_, err = client.RegistryNoCodeModules.UpgradeWorkspace(
+			ctx,
+			ncm.ID,
+			w.ID,
+			&RegistryNoCodeModuleUpgradeWorkspaceOptions{},
+		)
+		r.NoError(err)
+	})
+
+	t.Run("fail to upgrade workspace with invalid no-code module", func(t *testing.T) {
+		_, err = client.RegistryNoCodeModules.UpgradeWorkspace(
+			ctx,
+			ncm.ID+"-invalid",
+			w.ID,
+			&RegistryNoCodeModuleUpgradeWorkspaceOptions{},
+		)
+		r.Error(err)
+	})
+
+	t.Run("fail to upgrade workspace with invalid workspace ID", func(t *testing.T) {
+		_, err = client.RegistryNoCodeModules.UpgradeWorkspace(
+			ctx,
+			ncm.ID,
+			w.ID+"-invalid",
+			&RegistryNoCodeModuleUpgradeWorkspaceOptions{},
+		)
+		r.Error(err)
+	})
+}

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -385,3 +385,5 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		r.Error(err)
 	})
 }
+
+// TODO: Add workspace upgrade test


### PR DESCRIPTION
## Description

This PR adds a method to the no-code registry modules resource for upgrading a no-code workspace.

## Testing plan

Run `go test -run TestRegistryNoCodeModuleWorkspaceUpgrade -v ./...` with the necessary environment variables.
