### PR TITLE
TF-20627: Add Waypoint entitlements for organizations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## Enhancements
 
 * Add support for reading a no-code module's variables by @paladin-devops [#979](https://github.com/hashicorp/go-tfe/pull/979)
+* Add Waypoint entitlements (the `waypoint-actions` and `waypoint-templates-and-addons` attributes) to `Entitlements` by @ignatius-j [#984](https://github.com/hashicorp/go-tfe/pull/984)
 
 # v1.67.1
 

--- a/organization.go
+++ b/organization.go
@@ -157,19 +157,21 @@ type Capacity struct {
 
 // Entitlements represents the entitlements of an organization.
 type Entitlements struct {
-	ID                    string `jsonapi:"primary,entitlement-sets"`
-	Agents                bool   `jsonapi:"attr,agents"`
-	AuditLogging          bool   `jsonapi:"attr,audit-logging"`
-	CostEstimation        bool   `jsonapi:"attr,cost-estimation"`
-	GlobalRunTasks        bool   `jsonapi:"attr,global-run-tasks"`
-	Operations            bool   `jsonapi:"attr,operations"`
-	PrivateModuleRegistry bool   `jsonapi:"attr,private-module-registry"`
-	RunTasks              bool   `jsonapi:"attr,run-tasks"`
-	SSO                   bool   `jsonapi:"attr,sso"`
-	Sentinel              bool   `jsonapi:"attr,sentinel"`
-	StateStorage          bool   `jsonapi:"attr,state-storage"`
-	Teams                 bool   `jsonapi:"attr,teams"`
-	VCSIntegrations       bool   `jsonapi:"attr,vcs-integrations"`
+	ID                         string `jsonapi:"primary,entitlement-sets"`
+	Agents                     bool   `jsonapi:"attr,agents"`
+	AuditLogging               bool   `jsonapi:"attr,audit-logging"`
+	CostEstimation             bool   `jsonapi:"attr,cost-estimation"`
+	GlobalRunTasks             bool   `jsonapi:"attr,global-run-tasks"`
+	Operations                 bool   `jsonapi:"attr,operations"`
+	PrivateModuleRegistry      bool   `jsonapi:"attr,private-module-registry"`
+	RunTasks                   bool   `jsonapi:"attr,run-tasks"`
+	SSO                        bool   `jsonapi:"attr,sso"`
+	Sentinel                   bool   `jsonapi:"attr,sentinel"`
+	StateStorage               bool   `jsonapi:"attr,state-storage"`
+	Teams                      bool   `jsonapi:"attr,teams"`
+	VCSIntegrations            bool   `jsonapi:"attr,vcs-integrations"`
+	WaypointActions            bool   `jsonapi:"attr,waypoint-actions"`
+	WaypointTemplatesAndAddons bool   `jsonapi:"attr,waypoint-templates-and-addons"`
 }
 
 // RunQueue represents the current run queue of an organization.

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -458,6 +458,8 @@ func TestOrganizationsReadEntitlements(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
+	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+
 	t.Run("when the org exists", func(t *testing.T) {
 		entitlements, err := client.Organizations.ReadEntitlements(ctx, orgTest.Name)
 		require.NoError(t, err)
@@ -473,6 +475,8 @@ func TestOrganizationsReadEntitlements(t *testing.T) {
 		assert.True(t, entitlements.StateStorage)
 		assert.True(t, entitlements.Teams)
 		assert.True(t, entitlements.VCSIntegrations)
+		assert.True(t, entitlements.WaypointActions)
+		assert.True(t, entitlements.WaypointTemplatesAndAddons)
 	})
 
 	t.Run("with invalid name", func(t *testing.T) {

--- a/subscription_updater_test.go
+++ b/subscription_updater_test.go
@@ -27,11 +27,12 @@ type featureSetListOptions struct {
 type retryableFn func() (interface{}, error)
 
 type updateFeatureSetOptions struct {
-	Type               string     `jsonapi:"primary,subscription"`
-	RunsCeiling        *int       `jsonapi:"attr,runs-ceiling,omitempty"`
-	ContractStartAt    *time.Time `jsonapi:"attr,contract-start-at,iso8601,omitempty"`
-	ContractUserLimit  *int       `jsonapi:"attr,contract-user-limit,omitempty"`
-	ContractApplyLimit *int       `jsonapi:"attr,contract-apply-limit,omitempty"`
+	Type                          string     `jsonapi:"primary,subscription"`
+	RunsCeiling                   *int       `jsonapi:"attr,runs-ceiling,omitempty"`
+	ContractStartAt               *time.Time `jsonapi:"attr,contract-start-at,iso8601,omitempty"`
+	ContractUserLimit             *int       `jsonapi:"attr,contract-user-limit,omitempty"`
+	ContractApplyLimit            *int       `jsonapi:"attr,contract-apply-limit,omitempty"`
+	ContractManagedResourcesLimit *int       `jsonapi:"attr,contract-managed-resources-limit,omitempty"`
 
 	FeatureSet *featureSet `jsonapi:"relation,feature-set"`
 }
@@ -68,6 +69,19 @@ func (b *organizationSubscriptionUpdater) WithTrialPlan() *organizationSubscript
 	b.planName = "Trial"
 	ceiling := 1
 	b.updateOpts.RunsCeiling = &ceiling
+	return b
+}
+
+func (b *organizationSubscriptionUpdater) WithPlusEntitlementPlan() *organizationSubscriptionUpdater {
+	b.planName = "Plus (entitlement)"
+
+	start := time.Now()
+	ceiling := 1
+	managedResourcesLimit := 1000
+
+	b.updateOpts.ContractStartAt = &start
+	b.updateOpts.RunsCeiling = &ceiling
+	b.updateOpts.ContractManagedResourcesLimit = &managedResourcesLimit
 	return b
 }
 


### PR DESCRIPTION
## Description

These changes add to the organizational entitlement struct to be able to
utilize the new Waypoint-based entitlements granted with HCP Terraform
feature sets:

- waypoint-actions
- waypoint-templates-and-addons

## Testing plan

1. Create an admin user token for an admin user with role `PROVISION_LICENSES`
2. Copy the token value
3. Set the environment variable TFE_ADMIN_PROVISION_LICENSES_TOKEN to be that token value.
4. Run go test -run TestOrganizationsReadEntitlements -v ./..., with the other necessary testing environment variables.

## External links

- [Jira](https://hashicorp.atlassian.net/browse/TF-20627)
- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/hashicorp/atlas/pull/21086)

## Output from tests

```
$ TFE_ADDRESS="..." TFE_TOKEN="..." TFE_ADMIN_PROVISION_LICENSES_TOKEN="..." go test ./ -v -run TestOrganizationsReadEntitlements

=== RUN   TestOrganizationsReadEntitlements
=== RUN   TestOrganizationsReadEntitlements/when_the_org_exists
=== RUN   TestOrganizationsReadEntitlements/with_invalid_name
=== RUN   TestOrganizationsReadEntitlements/when_the_org_does_not_exist
--- PASS: TestOrganizationsReadEntitlements (4.51s)
    --- PASS: TestOrganizationsReadEntitlements/when_the_org_exists (0.34s)
    --- PASS: TestOrganizationsReadEntitlements/with_invalid_name (0.00s)
    --- PASS: TestOrganizationsReadEntitlements/when_the_org_does_not_exist (0.30s)
PASS
ok  	github.com/hashicorp/go-tfe	5.408s
```
