### PR TITLE
More flexible parameter handling in NewRequest and friends

### DIFF
--- a/admin_opa_version.go
+++ b/admin_opa_version.go
@@ -121,7 +121,7 @@ func (a *adminOPAVersions) Read(ctx context.Context, id string) (*AdminOPAVersio
 		return nil, ErrInvalidOPAVersionID
 	}
 
-	u := fmt.Sprintf("admin/opa-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/opa-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func (a *adminOPAVersions) Update(ctx context.Context, id string, options AdminO
 		return nil, ErrInvalidOPAVersionID
 	}
 
-	u := fmt.Sprintf("admin/opa-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/opa-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func (a *adminOPAVersions) Delete(ctx context.Context, id string) error {
 		return ErrInvalidOPAVersionID
 	}
 
-	u := fmt.Sprintf("admin/opa-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/opa-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/admin_organization.go
+++ b/admin_organization.go
@@ -136,7 +136,7 @@ func (s *adminOrganizations) ListModuleConsumers(ctx context.Context, organizati
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.PathEscape(organization))
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -158,7 +158,7 @@ func (s *adminOrganizations) Read(ctx context.Context, organization string) (*Ad
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -179,7 +179,7 @@ func (s *adminOrganizations) Update(ctx context.Context, organization string, op
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s", url.PathEscape(organization))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -200,7 +200,7 @@ func (s *adminOrganizations) UpdateModuleConsumers(ctx context.Context, organiza
 		return ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s/relationships/module-consumers", url.PathEscape(organization))
 
 	var organizations []*AdminOrganizationID
 	for _, id := range consumerOrganizationIDs {
@@ -229,7 +229,7 @@ func (s *adminOrganizations) Delete(ctx context.Context, organization string) er
 		return ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("admin/organizations/%s", url.QueryEscape(organization))
+	u := fmt.Sprintf("admin/organizations/%s", url.PathEscape(organization))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/admin_run.go
+++ b/admin_run.go
@@ -111,7 +111,7 @@ func (s *adminRuns) ForceCancel(ctx context.Context, runID string, options Admin
 		return ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("admin/runs/%s/actions/force-cancel", url.QueryEscape(runID))
+	u := fmt.Sprintf("admin/runs/%s/actions/force-cancel", url.PathEscape(runID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err

--- a/admin_sentinel_version.go
+++ b/admin_sentinel_version.go
@@ -121,7 +121,7 @@ func (a *adminSentinelVersions) Read(ctx context.Context, id string) (*AdminSent
 		return nil, ErrInvalidSentinelVersionID
 	}
 
-	u := fmt.Sprintf("admin/sentinel-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/sentinel-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -161,7 +161,7 @@ func (a *adminSentinelVersions) Update(ctx context.Context, id string, options A
 		return nil, ErrInvalidSentinelVersionID
 	}
 
-	u := fmt.Sprintf("admin/sentinel-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/sentinel-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func (a *adminSentinelVersions) Delete(ctx context.Context, id string) error {
 		return ErrInvalidSentinelVersionID
 	}
 
-	u := fmt.Sprintf("admin/sentinel-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/sentinel-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -123,7 +123,7 @@ func (a *adminTerraformVersions) Read(ctx context.Context, id string) (*AdminTer
 		return nil, ErrInvalidTerraformVersionID
 	}
 
-	u := fmt.Sprintf("admin/terraform-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/terraform-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -163,7 +163,7 @@ func (a *adminTerraformVersions) Update(ctx context.Context, id string, options 
 		return nil, ErrInvalidTerraformVersionID
 	}
 
-	u := fmt.Sprintf("admin/terraform-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/terraform-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -184,7 +184,7 @@ func (a *adminTerraformVersions) Delete(ctx context.Context, id string) error {
 		return ErrInvalidTerraformVersionID
 	}
 
-	u := fmt.Sprintf("admin/terraform-versions/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("admin/terraform-versions/%s", url.PathEscape(id))
 	req, err := a.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/admin_user.go
+++ b/admin_user.go
@@ -119,7 +119,7 @@ func (a *adminUsers) Delete(ctx context.Context, userID string) error {
 		return ErrInvalidUserValue
 	}
 
-	u := fmt.Sprintf("admin/users/%s", url.QueryEscape(userID))
+	u := fmt.Sprintf("admin/users/%s", url.PathEscape(userID))
 	req, err := a.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -134,7 +134,7 @@ func (a *adminUsers) Suspend(ctx context.Context, userID string) (*AdminUser, er
 		return nil, ErrInvalidUserValue
 	}
 
-	u := fmt.Sprintf("admin/users/%s/actions/suspend", url.QueryEscape(userID))
+	u := fmt.Sprintf("admin/users/%s/actions/suspend", url.PathEscape(userID))
 	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -155,7 +155,7 @@ func (a *adminUsers) Unsuspend(ctx context.Context, userID string) (*AdminUser, 
 		return nil, ErrInvalidUserValue
 	}
 
-	u := fmt.Sprintf("admin/users/%s/actions/unsuspend", url.QueryEscape(userID))
+	u := fmt.Sprintf("admin/users/%s/actions/unsuspend", url.PathEscape(userID))
 	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func (a *adminUsers) GrantAdmin(ctx context.Context, userID string) (*AdminUser,
 		return nil, ErrInvalidUserValue
 	}
 
-	u := fmt.Sprintf("admin/users/%s/actions/grant_admin", url.QueryEscape(userID))
+	u := fmt.Sprintf("admin/users/%s/actions/grant_admin", url.PathEscape(userID))
 	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func (a *adminUsers) RevokeAdmin(ctx context.Context, userID string) (*AdminUser
 		return nil, ErrInvalidUserValue
 	}
 
-	u := fmt.Sprintf("admin/users/%s/actions/revoke_admin", url.QueryEscape(userID))
+	u := fmt.Sprintf("admin/users/%s/actions/revoke_admin", url.PathEscape(userID))
 	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -219,7 +219,7 @@ func (a *adminUsers) Disable2FA(ctx context.Context, userID string) (*AdminUser,
 		return nil, ErrInvalidUserValue
 	}
 
-	u := fmt.Sprintf("admin/users/%s/actions/disable_two_factor", url.QueryEscape(userID))
+	u := fmt.Sprintf("admin/users/%s/actions/disable_two_factor", url.PathEscape(userID))
 	req, err := a.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err

--- a/admin_workspace.go
+++ b/admin_workspace.go
@@ -113,7 +113,7 @@ func (s *adminWorkspaces) Read(ctx context.Context, workspaceID string) (*AdminW
 		return nil, ErrInvalidWorkspaceValue
 	}
 
-	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("admin/workspaces/%s", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -134,7 +134,7 @@ func (s *adminWorkspaces) Delete(ctx context.Context, workspaceID string) error 
 		return ErrInvalidWorkspaceValue
 	}
 
-	u := fmt.Sprintf("admin/workspaces/%s", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("admin/workspaces/%s", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/agent.go
+++ b/agent.go
@@ -57,7 +57,7 @@ func (s *agents) Read(ctx context.Context, agentID string) (*Agent, error) {
 		return nil, ErrInvalidAgentID
 	}
 
-	u := fmt.Sprintf("agents/%s", url.QueryEscape(agentID))
+	u := fmt.Sprintf("agents/%s", url.PathEscape(agentID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -78,7 +78,7 @@ func (s *agents) List(ctx context.Context, agentPoolID string, options *AgentLis
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("agent-pools/%s/agents", url.QueryEscape(agentPoolID))
+	u := fmt.Sprintf("agent-pools/%s/agents", url.PathEscape(agentPoolID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -114,7 +114,7 @@ func (s *agentPools) List(ctx context.Context, organization string, options *Age
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/agent-pools", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/agent-pools", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -139,7 +139,7 @@ func (s *agentPools) Create(ctx context.Context, organization string, options Ag
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/agent-pools", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/agent-pools", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -168,7 +168,7 @@ func (s *agentPools) ReadWithOptions(ctx context.Context, agentpoolID string, op
 		return nil, err
 	}
 
-	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentpoolID))
+	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentpoolID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -224,7 +224,7 @@ func (s *agentPools) Update(ctx context.Context, agentPoolID string, options Age
 		return nil, err
 	}
 
-	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentPoolID))
+	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentPoolID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -244,7 +244,7 @@ func (s *agentPools) UpdateAllowedWorkspaces(ctx context.Context, agentPoolID st
 		return nil, ErrInvalidAgentPoolID
 	}
 
-	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentPoolID))
+	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentPoolID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -265,7 +265,7 @@ func (s *agentPools) Delete(ctx context.Context, agentPoolID string) error {
 		return ErrInvalidAgentPoolID
 	}
 
-	u := fmt.Sprintf("agent-pools/%s", url.QueryEscape(agentPoolID))
+	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentPoolID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/agent_token.go
+++ b/agent_token.go
@@ -70,7 +70,7 @@ func (s *agentTokens) List(ctx context.Context, agentPoolID string) (*AgentToken
 		return nil, ErrInvalidAgentPoolID
 	}
 
-	u := fmt.Sprintf("agent-pools/%s/authentication-tokens", url.QueryEscape(agentPoolID))
+	u := fmt.Sprintf("agent-pools/%s/authentication-tokens", url.PathEscape(agentPoolID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func (s *agentTokens) Create(ctx context.Context, agentPoolID string, options Ag
 		return nil, ErrAgentTokenDescription
 	}
 
-	u := fmt.Sprintf("agent-pools/%s/authentication-tokens", url.QueryEscape(agentPoolID))
+	u := fmt.Sprintf("agent-pools/%s/authentication-tokens", url.PathEscape(agentPoolID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (s *agentTokens) Read(ctx context.Context, agentTokenID string) (*AgentToke
 		return nil, ErrInvalidAgentTokenID
 	}
 
-	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(agentTokenID))
+	u := fmt.Sprintf("authentication-tokens/%s", url.PathEscape(agentTokenID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func (s *agentTokens) Delete(ctx context.Context, agentTokenID string) error {
 		return ErrInvalidAgentTokenID
 	}
 
-	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(agentTokenID))
+	u := fmt.Sprintf("authentication-tokens/%s", url.PathEscape(agentTokenID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/apply.go
+++ b/apply.go
@@ -75,7 +75,7 @@ func (s *applies) Read(ctx context.Context, applyID string) (*Apply, error) {
 		return nil, ErrInvalidApplyID
 	}
 
-	u := fmt.Sprintf("applies/%s", url.QueryEscape(applyID))
+	u := fmt.Sprintf("applies/%s", url.PathEscape(applyID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/comment.go
+++ b/comment.go
@@ -62,7 +62,7 @@ func (s *comments) List(ctx context.Context, runID string) (*CommentList, error)
 		return nil, ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("runs/%s/comments", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/comments", url.PathEscape(runID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (s *comments) Create(ctx context.Context, runID string, options CommentCrea
 		return nil, ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("runs/%s/comments", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/comments", url.PathEscape(runID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (s *comments) Read(ctx context.Context, commentID string) (*Comment, error)
 		return nil, ErrInvalidCommentID
 	}
 
-	u := fmt.Sprintf("comments/%s", url.QueryEscape(commentID))
+	u := fmt.Sprintf("comments/%s", url.PathEscape(commentID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/configuration_version.go
+++ b/configuration_version.go
@@ -214,7 +214,7 @@ func (s *configurationVersions) List(ctx context.Context, workspaceID string, op
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -236,7 +236,7 @@ func (s *configurationVersions) Create(ctx context.Context, workspaceID string, 
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/configuration-versions", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -285,7 +285,7 @@ func (s *configurationVersions) ReadWithOptions(ctx context.Context, cvID string
 		return nil, err
 	}
 
-	u := fmt.Sprintf("configuration-versions/%s", url.QueryEscape(cvID))
+	u := fmt.Sprintf("configuration-versions/%s", url.PathEscape(cvID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -331,7 +331,7 @@ func (s *configurationVersions) Archive(ctx context.Context, cvID string) error 
 
 	body := bytes.NewBuffer(nil)
 
-	u := fmt.Sprintf("configuration-versions/%s/actions/archive", url.QueryEscape(cvID))
+	u := fmt.Sprintf("configuration-versions/%s/actions/archive", url.PathEscape(cvID))
 	req, err := s.client.NewRequest("POST", u, body)
 	if err != nil {
 		return err
@@ -354,7 +354,7 @@ func (s *configurationVersions) Download(ctx context.Context, cvID string) ([]by
 		return nil, ErrInvalidConfigVersionID
 	}
 
-	u := fmt.Sprintf("configuration-versions/%s/download", url.QueryEscape(cvID))
+	u := fmt.Sprintf("configuration-versions/%s/download", url.PathEscape(cvID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/cost_estimate.go
+++ b/cost_estimate.go
@@ -75,7 +75,7 @@ func (s *costEstimates) Read(ctx context.Context, costEstimateID string) (*CostE
 		return nil, ErrInvalidCostEstimateID
 	}
 
-	u := fmt.Sprintf("cost-estimates/%s", url.QueryEscape(costEstimateID))
+	u := fmt.Sprintf("cost-estimates/%s", url.PathEscape(costEstimateID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (s *costEstimates) Logs(ctx context.Context, costEstimateID string) (io.Rea
 			}
 		}
 
-		u := fmt.Sprintf("cost-estimates/%s/output", url.QueryEscape(costEstimateID))
+		u := fmt.Sprintf("cost-estimates/%s/output", url.PathEscape(costEstimateID))
 		req, err := s.client.NewRequest("GET", u, nil)
 		if err != nil {
 			return nil, err

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -235,7 +235,7 @@ func (s *example) Create(ctx context.Context, organization string, options Examp
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/tasks", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/tasks", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -256,7 +256,7 @@ func (s *example) List(ctx context.Context, organization string, options *Exampl
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/examples", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/examples", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (s *example) ReadWithOptions(ctx context.Context, exampleID string, options
 		return nil, ErrInvalidExampleID
 	}
 
-	u := fmt.Sprintf("examples/%s", url.QueryEscape(exampleID))
+	u := fmt.Sprintf("examples/%s", url.PathEscape(exampleID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -307,7 +307,7 @@ func (s *example) Update(ctx context.Context, exampleID string, options ExampleU
 		return nil, err
 	}
 
-	u := fmt.Sprintf("examples/%s", url.QueryEscape(exampleID))
+	u := fmt.Sprintf("examples/%s", url.PathEscape(exampleID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -383,4 +383,3 @@ This script depends on `gh` and `jq`. It also requires you to `gh auth login`, p
 ```sh
 ./scripts/rebase-fork.sh 557
 ```
-

--- a/github_app_installation.go
+++ b/github_app_installation.go
@@ -72,7 +72,7 @@ func (s *gHAInstallations) Read(ctx context.Context, id string) (*GHAInstallatio
 		return nil, ErrInvalidOauthClientID
 	}
 
-	u := fmt.Sprintf("github-app/installation/%s", url.QueryEscape(id))
+	u := fmt.Sprintf("github-app/installation/%s", url.PathEscape(id))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/gpg_key.go
+++ b/gpg_key.go
@@ -92,7 +92,7 @@ func (s *gpgKeys) ListPrivate(ctx context.Context, options GPGKeyListOptions) (*
 		return nil, err
 	}
 
-	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys", url.QueryEscape(string(PrivateRegistry)))
+	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys", url.PathEscape(string(PrivateRegistry)))
 	req, err := s.client.NewRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
@@ -116,7 +116,7 @@ func (s *gpgKeys) Create(ctx context.Context, registryName RegistryName, options
 		return nil, ErrInvalidRegistryName
 	}
 
-	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys", url.QueryEscape(string(registryName)))
+	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys", url.PathEscape(string(registryName)))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -137,9 +137,9 @@ func (s *gpgKeys) Read(ctx context.Context, keyID GPGKeyID) (*GPGKey, error) {
 	}
 
 	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys/%s/%s",
-		url.QueryEscape(string(keyID.RegistryName)),
-		url.QueryEscape(keyID.Namespace),
-		url.QueryEscape(keyID.KeyID),
+		url.PathEscape(string(keyID.RegistryName)),
+		url.PathEscape(keyID.Namespace),
+		url.PathEscape(keyID.KeyID),
 	)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -165,9 +165,9 @@ func (s *gpgKeys) Update(ctx context.Context, keyID GPGKeyID, options GPGKeyUpda
 	}
 
 	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys/%s/%s",
-		url.QueryEscape(string(keyID.RegistryName)),
-		url.QueryEscape(keyID.Namespace),
-		url.QueryEscape(keyID.KeyID),
+		url.PathEscape(string(keyID.RegistryName)),
+		url.PathEscape(keyID.Namespace),
+		url.PathEscape(keyID.KeyID),
 	)
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
@@ -192,9 +192,9 @@ func (s *gpgKeys) Delete(ctx context.Context, keyID GPGKeyID) error {
 	}
 
 	u := fmt.Sprintf("/api/registry/%s/v2/gpg-keys/%s/%s",
-		url.QueryEscape(string(keyID.RegistryName)),
-		url.QueryEscape(keyID.Namespace),
-		url.QueryEscape(keyID.KeyID),
+		url.PathEscape(string(keyID.RegistryName)),
+		url.PathEscape(keyID.Namespace),
+		url.PathEscape(keyID.KeyID),
 	)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/notification_configuration.go
+++ b/notification_configuration.go
@@ -190,7 +190,7 @@ func (s *notificationConfigurations) List(ctx context.Context, workspaceID strin
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/notification-configurations", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/notification-configurations", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -214,7 +214,7 @@ func (s *notificationConfigurations) Create(ctx context.Context, workspaceID str
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/notification-configurations", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/notification-configurations", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (s *notificationConfigurations) Read(ctx context.Context, notificationConfi
 		return nil, ErrInvalidNotificationConfigID
 	}
 
-	u := fmt.Sprintf("notification-configurations/%s", url.QueryEscape(notificationConfigurationID))
+	u := fmt.Sprintf("notification-configurations/%s", url.PathEscape(notificationConfigurationID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -260,7 +260,7 @@ func (s *notificationConfigurations) Update(ctx context.Context, notificationCon
 		return nil, err
 	}
 
-	u := fmt.Sprintf("notification-configurations/%s", url.QueryEscape(notificationConfigurationID))
+	u := fmt.Sprintf("notification-configurations/%s", url.PathEscape(notificationConfigurationID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -281,7 +281,7 @@ func (s *notificationConfigurations) Delete(ctx context.Context, notificationCon
 		return ErrInvalidNotificationConfigID
 	}
 
-	u := fmt.Sprintf("notification-configurations/%s", url.QueryEscape(notificationConfigurationID))
+	u := fmt.Sprintf("notification-configurations/%s", url.PathEscape(notificationConfigurationID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -298,7 +298,7 @@ func (s *notificationConfigurations) Verify(ctx context.Context, notificationCon
 	}
 
 	u := fmt.Sprintf(
-		"notification-configurations/%s/actions/verify", url.QueryEscape(notificationConfigurationID))
+		"notification-configurations/%s/actions/verify", url.PathEscape(notificationConfigurationID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -224,7 +224,7 @@ func (s *oAuthClients) List(ctx context.Context, organization string, options *O
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/oauth-clients", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -248,7 +248,7 @@ func (s *oAuthClients) Create(ctx context.Context, organization string, options 
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/oauth-clients", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/oauth-clients", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -276,7 +276,7 @@ func (s *oAuthClients) ReadWithOptions(ctx context.Context, oAuthClientID string
 		return nil, err
 	}
 
-	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
+	u := fmt.Sprintf("oauth-clients/%s", url.PathEscape(oAuthClientID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -297,7 +297,7 @@ func (s *oAuthClients) Update(ctx context.Context, oAuthClientID string, options
 		return nil, ErrInvalidOauthClientID
 	}
 
-	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
+	u := fmt.Sprintf("oauth-clients/%s", url.PathEscape(oAuthClientID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -318,7 +318,7 @@ func (s *oAuthClients) Delete(ctx context.Context, oAuthClientID string) error {
 		return ErrInvalidOauthClientID
 	}
 
-	u := fmt.Sprintf("oauth-clients/%s", url.QueryEscape(oAuthClientID))
+	u := fmt.Sprintf("oauth-clients/%s", url.PathEscape(oAuthClientID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -361,7 +361,7 @@ func (s *oAuthClients) AddProjects(ctx context.Context, oAuthClientID string, op
 		return err
 	}
 
-	u := fmt.Sprintf("oauth-clients/%s/relationships/projects", url.QueryEscape(oAuthClientID))
+	u := fmt.Sprintf("oauth-clients/%s/relationships/projects", url.PathEscape(oAuthClientID))
 	req, err := s.client.NewRequest("POST", u, options.Projects)
 	if err != nil {
 		return err
@@ -379,7 +379,7 @@ func (s *oAuthClients) RemoveProjects(ctx context.Context, oAuthClientID string,
 		return err
 	}
 
-	u := fmt.Sprintf("oauth-clients/%s/relationships/projects", url.QueryEscape(oAuthClientID))
+	u := fmt.Sprintf("oauth-clients/%s/relationships/projects", url.PathEscape(oAuthClientID))
 	req, err := s.client.NewRequest("DELETE", u, options.Projects)
 	if err != nil {
 		return err

--- a/oauth_token.go
+++ b/oauth_token.go
@@ -79,7 +79,7 @@ func (s *oAuthTokens) List(ctx context.Context, organization string, options *OA
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/oauth-tokens", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/oauth-tokens", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -100,7 +100,7 @@ func (s *oAuthTokens) Read(ctx context.Context, oAuthTokenID string) (*OAuthToke
 		return nil, ErrInvalidOauthTokenID
 	}
 
-	u := fmt.Sprintf("oauth-tokens/%s", url.QueryEscape(oAuthTokenID))
+	u := fmt.Sprintf("oauth-tokens/%s", url.PathEscape(oAuthTokenID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -121,7 +121,7 @@ func (s *oAuthTokens) Update(ctx context.Context, oAuthTokenID string, options O
 		return nil, ErrInvalidOauthTokenID
 	}
 
-	u := fmt.Sprintf("oauth-tokens/%s", url.QueryEscape(oAuthTokenID))
+	u := fmt.Sprintf("oauth-tokens/%s", url.PathEscape(oAuthTokenID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -142,7 +142,7 @@ func (s *oAuthTokens) Delete(ctx context.Context, oAuthTokenID string) error {
 		return ErrInvalidOauthTokenID
 	}
 
-	u := fmt.Sprintf("oauth-tokens/%s", url.QueryEscape(oAuthTokenID))
+	u := fmt.Sprintf("oauth-tokens/%s", url.PathEscape(oAuthTokenID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/organization.go
+++ b/organization.go
@@ -346,7 +346,7 @@ func (s *organizations) ReadWithOptions(ctx context.Context, organization string
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
@@ -370,7 +370,7 @@ func (s *organizations) Update(ctx context.Context, organization string, options
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s", url.PathEscape(organization))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -391,7 +391,7 @@ func (s *organizations) Delete(ctx context.Context, organization string) error {
 		return ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s", url.PathEscape(organization))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -406,7 +406,7 @@ func (s *organizations) ReadCapacity(ctx context.Context, organization string) (
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/capacity", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/capacity", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -427,7 +427,7 @@ func (s *organizations) ReadEntitlements(ctx context.Context, organization strin
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/entitlement-set", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/entitlement-set", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -448,7 +448,7 @@ func (s *organizations) ReadRunQueue(ctx context.Context, organization string, o
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/runs/queue", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/runs/queue", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
@@ -468,7 +468,7 @@ func (s *organizations) ReadDataRetentionPolicy(ctx context.Context, organizatio
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/relationships/data-retention-policy", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/relationships/data-retention-policy", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -636,5 +636,5 @@ func (o OrganizationCreateOptions) valid() error {
 }
 
 func (s *organizations) dataRetentionPolicyLink(name string) string {
-	return fmt.Sprintf("organizations/%s/relationships/data-retention-policy", url.QueryEscape(name))
+	return fmt.Sprintf("organizations/%s/relationships/data-retention-policy", url.PathEscape(name))
 }

--- a/organization_membership.go
+++ b/organization_membership.go
@@ -123,7 +123,7 @@ func (s *organizationMemberships) List(ctx context.Context, organization string,
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/organization-memberships", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -147,7 +147,7 @@ func (s *organizationMemberships) Create(ctx context.Context, organization strin
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/organization-memberships", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/organization-memberships", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func (s *organizationMemberships) ReadWithOptions(ctx context.Context, organizat
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organization-memberships/%s", url.QueryEscape(organizationMembershipID))
+	u := fmt.Sprintf("organization-memberships/%s", url.PathEscape(organizationMembershipID))
 	req, err := s.client.NewRequest("GET", u, &options)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func (s *organizationMemberships) Delete(ctx context.Context, organizationMember
 		return ErrInvalidMembership
 	}
 
-	u := fmt.Sprintf("organization-memberships/%s", url.QueryEscape(organizationMembershipID))
+	u := fmt.Sprintf("organization-memberships/%s", url.PathEscape(organizationMembershipID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/organization_tags.go
+++ b/organization_tags.go
@@ -87,7 +87,7 @@ func (s *organizationTags) List(ctx context.Context, organization string, option
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/tags", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/tags", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -112,7 +112,7 @@ func (s *organizationTags) Delete(ctx context.Context, organization string, opti
 		return err
 	}
 
-	u := fmt.Sprintf("organizations/%s/tags", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/tags", url.PathEscape(organization))
 	var tagsToRemove []*tagID
 	for _, id := range options.IDs {
 		tagsToRemove = append(tagsToRemove, &tagID{ID: id})
@@ -141,7 +141,7 @@ func (s *organizationTags) AddWorkspaces(ctx context.Context, tag string, option
 		workspaces = append(workspaces, &workspaceID{ID: id})
 	}
 
-	u := fmt.Sprintf("tags/%s/relationships/workspaces", url.QueryEscape(tag))
+	u := fmt.Sprintf("tags/%s/relationships/workspaces", url.PathEscape(tag))
 	req, err := s.client.NewRequest("POST", u, workspaces)
 	if err != nil {
 		return err

--- a/organization_token.go
+++ b/organization_token.go
@@ -66,7 +66,7 @@ func (s *organizationTokens) CreateWithOptions(ctx context.Context, organization
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/authentication-token", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (s *organizationTokens) Read(ctx context.Context, organization string) (*Or
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/authentication-token", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (s *organizationTokens) Delete(ctx context.Context, organization string) er
 		return ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/authentication-token", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/authentication-token", url.PathEscape(organization))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/plan.go
+++ b/plan.go
@@ -84,7 +84,7 @@ func (s *plans) Read(ctx context.Context, planID string) (*Plan, error) {
 		return nil, ErrInvalidPlanID
 	}
 
-	u := fmt.Sprintf("plans/%s", url.QueryEscape(planID))
+	u := fmt.Sprintf("plans/%s", url.PathEscape(planID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -149,7 +149,7 @@ func (s *plans) ReadJSONOutput(ctx context.Context, planID string) ([]byte, erro
 		return nil, ErrInvalidPlanID
 	}
 
-	u := fmt.Sprintf("plans/%s/json-output", url.QueryEscape(planID))
+	u := fmt.Sprintf("plans/%s/json-output", url.PathEscape(planID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/plan_export.go
+++ b/plan_export.go
@@ -116,7 +116,7 @@ func (s *planExports) Read(ctx context.Context, planExportID string) (*PlanExpor
 		return nil, ErrInvalidPlanExportID
 	}
 
-	u := fmt.Sprintf("plan-exports/%s", url.QueryEscape(planExportID))
+	u := fmt.Sprintf("plan-exports/%s", url.PathEscape(planExportID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -137,7 +137,7 @@ func (s *planExports) Delete(ctx context.Context, planExportID string) error {
 		return ErrInvalidPlanExportID
 	}
 
-	u := fmt.Sprintf("plan-exports/%s", url.QueryEscape(planExportID))
+	u := fmt.Sprintf("plan-exports/%s", url.PathEscape(planExportID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -152,7 +152,7 @@ func (s *planExports) Download(ctx context.Context, planExportID string) ([]byte
 		return nil, ErrInvalidPlanExportID
 	}
 
-	u := fmt.Sprintf("plan-exports/%s/download", url.QueryEscape(planExportID))
+	u := fmt.Sprintf("plan-exports/%s/download", url.PathEscape(planExportID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/policy.go
+++ b/policy.go
@@ -162,7 +162,7 @@ func (s *policies) List(ctx context.Context, organization string, options *Polic
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/policies", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/policies", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func (s *policies) Create(ctx context.Context, organization string, options Poli
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/policies", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/policies", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -207,7 +207,7 @@ func (s *policies) Read(ctx context.Context, policyID string) (*Policy, error) {
 		return nil, ErrInvalidPolicyID
 	}
 
-	u := fmt.Sprintf("policies/%s", url.QueryEscape(policyID))
+	u := fmt.Sprintf("policies/%s", url.PathEscape(policyID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -228,7 +228,7 @@ func (s *policies) Update(ctx context.Context, policyID string, options PolicyUp
 		return nil, ErrInvalidPolicyID
 	}
 
-	u := fmt.Sprintf("policies/%s", url.QueryEscape(policyID))
+	u := fmt.Sprintf("policies/%s", url.PathEscape(policyID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -249,7 +249,7 @@ func (s *policies) Delete(ctx context.Context, policyID string) error {
 		return ErrInvalidPolicyID
 	}
 
-	u := fmt.Sprintf("policies/%s", url.QueryEscape(policyID))
+	u := fmt.Sprintf("policies/%s", url.PathEscape(policyID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -264,7 +264,7 @@ func (s *policies) Upload(ctx context.Context, policyID string, content []byte) 
 		return ErrInvalidPolicyID
 	}
 
-	u := fmt.Sprintf("policies/%s/upload", url.QueryEscape(policyID))
+	u := fmt.Sprintf("policies/%s/upload", url.PathEscape(policyID))
 	req, err := s.client.NewRequest("PUT", u, content)
 	if err != nil {
 		return err
@@ -279,7 +279,7 @@ func (s *policies) Download(ctx context.Context, policyID string) ([]byte, error
 		return nil, ErrInvalidPolicyID
 	}
 
-	u := fmt.Sprintf("policies/%s/download", url.QueryEscape(policyID))
+	u := fmt.Sprintf("policies/%s/download", url.PathEscape(policyID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/policy_check.go
+++ b/policy_check.go
@@ -141,7 +141,7 @@ func (s *policyChecks) List(ctx context.Context, runID string, options *PolicyCh
 		return nil, err
 	}
 
-	u := fmt.Sprintf("runs/%s/policy-checks", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/policy-checks", url.PathEscape(runID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (s *policyChecks) Read(ctx context.Context, policyCheckID string) (*PolicyC
 		return nil, ErrInvalidPolicyCheckID
 	}
 
-	u := fmt.Sprintf("policy-checks/%s", url.QueryEscape(policyCheckID))
+	u := fmt.Sprintf("policy-checks/%s", url.PathEscape(policyCheckID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -183,7 +183,7 @@ func (s *policyChecks) Override(ctx context.Context, policyCheckID string) (*Pol
 		return nil, ErrInvalidPolicyCheckID
 	}
 
-	u := fmt.Sprintf("policy-checks/%s/actions/override", url.QueryEscape(policyCheckID))
+	u := fmt.Sprintf("policy-checks/%s/actions/override", url.PathEscape(policyCheckID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -223,7 +223,7 @@ func (s *policyChecks) Logs(ctx context.Context, policyCheckID string) (io.Reade
 			}
 		}
 
-		u := fmt.Sprintf("policy-checks/%s/output", url.QueryEscape(policyCheckID))
+		u := fmt.Sprintf("policy-checks/%s/output", url.PathEscape(policyCheckID))
 		req, err := s.client.NewRequest("GET", u, nil)
 		if err != nil {
 			return nil, err

--- a/policy_evaluation.go
+++ b/policy_evaluation.go
@@ -97,7 +97,7 @@ func (s *policyEvaluation) List(ctx context.Context, taskStageID string, options
 		return nil, ErrInvalidTaskStageID
 	}
 
-	u := fmt.Sprintf("task-stages/%s/policy-evaluations", url.QueryEscape(taskStageID))
+	u := fmt.Sprintf("task-stages/%s/policy-evaluations", url.PathEscape(taskStageID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -240,7 +240,7 @@ func (s *policySetOutcome) Read(ctx context.Context, policySetOutcomeID string) 
 		return nil, ErrInvalidPolicySetOutcomeID
 	}
 
-	u := fmt.Sprintf("policy-set-outcomes/%s", url.QueryEscape(policySetOutcomeID))
+	u := fmt.Sprintf("policy-set-outcomes/%s", url.PathEscape(policySetOutcomeID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/policy_set.go
+++ b/policy_set.go
@@ -314,7 +314,7 @@ func (s *policySets) List(ctx context.Context, organization string, options *Pol
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/policy-sets", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -338,7 +338,7 @@ func (s *policySets) Create(ctx context.Context, organization string, options Po
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/policy-sets", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/policy-sets", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -367,7 +367,7 @@ func (s *policySets) ReadWithOptions(ctx context.Context, policySetID string, op
 		return nil, err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -391,7 +391,7 @@ func (s *policySets) Update(ctx context.Context, policySetID string, options Pol
 		return nil, err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -415,7 +415,7 @@ func (s *policySets) AddPolicies(ctx context.Context, policySetID string, option
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("POST", u, options.Policies)
 	if err != nil {
 		return err
@@ -433,7 +433,7 @@ func (s *policySets) RemovePolicies(ctx context.Context, policySetID string, opt
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/policies", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("DELETE", u, options.Policies)
 	if err != nil {
 		return err
@@ -451,7 +451,7 @@ func (s *policySets) AddWorkspaces(ctx context.Context, policySetID string, opti
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("POST", u, options.Workspaces)
 	if err != nil {
 		return err
@@ -469,7 +469,7 @@ func (s *policySets) RemoveWorkspaces(ctx context.Context, policySetID string, o
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspaces", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("DELETE", u, options.Workspaces)
 	if err != nil {
 		return err
@@ -487,7 +487,7 @@ func (s *policySets) AddWorkspaceExclusions(ctx context.Context, policySetID str
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/workspace-exclusions", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspace-exclusions", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("POST", u, options.WorkspaceExclusions)
 	if err != nil {
 		return err
@@ -505,7 +505,7 @@ func (s *policySets) RemoveWorkspaceExclusions(ctx context.Context, policySetID 
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/workspace-exclusions", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/workspace-exclusions", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("DELETE", u, options.WorkspaceExclusions)
 	if err != nil {
 		return err
@@ -523,7 +523,7 @@ func (s *policySets) AddProjects(ctx context.Context, policySetID string, option
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/projects", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/projects", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("POST", u, options.Projects)
 	if err != nil {
 		return err
@@ -541,7 +541,7 @@ func (s *policySets) RemoveProjects(ctx context.Context, policySetID string, opt
 		return err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/relationships/projects", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/relationships/projects", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("DELETE", u, options.Projects)
 	if err != nil {
 		return err
@@ -556,7 +556,7 @@ func (s *policySets) Delete(ctx context.Context, policySetID string) error {
 		return ErrInvalidPolicySetID
 	}
 
-	u := fmt.Sprintf("policy-sets/%s", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/policy_set_parameter.go
+++ b/policy_set_parameter.go
@@ -130,7 +130,7 @@ func (s *policySetParameters) Create(ctx context.Context, policySetID string, op
 		return nil, err
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/parameters", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/parameters", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func (s *policySetParameters) Read(ctx context.Context, policySetID, parameterID
 		return nil, ErrInvalidParamID
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
+	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.PathEscape(policySetID), url.PathEscape(parameterID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -178,7 +178,7 @@ func (s *policySetParameters) Update(ctx context.Context, policySetID, parameter
 		return nil, ErrInvalidParamID
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
+	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.PathEscape(policySetID), url.PathEscape(parameterID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -202,7 +202,7 @@ func (s *policySetParameters) Delete(ctx context.Context, policySetID, parameter
 		return ErrInvalidParamID
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.QueryEscape(policySetID), url.QueryEscape(parameterID))
+	u := fmt.Sprintf("policy-sets/%s/parameters/%s", url.PathEscape(policySetID), url.PathEscape(parameterID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -104,7 +104,7 @@ func (p *policySetVersions) Create(ctx context.Context, policySetID string) (*Po
 		return nil, ErrInvalidPolicySetID
 	}
 
-	u := fmt.Sprintf("policy-sets/%s/versions", url.QueryEscape(policySetID))
+	u := fmt.Sprintf("policy-sets/%s/versions", url.PathEscape(policySetID))
 	req, err := p.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -125,7 +125,7 @@ func (p *policySetVersions) Read(ctx context.Context, policySetVersionID string)
 		return nil, ErrInvalidPolicySetID
 	}
 
-	u := fmt.Sprintf("policy-set-versions/%s", url.QueryEscape(policySetVersionID))
+	u := fmt.Sprintf("policy-set-versions/%s", url.PathEscape(policySetVersionID))
 	req, err := p.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/project.go
+++ b/project.go
@@ -105,7 +105,7 @@ func (s *projects) List(ctx context.Context, organization string, options *Proje
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/projects", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/projects", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -130,7 +130,7 @@ func (s *projects) Create(ctx context.Context, organization string, options Proj
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/projects", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/projects", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -151,7 +151,7 @@ func (s *projects) Read(ctx context.Context, projectID string) (*Project, error)
 		return nil, ErrInvalidProjectID
 	}
 
-	u := fmt.Sprintf("projects/%s", url.QueryEscape(projectID))
+	u := fmt.Sprintf("projects/%s", url.PathEscape(projectID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -176,7 +176,7 @@ func (s *projects) Update(ctx context.Context, projectID string, options Project
 		return nil, err
 	}
 
-	u := fmt.Sprintf("projects/%s", url.QueryEscape(projectID))
+	u := fmt.Sprintf("projects/%s", url.PathEscape(projectID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -197,7 +197,7 @@ func (s *projects) Delete(ctx context.Context, projectID string) error {
 		return ErrInvalidProjectID
 	}
 
-	u := fmt.Sprintf("projects/%s", url.QueryEscape(projectID))
+	u := fmt.Sprintf("projects/%s", url.PathEscape(projectID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/registry_module.go
+++ b/registry_module.go
@@ -314,7 +314,7 @@ func (r *registryModules) List(ctx context.Context, organization string, options
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/registry-modules", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/registry-modules", url.PathEscape(organization))
 	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -337,10 +337,10 @@ func (r *registryModules) ListCommits(ctx context.Context, moduleID RegistryModu
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules/private/%s/%s/%s/commits",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
 	)
 	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -398,7 +398,7 @@ func (r *registryModules) Create(ctx context.Context, organization string, optio
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules",
-		url.QueryEscape(organization),
+		url.PathEscape(organization),
 	)
 	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
@@ -439,11 +439,11 @@ func (r *registryModules) Update(ctx context.Context, moduleID RegistryModuleID,
 		}
 	}
 
-	org := url.QueryEscape(moduleID.Organization)
-	registryName := url.QueryEscape(string(moduleID.RegistryName))
-	namespace := url.QueryEscape(moduleID.Namespace)
-	name := url.QueryEscape(moduleID.Name)
-	provider := url.QueryEscape(moduleID.Provider)
+	org := url.PathEscape(moduleID.Organization)
+	registryName := url.PathEscape(string(moduleID.RegistryName))
+	namespace := url.PathEscape(moduleID.Namespace)
+	name := url.PathEscape(moduleID.Name)
+	provider := url.PathEscape(moduleID.Provider)
 	registryModuleURL := fmt.Sprintf("organizations/%s/registry-modules/%s/%s/%s/%s", org, registryName, namespace, name, provider)
 
 	req, err := r.client.NewRequest(http.MethodPatch, registryModuleURL, &options)
@@ -471,9 +471,9 @@ func (r *registryModules) CreateVersion(ctx context.Context, moduleID RegistryMo
 
 	u := fmt.Sprintf(
 		"registry-modules/%s/%s/%s/versions",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
 	)
 	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
@@ -500,7 +500,7 @@ func (r *registryModules) CreateWithVCSConnection(ctx context.Context, options R
 	} else {
 		u = fmt.Sprintf(
 			"organizations/%s/registry-modules/vcs",
-			url.QueryEscape(*options.VCSRepo.OrganizationName),
+			url.PathEscape(*options.VCSRepo.OrganizationName),
 		)
 	}
 	req, err := r.client.NewRequest("POST", u, &options)
@@ -535,11 +535,11 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules/%s/%s/%s/%s",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(string(moduleID.RegistryName)),
-		url.QueryEscape(moduleID.Namespace),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(string(moduleID.RegistryName)),
+		url.PathEscape(moduleID.Namespace),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
 	)
 
 	req, err := r.client.NewRequest("GET", u, nil)
@@ -567,11 +567,11 @@ func (r *registryModules) ReadVersion(ctx context.Context, moduleID RegistryModu
 	}
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules/private/%s/%s/%s/version?module_version=%s",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
-		url.QueryEscape(version),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
+		url.PathEscape(version),
 	)
 	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -603,8 +603,8 @@ func (r *registryModules) Delete(ctx context.Context, organization, name string)
 
 	u := fmt.Sprintf(
 		"registry-modules/actions/delete/%s/%s",
-		url.QueryEscape(organization),
-		url.QueryEscape(name),
+		url.PathEscape(organization),
+		url.PathEscape(name),
 	)
 	req, err := r.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -622,10 +622,10 @@ func (r *registryModules) DeleteByName(ctx context.Context, module RegistryModul
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules/%s/%s/%s",
-		url.QueryEscape(module.Organization),
-		url.QueryEscape(string(module.RegistryName)),
-		url.QueryEscape(module.Namespace),
-		url.QueryEscape(module.Name),
+		url.PathEscape(module.Organization),
+		url.PathEscape(string(module.RegistryName)),
+		url.PathEscape(module.Namespace),
+		url.PathEscape(module.Name),
 	)
 
 	req, err := r.client.NewRequest("DELETE", u, nil)
@@ -644,11 +644,11 @@ func (r *registryModules) DeleteProvider(ctx context.Context, moduleID RegistryM
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules/%s/%s/%s/%s",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(string(moduleID.RegistryName)),
-		url.QueryEscape(moduleID.Namespace),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(string(moduleID.RegistryName)),
+		url.PathEscape(moduleID.Namespace),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
 	)
 
 	req, err := r.client.NewRequest("DELETE", u, nil)
@@ -674,12 +674,12 @@ func (r *registryModules) DeleteVersion(ctx context.Context, moduleID RegistryMo
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-modules/%s/%s/%s/%s/%s",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(string(moduleID.RegistryName)),
-		url.QueryEscape(moduleID.Namespace),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
-		url.QueryEscape(version),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(string(moduleID.RegistryName)),
+		url.PathEscape(moduleID.Namespace),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
+		url.PathEscape(version),
 	)
 	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil && errors.Is(err, ErrResourceNotFound) {
@@ -880,9 +880,9 @@ func (r *registryModules) deprecatedDeleteProvider(ctx context.Context, moduleID
 
 	u := fmt.Sprintf(
 		"registry-modules/actions/delete/%s/%s/%s",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
 	)
 	req, err := r.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -905,10 +905,10 @@ func (r *registryModules) deprecatedDeleteVersion(ctx context.Context, moduleID 
 
 	u := fmt.Sprintf(
 		"registry-modules/actions/delete/%s/%s/%s/%s",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider),
-		url.QueryEscape(version),
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider),
+		url.PathEscape(version),
 	)
 	req, err := r.client.NewRequest("POST", u, nil)
 	if err != nil {

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -190,7 +190,7 @@ func (r *registryNoCodeModules) Create(ctx context.Context, organization string,
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/no-code-modules", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/no-code-modules", url.PathEscape(organization))
 	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -215,7 +215,7 @@ func (r *registryNoCodeModules) Read(ctx context.Context, noCodeModuleID string,
 		return nil, err
 	}
 
-	u := fmt.Sprintf("no-code-modules/%s", url.QueryEscape(noCodeModuleID))
+	u := fmt.Sprintf("no-code-modules/%s", url.PathEscape(noCodeModuleID))
 	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -243,7 +243,7 @@ func (r *registryNoCodeModules) Update(ctx context.Context, noCodeModuleID strin
 		return nil, err
 	}
 
-	u := fmt.Sprintf("no-code-modules/%s", url.QueryEscape(noCodeModuleID))
+	u := fmt.Sprintf("no-code-modules/%s", url.PathEscape(noCodeModuleID))
 	req, err := r.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -264,7 +264,7 @@ func (r *registryNoCodeModules) Delete(ctx context.Context, noCodeModuleID strin
 		return ErrInvalidModuleID
 	}
 
-	u := fmt.Sprintf("no-code-modules/%s", url.QueryEscape(noCodeModuleID))
+	u := fmt.Sprintf("no-code-modules/%s", url.PathEscape(noCodeModuleID))
 	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -283,7 +283,7 @@ func (r *registryNoCodeModules) CreateWorkspace(
 		return nil, err
 	}
 
-	u := fmt.Sprintf("no-code-modules/%s/workspaces", url.QueryEscape(noCodeModuleID))
+	u := fmt.Sprintf("no-code-modules/%s/workspaces", url.PathEscape(noCodeModuleID))
 	req, err := r.client.NewRequest("POST", u, options)
 	if err != nil {
 		return nil, err
@@ -310,7 +310,7 @@ func (r *registryNoCodeModules) UpgradeWorkspace(
 	}
 
 	u := fmt.Sprintf("no-code-modules/%s/workspaces/%s/upgrade",
-		url.QueryEscape(noCodeModuleID),
+		url.PathEscape(noCodeModuleID),
 		workspaceID,
 	)
 	req, err := r.client.NewRequest("POST", u, options)

--- a/registry_provider.go
+++ b/registry_provider.go
@@ -134,7 +134,7 @@ func (r *registryProviders) List(ctx context.Context, organization string, optio
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/registry-providers", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/registry-providers", url.PathEscape(organization))
 	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -160,7 +160,7 @@ func (r *registryProviders) Create(ctx context.Context, organization string, opt
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers",
-		url.QueryEscape(organization),
+		url.PathEscape(organization),
 	)
 	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
@@ -183,10 +183,10 @@ func (r *registryProviders) Read(ctx context.Context, providerID RegistryProvide
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s",
-		url.QueryEscape(providerID.OrganizationName),
-		url.QueryEscape(string(providerID.RegistryName)),
-		url.QueryEscape(providerID.Namespace),
-		url.QueryEscape(providerID.Name),
+		url.PathEscape(providerID.OrganizationName),
+		url.PathEscape(string(providerID.RegistryName)),
+		url.PathEscape(providerID.Namespace),
+		url.PathEscape(providerID.Name),
 	)
 	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -209,10 +209,10 @@ func (r *registryProviders) Delete(ctx context.Context, providerID RegistryProvi
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s",
-		url.QueryEscape(providerID.OrganizationName),
-		url.QueryEscape(string(providerID.RegistryName)),
-		url.QueryEscape(providerID.Namespace),
-		url.QueryEscape(providerID.Name),
+		url.PathEscape(providerID.OrganizationName),
+		url.PathEscape(string(providerID.RegistryName)),
+		url.PathEscape(providerID.Namespace),
+		url.PathEscape(providerID.Name),
 	)
 	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/registry_provider_platform.go
+++ b/registry_provider_platform.go
@@ -94,11 +94,11 @@ func (r *registryProviderPlatforms) Create(ctx context.Context, versionID Regist
 	// POST /organizations/:organization_name/registry-providers/:registry_name/:namespace/:name/versions/:version/platforms
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions/%s/platforms",
-		url.QueryEscape(versionID.OrganizationName),
-		url.QueryEscape(string(versionID.RegistryName)),
-		url.QueryEscape(versionID.Namespace),
-		url.QueryEscape(versionID.Name),
-		url.QueryEscape(versionID.Version),
+		url.PathEscape(versionID.OrganizationName),
+		url.PathEscape(string(versionID.RegistryName)),
+		url.PathEscape(versionID.Namespace),
+		url.PathEscape(versionID.Name),
+		url.PathEscape(versionID.Version),
 	)
 	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
@@ -126,11 +126,11 @@ func (r *registryProviderPlatforms) List(ctx context.Context, versionID Registry
 	// GET /organizations/:organization_name/registry-providers/:registry_name/:namespace/:name/versions/:version/platforms
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions/%s/platforms",
-		url.QueryEscape(versionID.RegistryProviderID.OrganizationName),
-		url.QueryEscape(string(versionID.RegistryProviderID.RegistryName)),
-		url.QueryEscape(versionID.RegistryProviderID.Namespace),
-		url.QueryEscape(versionID.RegistryProviderID.Name),
-		url.QueryEscape(versionID.Version),
+		url.PathEscape(versionID.RegistryProviderID.OrganizationName),
+		url.PathEscape(string(versionID.RegistryProviderID.RegistryName)),
+		url.PathEscape(versionID.RegistryProviderID.Namespace),
+		url.PathEscape(versionID.RegistryProviderID.Name),
+		url.PathEscape(versionID.Version),
 	)
 	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -155,13 +155,13 @@ func (r *registryProviderPlatforms) Read(ctx context.Context, platformID Registr
 	// GET /organizations/:organization_name/registry-providers/:registry_name/:namespace/:name/versions/:version/platforms/:os/:arch
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions/%s/platforms/%s/%s",
-		url.QueryEscape(platformID.RegistryProviderID.OrganizationName),
-		url.QueryEscape(string(platformID.RegistryProviderID.RegistryName)),
-		url.QueryEscape(platformID.RegistryProviderID.Namespace),
-		url.QueryEscape(platformID.RegistryProviderID.Name),
-		url.QueryEscape(platformID.RegistryProviderVersionID.Version),
-		url.QueryEscape(platformID.OS),
-		url.QueryEscape(platformID.Arch),
+		url.PathEscape(platformID.RegistryProviderID.OrganizationName),
+		url.PathEscape(string(platformID.RegistryProviderID.RegistryName)),
+		url.PathEscape(platformID.RegistryProviderID.Namespace),
+		url.PathEscape(platformID.RegistryProviderID.Name),
+		url.PathEscape(platformID.RegistryProviderVersionID.Version),
+		url.PathEscape(platformID.OS),
+		url.PathEscape(platformID.Arch),
 	)
 	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -187,13 +187,13 @@ func (r *registryProviderPlatforms) Delete(ctx context.Context, platformID Regis
 	// DELETE /organizations/:organization_name/registry-providers/:registry_name/:namespace/:name/versions/:version/platforms/:os/:arch
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions/%s/platforms/%s/%s",
-		url.QueryEscape(platformID.OrganizationName),
-		url.QueryEscape(string(platformID.RegistryName)),
-		url.QueryEscape(platformID.Namespace),
-		url.QueryEscape(platformID.Name),
-		url.QueryEscape(platformID.Version),
-		url.QueryEscape(platformID.OS),
-		url.QueryEscape(platformID.Arch),
+		url.PathEscape(platformID.OrganizationName),
+		url.PathEscape(string(platformID.RegistryName)),
+		url.PathEscape(platformID.Namespace),
+		url.PathEscape(platformID.Name),
+		url.PathEscape(platformID.Version),
+		url.PathEscape(platformID.OS),
+		url.PathEscape(platformID.Arch),
 	)
 	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/registry_provider_version.go
+++ b/registry_provider_version.go
@@ -97,10 +97,10 @@ func (r *registryProviderVersions) List(ctx context.Context, providerID Registry
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions",
-		url.QueryEscape(providerID.OrganizationName),
-		url.QueryEscape(string(providerID.RegistryName)),
-		url.QueryEscape(providerID.Namespace),
-		url.QueryEscape(providerID.Name),
+		url.PathEscape(providerID.OrganizationName),
+		url.PathEscape(string(providerID.RegistryName)),
+		url.PathEscape(providerID.Namespace),
+		url.PathEscape(providerID.Name),
 	)
 	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -132,10 +132,10 @@ func (r *registryProviderVersions) Create(ctx context.Context, providerID Regist
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions",
-		url.QueryEscape(providerID.OrganizationName),
-		url.QueryEscape(string(providerID.RegistryName)),
-		url.QueryEscape(providerID.Namespace),
-		url.QueryEscape(providerID.Name),
+		url.PathEscape(providerID.OrganizationName),
+		url.PathEscape(string(providerID.RegistryName)),
+		url.PathEscape(providerID.Namespace),
+		url.PathEscape(providerID.Name),
 	)
 	req, err := r.client.NewRequest("POST", u, &options)
 	if err != nil {
@@ -159,11 +159,11 @@ func (r *registryProviderVersions) Read(ctx context.Context, versionID RegistryP
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions/%s",
-		url.QueryEscape(versionID.OrganizationName),
-		url.QueryEscape(string(versionID.RegistryName)),
-		url.QueryEscape(versionID.Namespace),
-		url.QueryEscape(versionID.Name),
-		url.QueryEscape(versionID.Version),
+		url.PathEscape(versionID.OrganizationName),
+		url.PathEscape(string(versionID.RegistryName)),
+		url.PathEscape(versionID.Namespace),
+		url.PathEscape(versionID.Name),
+		url.PathEscape(versionID.Version),
 	)
 	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -187,11 +187,11 @@ func (r *registryProviderVersions) Delete(ctx context.Context, versionID Registr
 
 	u := fmt.Sprintf(
 		"organizations/%s/registry-providers/%s/%s/%s/versions/%s",
-		url.QueryEscape(versionID.OrganizationName),
-		url.QueryEscape(string(versionID.RegistryName)),
-		url.QueryEscape(versionID.Namespace),
-		url.QueryEscape(versionID.Name),
-		url.QueryEscape(versionID.Version),
+		url.PathEscape(versionID.OrganizationName),
+		url.PathEscape(string(versionID.RegistryName)),
+		url.PathEscape(versionID.Namespace),
+		url.PathEscape(versionID.Name),
+		url.PathEscape(versionID.Version),
 	)
 	req, err := r.client.NewRequest("DELETE", u, nil)
 	if err != nil {

--- a/run.go
+++ b/run.go
@@ -383,7 +383,7 @@ func (s *runs) List(ctx context.Context, workspaceID string, options *RunListOpt
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/runs", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/runs", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -432,7 +432,7 @@ func (s *runs) ReadWithOptions(ctx context.Context, runID string, options *RunRe
 		return nil, err
 	}
 
-	u := fmt.Sprintf("runs/%s", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s", url.PathEscape(runID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -453,7 +453,7 @@ func (s *runs) Apply(ctx context.Context, runID string, options RunApplyOptions)
 		return ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("runs/%s/actions/apply", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/actions/apply", url.PathEscape(runID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
@@ -468,7 +468,7 @@ func (s *runs) Cancel(ctx context.Context, runID string, options RunCancelOption
 		return ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("runs/%s/actions/cancel", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/actions/cancel", url.PathEscape(runID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
@@ -483,7 +483,7 @@ func (s *runs) ForceCancel(ctx context.Context, runID string, options RunForceCa
 		return ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("runs/%s/actions/force-cancel", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/actions/force-cancel", url.PathEscape(runID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err
@@ -503,7 +503,7 @@ func (s *runs) ForceExecute(ctx context.Context, runID string) error {
 		return ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("runs/%s/actions/force-execute", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/actions/force-execute", url.PathEscape(runID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
@@ -518,7 +518,7 @@ func (s *runs) Discard(ctx context.Context, runID string, options RunDiscardOpti
 		return ErrInvalidRunID
 	}
 
-	u := fmt.Sprintf("runs/%s/actions/discard", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/actions/discard", url.PathEscape(runID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return err

--- a/run_event.go
+++ b/run_event.go
@@ -81,7 +81,7 @@ func (s *runEvents) List(ctx context.Context, runID string, options *RunEventLis
 		return nil, err
 	}
 
-	u := fmt.Sprintf("runs/%s/run-events", url.QueryEscape(runID))
+	u := fmt.Sprintf("runs/%s/run-events", url.PathEscape(runID))
 
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -111,7 +111,7 @@ func (s *runEvents) ReadWithOptions(ctx context.Context, runEventID string, opti
 		return nil, err
 	}
 
-	u := fmt.Sprintf("run-events/%s", url.QueryEscape(runEventID))
+	u := fmt.Sprintf("run-events/%s", url.PathEscape(runEventID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err

--- a/run_task.go
+++ b/run_task.go
@@ -172,7 +172,7 @@ func (s *runTasks) Create(ctx context.Context, organization string, options RunT
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/tasks", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/tasks", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -196,7 +196,7 @@ func (s *runTasks) List(ctx context.Context, organization string, options *RunTa
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/tasks", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/tasks", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -225,7 +225,7 @@ func (s *runTasks) ReadWithOptions(ctx context.Context, runTaskID string, option
 		return nil, err
 	}
 
-	u := fmt.Sprintf("tasks/%s", url.QueryEscape(runTaskID))
+	u := fmt.Sprintf("tasks/%s", url.PathEscape(runTaskID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -250,7 +250,7 @@ func (s *runTasks) Update(ctx context.Context, runTaskID string, options RunTask
 		return nil, err
 	}
 
-	u := fmt.Sprintf("tasks/%s", url.QueryEscape(runTaskID))
+	u := fmt.Sprintf("tasks/%s", url.PathEscape(runTaskID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err

--- a/run_trigger.go
+++ b/run_trigger.go
@@ -109,7 +109,7 @@ func (s *runTriggers) List(ctx context.Context, workspaceID string, options *Run
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/run-triggers", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -133,7 +133,7 @@ func (s *runTriggers) Create(ctx context.Context, workspaceID string, options Ru
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/run-triggers", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/run-triggers", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -154,7 +154,7 @@ func (s *runTriggers) Read(ctx context.Context, runTriggerID string) (*RunTrigge
 		return nil, ErrInvalidRunTriggerID
 	}
 
-	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
+	u := fmt.Sprintf("run-triggers/%s", url.PathEscape(runTriggerID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -175,7 +175,7 @@ func (s *runTriggers) Delete(ctx context.Context, runTriggerID string) error {
 		return ErrInvalidRunTriggerID
 	}
 
-	u := fmt.Sprintf("run-triggers/%s", url.QueryEscape(runTriggerID))
+	u := fmt.Sprintf("run-triggers/%s", url.PathEscape(runTriggerID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/ssh_key.go
+++ b/ssh_key.go
@@ -86,7 +86,7 @@ func (s *sshKeys) List(ctx context.Context, organization string, options *SSHKey
 		return nil, ErrInvalidOrg
 	}
 
-	u := fmt.Sprintf("organizations/%s/ssh-keys", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/ssh-keys", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -111,7 +111,7 @@ func (s *sshKeys) Create(ctx context.Context, organization string, options SSHKe
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/ssh-keys", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/ssh-keys", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (s *sshKeys) Read(ctx context.Context, sshKeyID string) (*SSHKey, error) {
 		return nil, ErrInvalidSHHKeyID
 	}
 
-	u := fmt.Sprintf("ssh-keys/%s", url.QueryEscape(sshKeyID))
+	u := fmt.Sprintf("ssh-keys/%s", url.PathEscape(sshKeyID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -153,7 +153,7 @@ func (s *sshKeys) Update(ctx context.Context, sshKeyID string, options SSHKeyUpd
 		return nil, ErrInvalidSHHKeyID
 	}
 
-	u := fmt.Sprintf("ssh-keys/%s", url.QueryEscape(sshKeyID))
+	u := fmt.Sprintf("ssh-keys/%s", url.PathEscape(sshKeyID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -174,7 +174,7 @@ func (s *sshKeys) Delete(ctx context.Context, sshKeyID string) error {
 		return ErrInvalidSHHKeyID
 	}
 
-	u := fmt.Sprintf("ssh-keys/%s", url.QueryEscape(sshKeyID))
+	u := fmt.Sprintf("ssh-keys/%s", url.PathEscape(sshKeyID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/state_version.go
+++ b/state_version.go
@@ -264,7 +264,7 @@ func (s *stateVersions) Create(ctx context.Context, workspaceID string, options 
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/state-versions", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/state-versions", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -321,7 +321,7 @@ func (s *stateVersions) ReadWithOptions(ctx context.Context, svID string, option
 		return nil, err
 	}
 
-	u := fmt.Sprintf("state-versions/%s", url.QueryEscape(svID))
+	u := fmt.Sprintf("state-versions/%s", url.PathEscape(svID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -350,7 +350,7 @@ func (s *stateVersions) ReadCurrentWithOptions(ctx context.Context, workspaceID 
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/current-state-version", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/current-state-version", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -395,7 +395,7 @@ func (s *stateVersions) ListOutputs(ctx context.Context, svID string, options *S
 		return nil, ErrInvalidStateVerID
 	}
 
-	u := fmt.Sprintf("state-versions/%s/outputs", url.QueryEscape(svID))
+	u := fmt.Sprintf("state-versions/%s/outputs", url.PathEscape(svID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err

--- a/state_version_output.go
+++ b/state_version_output.go
@@ -44,7 +44,7 @@ func (s *stateVersionOutputs) ReadCurrent(ctx context.Context, workspaceID strin
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/current-state-version-outputs", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/current-state-version-outputs", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -65,7 +65,7 @@ func (s *stateVersionOutputs) Read(ctx context.Context, outputID string) (*State
 		return nil, ErrInvalidOutputID
 	}
 
-	u := fmt.Sprintf("state-version-outputs/%s", url.QueryEscape(outputID))
+	u := fmt.Sprintf("state-version-outputs/%s", url.PathEscape(outputID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/subscription_updater_test.go
+++ b/subscription_updater_test.go
@@ -103,7 +103,7 @@ func (b *organizationSubscriptionUpdater) Update(t *testing.T) {
 
 	b.updateOpts.FeatureSet = fsl.Items[0]
 
-	u := fmt.Sprintf("admin/organizations/%s/subscription", url.QueryEscape(b.organization.Name))
+	u := fmt.Sprintf("admin/organizations/%s/subscription", url.PathEscape(b.organization.Name))
 	req, err = adminClient.NewRequest("POST", u, &b.updateOpts)
 	if err != nil {
 		t.Fatalf("Failed to create request: %v", err)

--- a/team.go
+++ b/team.go
@@ -185,7 +185,7 @@ func (s *teams) List(ctx context.Context, organization string, options *TeamList
 	if err := options.valid(); err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/teams", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -209,7 +209,7 @@ func (s *teams) Create(ctx context.Context, organization string, options TeamCre
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/teams", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/teams", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func (s *teams) Read(ctx context.Context, teamID string) (*Team, error) {
 		return nil, ErrInvalidTeamID
 	}
 
-	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -251,7 +251,7 @@ func (s *teams) Update(ctx context.Context, teamID string, options TeamUpdateOpt
 		return nil, ErrInvalidTeamID
 	}
 
-	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -272,7 +272,7 @@ func (s *teams) Delete(ctx context.Context, teamID string) error {
 		return ErrInvalidTeamID
 	}
 
-	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/team_access.go
+++ b/team_access.go
@@ -208,7 +208,7 @@ func (s *teamAccesses) Read(ctx context.Context, teamAccessID string) (*TeamAcce
 		return nil, ErrInvalidAccessTeamID
 	}
 
-	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
+	u := fmt.Sprintf("team-workspaces/%s", url.PathEscape(teamAccessID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -229,7 +229,7 @@ func (s *teamAccesses) Update(ctx context.Context, teamAccessID string, options 
 		return nil, ErrInvalidAccessTeamID
 	}
 
-	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
+	u := fmt.Sprintf("team-workspaces/%s", url.PathEscape(teamAccessID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -250,7 +250,7 @@ func (s *teamAccesses) Remove(ctx context.Context, teamAccessID string) error {
 		return ErrInvalidAccessTeamID
 	}
 
-	u := fmt.Sprintf("team-workspaces/%s", url.QueryEscape(teamAccessID))
+	u := fmt.Sprintf("team-workspaces/%s", url.PathEscape(teamAccessID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/team_member.go
+++ b/team_member.go
@@ -80,7 +80,7 @@ func (s *teamMembers) ListUsers(ctx context.Context, teamID string) ([]*User, er
 		Include: []TeamIncludeOpt{TeamUsers},
 	}
 
-	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -107,7 +107,7 @@ func (s *teamMembers) ListOrganizationMemberships(ctx context.Context, teamID st
 		Include: []TeamIncludeOpt{TeamOrganizationMemberships},
 	}
 
-	u := fmt.Sprintf("teams/%s", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -132,7 +132,7 @@ func (s *teamMembers) Add(ctx context.Context, teamID string, options TeamMember
 	}
 
 	usersOrMemberships := options.kind()
-	u := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
+	u := fmt.Sprintf("teams/%s/relationships/%s", url.PathEscape(teamID), usersOrMemberships)
 
 	var req *ClientRequest
 
@@ -171,7 +171,7 @@ func (s *teamMembers) Remove(ctx context.Context, teamID string, options TeamMem
 	}
 
 	usersOrMemberships := options.kind()
-	u := fmt.Sprintf("teams/%s/relationships/%s", url.QueryEscape(teamID), usersOrMemberships)
+	u := fmt.Sprintf("teams/%s/relationships/%s", url.PathEscape(teamID), usersOrMemberships)
 
 	var req *ClientRequest
 

--- a/team_project_access.go
+++ b/team_project_access.go
@@ -245,7 +245,7 @@ func (s *teamProjectAccesses) Read(ctx context.Context, teamProjectAccessID stri
 		return nil, ErrInvalidTeamProjectAccessID
 	}
 
-	u := fmt.Sprintf("team-projects/%s", url.QueryEscape(teamProjectAccessID))
+	u := fmt.Sprintf("team-projects/%s", url.PathEscape(teamProjectAccessID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -269,7 +269,7 @@ func (s *teamProjectAccesses) Update(ctx context.Context, teamProjectAccessID st
 	if err := validateTeamProjectAccessType(*options.Access); err != nil {
 		return nil, err
 	}
-	u := fmt.Sprintf("team-projects/%s", url.QueryEscape(teamProjectAccessID))
+	u := fmt.Sprintf("team-projects/%s", url.PathEscape(teamProjectAccessID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -290,7 +290,7 @@ func (s *teamProjectAccesses) Remove(ctx context.Context, teamProjectAccessID st
 		return ErrInvalidTeamProjectAccessID
 	}
 
-	u := fmt.Sprintf("team-projects/%s", url.QueryEscape(teamProjectAccessID))
+	u := fmt.Sprintf("team-projects/%s", url.PathEscape(teamProjectAccessID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/team_token.go
+++ b/team_token.go
@@ -66,7 +66,7 @@ func (s *teamTokens) CreateWithOptions(ctx context.Context, teamID string, optio
 		return nil, ErrInvalidTeamID
 	}
 
-	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s/authentication-token", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -87,7 +87,7 @@ func (s *teamTokens) Read(ctx context.Context, teamID string) (*TeamToken, error
 		return nil, ErrInvalidTeamID
 	}
 
-	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s/authentication-token", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -108,7 +108,7 @@ func (s *teamTokens) Delete(ctx context.Context, teamID string) error {
 		return ErrInvalidTeamID
 	}
 
-	u := fmt.Sprintf("teams/%s/authentication-token", url.QueryEscape(teamID))
+	u := fmt.Sprintf("teams/%s/authentication-token", url.PathEscape(teamID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/test_run.go
+++ b/test_run.go
@@ -171,7 +171,7 @@ func (s *testRuns) Read(ctx context.Context, moduleID RegistryModuleID, testRunI
 		return nil, ErrInvalidTestRunID
 	}
 
-	u := fmt.Sprintf("%s/%s", testRunsPath(moduleID), url.QueryEscape(testRunID))
+	u := fmt.Sprintf("%s/%s", testRunsPath(moduleID), url.PathEscape(testRunID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -278,7 +278,7 @@ func (s *testRuns) Cancel(ctx context.Context, moduleID RegistryModuleID, testRu
 		return ErrInvalidTestRunID
 	}
 
-	u := fmt.Sprintf("%s/%s/cancel", testRunsPath(moduleID), url.QueryEscape(testRunID))
+	u := fmt.Sprintf("%s/%s/cancel", testRunsPath(moduleID), url.PathEscape(testRunID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
@@ -297,7 +297,7 @@ func (s *testRuns) ForceCancel(ctx context.Context, moduleID RegistryModuleID, t
 		return ErrInvalidTestRunID
 	}
 
-	u := fmt.Sprintf("%s/%s/force-cancel", testRunsPath(moduleID), url.QueryEscape(testRunID))
+	u := fmt.Sprintf("%s/%s/force-cancel", testRunsPath(moduleID), url.PathEscape(testRunID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
@@ -324,9 +324,9 @@ func (o TestRunCreateOptions) valid() error {
 
 func testRunsPath(moduleID RegistryModuleID) string {
 	return fmt.Sprintf("organizations/%s/tests/registry-modules/%s/%s/%s/%s/test-runs",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(string(moduleID.RegistryName)),
-		url.QueryEscape(moduleID.Namespace),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider))
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(string(moduleID.RegistryName)),
+		url.PathEscape(moduleID.Namespace),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider))
 }

--- a/test_variables.go
+++ b/test_variables.go
@@ -68,7 +68,7 @@ func (s *testVariables) Read(ctx context.Context, moduleID RegistryModuleID, var
 		return nil, ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.PathEscape(variableID))
 
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -116,7 +116,7 @@ func (s *testVariables) Update(ctx context.Context, moduleID RegistryModuleID, v
 		return nil, ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func (s *testVariables) Delete(ctx context.Context, moduleID RegistryModuleID, v
 		return ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("%s/%s", testVarsPath(moduleID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -151,9 +151,9 @@ func (s *testVariables) Delete(ctx context.Context, moduleID RegistryModuleID, v
 
 func testVarsPath(moduleID RegistryModuleID) string {
 	return fmt.Sprintf("organizations/%s/tests/registry-modules/%s/%s/%s/%s/vars",
-		url.QueryEscape(moduleID.Organization),
-		url.QueryEscape(string(moduleID.RegistryName)),
-		url.QueryEscape(moduleID.Namespace),
-		url.QueryEscape(moduleID.Name),
-		url.QueryEscape(moduleID.Provider))
+		url.PathEscape(moduleID.Organization),
+		url.PathEscape(string(moduleID.RegistryName)),
+		url.PathEscape(moduleID.Namespace),
+		url.PathEscape(moduleID.Name),
+		url.PathEscape(moduleID.Provider))
 }

--- a/user_token.go
+++ b/user_token.go
@@ -77,7 +77,7 @@ func (s *userTokens) Create(ctx context.Context, userID string, options UserToke
 		return nil, ErrInvalidUserID
 	}
 
-	u := fmt.Sprintf("users/%s/authentication-tokens", url.QueryEscape(userID))
+	u := fmt.Sprintf("users/%s/authentication-tokens", url.PathEscape(userID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -98,7 +98,7 @@ func (s *userTokens) List(ctx context.Context, userID string) (*UserTokenList, e
 		return nil, ErrInvalidUserID
 	}
 
-	u := fmt.Sprintf("users/%s/authentication-tokens", url.QueryEscape(userID))
+	u := fmt.Sprintf("users/%s/authentication-tokens", url.PathEscape(userID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -119,7 +119,7 @@ func (s *userTokens) Read(ctx context.Context, tokenID string) (*UserToken, erro
 		return nil, ErrInvalidTokenID
 	}
 
-	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))
+	u := fmt.Sprintf("authentication-tokens/%s", url.PathEscape(tokenID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -140,7 +140,7 @@ func (s *userTokens) Delete(ctx context.Context, tokenID string) error {
 		return ErrInvalidTokenID
 	}
 
-	u := fmt.Sprintf("authentication-tokens/%s", url.QueryEscape(tokenID))
+	u := fmt.Sprintf("authentication-tokens/%s", url.PathEscape(tokenID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/variable.go
+++ b/variable.go
@@ -134,7 +134,7 @@ func (s *variables) List(ctx context.Context, workspaceID string, options *Varia
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/vars", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -158,7 +158,7 @@ func (s *variables) Create(ctx context.Context, workspaceID string, options Vari
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/vars", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/vars", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -182,7 +182,7 @@ func (s *variables) Read(ctx context.Context, workspaceID, variableID string) (*
 		return nil, ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("workspaces/%s/vars/%s", url.PathEscape(workspaceID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -206,7 +206,7 @@ func (s *variables) Update(ctx context.Context, workspaceID, variableID string, 
 		return nil, ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("workspaces/%s/vars/%s", url.PathEscape(workspaceID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -230,7 +230,7 @@ func (s *variables) Delete(ctx context.Context, workspaceID, variableID string) 
 		return ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/vars/%s", url.QueryEscape(workspaceID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("workspaces/%s/vars/%s", url.PathEscape(workspaceID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/variable_set.go
+++ b/variable_set.go
@@ -206,7 +206,7 @@ func (s *variableSets) List(ctx context.Context, organization string, options *V
 		}
 	}
 
-	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/varsets", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -232,7 +232,7 @@ func (s *variableSets) ListForWorkspace(ctx context.Context, workspaceID string,
 		}
 	}
 
-	u := fmt.Sprintf("workspaces/%s/varsets", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/varsets", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -258,7 +258,7 @@ func (s *variableSets) ListForProject(ctx context.Context, projectID string, opt
 		}
 	}
 
-	u := fmt.Sprintf("projects/%s/varsets", url.QueryEscape(projectID))
+	u := fmt.Sprintf("projects/%s/varsets", url.PathEscape(projectID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -282,7 +282,7 @@ func (s *variableSets) Create(ctx context.Context, organization string, options 
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/varsets", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/varsets", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, options)
 	if err != nil {
 		return nil, err
@@ -303,7 +303,7 @@ func (s *variableSets) Read(ctx context.Context, variableSetID string, options *
 		return nil, ErrInvalidVariableSetID
 	}
 
-	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -324,7 +324,7 @@ func (s *variableSets) Update(ctx context.Context, variableSetID string, options
 		return nil, ErrInvalidVariableSetID
 	}
 
-	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("PATCH", u, options)
 	if err != nil {
 		return nil, err
@@ -345,7 +345,7 @@ func (s *variableSets) Delete(ctx context.Context, variableSetID string) error {
 		return ErrInvalidVariableSetID
 	}
 
-	u := fmt.Sprintf("varsets/%s", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -364,7 +364,7 @@ func (s *variableSets) ApplyToWorkspaces(ctx context.Context, variableSetID stri
 		return err
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/workspaces", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s/relationships/workspaces", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("POST", u, options.Workspaces)
 	if err != nil {
 		return err
@@ -383,7 +383,7 @@ func (s *variableSets) RemoveFromWorkspaces(ctx context.Context, variableSetID s
 		return err
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/workspaces", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s/relationships/workspaces", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("DELETE", u, options.Workspaces)
 	if err != nil {
 		return err
@@ -402,7 +402,7 @@ func (s variableSets) ApplyToProjects(ctx context.Context, variableSetID string,
 		return err
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/projects", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s/relationships/projects", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("POST", u, options.Projects)
 	if err != nil {
 		return err
@@ -421,7 +421,7 @@ func (s variableSets) RemoveFromProjects(ctx context.Context, variableSetID stri
 		return err
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/projects", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s/relationships/projects", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("DELETE", u, options.Projects)
 	if err != nil {
 		return err
@@ -443,7 +443,7 @@ func (s *variableSets) UpdateWorkspaces(ctx context.Context, variableSetID strin
 	}
 
 	// We force inclusion of workspaces as that is the primary data for which we are concerned with confirming changes.
-	u := fmt.Sprintf("varsets/%s?include=%s", url.QueryEscape(variableSetID), VariableSetWorkspaces)
+	u := fmt.Sprintf("varsets/%s?include=%s", url.PathEscape(variableSetID), VariableSetWorkspaces)
 	req, err := s.client.NewRequest("PATCH", u, &o)
 	if err != nil {
 		return nil, err

--- a/variable_set_variable.go
+++ b/variable_set_variable.go
@@ -75,7 +75,7 @@ func (s *variableSetVariables) List(ctx context.Context, variableSetID string, o
 		}
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s/relationships/vars", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -138,7 +138,7 @@ func (s *variableSetVariables) Create(ctx context.Context, variableSetID string,
 		}
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/vars", url.QueryEscape(variableSetID))
+	u := fmt.Sprintf("varsets/%s/relationships/vars", url.PathEscape(variableSetID))
 	req, err := s.client.NewRequest("POST", u, options)
 	if err != nil {
 		return nil, err
@@ -162,7 +162,7 @@ func (s *variableSetVariables) Read(ctx context.Context, variableSetID, variable
 		return nil, ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.PathEscape(variableSetID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("GET", u, nil)
 
 	if err != nil {
@@ -211,7 +211,7 @@ func (s *variableSetVariables) Update(ctx context.Context, variableSetID, variab
 		return nil, ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.PathEscape(variableSetID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("PATCH", u, options)
 	if err != nil {
 		return nil, err
@@ -235,7 +235,7 @@ func (s *variableSetVariables) Delete(ctx context.Context, variableSetID, variab
 		return ErrInvalidVariableID
 	}
 
-	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.QueryEscape(variableSetID), url.QueryEscape(variableID))
+	u := fmt.Sprintf("varsets/%s/relationships/vars/%s", url.PathEscape(variableSetID), url.PathEscape(variableID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err

--- a/workspace.go
+++ b/workspace.go
@@ -700,7 +700,7 @@ func (s *workspaces) List(ctx context.Context, organization string, options *Wor
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/workspaces", url.PathEscape(organization))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -724,7 +724,7 @@ func (s *workspaces) Create(ctx context.Context, organization string, options Wo
 		return nil, err
 	}
 
-	u := fmt.Sprintf("organizations/%s/workspaces", url.QueryEscape(organization))
+	u := fmt.Sprintf("organizations/%s/workspaces", url.PathEscape(organization))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -758,8 +758,8 @@ func (s *workspaces) ReadWithOptions(ctx context.Context, organization, workspac
 
 	u := fmt.Sprintf(
 		"organizations/%s/workspaces/%s",
-		url.QueryEscape(organization),
-		url.QueryEscape(workspace),
+		url.PathEscape(organization),
+		url.PathEscape(workspace),
 	)
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -793,7 +793,7 @@ func (s *workspaces) ReadByIDWithOptions(ctx context.Context, workspaceID string
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -823,7 +823,7 @@ func (s *workspaces) Readme(ctx context.Context, workspaceID string) (io.Reader,
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s?include=readme", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s?include=readme", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -855,8 +855,8 @@ func (s *workspaces) Update(ctx context.Context, organization, workspace string,
 
 	u := fmt.Sprintf(
 		"organizations/%s/workspaces/%s",
-		url.QueryEscape(organization),
-		url.QueryEscape(workspace),
+		url.PathEscape(organization),
+		url.PathEscape(workspace),
 	)
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
@@ -878,7 +878,7 @@ func (s *workspaces) UpdateByID(ctx context.Context, workspaceID string, options
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -904,8 +904,8 @@ func (s *workspaces) Delete(ctx context.Context, organization, workspace string)
 
 	u := fmt.Sprintf(
 		"organizations/%s/workspaces/%s",
-		url.QueryEscape(organization),
-		url.QueryEscape(workspace),
+		url.PathEscape(organization),
+		url.PathEscape(workspace),
 	)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
@@ -921,7 +921,7 @@ func (s *workspaces) DeleteByID(ctx context.Context, workspaceID string) error {
 		return ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {
 		return err
@@ -941,8 +941,8 @@ func (s *workspaces) SafeDelete(ctx context.Context, organization, workspace str
 
 	u := fmt.Sprintf(
 		"organizations/%s/workspaces/%s/actions/safe-delete",
-		url.QueryEscape(organization),
-		url.QueryEscape(workspace),
+		url.PathEscape(organization),
+		url.PathEscape(workspace),
 	)
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
@@ -958,7 +958,7 @@ func (s *workspaces) SafeDeleteByID(ctx context.Context, workspaceID string) err
 		return ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/actions/safe-delete", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/actions/safe-delete", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return err
@@ -978,8 +978,8 @@ func (s *workspaces) RemoveVCSConnection(ctx context.Context, organization, work
 
 	u := fmt.Sprintf(
 		"organizations/%s/workspaces/%s",
-		url.QueryEscape(organization),
-		url.QueryEscape(workspace),
+		url.PathEscape(organization),
+		url.PathEscape(workspace),
 	)
 
 	req, err := s.client.NewRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
@@ -1002,7 +1002,7 @@ func (s *workspaces) RemoveVCSConnectionByID(ctx context.Context, workspaceID st
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s", url.PathEscape(workspaceID))
 
 	req, err := s.client.NewRequest("PATCH", u, &workspaceRemoveVCSConnectionOptions{})
 	if err != nil {
@@ -1024,7 +1024,7 @@ func (s *workspaces) Lock(ctx context.Context, workspaceID string, options Works
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/actions/lock", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/actions/lock", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, &options)
 	if err != nil {
 		return nil, err
@@ -1045,7 +1045,7 @@ func (s *workspaces) Unlock(ctx context.Context, workspaceID string) (*Workspace
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/actions/unlock", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/actions/unlock", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -1066,7 +1066,7 @@ func (s *workspaces) ForceUnlock(ctx context.Context, workspaceID string) (*Work
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/actions/force-unlock", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/actions/force-unlock", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, nil)
 	if err != nil {
 		return nil, err
@@ -1090,7 +1090,7 @@ func (s *workspaces) AssignSSHKey(ctx context.Context, workspaceID string, optio
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/ssh-key", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/ssh-key", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
 		return nil, err
@@ -1111,7 +1111,7 @@ func (s *workspaces) UnassignSSHKey(ctx context.Context, workspaceID string) (*W
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/ssh-key", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/ssh-key", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("PATCH", u, &workspaceUnassignSSHKeyOptions{})
 	if err != nil {
 		return nil, err
@@ -1132,7 +1132,7 @@ func (s *workspaces) ListRemoteStateConsumers(ctx context.Context, workspaceID s
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.PathEscape(workspaceID))
 
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -1157,7 +1157,7 @@ func (s *workspaces) AddRemoteStateConsumers(ctx context.Context, workspaceID st
 		return err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, options.Workspaces)
 	if err != nil {
 		return err
@@ -1175,7 +1175,7 @@ func (s *workspaces) RemoveRemoteStateConsumers(ctx context.Context, workspaceID
 		return err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("DELETE", u, options.Workspaces)
 	if err != nil {
 		return err
@@ -1193,7 +1193,7 @@ func (s *workspaces) UpdateRemoteStateConsumers(ctx context.Context, workspaceID
 		return err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/remote-state-consumers", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("PATCH", u, options.Workspaces)
 	if err != nil {
 		return err
@@ -1208,7 +1208,7 @@ func (s *workspaces) ListTags(ctx context.Context, workspaceID string, options *
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.PathEscape(workspaceID))
 
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
@@ -1233,7 +1233,7 @@ func (s *workspaces) AddTags(ctx context.Context, workspaceID string, options Wo
 		return err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("POST", u, options.Tags)
 	if err != nil {
 		return err
@@ -1251,7 +1251,7 @@ func (s *workspaces) RemoveTags(ctx context.Context, workspaceID string, options
 		return err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/tags", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("DELETE", u, options.Tags)
 	if err != nil {
 		return err
@@ -1265,7 +1265,7 @@ func (s *workspaces) ReadDataRetentionPolicy(ctx context.Context, workspaceID st
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/relationships/data-retention-policy", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/relationships/data-retention-policy", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err
@@ -1569,5 +1569,5 @@ func tagRegexDefined(options *VCSRepoOptions) bool {
 }
 
 func (s *workspaces) dataRetentionPolicyLink(wsID string) string {
-	return fmt.Sprintf("workspaces/%s/relationships/data-retention-policy", url.QueryEscape(wsID))
+	return fmt.Sprintf("workspaces/%s/relationships/data-retention-policy", url.PathEscape(wsID))
 }

--- a/workspace_resources.go
+++ b/workspace_resources.go
@@ -60,7 +60,7 @@ func (s *workspaceResources) List(ctx context.Context, workspaceID string, optio
 		return nil, err
 	}
 
-	u := fmt.Sprintf("workspaces/%s/resources", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/resources", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err

--- a/workspace_run_task.go
+++ b/workspace_run_task.go
@@ -87,7 +87,7 @@ func (s *workspaceRunTasks) List(ctx context.Context, workspaceID string, option
 		return nil, ErrInvalidWorkspaceID
 	}
 
-	u := fmt.Sprintf("workspaces/%s/tasks", url.QueryEscape(workspaceID))
+	u := fmt.Sprintf("workspaces/%s/tasks", url.PathEscape(workspaceID))
 	req, err := s.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -114,8 +114,8 @@ func (s *workspaceRunTasks) Read(ctx context.Context, workspaceID, workspaceTask
 
 	u := fmt.Sprintf(
 		"workspaces/%s/tasks/%s",
-		url.QueryEscape(workspaceID),
-		url.QueryEscape(workspaceTaskID),
+		url.PathEscape(workspaceID),
+		url.PathEscape(workspaceTaskID),
 	)
 	req, err := s.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -168,8 +168,8 @@ func (s *workspaceRunTasks) Update(ctx context.Context, workspaceID, workspaceTa
 
 	u := fmt.Sprintf(
 		"workspaces/%s/tasks/%s",
-		url.QueryEscape(workspaceID),
-		url.QueryEscape(workspaceTaskID),
+		url.PathEscape(workspaceID),
+		url.PathEscape(workspaceTaskID),
 	)
 	req, err := s.client.NewRequest("PATCH", u, &options)
 	if err != nil {
@@ -197,8 +197,8 @@ func (s *workspaceRunTasks) Delete(ctx context.Context, workspaceID, workspaceTa
 
 	u := fmt.Sprintf(
 		"workspaces/%s/tasks/%s",
-		url.QueryEscape(workspaceID),
-		url.QueryEscape(workspaceTaskID),
+		url.PathEscape(workspaceID),
+		url.PathEscape(workspaceTaskID),
 	)
 	req, err := s.client.NewRequest("DELETE", u, nil)
 	if err != nil {


### PR DESCRIPTION
@glennsarti noted that go-tfe demonstrated some odd query parameter encoding behavior depending on http method, and that url.QueryEncode was used throughout the code when we actually should have used the slightly more narrow url.PathEncode.