### PR TITLE
[TF-23534] Fix test panic

### DIFF
--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -132,8 +132,6 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		}()
 
 		assert.Equal(t, *opts.Version, tfv.Version)
-		assert.Equal(t, *opts.URL, tfv.URL)
-		assert.Equal(t, *opts.Sha, tfv.Sha)
 		assert.Equal(t, *opts.Official, tfv.Official)
 		assert.Equal(t, *opts.Deprecated, tfv.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *tfv.DeprecatedReason)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
A new test with a panic was introduced in [#1030](https://github.com/hashicorp/go-tfe/pull/1030). This PR fixes the panic by removing the nil pointer dereference causing it. In the coming weeks there will be a follow up PR which will support the comparison of the architectures returned by the terraform versions CREATE endpoint.
