### PR TITLE
Fix Stacks vcs-repo encoding

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -66,10 +66,10 @@ type StackList struct {
 
 // StackVCSRepo represents the version control system repository for a stack.
 type StackVCSRepo struct {
-	Identifier        string `json:"identifier"`
-	Branch            string `json:"branch,omitempty"`
-	GHAInstallationID string `json:"github-app-installation-id,omitempty"`
-	OAuthTokenID      string `json:"oauth-token-id,omitempty"`
+	Identifier        string `jsonapi:"attr,identifier"`
+	Branch            string `jsonapi:"attr,branch,omitempty"`
+	GHAInstallationID string `jsonapi:"attr,github-app-installation-id,omitempty"`
+	OAuthTokenID      string `jsonapi:"attr,oauth-token-id,omitempty"`
 }
 
 // Stack represents a stack.

--- a/stack_integration_test.go
+++ b/stack_integration_test.go
@@ -146,6 +146,7 @@ func TestStackReadUpdateDelete(t *testing.T) {
 		VCSRepo: &StackVCSRepo{
 			Identifier:   "brandonc/pet-nulls-stack",
 			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+			Branch:       "main",
 		},
 		Project: &Project{
 			ID: orgTest.DefaultProject.ID,
@@ -154,9 +155,15 @@ func TestStackReadUpdateDelete(t *testing.T) {
 
 	require.NoError(t, err)
 	require.NotNil(t, stack)
+	require.NotEmpty(t, stack.VCSRepo.Identifier)
+	require.NotEmpty(t, stack.VCSRepo.OAuthTokenID)
+	require.NotEmpty(t, stack.VCSRepo.Branch)
 
 	stackRead, err := client.Stacks.Read(ctx, stack.ID, nil)
 	require.NoError(t, err)
+	require.Equal(t, stack.VCSRepo.Identifier, stackRead.VCSRepo.Identifier)
+	require.Equal(t, stack.VCSRepo.OAuthTokenID, stackRead.VCSRepo.OAuthTokenID)
+	require.Equal(t, stack.VCSRepo.Branch, stackRead.VCSRepo.Branch)
 
 	assert.Equal(t, stack, stackRead)
 


### PR DESCRIPTION
## Description

There was a regression in terraform-provider-tfe after the last go-tfe bump which I narrowed down to this [encoding change](https://github.com/hashicorp/go-tfe/commit/3d40746ead346ec48feb609f9e4b2f318080fcb3).

## Testing plan

See test output below

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ OAUTH_CLIENT_GITHUB_TOKEN=$GITHUB_TOKEN ENABLE_BETA=1 go test ./... -v -run "TestWorkspacesCreateTableDriven/when_options_include_vcs-repo"
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestWorkspacesCreateTableDriven
=== RUN   TestWorkspacesCreateTableDriven/when_options_include_vcs-repo
--- PASS: TestWorkspacesCreateTableDriven (8.21s)
    --- PASS: TestWorkspacesCreateTableDriven/when_options_include_vcs-repo (4.75s)
=== RUN   TestWorkspacesCreateTableDrivenWithGithubApp
    workspace_integration_test.go:476: Export a valid GITHUB_APP_INSTALLATION_ID before running this test!
--- SKIP: TestWorkspacesCreateTableDrivenWithGithubApp (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     8.470s
```

```
$ OAUTH_CLIENT_GITHUB_TOKEN=$GITHUB_TOKEN ENABLE_BETA=1 go test ./... -v -run "TestStackReadUpdateDelete"
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestStackReadUpdateDelete
--- PASS: TestStackReadUpdateDelete (6.50s)
PASS
ok      github.com/hashicorp/go-tfe     6.773s
```

![image](https://github.com/user-attachments/assets/65986cdd-7fc5-4a4e-bfe7-8985ab0612a0)