### PR TITLE
Remove beta flag for variable set permission in team project

### DIFF
--- a/team_project_access.go
+++ b/team_project_access.go
@@ -72,7 +72,6 @@ type TeamProjectAccessProjectPermissions struct {
 	ProjectSettingsPermission ProjectSettingsPermissionType `jsonapi:"attr,settings"`
 	ProjectTeamsPermission    ProjectTeamsPermissionType    `jsonapi:"attr,teams"`
 	// ProjectVariableSetsPermission represents read, manage, and no access custom permission for project-level variable sets
-	// This relation is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
 	ProjectVariableSetsPermission ProjectVariableSetsPermissionType `jsonapi:"attr,variable-sets"`
 }
 
@@ -108,7 +107,6 @@ const (
 )
 
 // ProjectVariableSetsPermissionType represents the permission type to a project's variable sets
-// This relation is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
 type ProjectVariableSetsPermissionType string
 
 const (
@@ -154,9 +152,8 @@ const (
 )
 
 type TeamProjectAccessProjectPermissionsOptions struct {
-	Settings *ProjectSettingsPermissionType `json:"settings,omitempty"`
-	Teams    *ProjectTeamsPermissionType    `json:"teams,omitempty"`
-	// This relation is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
+	Settings     *ProjectSettingsPermissionType     `json:"settings,omitempty"`
+	Teams        *ProjectTeamsPermissionType        `json:"teams,omitempty"`
 	VariableSets *ProjectVariableSetsPermissionType `json:"variable-sets,omitempty"`
 }
 

--- a/team_project_access_integration_test.go
+++ b/team_project_access_integration_test.go
@@ -166,7 +166,6 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 	})
 
 	t.Run("with no project access options for custom TeamProject permissions", func(t *testing.T) {
-		skipUnlessBeta(t)
 		options := TeamProjectAccessAddOptions{
 			Access:        *ProjectAccess(TeamProjectAccessCustom),
 			Team:          tmTest,
@@ -274,7 +273,6 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 	})
 
 	t.Run("with valid options for custom variable sets permissions", func(t *testing.T) {
-		skipUnlessBeta(t)
 		options := TeamProjectAccessAddOptions{
 			Access:  *ProjectAccess(TeamProjectAccessCustom),
 			Team:    tmTest,
@@ -481,7 +479,6 @@ func TestTeamProjectAccessesUpdate(t *testing.T) {
 	})
 
 	t.Run("with valid custom permissions attributes for variable sets permissions", func(t *testing.T) {
-		skipUnlessBeta(t)
 		// create tpaCustomTest to verify unupdated attributes stay the same for custom permissions
 		// because going from admin to read to custom changes the values of all custom permissions
 		tm2Test, tm2TestCleanup := createTeam(t, client, orgTest)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Since the project is now GA, and the provider changes have been merged, the beta flags can be removed.

## Testing plan

The tests should pass

## External links
- [Jira ](https://hashicorp.atlassian.net/browse/TF-23828)
