### PR TITLE
Nightly Fix: Test using FF gated code not marked with `skipUnlessBeta`

### DIFF
--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -97,6 +97,7 @@ func TestAdminTerraformVersions_List(t *testing.T) {
 
 func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 	skipUnlessEnterprise(t)
+	skipUnlessBeta(t)
 
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Description

Currently the nightly fails on `TestAdminTerraformVersions_CreateDelete` with a nil pointer dereference– namely due to these assertions:
```go
assert.Equal(t, *opts.URL, tfv.URL)
assert.Equal(t, *opts.Sha, tfv.Sha)
```
Since the URL and SHA aren't present in the struct.

The reason they aren't being rendered in the response from atlas is due to their serialization being gated by the `arm64-agent-support` feature flag. 

in [tool_version_serializer.rb](https://github.com/hashicorp/atlas/blob/227c338762e99ed755c13bc187f24f73cf305d5c/app/serializers/api/v2/admin/tool_version_serializer.rb#L20):
```ruby
 attribute :archs, if: -> { feature_on?(Feature::Flags::ARM64_AGENT_SUPPORT, context: current_user) }

def archs
  ActiveModelSerializers::SerializableResource.new(
      object.architectures,
      each_serializer: ToolVersionArchitectureSerializer,
      adapter: :attributes
    ).serializable_hash
end
```

Then in [`ToolVersionArchitectureSerializer`](https://github.com/hashicorp/atlas/blob/main/app/serializers/api/v2/admin/tool_version_architecture_serializer.rb)
```ruby
# typed: true
module Api
  module V2
    module Admin
      class ToolVersionArchitectureSerializer < BaseSerializer
        attributes :url, :sha, :os, :arch
      end
    end
  end
end
```


As such I've added the `skipUnlessBeta` helper to the affected test




