### PR TITLE
Support unsetting an organization's default project

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/hashicorp/go-slug v0.16.4
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/go-version v1.7.0
-	github.com/hashicorp/jsonapi v1.4.1
+	github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e
 	github.com/stretchr/testify v1.10.0
 	go.uber.org/mock v0.4.0
 	golang.org/x/sync v0.10.0

--- a/go.sum
+++ b/go.sum
@@ -16,8 +16,8 @@ github.com/hashicorp/go-uuid v1.0.3 h1:2gKiV6YVmrJ1i2CKKa9obLvRieoRGviZFL26PcT/C
 github.com/hashicorp/go-uuid v1.0.3/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.7.0 h1:5tqGy27NaOTB8yJKUZELlFAS/LTKJkrmONwQKeRZfjY=
 github.com/hashicorp/go-version v1.7.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
-github.com/hashicorp/jsonapi v1.4.1 h1:U6CZvnS70Sg7im0kpfhWAoF3NasLumaMndQhEWniHZA=
-github.com/hashicorp/jsonapi v1.4.1/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
+github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e h1:xwy/1T0cxHWaLx2MM0g4BlaQc1BXn/9835mPrBqwSPU=
+github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e/go.mod h1:kWfdn49yCjQvbpnvY1dxxAuAFzISwrrMDQOcu6NsFoM=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/organization.go
+++ b/organization.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"net/url"
 	"time"
+
+	"github.com/hashicorp/jsonapi"
 )
 
 // Compile-time proof of interface implementation.
@@ -314,7 +316,7 @@ type OrganizationUpdateOptions struct {
 
 	// Optional: DefaultProject is the default project that workspaces are created in when no project is specified.
 	// This setting is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
-	DefaultProject *Project `jsonapi:"relation,default-project,omitempty"`
+	DefaultProject jsonapi.NullableRelationship[*Project] `jsonapi:"relation,default-project,omitempty"`
 }
 
 // ReadRunQueueOptions represents the options for showing the queue.


### PR DESCRIPTION
## Description

Allows explicitly unsetting an organization's default project by setting it as a `NullableRelationship` rather than just a `Project`, as it's not required to have a default project.

## Testing plan
1. Create an organization.
1. Create a new project in the organization
1. Update the organization’s default project to the new project
1. Verify in the UI on the organization's settings that the default project has been updated
1. Delete the default project setting
1. Verify in the UI on the organization's settings that there is not a default project set


## Output from tests
```
-> % ENABLE_BETA=1 go test ./... -v -run "TestOrganizationsUpdate/with_different_default_project"
?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/projects	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestOrganizationsUpdate
=== RUN   TestOrganizationsUpdate/with_different_default_project
--- PASS: TestOrganizationsUpdate (2.56s)
    --- PASS: TestOrganizationsUpdate/with_different_default_project (2.22s)
PASS
ok  	github.com/hashicorp/go-tfe	2.851s
...
```
