### PR TITLE
Add support to update an organization’s default project

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds `DefaultProject` to `OrganizationUpdateOptions` to support updating an organization's default project. This provides BETA support, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users, by @mkam [#1056](https://github.com/hashicorp/go-tfe/pull/1056)
+
 ## Bug fixes
 
 * Adds `ToolVersionArchitecture` to `AdminTerraformVersionUpdateOptions` and `AdminTerraformVersion`. This provides BETA support, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @kelsi-hoyle [#1047](https://github.com/hashicorp/go-tfe/pull/1047)

--- a/organization.go
+++ b/organization.go
@@ -311,6 +311,10 @@ type OrganizationUpdateOptions struct {
 	// Optional: StacksEnabled toggles whether stacks are enabled for the organization. This setting
 	// is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
 	StacksEnabled *bool `jsonapi:"attr,stacks-enabled,omitempty"`
+
+	// Optional: DefaultProject is the default project that workspaces are created in when no project is specified.
+	// This setting is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
+	DefaultProject *Project `jsonapi:"relation,default-project,omitempty"`
 }
 
 // ReadRunQueueOptions represents the options for showing the queue.

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -388,6 +388,27 @@ func TestOrganizationsUpdate(t *testing.T) {
 
 		t.Cleanup(orgAgentTestCleanup)
 	})
+
+	t.Run("with different default project", func(t *testing.T) {
+		skipUnlessBeta(t)
+
+		// Create an organization and a second project in the organization
+		org, orgCleanup := createOrganization(t, client)
+		t.Cleanup(orgCleanup)
+
+		proj, _ := createProject(t, client, org) // skip cleanup because default project cannot be deleted
+
+		// Update the default project and verify the change
+		updated, err := client.Organizations.Update(ctx, org.Name, OrganizationUpdateOptions{
+			DefaultProject: proj,
+		})
+		require.NoError(t, err)
+		require.Equal(t, proj.ID, updated.DefaultProject.ID)
+
+		fetched, err := client.Organizations.Read(ctx, org.Name)
+		require.NoError(t, err)
+		require.Equal(t, proj.ID, fetched.DefaultProject.ID)
+	})
 }
 
 func TestOrganizationsDelete(t *testing.T) {


### PR DESCRIPTION
## Description

This PR adds support for updating the default project of an organization, which determines which project a workspace is created in when no project is specified. This is a BETA feature that is not yet available to all users. 
## Testing plan

1. Create an organization, which is created with a default project.
1. Create a new project in the organization
1. Update the organization’s default project to the new project
1. Create a workspace without specifying a project
1. Verify that the workspace was created in the new project

## Output from tests
```
-> % ENABLE_BETA=1 go test ./... -v -run "TestOrganizationsUpdate/with_different_default_project"

?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/projects	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestOrganizationsUpdate
=== RUN   TestOrganizationsUpdate/with_different_default_project
--- PASS: TestOrganizationsUpdate (1.93s)
    --- PASS: TestOrganizationsUpdate/with_different_default_project (1.33s)
PASS
ok  	github.com/hashicorp/go-tfe	2.215s
```
