### PR TITLE
Add no-code endpoint for fetching registry module variables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Fixes a bug in `NewRequest` that did not allow query parameters to be specified in the first parameter, which broke several methods: `RegistryModules ReadVersion`, `VariableSets UpdateWorkspaces`, and `Workspaces Readme` by @brandonc [#982](https://github.com/hashicorp/go-tfe/pull/982)
 
+## Enhancements
+
+* Add support for reading a no-code module's variables by @paladin-devops [#979](https://github.com/hashicorp/go-tfe/pull/979)
+
 # v1.67.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,12 @@
+## Enhancements
+
+* Add support for reading a no-code module's variables by @paladin-devops [#979](https://github.com/hashicorp/go-tfe/pull/979)
+
 # v1.67.1
 
 ## Bug Fixes
 
 * Fixes a bug in `NewRequest` that did not allow query parameters to be specified in the first parameter, which broke several methods: `RegistryModules ReadVersion`, `VariableSets UpdateWorkspaces`, and `Workspaces Readme` by @brandonc [#982](https://github.com/hashicorp/go-tfe/pull/982)
-
-## Enhancements
-
-* Add support for reading a no-code module's variables by @paladin-devops [#979](https://github.com/hashicorp/go-tfe/pull/979)
 
 # v1.67.0
 

--- a/mocks/registry_no_code_module_mocks.go
+++ b/mocks/registry_no_code_module_mocks.go
@@ -99,6 +99,21 @@ func (mr *MockRegistryNoCodeModulesMockRecorder) Read(ctx, noCodeModuleID, optio
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockRegistryNoCodeModules)(nil).Read), ctx, noCodeModuleID, options)
 }
 
+// ReadVariables mocks base method.
+func (m *MockRegistryNoCodeModules) ReadVariables(ctx context.Context, noCodeModuleID, noCodeModuleVersion string, options *tfe.RegistryNoCodeModuleReadVariablesOptions) (*tfe.RegistryModuleVariableList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadVariables", ctx, noCodeModuleID, noCodeModuleVersion, options)
+	ret0, _ := ret[0].(*tfe.RegistryModuleVariableList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadVariables indicates an expected call of ReadVariables.
+func (mr *MockRegistryNoCodeModulesMockRecorder) ReadVariables(ctx, noCodeModuleID, noCodeModuleVersion, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadVariables", reflect.TypeOf((*MockRegistryNoCodeModules)(nil).ReadVariables), ctx, noCodeModuleID, noCodeModuleVersion, options)
+}
+
 // Update mocks base method.
 func (m *MockRegistryNoCodeModules) Update(ctx context.Context, noCodeModuleID string, options tfe.RegistryNoCodeModuleUpdateOptions) (*tfe.RegistryNoCodeModule, error) {
 	m.ctrl.T.Helper()

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -46,6 +46,7 @@ type RegistryNoCodeModules interface {
 }
 
 // RegistryModuleVariableList is a list of registry module variables.
+// **Note: This API is still in BETA and subject to change.**
 type RegistryModuleVariableList struct {
 	Items []*RegistryModuleVariable
 

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -203,6 +203,8 @@ type RegistryNoCodeModuleReadOptions struct {
 	Include []RegistryNoCodeModuleIncludeOpt `url:"include,omitempty"`
 }
 
+// RegistryNoCodeModuleReadVariablesOptions is used when reading the variables
+// for a no-code module.
 type RegistryNoCodeModuleReadVariablesOptions struct {
 	// Type is a public field utilized by JSON:API to
 	// set the resource type via the field tag.

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -211,6 +211,34 @@ func TestRegistryNoCodeModulesRead(t *testing.T) {
 	})
 }
 
+// TestRegistryNoCodeModuleReadVariables tests the ReadVariables method of the
+// RegistryNoCodeModules service.
+//
+// This test requires that the environment variable "NO_CODE_MODULE_ID" is set
+// with the ID of an existing no-code module that has variables.
+func TestRegistryNoCodeModulesReadVariables(t *testing.T) {
+	skipUnlessBeta(t)
+	client := testClient(t)
+	ctx := context.Background()
+	r := require.New(t)
+
+	ncmID := os.Getenv("NO_CODE_MODULE_ID")
+	if ncmID == "" {
+		t.Skip("Export a valid NO_CODE_MODULE_ID before running this test")
+	}
+
+	ncm, err := client.RegistryNoCodeModules.Read(ctx, ncmID, nil)
+	r.NoError(err)
+	r.NotNil(ncm)
+
+	t.Run("happy path", func(t *testing.T) {
+		vars, err := client.RegistryNoCodeModules.ReadVariables(ctx, ncm.ID, ncm.VersionPin, &RegistryNoCodeModuleReadVariablesOptions{})
+		r.NoError(err)
+		r.NotNil(vars)
+		r.NotEmpty(vars)
+	})
+}
+
 func TestRegistryNoCodeModulesUpdate(t *testing.T) {
 	skipUnlessBeta(t)
 	client := testClient(t)

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -214,7 +214,7 @@ func TestRegistryNoCodeModulesRead(t *testing.T) {
 // TestRegistryNoCodeModuleReadVariables tests the ReadVariables method of the
 // RegistryNoCodeModules service.
 //
-// This test requires that the environment variable "NO_CODE_MODULE_ID" is set
+// This test requires that the environment variable "GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER" is set
 // with the ID of an existing no-code module that has variables.
 func TestRegistryNoCodeModulesReadVariables(t *testing.T) {
 	skipUnlessBeta(t)
@@ -222,9 +222,9 @@ func TestRegistryNoCodeModulesReadVariables(t *testing.T) {
 	ctx := context.Background()
 	r := require.New(t)
 
-	ncmID := os.Getenv("NO_CODE_MODULE_ID")
+	ncmID := os.Getenv("GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER")
 	if ncmID == "" {
-		t.Skip("Export a valid NO_CODE_MODULE_ID before running this test")
+		t.Skip("Export a valid GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER before running this test")
 	}
 
 	ncm, err := client.RegistryNoCodeModules.Read(ctx, ncmID, nil)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds support to go-tfe for the HCP Terraform endpoint to retrieve a no-code module's variables.

## Testing plan

1. Create a no-code module with at least one required input variable.
2. Get the ID of the no-code module.
    - expected format: `nocode-abcdefgh12345678`
3. Set the environment variable `NO_CODE_MODULE_ID` to be that ID.
4. Run `go test -run TestRegistryNoCodeModule -v ./...`, with the other necessary testing environment variables.

## Test Output

```terminal
=== RUN   TestRegistryNoCodeModulesReadVariables
--- PASS: TestRegistryNoCodeModulesReadVariables (7.94s)
=== RUN   TestRegistryNoCodeModulesReadVariables/happy_path
    --- PASS: TestRegistryNoCodeModulesReadVariables/happy_path (7.66s)
PASS
```