### PR TITLE
[TF-20366] Return correct error message when workspace is locked by a Team or User

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -63,6 +63,12 @@ var (
 	// ErrWorkspaceLockedByRun is returned when trying to unlock a workspace locked by a run.
 	ErrWorkspaceLockedByRun = errors.New("unable to unlock workspace locked by run")
 
+	// ErrWorkspaceLockedByTeam is returned when trying to unlock a workspace locked by a team.
+	ErrWorkspaceLockedByTeam = errors.New("unable to unlock workspace locked by team")
+
+	// ErrWorkspaceLockedByUser is returned when trying to unlock a workspace locked by a user.
+	ErrWorkspaceLockedByUser = errors.New("unable to unlock workspace locked by user")
+
 	// ErrWorkspaceStillProcessing is returned when a workspace is still processing state
 	// to determine if it is safe to delete. "conflict" followed by newline is used to
 	// preserve go-tfe version compatibility with the error constructed at runtime before it was

--- a/tfe.go
+++ b/tfe.go
@@ -973,6 +973,14 @@ func checkResponseCode(r *http.Response) error {
 				return ErrWorkspaceLockedByRun
 			}
 
+			if errorPayloadContains(errs, "is locked by Team") {
+				return ErrWorkspaceLockedByTeam
+			}
+
+			if errorPayloadContains(errs, "is locked by User") {
+				return ErrWorkspaceLockedByUser
+			}
+
 			return ErrWorkspaceNotLocked
 		case strings.HasSuffix(r.Request.URL.Path, "actions/force-unlock"):
 			return ErrWorkspaceNotLocked

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -2041,6 +2041,7 @@ func TestWorkspacesUnlock(t *testing.T) {
 			Team:      tmTest,
 			Workspace: wTest2,
 		})
+		assert.Nil(t, err)
 		defer func() {
 			err := client.TeamAccess.Remove(ctx, ta.ID)
 			if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
This PR aims to close https://github.com/hashicorp/go-tfe/issues/971 where the tfe client would return an incorrect error message whenever a user attempted to unlock a workspace that was already locked by a team or a different user.

The current implementation of this client defaults to "workspaces already unlocked" whenever a status 409 is received from the workspace unlock endpoint. A matcher function `errorPayloadHasMatch` currently parses the the error detail and searches for the "locked by Run" substring that indicates the workspace was locked by a run.

This pattern was extended for the two other instances in which a status 409 is returned. The "locked by Team" substring indicates the workspace was locked by a Team, and similarly the "locked by User" substring indicates that the workspace was locked by a different User.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
To run the integration test:

```sh
go test -run TestWorkspacesUnlock -v ./... -tags=integration
```

Because I've modified tfe.go, it's always good to verify those tests as well:

```sh
go test -run TestClient -v ./... -tags=integration
```

I wasn't able to find a way to create a secondary user in the integration tests to test the "locked by User" scenario in a automated fashion. Any suggestions on how to accomplish this would be appreciated.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

-->
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces#unlock-a-workspace)
- [Related PR](https://github.com/hashicorp/go-tfe/pull/302)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
For `TestWorkspacesUnlock`:

```
=== RUN   TestWorkspacesUnlock
=== RUN   TestWorkspacesUnlock/with_valid_options
=== RUN   TestWorkspacesUnlock/when_workspace_is_already_unlocked
=== RUN   TestWorkspacesUnlock/when_a_workspace_is_locked_by_a_run
=== RUN   TestWorkspacesUnlock/when_a_workspace_is_locked_by_a_team
=== RUN   TestWorkspacesUnlock/without_a_valid_workspace_ID
--- PASS: TestWorkspacesUnlock (11.35s)
    --- PASS: TestWorkspacesUnlock/with_valid_options (0.23s)
    --- PASS: TestWorkspacesUnlock/when_workspace_is_already_unlocked (0.17s)
    --- PASS: TestWorkspacesUnlock/when_a_workspace_is_locked_by_a_run (5.82s)
    --- PASS: TestWorkspacesUnlock/when_a_workspace_is_locked_by_a_team (3.43s)
    --- PASS: TestWorkspacesUnlock/without_a_valid_workspace_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
```

For `TestClient`:

```
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestClientRequest_DoJSON
=== RUN   TestClientRequest_DoJSON/Success_200_responses
2024/09/12 11:07:54 [DEBUG] PUT http://127.0.0.1:62369/ok_request
=== RUN   TestClientRequest_DoJSON/Success_response_with_no_body
2024/09/12 11:07:54 [DEBUG] POST http://127.0.0.1:62369/created_request
=== RUN   TestClientRequest_DoJSON/Not_Modified_response
2024/09/12 11:07:54 [DEBUG] POST http://127.0.0.1:62369/not_modified_request
=== RUN   TestClientRequest_DoJSON/Bad_400_responses
2024/09/12 11:07:54 [DEBUG] POST http://127.0.0.1:62369/bad_request
--- PASS: TestClientRequest_DoJSON (0.00s)
    --- PASS: TestClientRequest_DoJSON/Success_200_responses (0.00s)
    --- PASS: TestClientRequest_DoJSON/Success_response_with_no_body (0.00s)
    --- PASS: TestClientRequest_DoJSON/Not_Modified_response (0.00s)
    --- PASS: TestClientRequest_DoJSON/Bad_400_responses (0.00s)
=== RUN   TestClient_newClient
=== RUN   TestClient_newClient/uses_env_vars_if_values_are_missing
=== RUN   TestClient_newClient/fails_if_token_is_empty
=== RUN   TestClient_newClient/makes_a_new_client_with_good_settings
--- PASS: TestClient_newClient (0.00s)
    --- PASS: TestClient_newClient/uses_env_vars_if_values_are_missing (0.00s)
    --- PASS: TestClient_newClient/fails_if_token_is_empty (0.00s)
    --- PASS: TestClient_newClient/makes_a_new_client_with_good_settings (0.00s)
=== RUN   TestClient_defaultConfig
=== RUN   TestClient_defaultConfig/with_no_environment_variables
=== RUN   TestClient_defaultConfig/with_environment_variables
=== RUN   TestClient_defaultConfig/with_environment_variables/with_TFE_ADDRESS_set
=== RUN   TestClient_defaultConfig/with_environment_variables/with_TFE_HOSTNAME_set
--- PASS: TestClient_defaultConfig (0.00s)
    --- PASS: TestClient_defaultConfig/with_no_environment_variables (0.00s)
    --- PASS: TestClient_defaultConfig/with_environment_variables (0.00s)
        --- PASS: TestClient_defaultConfig/with_environment_variables/with_TFE_ADDRESS_set (0.00s)
        --- PASS: TestClient_defaultConfig/with_environment_variables/with_TFE_HOSTNAME_set (0.00s)
=== RUN   TestClient_headers
--- PASS: TestClient_headers (0.00s)
=== RUN   TestClient_userAgent
--- PASS: TestClient_userAgent (0.00s)
=== RUN   TestClient_requestBodySerialization
=== RUN   TestClient_requestBodySerialization/jsonapi_request
=== RUN   TestClient_requestBodySerialization/jsonapi_slice_of_pointers_request
=== RUN   TestClient_requestBodySerialization/plain_json_request
=== RUN   TestClient_requestBodySerialization/plain_json_slice_of_pointers_request
=== RUN   TestClient_requestBodySerialization/nil_request
=== RUN   TestClient_requestBodySerialization/invalid_struct_request
=== RUN   TestClient_requestBodySerialization/non-pointer_request
=== RUN   TestClient_requestBodySerialization/slice_of_non-pointer_request
=== RUN   TestClient_requestBodySerialization/map_request
=== RUN   TestClient_requestBodySerialization/string_request
--- PASS: TestClient_requestBodySerialization (2.97s)
    --- PASS: TestClient_requestBodySerialization/jsonapi_request (0.39s)
    --- PASS: TestClient_requestBodySerialization/jsonapi_slice_of_pointers_request (0.26s)
    --- PASS: TestClient_requestBodySerialization/plain_json_request (0.32s)
    --- PASS: TestClient_requestBodySerialization/plain_json_slice_of_pointers_request (0.26s)
    --- PASS: TestClient_requestBodySerialization/nil_request (0.25s)
    --- PASS: TestClient_requestBodySerialization/invalid_struct_request (0.31s)
    --- PASS: TestClient_requestBodySerialization/non-pointer_request (0.26s)
    --- PASS: TestClient_requestBodySerialization/slice_of_non-pointer_request (0.30s)
    --- PASS: TestClient_requestBodySerialization/map_request (0.31s)
    --- PASS: TestClient_requestBodySerialization/string_request (0.32s)
=== RUN   TestClient_configureLimiter
--- PASS: TestClient_configureLimiter (0.00s)
=== RUN   TestClient_retryHTTPCheck
--- PASS: TestClient_retryHTTPCheck (0.00s)
=== RUN   TestClient_retryHTTPBackoff
--- PASS: TestClient_retryHTTPBackoff (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     (cached)
```
