### PR TITLE
Fix no-code upgrade return value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+## Bug Fixes
+
+* Fixed `RegistryNoCodeModules` method `UpgradeWorkspace` to return a `WorkspaceUpgrade` type. This resulted in a BREAKING CHANGE, yet the previous type was not properly decoded nor reflective of the actual API result by @paladin-devops [#955](https://github.com/hashicorp/go-tfe/pull/955)
+
 # v1.64.1
 
 # Bug Fixes

--- a/mocks/registry_no_code_module_mocks.go
+++ b/mocks/registry_no_code_module_mocks.go
@@ -115,10 +115,10 @@ func (mr *MockRegistryNoCodeModulesMockRecorder) Update(ctx, noCodeModuleID, opt
 }
 
 // UpgradeWorkspace mocks base method.
-func (m *MockRegistryNoCodeModules) UpgradeWorkspace(ctx context.Context, noCodeModuleID, workspaceID string, options *tfe.RegistryNoCodeModuleUpgradeWorkspaceOptions) (*tfe.Workspace, error) {
+func (m *MockRegistryNoCodeModules) UpgradeWorkspace(ctx context.Context, noCodeModuleID, workspaceID string, options *tfe.RegistryNoCodeModuleUpgradeWorkspaceOptions) (*tfe.WorkspaceUpgrade, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "UpgradeWorkspace", ctx, noCodeModuleID, workspaceID, options)
-	ret0, _ := ret[0].(*tfe.Workspace)
+	ret0, _ := ret[0].(*tfe.WorkspaceUpgrade)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -358,7 +358,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 		return nil, fmt.Errorf("workspace not upgraded: %s", wuf.Message)
 	}
 
-	return nil, fmt.Errorf("failed to unmarshal response into known structures: %q", string(raw.Bytes()))
+	return nil, fmt.Errorf("failed to unmarshal response into known structures: %q", raw.String())
 }
 
 func (o RegistryNoCodeModuleCreateOptions) valid() error {

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -181,9 +181,13 @@ type RegistryNoCodeModuleUpdateOptions struct {
 	VariableOptions []*NoCodeVariableOption `jsonapi:"relation,variable-options,omitempty"`
 }
 
+// WorkspaceUpgrade contains the data returned by the no-code workspace upgrade
+// API endpoint.
 type WorkspaceUpgrade struct {
+	// Status is the status of the run of the upgrade
 	Status string `jsonapi:"attr,status"`
 
+	// PlanURL is the URL to the plan of the upgrade
 	PlanURL string `jsonapi:"attr,plan-url"`
 }
 

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/hashicorp/jsonapi"
 	"net/url"
 )
 
@@ -346,7 +347,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 	// first attempt to unmarshal to the "happy path" - if an upgrade is
 	// available and was started
 	wu := WorkspaceUpgrade{}
-	if err := json.Unmarshal(raw.Bytes(), &wu); err == nil && wu.Status != "" && wu.PlanURL != "" {
+	if err := jsonapi.UnmarshalPayload(&raw, &wu); err == nil && wu.Status != "" && wu.PlanURL != "" {
 		return &wu, nil
 	}
 
@@ -357,7 +358,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 		return nil, fmt.Errorf("workspace not upgraded: %s", wuf.Message)
 	}
 
-	return nil, fmt.Errorf("failed to unmarshal response into known structures")
+	return nil, fmt.Errorf("failed to unmarshal response into known structures: %q", string(raw.Bytes()))
 }
 
 func (o RegistryNoCodeModuleCreateOptions) valid() error {

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -38,7 +38,7 @@ type RegistryNoCodeModules interface {
 	CreateWorkspace(ctx context.Context, noCodeModuleID string, options *RegistryNoCodeModuleCreateWorkspaceOptions) (*Workspace, error)
 
 	// UpgradeWorkspace initiates an upgrade of an existing no-code module workspace.
-	UpgradeWorkspace(ctx context.Context, noCodeModuleID string, workspaceID string, options *RegistryNoCodeModuleUpgradeWorkspaceOptions) (*Workspace, error)
+	UpgradeWorkspace(ctx context.Context, noCodeModuleID string, workspaceID string, options *RegistryNoCodeModuleUpgradeWorkspaceOptions) (*WorkspaceUpgrade, error)
 }
 
 type RegistryNoCodeModuleCreateWorkspaceOptions struct {
@@ -181,6 +181,12 @@ type RegistryNoCodeModuleUpdateOptions struct {
 	VariableOptions []*NoCodeVariableOption `jsonapi:"relation,variable-options,omitempty"`
 }
 
+type WorkspaceUpgrade struct {
+	Status string `jsonapi:"attr,status"`
+
+	PlanURL string `jsonapi:"attr,plan-url"`
+}
+
 // Create a new registry no-code module
 func (r *registryNoCodeModules) Create(ctx context.Context, organization string, options RegistryNoCodeModuleCreateOptions) (*RegistryNoCodeModule, error) {
 	if !validStringID(&organization) {
@@ -304,7 +310,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 	noCodeModuleID string,
 	workspaceID string,
 	options *RegistryNoCodeModuleUpgradeWorkspaceOptions,
-) (*Workspace, error) {
+) (*WorkspaceUpgrade, error) {
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
@@ -318,7 +324,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 		return nil, err
 	}
 
-	w := &Workspace{}
+	w := &WorkspaceUpgrade{}
 	err = req.Do(ctx, w)
 	if err != nil {
 		return nil, err

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -470,15 +470,14 @@ func TestRegistryNoCodeModuleWorkspaceUpgrade(t *testing.T) {
 	r.NotNil(uncm)
 
 	t.Run("test upgrading a workspace via a no-code module", func(t *testing.T) {
-		ws, err := client.RegistryNoCodeModules.UpgradeWorkspace(
+		wu, err := client.RegistryNoCodeModules.UpgradeWorkspace(
 			ctx,
 			ncm.ID,
 			w.ID,
 			&RegistryNoCodeModuleUpgradeWorkspaceOptions{},
 		)
 		r.NoError(err)
-		r.NotNil(ws)
-		r.Equal(w.ID, ws.ID)
+		r.NotNil(wu)
 	})
 
 	t.Run("fail to upgrade workspace with invalid no-code module", func(t *testing.T) {

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -478,6 +478,8 @@ func TestRegistryNoCodeModuleWorkspaceUpgrade(t *testing.T) {
 		)
 		r.NoError(err)
 		r.NotNil(wu)
+		r.NotEmpty(wu.Status)
+		r.NotEmpty(wu.PlanURL)
 	})
 
 	t.Run("fail to upgrade workspace with invalid no-code module", func(t *testing.T) {


### PR DESCRIPTION
The no-code workspace upgrade endpoint does not return a workspace, but does return a "workspace-upgrade", which contains different data than a workspace does.

API Endpoint documentation: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/no-code-provisioning#initiate-a-no-code-workspace-update
