### PR TITLE
Add inclusion of no-code module when listing modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 * Add support for listing effective tag bindings for a workspace or project by @brandonc
+* Add support for listing no-code modules by @paladin-devops [#927](https://github.com/hashicorp/go-tfe/pull/1003)
 
 # v1.69.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 
 * Add support for listing effective tag bindings for a workspace or project by @brandonc
-* Add support for listing no-code modules by @paladin-devops [#927](https://github.com/hashicorp/go-tfe/pull/1003)
+* Add support for listing no-code modules by @paladin-devops [#1003](https://github.com/hashicorp/go-tfe/pull/1003)
 
 # v1.69.0
 

--- a/docs/TESTS.md
+++ b/docs/TESTS.md
@@ -111,4 +111,4 @@ $ TFE_TOKEN=xyz TFE_HOSTNAME=tfe.local ENABLE_TFE=1 go test ./... -timeout=30m
 
 ### Running tests for HCP Terraform features that require paid plans (HashiCorp Employees)
 
-You can use the test helper `upgradeOrganizationSubscription()` to upgrade your test organization to a Business Plan, giving the organization access to all features in HCP Terraform. This method requires `TFE_TOKEN` to be a user token with administrator access in the target test environment. Furthermore, you **can not** have enterprise features enabled (`ENABLE_TFE=1`) in order to use this method since the API call fails against Terraform Enterprise test environments.
+You can use the test helper `newSubscriptionUpdater()` to upgrade your test organization to a Business Plan, giving the organization access to all features in HCP Terraform. This method requires `TFE_TOKEN` to be a user token with administrator access in the target test environment. Furthermore, you **can not** have enterprise features enabled (`ENABLE_TFE=1`) in order to use this method since the API call fails against Terraform Enterprise test environments.

--- a/registry_module.go
+++ b/registry_module.go
@@ -22,7 +22,7 @@ var _ RegistryModules = (*registryModules)(nil)
 //
 // TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/private-registry/modules
 type RegistryModules interface {
-	// List all the registory modules within an organization
+	// List all the registry modules within an organization
 	List(ctx context.Context, organization string, options *RegistryModuleListOptions) (*RegistryModuleList, error)
 
 	// ListCommits List the commits for the registry module
@@ -157,6 +157,8 @@ type RegistryModule struct {
 
 	// Relations
 	Organization *Organization `jsonapi:"relation,organization"`
+
+	RegistryNoCodeModule []*RegistryNoCodeModule `jsonapi:"relation,no-code-modules"`
 }
 
 // Commit represents a commit
@@ -202,7 +204,14 @@ type RegistryModuleVersionStatuses struct {
 // RegistryModuleListOptions represents the options for listing registry modules.
 type RegistryModuleListOptions struct {
 	ListOptions
+
+	// Include is a list of relations to include.
+	Include []RegistryModuleListIncludeOpt `url:"include,omitempty"`
 }
+
+type RegistryModuleListIncludeOpt string
+
+const IncludeNoCodeModules RegistryModuleListIncludeOpt = "no-code-modules"
 
 // RegistryModuleCreateOptions is used when creating a registry module without a VCS repo
 type RegistryModuleCreateOptions struct {
@@ -311,7 +320,7 @@ type RegistryModuleVCSRepoUpdateOptions struct {
 	Tags   *bool   `json:"tags,omitempty"`
 }
 
-// List all the registory modules within an organization.
+// List all the registry modules within an organization.
 func (r *registryModules) List(ctx context.Context, organization string, options *RegistryModuleListOptions) (*RegistryModuleList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg

--- a/registry_module_integration_test.go
+++ b/registry_module_integration_test.go
@@ -62,6 +62,31 @@ func TestRegistryModulesList(t *testing.T) {
 		assert.NotEmpty(t, modl.Items)
 		assert.Equal(t, 1, modl.CurrentPage)
 	})
+
+	t.Run("include no-code modules", func(t *testing.T) {
+		options := RegistryModuleCreateOptions{
+			Name:         String("iam"),
+			Provider:     String("aws"),
+			NoCode:       Bool(true),
+			RegistryName: PrivateRegistry,
+		}
+		rm, err := client.RegistryModules.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		modl, err := client.RegistryModules.List(ctx, orgTest.Name, &RegistryModuleListOptions{
+			Include: []RegistryModuleListIncludeOpt{
+				IncludeNoCodeModules,
+			},
+		})
+		require.NoError(t, err)
+		assert.Len(t, modl.Items, 3)
+		for _, m := range modl.Items {
+			if m.ID == rm.ID {
+				assert.True(t, m.NoCode)
+				assert.Len(t, m.RegistryNoCodeModule, 1)
+			}
+		}
+	})
 }
 
 func TestRegistryModulesCreate(t *testing.T) {


### PR DESCRIPTION
## Description

This PR enables the use of the [inclusion of related resources](https://developer.hashicorp.com/terraform/cloud-docs/api-docs#inclusion-of-related-resources) for `RegistryModule`. The only one added for support in this PR is the no-code module relation.

## Testing plan

1. Create a no-code module in the registry
2. Attempt to list it using the `List` endpoint of this client, by setting the `Include` field of the list options