### PR TITLE
Enable alternative reading of a registry module by its ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Unreleased
 
+## Enhancements
+
+* Add support for reading a registry module by its unique identifier by @dsa0x
+ [#988](https://github.com/hashicorp/go-tfe/pull/988)
+
 # v1.68.0
 
 ## Enhancements

--- a/registry_module.go
+++ b/registry_module.go
@@ -530,7 +530,6 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 	if moduleID.ExternalID != "" {
 		u = fmt.Sprintf("registry-modules/%s", url.PathEscape(moduleID.ExternalID))
 	} else {
-
 		if moduleID.RegistryName == "" {
 			log.Println("[WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.")
 			moduleID.RegistryName = PrivateRegistry

--- a/registry_module.go
+++ b/registry_module.go
@@ -111,8 +111,8 @@ const (
 // Use NewPublicRegistryModuleID or NewPrivateRegistryModuleID to build one
 
 type RegistryModuleID struct {
-	// The unique external ID of the organization. If given, the other fields are ignored.
-	ExternalID string
+	// The unique ID of the module. If given, the other fields are ignored.
+	ID string
 	// The organization the module belongs to, see RegistryModule.Organization.Name
 	Organization string
 	// The name of the module, see RegistryModule.Name
@@ -527,7 +527,7 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 	}
 
 	var u string
-	if moduleID.ExternalID == "" {
+	if moduleID.ID == "" {
 		if moduleID.RegistryName == "" {
 			log.Println("[WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.")
 			moduleID.RegistryName = PrivateRegistry
@@ -547,7 +547,7 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 			url.PathEscape(moduleID.Provider),
 		)
 	} else {
-		u = fmt.Sprintf("registry-modules/%s", url.PathEscape(moduleID.ExternalID))
+		u = fmt.Sprintf("registry-modules/%s", url.PathEscape(moduleID.ID))
 	}
 
 	req, err := r.client.NewRequest("GET", u, nil)
@@ -698,7 +698,7 @@ func (r *registryModules) DeleteVersion(ctx context.Context, moduleID RegistryMo
 }
 
 func (o RegistryModuleID) valid() error {
-	if validString(&o.ExternalID) && validStringID(&o.ExternalID) {
+	if validString(&o.ID) && validStringID(&o.ID) {
 		return nil
 	}
 

--- a/registry_module.go
+++ b/registry_module.go
@@ -109,7 +109,10 @@ const (
 
 // RegistryModuleID represents the set of IDs that identify a RegistryModule
 // Use NewPublicRegistryModuleID or NewPrivateRegistryModuleID to build one
+
 type RegistryModuleID struct {
+	// The unique external ID of the organization. If given, the other fields are ignored.
+	ExternalID string
 	// The organization the module belongs to, see RegistryModule.Organization.Name
 	Organization string
 	// The name of the module, see RegistryModule.Name
@@ -523,24 +526,30 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 		return nil, err
 	}
 
-	if moduleID.RegistryName == "" {
-		log.Println("[WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.")
-		moduleID.RegistryName = PrivateRegistry
-	}
+	var u string
+	if moduleID.ExternalID != "" {
+		u = fmt.Sprintf("registry-modules/%s", url.PathEscape(moduleID.ExternalID))
+	} else {
 
-	if moduleID.RegistryName == PrivateRegistry && strings.TrimSpace(moduleID.Namespace) == "" {
-		log.Println("[WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.")
-		moduleID.Namespace = moduleID.Organization
-	}
+		if moduleID.RegistryName == "" {
+			log.Println("[WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.")
+			moduleID.RegistryName = PrivateRegistry
+		}
 
-	u := fmt.Sprintf(
-		"organizations/%s/registry-modules/%s/%s/%s/%s",
-		url.PathEscape(moduleID.Organization),
-		url.PathEscape(string(moduleID.RegistryName)),
-		url.PathEscape(moduleID.Namespace),
-		url.PathEscape(moduleID.Name),
-		url.PathEscape(moduleID.Provider),
-	)
+		if moduleID.RegistryName == PrivateRegistry && strings.TrimSpace(moduleID.Namespace) == "" {
+			log.Println("[WARN] Support for using the RegistryModuleID without Namespace is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the Namespace in RegistryModuleID.")
+			moduleID.Namespace = moduleID.Organization
+		}
+
+		u = fmt.Sprintf(
+			"organizations/%s/registry-modules/%s/%s/%s/%s",
+			url.PathEscape(moduleID.Organization),
+			url.PathEscape(string(moduleID.RegistryName)),
+			url.PathEscape(moduleID.Namespace),
+			url.PathEscape(moduleID.Name),
+			url.PathEscape(moduleID.Provider),
+		)
+	}
 
 	req, err := r.client.NewRequest("GET", u, nil)
 	if err != nil {
@@ -690,6 +699,10 @@ func (r *registryModules) DeleteVersion(ctx context.Context, moduleID RegistryMo
 }
 
 func (o RegistryModuleID) valid() error {
+	if validString(&o.ExternalID) && validStringID(&o.ExternalID) {
+		return nil
+	}
+
 	if !validStringID(&o.Organization) {
 		return ErrInvalidOrg
 	}

--- a/registry_module.go
+++ b/registry_module.go
@@ -527,9 +527,7 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 	}
 
 	var u string
-	if moduleID.ExternalID != "" {
-		u = fmt.Sprintf("registry-modules/%s", url.PathEscape(moduleID.ExternalID))
-	} else {
+	if moduleID.ExternalID == "" {
 		if moduleID.RegistryName == "" {
 			log.Println("[WARN] Support for using the RegistryModuleID without RegistryName is deprecated as of release 1.5.0 and may be removed in a future version. The preferred method is to include the RegistryName in RegistryModuleID.")
 			moduleID.RegistryName = PrivateRegistry
@@ -548,6 +546,8 @@ func (r *registryModules) Read(ctx context.Context, moduleID RegistryModuleID) (
 			url.PathEscape(moduleID.Name),
 			url.PathEscape(moduleID.Provider),
 		)
+	} else {
+		u = fmt.Sprintf("registry-modules/%s", url.PathEscape(moduleID.ExternalID))
 	}
 
 	req, err := r.client.NewRequest("GET", u, nil)

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -1193,6 +1193,27 @@ func TestRegistryModulesRead(t *testing.T) {
 		})
 	})
 
+	t.Run("with a external ID field for private module", func(t *testing.T) {
+		rm, err := client.RegistryModules.Read(ctx, RegistryModuleID{
+			ExternalID: registryModuleTest.ID,
+		})
+		require.NoError(t, err)
+		require.NotEmpty(t, rm)
+		assert.Equal(t, registryModuleTest.ID, rm.ID)
+
+		t.Run("permissions are properly decoded", func(t *testing.T) {
+			require.NotEmpty(t, rm.Permissions)
+			assert.True(t, rm.Permissions.CanDelete)
+			assert.True(t, rm.Permissions.CanResync)
+			assert.True(t, rm.Permissions.CanRetry)
+		})
+
+		t.Run("timestamps are properly decoded", func(t *testing.T) {
+			assert.NotEmpty(t, rm.CreatedAt)
+			assert.NotEmpty(t, rm.UpdatedAt)
+		})
+	})
+
 	t.Run("without a name", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, RegistryModuleID{
 			Organization: orgTest.Name,

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -1193,9 +1193,9 @@ func TestRegistryModulesRead(t *testing.T) {
 		})
 	})
 
-	t.Run("with a external ID field for private module", func(t *testing.T) {
+	t.Run("with a unique ID field for private module", func(t *testing.T) {
 		rm, err := client.RegistryModules.Read(ctx, RegistryModuleID{
-			ExternalID: registryModuleTest.ID,
+			ID: registryModuleTest.ID,
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, rm)

--- a/tfe.go
+++ b/tfe.go
@@ -319,7 +319,12 @@ func (c *Client) NewRequestWithAdditionalQueryParams(method, path string, reqBod
 		q[k] = v
 	}
 
-	u.RawQuery = strings.Join([]string{u.RawQuery, encodeQueryParams(q)}, "&")
+	encodedParams := encodeQueryParams(q)
+	if u.RawQuery == "" {
+		u.RawQuery = encodedParams
+	} else if encodedParams != "" {
+		u.RawQuery = strings.Join([]string{u.RawQuery, encodedParams}, "&")
+	}
 
 	req, err := retryablehttp.NewRequest(method, u.String(), body)
 	if err != nil {

--- a/tfe.go
+++ b/tfe.go
@@ -319,7 +319,7 @@ func (c *Client) NewRequestWithAdditionalQueryParams(method, path string, reqBod
 		q[k] = v
 	}
 
-	u.RawQuery = encodeQueryParams(q)
+	u.RawQuery = strings.Join([]string{u.RawQuery, encodeQueryParams(q)}, "&")
 
 	req, err := retryablehttp.NewRequest(method, u.String(), body)
 	if err != nil {

--- a/tfe.go
+++ b/tfe.go
@@ -319,12 +319,7 @@ func (c *Client) NewRequestWithAdditionalQueryParams(method, path string, reqBod
 		q[k] = v
 	}
 
-	encodedParams := encodeQueryParams(q)
-	if u.RawQuery == "" {
-		u.RawQuery = encodedParams
-	} else if encodedParams != "" {
-		u.RawQuery = strings.Join([]string{u.RawQuery, encodedParams}, "&")
-	}
+	u.RawQuery = encodeQueryParams(q)
 
 	req, err := retryablehttp.NewRequest(method, u.String(), body)
 	if err != nil {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This enables an alternative way to read a registry module by its ID instead of its address (namespace/name/system). When the external ID is given, all other attributes are ignored.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
- Create a token in your HCP TF instance
- Add the TFE_ADDRESS and TFE_TOKEN variables to your environment
- Running `go test -v -run ^TestRegistryModulesRead$ github.com/hashicorp/go-tfe` should succeed.

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/TFECO-6399)
<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test -v -run ^TestRegistryModulesRead$ github.com/hashicorp/go-tfe
=== RUN   TestRegistryModulesRead/with_a_external_ID_field_for_private_module
=== RUN   TestRegistryModulesRead/with_a_external_ID_field_for_private_module/permissions_are_properly_decoded
=== RUN   TestRegistryModulesRead/with_a_external_ID_field_for_private_module/timestamps_are_properly_decoded
...
    --- PASS: TestRegistryModulesRead/with_a_external_ID_field_for_private_module (0.21s)
        --- PASS: TestRegistryModulesRead/with_a_external_ID_field_for_private_module/permissions_are_properly_decoded (0.00s)
        --- PASS: TestRegistryModulesRead/with_a_external_ID_field_for_private_module/timestamps_are_properly_decoded (0.00s)
...
PASS
ok      github.com/hashicorp/go-tfe     3.926s

...
```
