### PR TITLE
polling helpers for stack plan/configuration state

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -74,16 +74,16 @@ type StackVCSRepo struct {
 
 // Stack represents a stack.
 type Stack struct {
-	ID                      string        `jsonapi:"primary,stacks"`
-	Name                    string        `jsonapi:"attr,name"`
-	Description             string        `jsonapi:"attr,description"`
-	DeploymentNames         []string      `jsonapi:"attr,deployment-names"`
-	VCSRepo                 *StackVCSRepo `jsonapi:"attr,vcs-repo"`
-	ErrorsCount             int           `jsonapi:"attr,errors-count"`
-	WarningsCount           int           `jsonapi:"attr,warnings-count"`
-	SpeculativePlansEnabled bool          `jsonapi:"attr,speculative-enabled"`
-	CreatedAt               time.Time     `jsonapi:"attr,created-at,iso8601"`
-	UpdatedAt               time.Time     `jsonapi:"attr,updated-at,iso8601"`
+	ID                 string        `jsonapi:"primary,stacks"`
+	Name               string        `jsonapi:"attr,name"`
+	Description        string        `jsonapi:"attr,description"`
+	DeploymentNames    []string      `jsonapi:"attr,deployment-names"`
+	VCSRepo            *StackVCSRepo `jsonapi:"attr,vcs-repo"`
+	ErrorsCount        int           `jsonapi:"attr,errors-count"`
+	WarningsCount      int           `jsonapi:"attr,warnings-count"`
+	SpeculativeEnabled bool          `jsonapi:"attr,speculative-enabled"`
+	CreatedAt          time.Time     `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt          time.Time     `jsonapi:"attr,updated-at,iso8601"`
 
 	// Relationships
 	Project                  *Project            `jsonapi:"relation,project"`

--- a/stack.go
+++ b/stack.go
@@ -168,6 +168,22 @@ type StackUpdateOptions struct {
 	VCSRepo     *StackVCSRepo `jsonapi:"attr,vcs-repo,omitempty"`
 }
 
+// WaitForStatusResult is the data structure that is sent over the channel
+// returned by various status polling functions. For each result, either the
+// Error or the Status will be set, but not both. If the Quit field is set,
+// the channel will be closed. If the Quit field is set and the Error is
+// nil, the Status field will be set to a specified quit status.
+type WaitForStatusResult struct {
+	ID           string
+	Status       string
+	ReadAttempts int
+	Error        error
+	Quit         bool
+}
+
+const minimumPollingIntervalMs = 3000
+const maximumPollingIntervalMs = 5000
+
 // UpdateConfiguration updates the configuration of a stack, triggering stack operations
 func (s *stacks) UpdateConfiguration(ctx context.Context, stackID string) (*Stack, error) {
 	req, err := s.client.NewRequest("POST", fmt.Sprintf("stacks/%s/actions/update-configuration", url.PathEscape(stackID)), nil)
@@ -288,4 +304,59 @@ func (s StackVCSRepo) valid() error {
 	}
 
 	return nil
+}
+
+// awaitPoll is a helper function that uses a callback to read a status, then
+// waits for a terminal status or an error. The callback should return the
+// current status, or an error. For each time the status changes, the channel
+// emits a new result. The id parameter should be the ID of the resource being
+// polled, which is used in the result to help identify the resource being polled.
+func awaitPoll(ctx context.Context, id string, reader func(ctx context.Context) (string, error), quitStatus []string) <-chan WaitForStatusResult {
+	resultCh := make(chan WaitForStatusResult)
+
+	mapStatus := make(map[string]struct{}, len(quitStatus))
+	for _, status := range quitStatus {
+		mapStatus[status] = struct{}{}
+	}
+
+	go func() {
+		defer close(resultCh)
+
+		reads := 0
+		lastStatus := ""
+		for {
+			select {
+			case <-ctx.Done():
+				resultCh <- WaitForStatusResult{ID: id, Error: fmt.Errorf("context canceled: %w", ctx.Err())}
+				return
+			case <-time.After(backoff(minimumPollingIntervalMs, maximumPollingIntervalMs, reads)):
+				status, err := reader(ctx)
+				if err != nil {
+					resultCh <- WaitForStatusResult{ID: id, Error: err, Quit: true}
+					return
+				}
+
+				_, terminal := mapStatus[status]
+
+				if status != lastStatus {
+					resultCh <- WaitForStatusResult{
+						ID:           id,
+						Status:       status,
+						ReadAttempts: reads + 1,
+						Quit:         terminal,
+					}
+				}
+
+				lastStatus = status
+
+				if terminal {
+					return
+				}
+
+				reads += 1
+			}
+		}
+	}()
+
+	return resultCh
 }

--- a/stack_plan.go
+++ b/stack_plan.go
@@ -33,9 +33,9 @@ type StackPlans interface {
 	// PlanDescription returns the plan description for a stack plan.
 	PlanDescription(ctx context.Context, stackPlanID string) (*JSONChangeDesc, error)
 
-	// AwaitTerminalState generates a channel that will receive the status of the stack plan as it progresses.
+	// AwaitTerminal generates a channel that will receive the status of the stack plan as it progresses.
 	// See WaitForStatusResult for more information.
-	AwaitTerminalState(ctx context.Context, stackPlanID string) <-chan WaitForStatusResult
+	AwaitTerminal(ctx context.Context, stackPlanID string) <-chan WaitForStatusResult
 
 	// AwaitRunning generates a channel that will receive the status of the stack plan as it progresses.
 	// See WaitForStatusResult for more information.
@@ -291,14 +291,14 @@ func (s stackPlans) PlanDescription(ctx context.Context, stackPlanID string) (*J
 	return jd, nil
 }
 
-// AwaitTerminalState generates a channel that will receive the status of the stack plan as it progresses.
+// AwaitTerminal generates a channel that will receive the status of the stack plan as it progresses.
 // The channel will be closed when the stack plan reaches a final status or an error occurs. The
 // read will be retried dependending on the configuration of the client. When the channel is closed,
 // the last value will either be a terminal status (finished, finished_no_changes, finished_applied,
 // finished_planned, discarded, canceled, errorer), or an error. The status check will continue even
 // if the stack plan is waiting for approval. Check the status within the the channel to determine
 // if the stack plan needs approval.
-func (s stackPlans) AwaitTerminalState(ctx context.Context, stackPlanID string) <-chan WaitForStatusResult {
+func (s stackPlans) AwaitTerminal(ctx context.Context, stackPlanID string) <-chan WaitForStatusResult {
 	return awaitPoll(ctx, stackPlanID, func(ctx context.Context) (string, error) {
 		stackPlan, err := s.Read(ctx, stackPlanID)
 		if err != nil {


### PR DESCRIPTION
## Description

Stack configurations, stack plans, and stack plan operations are driven through their lifecycle through various states, and these can be repetitive and difficult to correctly handle when developing client applications. It would be really nice if the SDK provided some simple polling helpers to assist with building client applications.

## Testing plan

Utilized this in canary tests. DM for details. Here's an example:

Waiting for configuration prepared:
```go
waitForPrepared := client.StackConfigurations.AwaitPrepared(ctx, stack.LatestStackConfiguration.ID)
for {
    result := <-waitForPrepared
    if result.Error != nil {
        return fmt.Errorf("error waiting for status: %w", result.Error)
    }
    if result.Quit {
        logf("%s reached quit status %s", result.ID, result.Status)
        return nil
    }
    logf("%s had status %s", result.ID, result.Status)
}
```

Fan-in plans triggered by prepared configuration:
```go
plans, err := client.StackPlans.ListByConfiguration(ctx, stack.LatestStackConfiguration.ID, nil)
if err != nil {
    return fmt.Errorf("error listing stack plans: %w", err)
}

c.logger.Debug().Msgf("Found %d plans for stack %s", len(plans.Items), stack.ID)

// Wait on all the plans to finish
planWaits := make([]<-chan tfe.WaitForStatusResult, len(plans.Items))
for idx, plan := range plans.Items {
    planWaits[idx] = client.StackPlans.AwaitTerminalState(ctx, plan.ID)
    logf("Waiting for plan %s to finish...", plan.ID)
}

// Fan-in all waitings
planFinished := make(chan tfe.WaitForStatusResult)
for _, ch := range planWaits {
go func() {
    for result := range ch {
        planFinished <- result
    }
}()
}

done := 0

loop:
for {
    select {
    case <-ctx.Done():
        return fmt.Errorf("context was canceled: %w", ctx.Err())
    case progress := <-planFinished:
        if progress.Error != nil {
            return fmt.Errorf("plan %q could not finish: %w", progress.ID, progress.Error)
        }
	logf("Plan %s has status %s", progress.ID, progress.Status)
	if progress.Quit {
            done += 1
            logf("Plan %s reached quit status %s", progress.ID, progress.Status)
            if done == len(plans.Items) {
                break loop
            }
        } else if progress.Status == "paused_planned" {
            err = client.StackPlans.Approve(ctx, progress.ID)
            if err != nil {
                return fmt.Errorf("error approving plan %q: %w", progress.ID, err)
            }
        }
    }
}

```
