### PR TITLE
[TF-23277] Fix archs field in terraform-versions CREATE request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 * Add support for team notification configurations @notchairmk [#1016](https://github.com/hashicorp/go-tfe/pull/1016)
 
+## Bug Fixes
+
+* Fixes a bug in BETA support for Linux arm64 agents, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users @natalie-todd [#1022](https://github.com/hashicorp/go-tfe/pull/1022)
+
 # v1.72.0
 
 ## Enhancements

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -63,10 +63,10 @@ type AdminTerraformVersion struct {
 }
 
 type ToolVersionArchitecture struct {
-	URL  string `jsonapi:"attr,url"`
-	Sha  string `jsonapi:"attr,sha"`
-	OS   string `jsonapi:"attr,os"`
-	Arch string `jsonapi:"attr,arch"`
+	URL  string `json:"url"`
+	Sha  string `json:"sha"`
+	OS   string `json:"os"`
+	Arch string `json:"arch"`
 }
 
 // AdminTerraformVersionsListOptions represents the options for listing
@@ -168,7 +168,6 @@ func (a *adminTerraformVersions) Create(ctx context.Context, options AdminTerraf
 	if err != nil {
 		return nil, err
 	}
-
 	return tfv, nil
 }
 

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -62,7 +62,7 @@ type AdminTerraformVersion struct {
 	CreatedAt        time.Time `jsonapi:"attr,created-at,iso8601"`
 }
 
-type ToolVersionArchitecture struct {
+type ToolVersionArchitectureOptions struct {
 	URL  string `json:"url"`
 	Sha  string `json:"sha"`
 	OS   string `json:"os"`
@@ -84,16 +84,16 @@ type AdminTerraformVersionsListOptions struct {
 // AdminTerraformVersionCreateOptions for creating a terraform version.
 // https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/terraform-versions#request-body
 type AdminTerraformVersionCreateOptions struct {
-	Type             string                     `jsonapi:"primary,terraform-versions"`
-	Version          *string                    `jsonapi:"attr,version"` // Required
-	URL              *string                    `jsonapi:"attr,url"`     // Required
-	Sha              *string                    `jsonapi:"attr,sha"`     // Required
-	Official         *bool                      `jsonapi:"attr,official,omitempty"`
-	Deprecated       *bool                      `jsonapi:"attr,deprecated,omitempty"`
-	DeprecatedReason *string                    `jsonapi:"attr,deprecated-reason,omitempty"`
-	Enabled          *bool                      `jsonapi:"attr,enabled,omitempty"`
-	Beta             *bool                      `jsonapi:"attr,beta,omitempty"`
-	Archs            []*ToolVersionArchitecture `jsonapi:"attr,archs,omitempty"`
+	Type             string                            `jsonapi:"primary,terraform-versions"`
+	Version          *string                           `jsonapi:"attr,version"` // Required
+	URL              *string                           `jsonapi:"attr,url"`     // Required
+	Sha              *string                           `jsonapi:"attr,sha"`     // Required
+	Official         *bool                             `jsonapi:"attr,official,omitempty"`
+	Deprecated       *bool                             `jsonapi:"attr,deprecated,omitempty"`
+	DeprecatedReason *string                           `jsonapi:"attr,deprecated-reason,omitempty"`
+	Enabled          *bool                             `jsonapi:"attr,enabled,omitempty"`
+	Beta             *bool                             `jsonapi:"attr,beta,omitempty"`
+	Archs            []*ToolVersionArchitectureOptions `jsonapi:"attr,archs,omitempty"`
 }
 
 // AdminTerraformVersionUpdateOptions for updating terraform version.

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -100,25 +100,28 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 
 	client := testClient(t)
 	ctx := context.Background()
-	version := genSafeRandomTerraformVersion()
 
 	t.Run("with valid options", func(t *testing.T) {
-		sha := String(genSha(t))
 		opts := AdminTerraformVersionCreateOptions{
-			Version:          String(version),
-			URL:              String("https://www.hashicorp.com"),
-			Sha:              sha,
+			Version:          String(genSafeRandomTerraformVersion()),
 			Deprecated:       Bool(true),
 			DeprecatedReason: String("Test Reason"),
 			Official:         Bool(false),
 			Enabled:          Bool(false),
 			Beta:             Bool(false),
-			Archs: []*ToolVersionArchitecture{{
-				URL:  "https://www.hashicorp.com",
-				Sha:  *sha,
-				OS:   linux,
-				Arch: amd64,
-			}},
+			Archs: []*ToolVersionArchitecture{
+				{
+					URL:  "https://www.hashicorp.com",
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: amd64,
+				},
+				{
+					URL:  "https://www.hashicorp.com",
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: arm64,
+				}},
 		}
 		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
 		require.NoError(t, err)

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -109,7 +109,7 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 			Official:         Bool(false),
 			Enabled:          Bool(false),
 			Beta:             Bool(false),
-			Archs: []*ToolVersionArchitecture{
+			Archs: []*ToolVersionArchitectureOptions{
 				{
 					URL:  "https://www.hashicorp.com",
 					Sha:  *String(genSha(t)),
@@ -219,7 +219,7 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 			DeprecatedReason: String("Test Reason"),
 			Enabled:          Bool(false),
 			Beta:             Bool(false),
-			Archs: []*ToolVersionArchitecture{{
+			Archs: []*ToolVersionArchitectureOptions{{
 				URL:  "https://www.hashicorp.com",
 				Sha:  *sha,
 				OS:   linux,

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -101,7 +101,7 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	t.Run("with valid options", func(t *testing.T) {
+	t.Run("with valid options and archs", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
 			Version:          String(genSafeRandomTerraformVersion()),
 			Deprecated:       Bool(true),
@@ -122,6 +122,35 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 					OS:   linux,
 					Arch: arm64,
 				}},
+		}
+		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
+		require.NoError(t, err)
+
+		defer func() {
+			deleteErr := client.Admin.TerraformVersions.Delete(ctx, tfv.ID)
+			require.NoError(t, deleteErr)
+		}()
+
+		assert.Equal(t, *opts.Version, tfv.Version)
+		assert.Equal(t, *opts.URL, tfv.URL)
+		assert.Equal(t, *opts.Sha, tfv.Sha)
+		assert.Equal(t, *opts.Official, tfv.Official)
+		assert.Equal(t, *opts.Deprecated, tfv.Deprecated)
+		assert.Equal(t, *opts.DeprecatedReason, *tfv.DeprecatedReason)
+		assert.Equal(t, *opts.Enabled, tfv.Enabled)
+		assert.Equal(t, *opts.Beta, tfv.Beta)
+	})
+
+	t.Run("with valid options, url, and sha", func(t *testing.T) {
+		opts := AdminTerraformVersionCreateOptions{
+			Version:          String(genSafeRandomTerraformVersion()),
+			URL:              String("https://www.hashicorp.com"),
+			Sha:              String(genSha(t)),
+			Deprecated:       Bool(true),
+			DeprecatedReason: String("Test Reason"),
+			Official:         Bool(false),
+			Enabled:          Bool(false),
+			Beta:             Bool(false),
 		}
 		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
 		require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

This PR fixes the formatting of the archs param in the terraform-versions CREATE request. It is for the Beta of arm64 arch support for agents. 

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

-->
- [Original PR](https://github.com/hashicorp/go-tfe/pull/1022)
- [Dependent PR](https://github.com/hashicorp/terraform-releases/pull/150)