### PR TITLE
add new non-TBW timeout attributes

### DIFF
--- a/admin_organization.go
+++ b/admin_organization.go
@@ -53,6 +53,8 @@ type AdminOrganization struct {
 	SsoEnabled                       bool   `jsonapi:"attr,sso-enabled"`
 	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
 	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
+	ApplyTimeout                     string `jsonapi:"attr,apply-timeout"`
+	PlanTimeout                      string `jsonapi:"attr,plan-timeout"`
 	TerraformWorkerSudoEnabled       bool   `jsonapi:"attr,terraform-worker-sudo-enabled"`
 	WorkspaceLimit                   *int   `jsonapi:"attr,workspace-limit"`
 
@@ -69,6 +71,8 @@ type AdminOrganizationUpdateOptions struct {
 	IsDisabled                       *bool   `jsonapi:"attr,is-disabled,omitempty"`
 	TerraformBuildWorkerApplyTimeout *string `jsonapi:"attr,terraform-build-worker-apply-timeout,omitempty"`
 	TerraformBuildWorkerPlanTimeout  *string `jsonapi:"attr,terraform-build-worker-plan-timeout,omitempty"`
+	ApplyTimeout                     *string `jsonapi:"attr,apply-timeout,omitempty"`
+	PlanTimeout                      *string `jsonapi:"attr,plan-timeout,omitempty"`
 	TerraformWorkerSudoEnabled       bool    `jsonapi:"attr,terraform-worker-sudo-enabled,omitempty"`
 	WorkspaceLimit                   *int    `jsonapi:"attr,workspace-limit,omitempty"`
 }

--- a/admin_organization_integration_test.go
+++ b/admin_organization_integration_test.go
@@ -222,8 +222,8 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		globalModuleSharing := false
 		globalProviderSharing := false
 		isDisabled := false
-		terraformBuildWorkerApplyTimeout := "24h"
-		terraformBuildWorkerPlanTimeout := "24h"
+		applyTimeout := "24h"
+		planTimeout := "24h"
 		terraformWorkerSudoEnabled := true
 
 		opts := AdminOrganizationUpdateOptions{
@@ -231,8 +231,10 @@ func TestAdminOrganizations_Update(t *testing.T) {
 			GlobalModuleSharing:              &globalModuleSharing,
 			GlobalProviderSharing:            &globalProviderSharing,
 			IsDisabled:                       &isDisabled,
-			TerraformBuildWorkerApplyTimeout: &terraformBuildWorkerApplyTimeout,
-			TerraformBuildWorkerPlanTimeout:  &terraformBuildWorkerPlanTimeout,
+			TerraformBuildWorkerApplyTimeout: &applyTimeout,
+			TerraformBuildWorkerPlanTimeout:  &planTimeout,
+			ApplyTimeout:                     &applyTimeout,
+			PlanTimeout:                      &planTimeout,
 			TerraformWorkerSudoEnabled:       terraformWorkerSudoEnabled,
 		}
 
@@ -244,8 +246,10 @@ func TestAdminOrganizations_Update(t *testing.T) {
 		assert.Equal(t, adminOrg.GlobalModuleSharing, &globalModuleSharing)
 		assert.Equal(t, adminOrg.GlobalProviderSharing, &globalProviderSharing)
 		assert.Equal(t, isDisabled, adminOrg.IsDisabled)
-		assert.Equal(t, terraformBuildWorkerApplyTimeout, adminOrg.TerraformBuildWorkerApplyTimeout)
-		assert.Equal(t, terraformBuildWorkerPlanTimeout, adminOrg.TerraformBuildWorkerPlanTimeout)
+		assert.Equal(t, applyTimeout, adminOrg.TerraformBuildWorkerApplyTimeout)
+		assert.Equal(t, planTimeout, adminOrg.TerraformBuildWorkerPlanTimeout)
+		assert.Equal(t, applyTimeout, adminOrg.ApplyTimeout)
+		assert.Equal(t, planTimeout, adminOrg.PlanTimeout)
 		assert.Equal(t, terraformWorkerSudoEnabled, adminOrg.TerraformWorkerSudoEnabled)
 		assert.Nil(t, adminOrg.WorkspaceLimit, "default workspace limit should be nil")
 

--- a/admin_setting_general.go
+++ b/admin_setting_general.go
@@ -40,6 +40,8 @@ type AdminGeneralSetting struct {
 	DefaultWorkspacesPerOrgCeiling   int    `jsonapi:"attr,default-workspaces-per-organization-ceiling"`
 	TerraformBuildWorkerApplyTimeout string `jsonapi:"attr,terraform-build-worker-apply-timeout"`
 	TerraformBuildWorkerPlanTimeout  string `jsonapi:"attr,terraform-build-worker-plan-timeout"`
+	ApplyTimeout                     string `jsonapi:"attr,apply-timeout"`
+	PlanTimeout                      string `jsonapi:"attr,plan-timeout"`
 	DefaultRemoteStateAccess         bool   `jsonapi:"attr,default-remote-state-access"`
 }
 
@@ -47,12 +49,14 @@ type AdminGeneralSetting struct {
 // general settings.
 // https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/settings#request-body
 type AdminGeneralSettingsUpdateOptions struct {
-	LimitUserOrgCreation              *bool `jsonapi:"attr,limit-user-organization-creation,omitempty"`
-	APIRateLimitingEnabled            *bool `jsonapi:"attr,api-rate-limiting-enabled,omitempty"`
-	APIRateLimit                      *int  `jsonapi:"attr,api-rate-limit,omitempty"`
-	SendPassingStatusUntriggeredPlans *bool `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
-	AllowSpeculativePlansOnPR         *bool `jsonapi:"attr,allow-speculative-plans-on-pull-requests-from-forks,omitempty"`
-	DefaultRemoteStateAccess          *bool `jsonapi:"attr,default-remote-state-access,omitempty"`
+	LimitUserOrgCreation              *bool   `jsonapi:"attr,limit-user-organization-creation,omitempty"`
+	APIRateLimitingEnabled            *bool   `jsonapi:"attr,api-rate-limiting-enabled,omitempty"`
+	APIRateLimit                      *int    `jsonapi:"attr,api-rate-limit,omitempty"`
+	SendPassingStatusUntriggeredPlans *bool   `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans,omitempty"`
+	AllowSpeculativePlansOnPR         *bool   `jsonapi:"attr,allow-speculative-plans-on-pull-requests-from-forks,omitempty"`
+	DefaultRemoteStateAccess          *bool   `jsonapi:"attr,default-remote-state-access,omitempty"`
+	ApplyTimeout                      *string `jsonapi:"attr,apply-timeout"`
+	PlanTimeout                       *string `jsonapi:"attr,plan-timeout"`
 }
 
 // Read returns the general settings.

--- a/admin_setting_general_integration_test.go
+++ b/admin_setting_general_integration_test.go
@@ -34,6 +34,8 @@ func TestAdminSettings_General_Read(t *testing.T) {
 	assert.NotNil(t, generalSettings.DefaultWorkspacesPerOrgCeiling)
 	assert.NotNil(t, generalSettings.TerraformBuildWorkerApplyTimeout)
 	assert.NotNil(t, generalSettings.TerraformBuildWorkerPlanTimeout)
+	assert.NotNil(t, generalSettings.ApplyTimeout)
+	assert.NotNil(t, generalSettings.PlanTimeout)
 	assert.NotNil(t, generalSettings.DefaultRemoteStateAccess)
 }
 
@@ -50,23 +52,31 @@ func TestAdminSettings_General_Update(t *testing.T) {
 	origAPIRateLimitEnabled := generalSettings.APIRateLimitingEnabled
 	origAPIRateLimit := generalSettings.APIRateLimit
 	origDefaultRemoteState := generalSettings.DefaultRemoteStateAccess
+	origApplyTimeout := generalSettings.ApplyTimeout
+	origPlanTimeout := generalSettings.PlanTimeout
 
 	limitOrgCreation := true
 	apiRateLimitEnabled := true
 	apiRateLimit := 50
 	defaultRemoteStateAccess := false
+	applyTimeout := "2h"
+	planTimeout := "30m"
 
 	generalSettings, err = client.Admin.Settings.General.Update(ctx, AdminGeneralSettingsUpdateOptions{
 		LimitUserOrgCreation:     Bool(limitOrgCreation),
 		APIRateLimitingEnabled:   Bool(apiRateLimitEnabled),
 		APIRateLimit:             Int(apiRateLimit),
 		DefaultRemoteStateAccess: Bool(defaultRemoteStateAccess),
+		ApplyTimeout:             &applyTimeout,
+		PlanTimeout:              &planTimeout,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, limitOrgCreation, generalSettings.LimitUserOrganizationCreation)
 	assert.Equal(t, apiRateLimitEnabled, generalSettings.APIRateLimitingEnabled)
 	assert.Equal(t, apiRateLimit, generalSettings.APIRateLimit)
 	assert.Equal(t, defaultRemoteStateAccess, generalSettings.DefaultRemoteStateAccess)
+	assert.Equal(t, applyTimeout, generalSettings.ApplyTimeout)
+	assert.Equal(t, planTimeout, generalSettings.PlanTimeout)
 
 	// Undo Updates, revert back to original
 	generalSettings, err = client.Admin.Settings.General.Update(ctx, AdminGeneralSettingsUpdateOptions{
@@ -74,10 +84,14 @@ func TestAdminSettings_General_Update(t *testing.T) {
 		APIRateLimitingEnabled:   Bool(origAPIRateLimitEnabled),
 		APIRateLimit:             Int(origAPIRateLimit),
 		DefaultRemoteStateAccess: Bool(origDefaultRemoteState),
+		ApplyTimeout:             &origApplyTimeout,
+		PlanTimeout:              &origPlanTimeout,
 	})
 	require.NoError(t, err)
 	assert.Equal(t, origLimitOrgCreation, generalSettings.LimitUserOrganizationCreation)
 	assert.Equal(t, origAPIRateLimitEnabled, generalSettings.APIRateLimitingEnabled)
 	assert.Equal(t, origAPIRateLimit, generalSettings.APIRateLimit)
 	assert.Equal(t, origDefaultRemoteState, generalSettings.DefaultRemoteStateAccess)
+	assert.Equal(t, origApplyTimeout, generalSettings.ApplyTimeout)
+	assert.Equal(t, origPlanTimeout, generalSettings.PlanTimeout)
 }


### PR DESCRIPTION
## Description

Small cleanup PR to indicate that the `terraform-build-worker-plan-timeout` and `terraform-build-worker-apply-timeout` attributes in the admin API are being phased out and replaced with `plan-timeout` and `apply-timeout`, respectively. The new attributes are entirely interchangeable with the old, only the name is different.
