### PR TITLE
Adds ErrWorkspaceLockedStateVersionStillPending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # UNRELEASED
 
+## Enhancements
+
+* `Workspaces`: The `Unlock` method now returns a `ErrWorkspaceLockedStateVersionStillPending` error if the latest state version upload is still pending within the platform. This is a retryable error. by @brandonc
+
 # v1.66.0
 
 ## Enhancements

--- a/errors.go
+++ b/errors.go
@@ -69,6 +69,10 @@ var (
 	// ErrWorkspaceLockedByUser is returned when trying to unlock a workspace locked by a user.
 	ErrWorkspaceLockedByUser = errors.New("unable to unlock workspace locked by user")
 
+	// ErrWorkspaceLockedStateVersionStillPending is returned when trying to unlock whose
+	// latest state version is still pending.
+	ErrWorkspaceLockedStateVersionStillPending = errors.New("unable to unlock workspace while state version upload is still pending")
+
 	// ErrWorkspaceStillProcessing is returned when a workspace is still processing state
 	// to determine if it is safe to delete. "conflict" followed by newline is used to
 	// preserve go-tfe version compatibility with the error constructed at runtime before it was

--- a/tfe.go
+++ b/tfe.go
@@ -934,10 +934,10 @@ func parsePagination(body io.Reader) (*Pagination, error) {
 	return &raw.Meta.Pagination, nil
 }
 
-// checkResponseCode can be used to check the status code of an HTTP request.
-
+// checkResponseCode refines typical API errors into more specific errors
+// if possible. It returns nil if the response code < 400
 func checkResponseCode(r *http.Response) error {
-	if r.StatusCode >= 200 && r.StatusCode <= 299 {
+	if r.StatusCode >= 200 && r.StatusCode <= 399 {
 		return nil
 	}
 

--- a/workspace.go
+++ b/workspace.go
@@ -1054,6 +1054,9 @@ func (s *workspaces) Unlock(ctx context.Context, workspaceID string) (*Workspace
 	w := &Workspace{}
 	err = req.Do(ctx, w)
 	if err != nil {
+		if strings.Contains(err.Error(), "latest state version is still pending") {
+			return nil, ErrWorkspaceLockedStateVersionStillPending
+		}
 		return nil, err
 	}
 


### PR DESCRIPTION
## Description

Adds `ErrWorkspaceLockedStateVersionStillPending`, indicating that a workspace can't be unlocked yet because the latest state version upload is still pending. This will help signal to terraform that it should retry this operation.