### PR TITLE
[BETA] Create a project-owned varset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for filtering by key/value tags by @brandonc [#987](https://github.com/hashicorp/go-tfe/pull/987)
 * Add support for reading a registry module by its unique identifier by @dsa0x
  [#988](https://github.com/hashicorp/go-tfe/pull/988)
+* Adds BETA support for a variable set `Parent` relation, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @jbonhag [#992](https://github.com/hashicorp/go-tfe/pull/992)
 
 # v1.68.0
 

--- a/variable_set.go
+++ b/variable_set.go
@@ -65,6 +65,13 @@ type VariableSetList struct {
 	Items []*VariableSet
 }
 
+// Parent represents the variable set's parent (currently only organizations and projects are supported).
+// This relation is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
+type Parent struct {
+	Organization *Organization
+	Project      *Project
+}
+
 // VariableSet represents a Terraform Enterprise variable set.
 type VariableSet struct {
 	ID          string `jsonapi:"primary,varsets"`
@@ -74,10 +81,13 @@ type VariableSet struct {
 	Priority    bool   `jsonapi:"attr,priority"`
 
 	// Relations
-	Organization *Organization          `jsonapi:"relation,organization"`
-	Workspaces   []*Workspace           `jsonapi:"relation,workspaces,omitempty"`
-	Projects     []*Project             `jsonapi:"relation,projects,omitempty"`
-	Variables    []*VariableSetVariable `jsonapi:"relation,vars,omitempty"`
+	Organization *Organization `jsonapi:"relation,organization"`
+	// Optional: Parent represents the variable set's parent (currently only organizations and projects are supported).
+	// This relation is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
+	Parent     *Parent                `jsonapi:"polyrelation,parent"`
+	Workspaces []*Workspace           `jsonapi:"relation,workspaces,omitempty"`
+	Projects   []*Project             `jsonapi:"relation,projects,omitempty"`
+	Variables  []*VariableSetVariable `jsonapi:"relation,vars,omitempty"`
 }
 
 // A list of relations to include. See available resources
@@ -122,6 +132,10 @@ type VariableSetCreateOptions struct {
 	// If true the variables in the set override any other variable values set
 	// in a more specific scope including values set on the command line.
 	Priority *bool `jsonapi:"attr,priority,omitempty"`
+
+	// Optional: Parent represents the variable set's parent (currently only organizations and projects are supported).
+	// This relation is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
+	Parent *Parent `jsonapi:"polyrelation,parent"`
 }
 
 // VariableSetReadOptions represents the options for reading variable sets.

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -232,6 +232,40 @@ func TestVariableSetsCreate(t *testing.T) {
 		assert.Nil(t, vs)
 		assert.EqualError(t, err, ErrRequiredGlobalFlag.Error())
 	})
+
+	t.Run("when creating project-owned variable set", func(t *testing.T) {
+		skipUnlessBeta(t)
+
+		prjTest, prjTestCleanup := createProject(t, client, orgTest)
+		t.Cleanup(prjTestCleanup)
+
+		options := VariableSetCreateOptions{
+			Name:        String("project-varset"),
+			Description: String("a project variable set"),
+			Global:      Bool(false),
+			Parent: &Parent{
+				Project: prjTest,
+			},
+		}
+
+		vs, err := client.VariableSets.Create(ctx, orgTest.Name, &options)
+		require.NoError(t, err)
+
+		// Get refreshed view from the API
+		refreshed, err := client.VariableSets.Read(ctx, vs.ID, nil)
+		require.NoError(t, err)
+
+		for _, item := range []*VariableSet{
+			vs,
+			refreshed,
+		} {
+			assert.NotEmpty(t, item.ID)
+			assert.Equal(t, *options.Name, item.Name)
+			assert.Equal(t, *options.Description, item.Description)
+			assert.Equal(t, *options.Global, item.Global)
+			assert.Equal(t, options.Parent.Project.ID, item.Parent.Project.ID)
+		}
+	})
 }
 
 func TestVariableSetsRead(t *testing.T) {

--- a/variable_set_test.go
+++ b/variable_set_test.go
@@ -289,6 +289,15 @@ func TestVariableSetsRead(t *testing.T) {
 		assert.Nil(t, vs)
 		assert.Error(t, err)
 	})
+
+	t.Run("with parent relationship", func(t *testing.T) {
+		skipUnlessBeta(t)
+
+		vs, err := client.VariableSets.Read(ctx, vsTest.ID, nil)
+		require.NoError(t, err)
+		assert.Equal(t, vsTest, vs)
+		assert.Equal(t, orgTest.Name, vs.Parent.Organization.Name)
+	})
 }
 
 func TestVariableSetsUpdate(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This adds an optional `Parent` relationship to a variable set, which allows setting either an organization or a project as the varset's parent. This is a feature that allows a variable set to be owned directly by a project.

## Testing plan

1. An example of creating a project-owned varset is included in TestVariableSetsCreate
2. Without the feature enabled, the `Parent` relationship will be ignored by the backend, and will not be returned from the API. 

## Output from tests

```
❯ TFE_ADDRESS="<address>" TFE_TOKEN="<token>" ENABLE_BETA=1 go test ./... -v -run "TestVariableSets(Create|Read)"

?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestVariableSetsCreate
=== RUN   TestVariableSetsCreate/with_valid_options
=== RUN   TestVariableSetsCreate/when_options_is_missing_name
=== RUN   TestVariableSetsCreate/when_options_is_missing_global_flag
=== RUN   TestVariableSetsCreate/when_creating_project-owned_variable_set
--- PASS: TestVariableSetsCreate (2.04s)
    --- PASS: TestVariableSetsCreate/with_valid_options (0.39s)
    --- PASS: TestVariableSetsCreate/when_options_is_missing_name (0.00s)
    --- PASS: TestVariableSetsCreate/when_options_is_missing_global_flag (0.00s)
    --- PASS: TestVariableSetsCreate/when_creating_project-owned_variable_set (0.83s)
=== RUN   TestVariableSetsRead
=== RUN   TestVariableSetsRead/when_the_variable_set_exists
=== RUN   TestVariableSetsRead/when_variable_set_does_not_exist
=== RUN   TestVariableSetsRead/with_parent_relationship
--- PASS: TestVariableSetsRead (1.70s)
    --- PASS: TestVariableSetsRead/when_the_variable_set_exists (0.20s)
    --- PASS: TestVariableSetsRead/when_variable_set_does_not_exist (0.19s)
    --- PASS: TestVariableSetsRead/with_parent_relationship (0.18s)
PASS
ok  	github.com/hashicorp/go-tfe	4.039s
```
