### PR TITLE
Adds PATCH tag-bindings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Add support for enabling Stacks on an organization by @brandonc [#987](https://github.com/hashicorp/go-tfe/pull/987)
 * Add support for filtering by key/value tags by @brandonc [#987](https://github.com/hashicorp/go-tfe/pull/987)
+* Add support for adding/updating key/value tags by @brandonc [#991](https://github.com/hashicorp/go-tfe/pull/991)
 * Add support for reading a registry module by its unique identifier by @dsa0x [#988](https://github.com/hashicorp/go-tfe/pull/988)
 
 # v1.68.0

--- a/errors.go
+++ b/errors.go
@@ -382,6 +382,8 @@ var (
 
 	ErrRequiredRegistryModule = errors.New("registry module is required")
 
+	ErrRequiredTagBindings = errors.New("TagBindings are required")
+
 	ErrInvalidTestRunID = errors.New("invalid value for test run id")
 
 	ErrTerraformVersionValidForPlanOnly = errors.New("setting terraform-version is only valid when plan-only is set to true")

--- a/mocks/project_mocks.go
+++ b/mocks/project_mocks.go
@@ -40,6 +40,21 @@ func (m *MockProjects) EXPECT() *MockProjectsMockRecorder {
 	return m.recorder
 }
 
+// AddTagBindings mocks base method.
+func (m *MockProjects) AddTagBindings(ctx context.Context, projectID string, options tfe.ProjectAddTagBindingsOptions) ([]*tfe.TagBinding, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTagBindings", ctx, projectID, options)
+	ret0, _ := ret[0].([]*tfe.TagBinding)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddTagBindings indicates an expected call of AddTagBindings.
+func (mr *MockProjectsMockRecorder) AddTagBindings(ctx, projectID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTagBindings", reflect.TypeOf((*MockProjects)(nil).AddTagBindings), ctx, projectID, options)
+}
+
 // Create mocks base method.
 func (m *MockProjects) Create(ctx context.Context, organization string, options tfe.ProjectCreateOptions) (*tfe.Project, error) {
 	m.ctrl.T.Helper()

--- a/mocks/workspace_mocks.go
+++ b/mocks/workspace_mocks.go
@@ -55,6 +55,21 @@ func (mr *MockWorkspacesMockRecorder) AddRemoteStateConsumers(ctx, workspaceID, 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddRemoteStateConsumers", reflect.TypeOf((*MockWorkspaces)(nil).AddRemoteStateConsumers), ctx, workspaceID, options)
 }
 
+// AddTagBindings mocks base method.
+func (m *MockWorkspaces) AddTagBindings(ctx context.Context, workspaceID string, options tfe.WorkspaceAddTagBindingsOptions) ([]*tfe.TagBinding, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTagBindings", ctx, workspaceID, options)
+	ret0, _ := ret[0].([]*tfe.TagBinding)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// AddTagBindings indicates an expected call of AddTagBindings.
+func (mr *MockWorkspacesMockRecorder) AddTagBindings(ctx, workspaceID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTagBindings", reflect.TypeOf((*MockWorkspaces)(nil).AddTagBindings), ctx, workspaceID, options)
+}
+
 // AddTags mocks base method.
 func (m *MockWorkspaces) AddTags(ctx context.Context, workspaceID string, options tfe.WorkspaceAddTagsOptions) error {
 	m.ctrl.T.Helper()

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -248,6 +248,8 @@ func TestProjectsUpdate(t *testing.T) {
 }
 
 func TestProjectsAddTagBindings(t *testing.T) {
+	skipUnlessBeta(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -267,7 +267,7 @@ func TestProjectsAddTagBindings(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Len(t, bindings, 2)
+		require.Len(t, bindings, 2)
 		assert.Equal(t, tagBindings[0].Key, bindings[0].Key)
 		assert.Equal(t, tagBindings[0].Value, bindings[0].Value)
 		assert.Equal(t, tagBindings[1].Key, bindings[1].Key)

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -66,22 +66,22 @@ func TestProjectsList(t *testing.T) {
 	t.Run("when using a tags filter", func(t *testing.T) {
 		skipUnlessBeta(t)
 
-		p1, wTestCleanup1 := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
+		p1, pTestCleanup1 := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
 			Name: randomStringWithoutSpecialChar(t),
 			TagBindings: []*TagBinding{
 				{Key: "key1", Value: "value1"},
 				{Key: "key2", Value: "value2a"},
 			},
 		})
-		p2, wTestCleanup2 := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
+		p2, pTestCleanup2 := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
 			Name: randomStringWithoutSpecialChar(t),
 			TagBindings: []*TagBinding{
 				{Key: "key2", Value: "value2b"},
 				{Key: "key3", Value: "value3"},
 			},
 		})
-		t.Cleanup(wTestCleanup1)
-		t.Cleanup(wTestCleanup2)
+		t.Cleanup(pTestCleanup1)
+		t.Cleanup(pTestCleanup2)
 
 		// List all the workspaces under the given tag
 		pl, err := client.Projects.List(ctx, orgTest.Name, &ProjectListOptions{
@@ -244,6 +244,68 @@ func TestProjectsUpdate(t *testing.T) {
 		w, err := client.Projects.Update(ctx, badIdentifier, ProjectUpdateOptions{})
 		assert.Nil(t, w)
 		assert.EqualError(t, err, ErrInvalidProjectID.Error())
+	})
+}
+
+func TestProjectsAddTagBindings(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	pTest, wCleanup := createProject(t, client, nil)
+	t.Cleanup(wCleanup)
+
+	t.Run("when adding tag bindings to a project", func(t *testing.T) {
+		tagBindings := []*TagBinding{
+			{Key: "foo", Value: "bar"},
+			{Key: "baz", Value: "qux"},
+		}
+
+		bindings, err := client.Projects.AddTagBindings(ctx, pTest.ID, ProjectAddTagBindingsOptions{
+			TagBindings: tagBindings,
+		})
+		require.NoError(t, err)
+
+		assert.Len(t, bindings, 2)
+		assert.Equal(t, tagBindings[0].Key, bindings[0].Key)
+		assert.Equal(t, tagBindings[0].Value, bindings[0].Value)
+		assert.Equal(t, tagBindings[1].Key, bindings[1].Key)
+		assert.Equal(t, tagBindings[1].Value, bindings[1].Value)
+	})
+
+	t.Run("when adding 26 tags", func(t *testing.T) {
+		tagBindings := []*TagBinding{
+			{Key: "alpha"},
+			{Key: "bravo"},
+			{Key: "charlie"},
+			{Key: "delta"},
+			{Key: "echo"},
+			{Key: "foxtrot"},
+			{Key: "golf"},
+			{Key: "hotel"},
+			{Key: "india"},
+			{Key: "juliet"},
+			{Key: "kilo"},
+			{Key: "lima"},
+			{Key: "mike"},
+			{Key: "november"},
+			{Key: "oscar"},
+			{Key: "papa"},
+			{Key: "quebec"},
+			{Key: "romeo"},
+			{Key: "sierra"},
+			{Key: "tango"},
+			{Key: "uniform"},
+			{Key: "victor"},
+			{Key: "whiskey"},
+			{Key: "xray"},
+			{Key: "yankee"},
+			{Key: "zulu"},
+		}
+
+		_, err := client.Workspaces.AddTagBindings(ctx, pTest.ID, WorkspaceAddTagBindingsOptions{
+			TagBindings: tagBindings,
+		})
+		require.Error(t, err, "cannot exceed 10 bindings per resource")
 	})
 }
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1193,7 +1193,7 @@ func TestWorkspacesAddTagBindings(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Len(t, bindings, 2)
+		require.Len(t, bindings, 2)
 		assert.Equal(t, tagBindings[0].Key, bindings[0].Key)
 		assert.Equal(t, tagBindings[0].Value, bindings[0].Value)
 		assert.Equal(t, tagBindings[1].Key, bindings[1].Key)

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1173,7 +1173,7 @@ func TestWorkspacesReadByID(t *testing.T) {
 	})
 }
 
-func TestWorkspaceAddTagBindings(t *testing.T) {
+func TestWorkspacesAddTagBindings(t *testing.T) {
 	skipUnlessBeta(t)
 
 	client := testClient(t)

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1174,6 +1174,8 @@ func TestWorkspacesReadByID(t *testing.T) {
 }
 
 func TestWorkspaceAddTagBindings(t *testing.T) {
+	skipUnlessBeta(t)
+
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1173,6 +1173,68 @@ func TestWorkspacesReadByID(t *testing.T) {
 	})
 }
 
+func TestWorkspaceAddTagBindings(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	wTest, wCleanup := createWorkspace(t, client, nil)
+	t.Cleanup(wCleanup)
+
+	t.Run("when adding tag bindings to a workspace", func(t *testing.T) {
+		tagBindings := []*TagBinding{
+			{Key: "foo", Value: "bar"},
+			{Key: "baz", Value: "qux"},
+		}
+
+		bindings, err := client.Workspaces.AddTagBindings(ctx, wTest.ID, WorkspaceAddTagBindingsOptions{
+			TagBindings: tagBindings,
+		})
+		require.NoError(t, err)
+
+		assert.Len(t, bindings, 2)
+		assert.Equal(t, tagBindings[0].Key, bindings[0].Key)
+		assert.Equal(t, tagBindings[0].Value, bindings[0].Value)
+		assert.Equal(t, tagBindings[1].Key, bindings[1].Key)
+		assert.Equal(t, tagBindings[1].Value, bindings[1].Value)
+	})
+
+	t.Run("when adding 26 tags", func(t *testing.T) {
+		tagBindings := []*TagBinding{
+			{Key: "alpha"},
+			{Key: "bravo"},
+			{Key: "charlie"},
+			{Key: "delta"},
+			{Key: "echo"},
+			{Key: "foxtrot"},
+			{Key: "golf"},
+			{Key: "hotel"},
+			{Key: "india"},
+			{Key: "juliet"},
+			{Key: "kilo"},
+			{Key: "lima"},
+			{Key: "mike"},
+			{Key: "november"},
+			{Key: "oscar"},
+			{Key: "papa"},
+			{Key: "quebec"},
+			{Key: "romeo"},
+			{Key: "sierra"},
+			{Key: "tango"},
+			{Key: "uniform"},
+			{Key: "victor"},
+			{Key: "whiskey"},
+			{Key: "xray"},
+			{Key: "yankee"},
+			{Key: "zulu"},
+		}
+
+		_, err := client.Workspaces.AddTagBindings(ctx, wTest.ID, WorkspaceAddTagBindingsOptions{
+			TagBindings: tagBindings,
+		})
+		require.Error(t, err, "cannot exceed 10 bindings per resource")
+	})
+}
+
 func TestWorkspacesUpdate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Description

Adds support for the PATCH tag-bindings resources (`/workspaces/:id/tag-bindings` and `/projects/:id/tag-bindings`)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
$ ENABLE_BETA=1 go test ./... -v -run "Test(Projects|Workspaces)AddTagBindings"
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestProjectsAddTagBindings
=== RUN   TestProjectsAddTagBindings/when_adding_tag_bindings_to_a_project
=== RUN   TestProjectsAddTagBindings/when_adding_26_tags
--- PASS: TestProjectsAddTagBindings (1.87s)
    --- PASS: TestProjectsAddTagBindings/when_adding_tag_bindings_to_a_project (0.23s)
    --- PASS: TestProjectsAddTagBindings/when_adding_26_tags (0.21s)
=== RUN   TestWorkspacesAddTagBindings
=== RUN   TestWorkspacesAddTagBindings/when_adding_tag_bindings_to_a_workspace
=== RUN   TestWorkspacesAddTagBindings/when_adding_26_tags
--- PASS: TestWorkspacesAddTagBindings (2.02s)
    --- PASS: TestWorkspacesAddTagBindings/when_adding_tag_bindings_to_a_workspace (0.26s)
    --- PASS: TestWorkspacesAddTagBindings/when_adding_26_tags (0.23s)
PASS
ok      github.com/hashicorp/go-tfe     4.148s
...
```
