### PR TITLE
fixes NewRequest strips query from path parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
-# v1.66.1
+# v1.67.1
 
 ## Bug Fixes
 
-* Fixes a bug in `NewRequest` that did not allow query parameters to be specified in the first parameter, which broke several methods: `RegistryModules ReadVersion`, `VariableSets UpdateWorkspaces`, and `Workspaces Readme` by @brandonc
+* Fixes a bug in `NewRequest` that did not allow query parameters to be specified in the first parameter, which broke several methods: `RegistryModules ReadVersion`, `VariableSets UpdateWorkspaces`, and `Workspaces Readme` by @brandonc [#982](https://github.com/hashicorp/go-tfe/pull/982)
 
 # v1.67.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,8 @@
-# UNRELEASED
+# v1.66.1
+
+## Bug Fixes
+
+* Fixes a bug in `NewRequest` that did not allow query parameters to be specified in the first parameter, which broke several methods: `RegistryModules ReadVersion`, `VariableSets UpdateWorkspaces`, and `Workspaces Readme` by @brandonc
 
 # v1.67.0
 

--- a/tfe.go
+++ b/tfe.go
@@ -277,6 +277,8 @@ func (c *Client) NewRequestWithAdditionalQueryParams(method, path string, reqBod
 		}
 	}
 
+	// Will contain combined query values from path parsing and
+	// additionalQueryParams parameter
 	q := make(url.Values)
 
 	// Create a request specific headers map.
@@ -310,6 +312,9 @@ func (c *Client) NewRequestWithAdditionalQueryParams(method, path string, reqBod
 		body = reqBody
 	}
 
+	for k, v := range u.Query() {
+		q[k] = v
+	}
 	for k, v := range additionalQueryParams {
 		q[k] = v
 	}


### PR DESCRIPTION
Fixes a bug in `NewRequest` that did not allow query parameters to be specified in the first parameter, which broke several methods: `RegistryModules ReadVersion`, `VariableSets UpdateWorkspaces`, and `Workspaces Readme`

Closes #981 