### PR TITLE
Bumping test helper timeout to resolve Nightly failure

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -1467,7 +1467,7 @@ func createPlanExport(t *testing.T, client *Client, r *Run) (*PlanExport, func()
 		t.Fatal(err)
 	}
 
-	timeout := 15 * time.Minute
+	timeout := 20 * time.Minute
 
 	ctxPollExportReady, cancelPollExportReady := context.WithTimeout(ctx, timeout)
 	t.Cleanup(cancelPollExportReady)

--- a/helper_test.go
+++ b/helper_test.go
@@ -1467,7 +1467,7 @@ func createPlanExport(t *testing.T, client *Client, r *Run) (*PlanExport, func()
 		t.Fatal(err)
 	}
 
-	timeout := 10 * time.Minute
+	timeout := 15 * time.Minute
 
 	ctxPollExportReady, cancelPollExportReady := context.WithTimeout(ctx, timeout)
 	t.Cleanup(cancelPollExportReady)


### PR DESCRIPTION
Seeing [this current failure](https://github.com/hashicorp/go-tfe/actions/runs/12251443028/job/34270299223#step:4:6981) in our nightly test. Looks related to [this failure](https://github.com/hashicorp/go-tfe/actions/runs/12175205984/job/33958806389) that we saw last week in that while they are different tests, the timeout is coming from the same line in the helper function. Otherwise that failure from last week passed on [a subsequent retry](https://github.com/hashicorp/go-tfe/actions/runs/12184270129/job/33988229042), so seems like the issue is nothing beyond the context deadline being exceeded in certain instances.

