### PR TITLE
Add SpeculativePlanManagementEnabled organization setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Add support for reading a registry module by its unique identifier by @dsa0x
  [#988](https://github.com/hashicorp/go-tfe/pull/988)
 * Adds BETA support for a variable set `Parent` relation, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @jbonhag [#992](https://github.com/hashicorp/go-tfe/pull/992)
+* Adds `SpeculativePlanManagementEnabled` field to `Organization` by @lilincmu [#983](https://github.com/hashicorp/go-tfe/pull/983)
 
 # v1.68.0
 

--- a/organization.go
+++ b/organization.go
@@ -115,6 +115,7 @@ type Organization struct {
 	TwoFactorConformant                               bool                     `jsonapi:"attr,two-factor-conformant"`
 	SendPassingStatusesForUntriggeredSpeculativePlans bool                     `jsonapi:"attr,send-passing-statuses-for-untriggered-speculative-plans"`
 	RemainingTestableCount                            int                      `jsonapi:"attr,remaining-testable-count"`
+	SpeculativePlanManagementEnabled                  bool                     `jsonapi:"attr,speculative-plan-management-enabled"`
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
 	AggregatedCommitStatusEnabled bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 	// Note: This will be false for TFE versions older than v202211, where the setting was introduced.
@@ -243,6 +244,9 @@ type OrganizationCreateOptions struct {
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
 	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
 
+	// Optional: SpeculativePlanManagementEnabled toggles whether pending speculative plans from outdated commits will be cancelled if a newer commit is pushed to the same branch.
+	SpeculativePlanManagementEnabled *bool `jsonapi:"attr,speculative-plan-management-enabled,omitempty"`
+
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`
 
@@ -291,6 +295,9 @@ type OrganizationUpdateOptions struct {
 
 	// Optional: If enabled, SendPassingStatusesForUntriggeredSpeculativePlans needs to be false.
 	AggregatedCommitStatusEnabled *bool `jsonapi:"attr,aggregated-commit-status-enabled,omitempty"`
+
+	// Optional: SpeculativePlanManagementEnabled toggles whether pending speculative plans from outdated commits will be cancelled if a newer commit is pushed to the same branch.
+	SpeculativePlanManagementEnabled *bool `jsonapi:"attr,speculative-plan-management-enabled,omitempty"`
 
 	// Optional: AllowForceDeleteWorkspaces toggles behavior of allowing workspace admins to delete workspaces with resources under management.
 	AllowForceDeleteWorkspaces *bool `jsonapi:"attr,allow-force-delete-workspaces,omitempty"`

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -275,6 +275,24 @@ func TestOrganizationsUpdate(t *testing.T) {
 		}
 	})
 
+	t.Run("with new SpeculativePlanManagementEnabled option", func(t *testing.T) {
+		skipIfEnterprise(t)
+
+		for _, testCase := range []bool{true, false} {
+			orgTest, orgTestCleanup := createOrganization(t, client)
+			t.Cleanup(orgTestCleanup)
+
+			options := OrganizationUpdateOptions{
+				SpeculativePlanManagementEnabled: Bool(testCase),
+			}
+
+			org, err := client.Organizations.Update(ctx, orgTest.Name, options)
+			require.NoError(t, err)
+
+			assert.Equal(t, testCase, org.SpeculativePlanManagementEnabled)
+		}
+	})
+
 	t.Run("with valid options", func(t *testing.T) {
 		orgTest, orgTestCleanup := createOrganization(t, client)
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds a new organization field, `SpeculativePlanManagementEnabled`, that can toggle the behavior of [Automatically cancel plan-only runs](https://developer.hashicorp.com/terraform/cloud-docs/users-teams-organizations/organizations/vcs-speculative-plan-management).

## Testing plan

1. Generate the required environment variables for go test, `TFE_ADDRESS` and `TFE_TOKEN`
2. Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestOrganizationsUpdate`. The tests should pass.

## External links

- [Jira](https://hashicorp.atlassian.net/browse/TF-18647)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestOrganizationsUpdate
=== RUN   TestOrganizationsUpdate
=== RUN   TestOrganizationsUpdate/with_HCP_Terraform-only_options
=== RUN   TestOrganizationsUpdate/with_new_AggregatedCommitStatusEnabled_option
=== RUN   TestOrganizationsUpdate/with_new_SpeculativePlanManagementEnabled_option
=== RUN   TestOrganizationsUpdate/with_valid_options
=== RUN   TestOrganizationsUpdate/with_invalid_name
=== RUN   TestOrganizationsUpdate/with_agent_pool_provided,_but_remote_execution_mode
=== RUN   TestOrganizationsUpdate/when_only_updating_a_subset_of_fields
=== RUN   TestOrganizationsUpdate/with_different_default_execution_modes
--- PASS: TestOrganizationsUpdate (8.03s)
    --- PASS: TestOrganizationsUpdate/with_HCP_Terraform-only_options (0.77s)
    --- PASS: TestOrganizationsUpdate/with_new_AggregatedCommitStatusEnabled_option (1.50s)
    --- PASS: TestOrganizationsUpdate/with_new_SpeculativePlanManagementEnabled_option (1.36s)
    --- PASS: TestOrganizationsUpdate/with_valid_options (1.06s)
    --- PASS: TestOrganizationsUpdate/with_invalid_name (0.00s)
    --- PASS: TestOrganizationsUpdate/with_agent_pool_provided,_but_remote_execution_mode (0.75s)
    --- PASS: TestOrganizationsUpdate/when_only_updating_a_subset_of_fields (0.59s)
    --- PASS: TestOrganizationsUpdate/with_different_default_execution_modes (1.47s)
PASS
ok      github.com/hashicorp/go-tfe     8.645s
...
```
