### PR TITLE
[WAYP-2855] Enable execution mode option for creating no-code workspaces

### DIFF
--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -43,7 +43,6 @@ type RegistryNoCodeModules interface {
 
 type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 	Type string `jsonapi:"primary,no-code-module-workspace"`
-	// Add more create options here
 
 	// Name is the name of the workspace, which can only include letters,
 	// numbers, and _. This will be used as an identifier and must be unique in
@@ -68,6 +67,9 @@ type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 
 	// SourceUrl is the URL of the source of the workspace.
 	SourceURL *string `jsonapi:"attr,source-url,omitempty"`
+
+	// ExecutionMode is the execution mode of the workspace.
+	ExecutionMode *string `jsonapi:"attr,execution-mode,omitempty"`
 }
 
 type RegistryNoCodeModuleUpgradeWorkspaceOptions struct {

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -70,6 +70,11 @@ type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 
 	// ExecutionMode is the execution mode of the workspace.
 	ExecutionMode *string `jsonapi:"attr,execution-mode,omitempty"`
+
+	// AgentPoolId is the ID of the agent pool to use for the workspace.
+	// This is required when execution mode is set to "agent".
+	// This must not be specified when execution mode is set to "remote".
+	AgentPoolID *string `jsonapi:"attr,agent-pool-id,omitempty"`
 }
 
 type RegistryNoCodeModuleUpgradeWorkspaceOptions struct {

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -359,9 +359,10 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 			ctx,
 			ncm.ID,
 			&RegistryNoCodeModuleCreateWorkspaceOptions{
-				Name:       wn,
-				SourceName: String(sn),
-				SourceURL:  String(su),
+				Name:          wn,
+				SourceName:    String(sn),
+				SourceURL:     String(su),
+				ExecutionMode: String("remote"),
 			},
 		)
 		r.NoError(err)
@@ -371,6 +372,7 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		r.Equal(wn, w.Name)
 		r.Equal(sn, w.SourceName)
 		r.Equal(su, w.SourceURL)
+		r.Equal("remote", w.ExecutionMode)
 	})
 
 	t.Run("fail to create a workspace with a bad module ID", func(t *testing.T) {


### PR DESCRIPTION
## Description
This PR adds the option to set the execution mode of a Terraform no-code workspace when creating it.

## Testing plan
Run `go-tfe go test -run TestRegistryNoCodeModule -v ./...` with the necessary environment variables.