### PR TITLE
Org: Include no-code specific permissions to `OrganizationPermissions`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# UNRELEASED
+
+## Enhancements
+
+* Adds support for including no-code permissions to the `OrganizationPermissions` struct [#967](https://github.com/hashicorp/go-tfe/pull/967)
+
 # v1.64.1
 
 # Bug Fixes

--- a/organization.go
+++ b/organization.go
@@ -183,7 +183,9 @@ type OrganizationPermissions struct {
 	CanCreateTeam               bool `jsonapi:"attr,can-create-team"`
 	CanCreateWorkspace          bool `jsonapi:"attr,can-create-workspace"`
 	CanCreateWorkspaceMigration bool `jsonapi:"attr,can-create-workspace-migration"`
+	CanDeployNoCodeModules      bool `jsonapi:"attr,can-deploy-no-code-modules"`
 	CanDestroy                  bool `jsonapi:"attr,can-destroy"`
+	CanManageNoCodeModules      bool `jsonapi:"attr,can-manage-no-code-modules"`
 	CanManageRunTasks           bool `jsonapi:"attr,can-manage-run-tasks"`
 	CanTraverse                 bool `jsonapi:"attr,can-traverse"`
 	CanUpdate                   bool `jsonapi:"attr,can-update"`


### PR DESCRIPTION
## Description

Prior to this commit, the organization permissions struct left out a couple of permissions around the no-code provisioning feature:

- https://developer.hashicorp.com/terraform/tutorials/cloud/no-code-provisioning

This commit includes those permissions, which are already being returned by the TF API, into the `OrganizationPermissions` struct.

Fixes WAYP-2963 TF-19913

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

- [Tutorial](https://developer.hashicorp.com/terraform/tutorials/cloud/no-code-provisioning)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/organizations#sample-response)

## Output from tests

