### PR TITLE
[TF-20104] Add force delete for stacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UNRELEASED
 
+## Enhancements
+
+* Adds support for deleting `Stacks` that still have deployments through `ForceDelete` by @hashimoon [#969](https://github.com/hashicorp/go-tfe/pull/969)
+
 ## Bug Fixes
 
 * Fixed `RegistryNoCodeModules` method `UpgradeWorkspace` to return a `WorkspaceUpgrade` type. This resulted in a BREAKING CHANGE, yet the previous type was not properly decoded nor reflective of the actual API result by @paladin-devops [#955](https://github.com/hashicorp/go-tfe/pull/955)

--- a/stack.go
+++ b/stack.go
@@ -29,6 +29,9 @@ type Stacks interface {
 	// Delete deletes a stack.
 	Delete(ctx context.Context, stackID string) error
 
+	// ForceDelete deletes a stack.
+	ForceDelete(ctx context.Context, stackID string) error
+
 	// UpdateConfiguration updates the configuration of a stack, triggering stack preparation.
 	UpdateConfiguration(ctx context.Context, stackID string) (*Stack, error)
 }
@@ -290,6 +293,16 @@ func (s stacks) Update(ctx context.Context, stackID string, options StackUpdateO
 // Delete deletes a stack.
 func (s stacks) Delete(ctx context.Context, stackID string) error {
 	req, err := s.client.NewRequest("POST", fmt.Sprintf("stacks/%s/delete", url.PathEscape(stackID)), nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// ForceDelete deletes a stack that still has deployments.
+func (s stacks) ForceDelete(ctx context.Context, stackID string) error {
+	req, err := s.client.NewRequest("POST", fmt.Sprintf("stacks/%s/force-delete", url.PathEscape(stackID)), nil)
 	if err != nil {
 		return err
 	}

--- a/stack_integration_test.go
+++ b/stack_integration_test.go
@@ -186,6 +186,63 @@ func TestStackReadUpdateDelete(t *testing.T) {
 	require.Nil(t, stackReadAfterDelete)
 }
 
+func TestStackReadUpdateForceDelete(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Name: "test-stack",
+		VCSRepo: &StackVCSRepo{
+			Identifier:   "brandonc/pet-nulls-stack",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+			Branch:       "main",
+		},
+		Project: &Project{
+			ID: orgTest.DefaultProject.ID,
+		},
+	})
+
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+	require.NotEmpty(t, stack.VCSRepo.Identifier)
+	require.NotEmpty(t, stack.VCSRepo.OAuthTokenID)
+	require.NotEmpty(t, stack.VCSRepo.Branch)
+
+	stackRead, err := client.Stacks.Read(ctx, stack.ID, nil)
+	require.NoError(t, err)
+	require.Equal(t, stack.VCSRepo.Identifier, stackRead.VCSRepo.Identifier)
+	require.Equal(t, stack.VCSRepo.OAuthTokenID, stackRead.VCSRepo.OAuthTokenID)
+	require.Equal(t, stack.VCSRepo.Branch, stackRead.VCSRepo.Branch)
+
+	assert.Equal(t, stack, stackRead)
+
+	stackUpdated, err := client.Stacks.Update(ctx, stack.ID, StackUpdateOptions{
+		Description: String("updated description"),
+	})
+
+	require.NoError(t, err)
+	require.Equal(t, "updated description", stackUpdated.Description)
+
+	stackUpdatedConfig, err := client.Stacks.UpdateConfiguration(ctx, stack.ID)
+	require.NoError(t, err)
+	require.Equal(t, stack.Name, stackUpdatedConfig.Name)
+
+	err = client.Stacks.ForceDelete(ctx, stack.ID)
+	require.NoError(t, err)
+
+	stackReadAfterDelete, err := client.Stacks.Read(ctx, stack.ID, nil)
+	require.ErrorIs(t, err, ErrResourceNotFound)
+	require.Nil(t, stackReadAfterDelete)
+}
+
 func pollStackDeployments(t *testing.T, ctx context.Context, client *Client, stackID string) (stack *Stack) {
 	t.Helper()
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This changes adds the `ForceDelete` function to stacks.

## Testing plan

1. Create a stack
1. Call `ForceDelete`
1. Verify stack was deleted
<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
/opt/homebrew/opt/go/libexec/bin/go tool test2json -t /Users/joseph/Library/Caches/JetBrains/IntelliJIdea2024.1/tmp/GoLand/___2TestStackReadUpdateForceDelete_in_github_com_hashicorp_go_tfe.test -test.v -test.paniconexit0 -test.run ^\QTestStackReadUpdateForceDelete\E$
=== RUN   TestStackReadUpdateForceDelete
--- PASS: TestStackReadUpdateForceDelete (5.90s)
PASS

Process finished with the exit code 0
...
```
