### PR TITLE
Fix returned workspace for created & upgraded no-code workspaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # UNRELEASED
 * Adds `AllowMemberTokenManagement` permission to `Team` by @juliannatetreault [#922](https://github.com/hashicorp/go-tfe/pull/922)
 
+## Bug Fixes
+* Fix returned workspace for no-code workspace creation & upgrade by @paladin-devops [#954](https://github.com/hashicorp/go-tfe/pull/954)
+
 # v1.61.0
 
 ## Enhancements

--- a/mocks/registry_no_code_module_mocks.go
+++ b/mocks/registry_no_code_module_mocks.go
@@ -56,10 +56,10 @@ func (mr *MockRegistryNoCodeModulesMockRecorder) Create(ctx, organization, optio
 }
 
 // CreateWorkspace mocks base method.
-func (m *MockRegistryNoCodeModules) CreateWorkspace(ctx context.Context, noCodeModuleID string, options *tfe.RegistryNoCodeModuleCreateWorkspaceOptions) (*tfe.RegistryNoCodeModuleWorkspace, error) {
+func (m *MockRegistryNoCodeModules) CreateWorkspace(ctx context.Context, noCodeModuleID string, options *tfe.RegistryNoCodeModuleCreateWorkspaceOptions) (*tfe.Workspace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "CreateWorkspace", ctx, noCodeModuleID, options)
-	ret0, _ := ret[0].(*tfe.RegistryNoCodeModuleWorkspace)
+	ret0, _ := ret[0].(*tfe.Workspace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
@@ -115,10 +115,10 @@ func (mr *MockRegistryNoCodeModulesMockRecorder) Update(ctx, noCodeModuleID, opt
 }
 
 // UpgradeWorkspace mocks base method.
-func (m *MockRegistryNoCodeModules) UpgradeWorkspace(ctx context.Context, noCodeModuleID, workspaceID string, options *tfe.RegistryNoCodeModuleUpgradeWorkspaceOptions) (*tfe.RegistryNoCodeModuleWorkspace, error) {
+func (m *MockRegistryNoCodeModules) UpgradeWorkspace(ctx context.Context, noCodeModuleID, workspaceID string, options *tfe.RegistryNoCodeModuleUpgradeWorkspaceOptions) (*tfe.Workspace, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeWorkspace", ctx, noCodeModuleID, workspaceID, options)
-	ret0, _ := ret[0].(*tfe.RegistryNoCodeModuleWorkspace)
+	ret0, _ := ret[0].(*tfe.Workspace)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -35,10 +35,10 @@ type RegistryNoCodeModules interface {
 	Delete(ctx context.Context, ID string) error
 
 	// CreateWorkspace creates a workspace using a no-code module.
-	CreateWorkspace(ctx context.Context, noCodeModuleID string, options *RegistryNoCodeModuleCreateWorkspaceOptions) (*RegistryNoCodeModuleWorkspace, error)
+	CreateWorkspace(ctx context.Context, noCodeModuleID string, options *RegistryNoCodeModuleCreateWorkspaceOptions) (*Workspace, error)
 
 	// UpgradeWorkspace initiates an upgrade of an existing no-code module workspace.
-	UpgradeWorkspace(ctx context.Context, noCodeModuleID string, workspaceID string, options *RegistryNoCodeModuleUpgradeWorkspaceOptions) (*RegistryNoCodeModuleWorkspace, error)
+	UpgradeWorkspace(ctx context.Context, noCodeModuleID string, workspaceID string, options *RegistryNoCodeModuleUpgradeWorkspaceOptions) (*Workspace, error)
 }
 
 type RegistryNoCodeModuleCreateWorkspaceOptions struct {
@@ -83,10 +83,6 @@ type RegistryNoCodeModuleUpgradeWorkspaceOptions struct {
 	// Variables is the slice of variables to be configured for the no-code
 	// workspace.
 	Variables []*Variable `jsonapi:"relation,vars,omitempty"`
-}
-
-type RegistryNoCodeModuleWorkspace struct {
-	Workspace
 }
 
 // registryNoCodeModules implements RegistryNoCodeModules.
@@ -282,7 +278,7 @@ func (r *registryNoCodeModules) CreateWorkspace(
 	ctx context.Context,
 	noCodeModuleID string,
 	options *RegistryNoCodeModuleCreateWorkspaceOptions,
-) (*RegistryNoCodeModuleWorkspace, error) {
+) (*Workspace, error) {
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
@@ -293,7 +289,7 @@ func (r *registryNoCodeModules) CreateWorkspace(
 		return nil, err
 	}
 
-	w := &RegistryNoCodeModuleWorkspace{}
+	w := &Workspace{}
 	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err
@@ -308,7 +304,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 	noCodeModuleID string,
 	workspaceID string,
 	options *RegistryNoCodeModuleUpgradeWorkspaceOptions,
-) (*RegistryNoCodeModuleWorkspace, error) {
+) (*Workspace, error) {
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
@@ -322,7 +318,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 		return nil, err
 	}
 
-	w := &RegistryNoCodeModuleWorkspace{}
+	w := &Workspace{}
 	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -355,7 +355,7 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		wn := fmt.Sprintf("foo-%s", randomString(t))
 		sn := "my-app"
 		su := "http://my-app.com"
-		_, err = client.RegistryNoCodeModules.CreateWorkspace(
+		w, err := client.RegistryNoCodeModules.CreateWorkspace(
 			ctx,
 			ncm.ID,
 			&RegistryNoCodeModuleCreateWorkspaceOptions{
@@ -365,9 +365,6 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 				ExecutionMode: String("remote"),
 			},
 		)
-		r.NoError(err)
-
-		w, err := client.Workspaces.Read(ctx, org.Name, wn)
 		r.NoError(err)
 		r.Equal(wn, w.Name)
 		r.Equal(sn, w.SourceName)
@@ -473,13 +470,15 @@ func TestRegistryNoCodeModuleWorkspaceUpgrade(t *testing.T) {
 	r.NotNil(uncm)
 
 	t.Run("test upgrading a workspace via a no-code module", func(t *testing.T) {
-		_, err = client.RegistryNoCodeModules.UpgradeWorkspace(
+		ws, err := client.RegistryNoCodeModules.UpgradeWorkspace(
 			ctx,
 			ncm.ID,
 			w.ID,
 			&RegistryNoCodeModuleUpgradeWorkspaceOptions{},
 		)
 		r.NoError(err)
+		r.NotNil(ws)
+		r.Equal(w.ID, ws.ID)
 	})
 
 	t.Run("fail to upgrade workspace with invalid no-code module", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This change is being made because the create and upgrade methods for no-code workspaces _do not_ properly return the workspace. They _do_ correctly create and upgrade no-code workspaces, respectively; however the workspace they return is a zero-value `tfe.Workspace`.

This PR fixes this issue by removing the `RegistryNoCodeModuleWorkspace` struct, which was a struct that only "wrapped" an embedded `tfe.Workspace` struct field. This was done with the intent of future-proofing the endpoint in the event that other data was returned. However, the documented API response clearly is only a `tfe.Workspace`, and so this PR corrects the method to return that value.

The integration tests passed prior to this PR because the tests only tested the "refreshed" workspace, meaning that the endpoint to fetch the workspace after it was created was used to check that the desired input workspace was created as expected. The test should have used the workspace returned by the "post" endpoints themselves.

## Testing plan

```shell
$ go test -run TestRegistryNoCodeModulesCreateWorkspace -v ./...

$ go test -run TestRegistryNoCodeModulesUpgradeWorkspace -v ./...
```

## External links

Relevant API endpoints:
1. https://developer.hashicorp.com/terraform/cloud-docs/api-docs/no-code-provisioning#create-a-no-code-module-workspace
2. https://developer.hashicorp.com/terraform/cloud-docs/api-docs/no-code-provisioning#initiate-a-no-code-workspace-update
