### PR TITLE
Adds ListEffectiveTagBindings to Workspaces/Projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Add support for listing effective tag bindings for a workspace or project by @brandonc
+
 # v1.69.0
 
 ## Enhancements

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -204,7 +204,7 @@ func TestProjectsUpdate(t *testing.T) {
 
 	t.Run("with valid options", func(t *testing.T) {
 		kBefore, kTestCleanup := createProject(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		kAfter, err := client.Projects.Update(ctx, kBefore.ID, ProjectUpdateOptions{
 			Name:        String("new project name"),
@@ -226,6 +226,40 @@ func TestProjectsUpdate(t *testing.T) {
 			assert.Len(t, bindings, 1)
 			assert.Equal(t, "foo", bindings[0].Key)
 			assert.Equal(t, "bar", bindings[0].Value)
+
+			effectiveBindings, err := client.Projects.ListEffectiveTagBindings(ctx, kAfter.ID)
+			require.NoError(t, err)
+
+			assert.Len(t, effectiveBindings, 1)
+			assert.Equal(t, "foo", effectiveBindings[0].Key)
+			assert.Equal(t, "bar", effectiveBindings[0].Value)
+
+			ws, err := client.Workspaces.Create(ctx, orgTest.Name, WorkspaceCreateOptions{
+				Name:    String("new-workspace-inherits-tags"),
+				Project: kAfter,
+				TagBindings: []*TagBinding{
+					{Key: "baz", Value: "qux"},
+				},
+			})
+			require.NoError(t, err)
+
+			t.Cleanup(func() {
+				client.Workspaces.DeleteByID(ctx, ws.ID)
+			})
+
+			wsEffectiveBindings, err := client.Workspaces.ListEffectiveTagBindings(ctx, ws.ID)
+			require.NoError(t, err)
+
+			assert.Len(t, wsEffectiveBindings, 2)
+			for _, b := range wsEffectiveBindings {
+				if b.Key == "foo" {
+					assert.Equal(t, "bar", b.Value)
+				} else if b.Key == "baz" {
+					assert.Equal(t, "qux", b.Value)
+				} else {
+					assert.Fail(t, "unexpected tag binding %q", b.Key)
+				}
+			}
 		}
 	})
 

--- a/tag.go
+++ b/tag.go
@@ -22,6 +22,12 @@ type TagBinding struct {
 	Value string `jsonapi:"attr,value,omitempty"`
 }
 
+type EffectiveTagBinding struct {
+	ID    string `jsonapi:"primary,effective-tag-bindings"`
+	Key   string `jsonapi:"attr,key"`
+	Value string `jsonapi:"attr,value,omitempty"`
+}
+
 func encodeTagFiltersAsParams(filters []*TagBinding) map[string][]string {
 	if len(filters) == 0 {
 		return nil

--- a/workspace.go
+++ b/workspace.go
@@ -135,6 +135,10 @@ type Workspaces interface {
 	// ListTagBindings lists all tag bindings associated with the workspace.
 	ListTagBindings(ctx context.Context, workspaceID string) ([]*TagBinding, error)
 
+	// ListEffectiveTagBindings lists all tag bindings associated with the workspace which may be
+	// either inherited from a project or binded to the workspace itself.
+	ListEffectiveTagBindings(ctx context.Context, workspaceID string) ([]*EffectiveTagBinding, error)
+
 	// AddTagBindings adds or modifies the value of existing tag binding keys for a workspace.
 	AddTagBindings(ctx context.Context, workspaceID string, options WorkspaceAddTagBindingsOptions) ([]*TagBinding, error)
 }
@@ -759,6 +763,30 @@ func (s *workspaces) ListTagBindings(ctx context.Context, workspaceID string) ([
 	var list struct {
 		*Pagination
 		Items []*TagBinding
+	}
+
+	err = req.Do(ctx, &list)
+	if err != nil {
+		return nil, err
+	}
+
+	return list.Items, nil
+}
+
+func (s *workspaces) ListEffectiveTagBindings(ctx context.Context, workspaceID string) ([]*EffectiveTagBinding, error) {
+	if !validStringID(&workspaceID) {
+		return nil, ErrInvalidWorkspaceID
+	}
+
+	u := fmt.Sprintf("workspaces/%s/effective-tag-bindings", url.PathEscape(workspaceID))
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var list struct {
+		*Pagination
+		Items []*EffectiveTagBinding
 	}
 
 	err = req.Do(ctx, &list)

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1373,6 +1373,13 @@ func TestWorkspacesUpdate(t *testing.T) {
 			assert.Len(t, bindings, 1)
 			assert.Equal(t, "foo", bindings[0].Key)
 			assert.Equal(t, "bar", bindings[0].Value)
+
+			effectiveBindings, err := client.Workspaces.ListEffectiveTagBindings(ctx, wTest.ID)
+			require.NoError(t, err)
+
+			assert.Len(t, effectiveBindings, 1)
+			assert.Equal(t, "foo", effectiveBindings[0].Key)
+			assert.Equal(t, "bar", effectiveBindings[0].Value)
 		}
 	})
 


### PR DESCRIPTION
Test results

```
$ ENABLE_BETA=1 go test ./... -v -run "Test(Projects|Workspaces)Update/with_valid_options"
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
=== RUN   TestProjectsUpdate
=== RUN   TestProjectsUpdate/with_valid_options
--- PASS: TestProjectsUpdate (2.42s)
    --- PASS: TestProjectsUpdate/with_valid_options (1.55s)
=== RUN   TestWorkspacesUpdate
=== RUN   TestWorkspacesUpdate/with_valid_options
--- PASS: TestWorkspacesUpdate (3.43s)
    --- PASS: TestWorkspacesUpdate/with_valid_options (0.99s)
=== RUN   TestWorkspacesUpdateTableDriven
--- PASS: TestWorkspacesUpdateTableDriven (1.31s)
=== RUN   TestWorkspacesUpdateTableDrivenWithGithubApp
    workspace_integration_test.go:1654: Export a valid GITHUB_APP_INSTALLATION_ID before running this test!
--- SKIP: TestWorkspacesUpdateTableDrivenWithGithubApp (0.00s)
=== RUN   TestWorkspacesUpdateByID
=== RUN   TestWorkspacesUpdateByID/with_valid_options
--- PASS: TestWorkspacesUpdateByID (1.80s)
    --- PASS: TestWorkspacesUpdateByID/with_valid_options (0.51s)
=== RUN   TestWorkspacesUpdateWithDefaultExecutionMode
--- PASS: TestWorkspacesUpdateWithDefaultExecutionMode (1.85s)
PASS
ok      github.com/hashicorp/go-tfe     11.302s
```