### PR TITLE
Add billable RUM count to state version

### DIFF
--- a/state_version.go
+++ b/state_version.go
@@ -89,16 +89,17 @@ type StateVersionList struct {
 
 // StateVersion represents a Terraform Enterprise state version.
 type StateVersion struct {
-	ID              string             `jsonapi:"primary,state-versions"`
-	CreatedAt       time.Time          `jsonapi:"attr,created-at,iso8601"`
-	DownloadURL     string             `jsonapi:"attr,hosted-state-download-url"`
-	UploadURL       string             `jsonapi:"attr,hosted-state-upload-url"`
-	Status          StateVersionStatus `jsonapi:"attr,status"`
-	JSONUploadURL   string             `jsonapi:"attr,hosted-json-state-upload-url"`
-	JSONDownloadURL string             `jsonapi:"attr,hosted-json-state-download-url"`
-	Serial          int64              `jsonapi:"attr,serial"`
-	VCSCommitSHA    string             `jsonapi:"attr,vcs-commit-sha"`
-	VCSCommitURL    string             `jsonapi:"attr,vcs-commit-url"`
+	ID               string             `jsonapi:"primary,state-versions"`
+	CreatedAt        time.Time          `jsonapi:"attr,created-at,iso8601"`
+	DownloadURL      string             `jsonapi:"attr,hosted-state-download-url"`
+	UploadURL        string             `jsonapi:"attr,hosted-state-upload-url"`
+	Status           StateVersionStatus `jsonapi:"attr,status"`
+	JSONUploadURL    string             `jsonapi:"attr,hosted-json-state-upload-url"`
+	JSONDownloadURL  string             `jsonapi:"attr,hosted-json-state-download-url"`
+	Serial           int64              `jsonapi:"attr,serial"`
+	VCSCommitSHA     string             `jsonapi:"attr,vcs-commit-sha"`
+	VCSCommitURL     string             `jsonapi:"attr,vcs-commit-url"`
+	BillableRUMCount uint32             `jsonapi:"attr,billable-rum-count"`
 	// Whether HCP Terraform has finished populating any StateVersion fields that required async processing.
 	// If `false`, some fields may appear empty even if they should actually contain data; see comments on
 	// individual fields for details.

--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -443,6 +443,7 @@ func TestStateVersionsRead(t *testing.T) {
 			}
 		}
 
+		assert.NotEmpty(t, sv.BillableRUMCount)
 		assert.NotEmpty(t, sv.DownloadURL)
 		assert.NotEmpty(t, sv.StateVersion)
 		assert.NotEmpty(t, sv.TerraformVersion)


### PR DESCRIPTION


<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

For our internal accounting we want to track billable resources at workspace level and saw some discrepancies when comparing the usage API value with how we counted billable resources. Via a support ticket we were notified about the `billable-rum-count` attribute which is working for us and would like to continue using 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

This value should always be there now (assumption) so should pop up in the usual integration tests.

## Output from tests

No TFE instance, but in another project where I use this package I'm now able to sum the billable resources across workspaces using this attribute and the total matches the billable resources in the Usage page.