### PR TITLE
CODEOWNERS needs to have a default owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,1 @@
-.github/ @hashicorp/tf-core-cloud
-Makefile @hashicorp/tf-core-cloud
+* @hashicorp/tf-core-cloud

--- a/META.d/_summary.yaml
+++ b/META.d/_summary.yaml
@@ -8,6 +8,6 @@ partition: tfc
 category: library
 
 summary:
-  owner: team-tf-cli
+  owner: team-tf-core-cloud
   description: HCP Terraform and Terraform Enterprise API Client/SDK in Golang
   visibility: external


### PR DESCRIPTION
CODEOWNERS needs to have a default owner, so I copied the settings from terraform-provider-tfe.

https://hashicorp.atlassian.net/browse/TF-21760