### PR TITLE
Add CHANGELOG entry for external ID validation change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -169,6 +169,7 @@
 ## Enhancements
 
 * Adds BETA support for `Stacks` resources, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @brandonc. [#920](https://github.com/hashicorp/go-tfe/pull/920)
+* Adds support for managing resources that have HCP IDs by @roncodingenthusiast. [#924](https://github.com/hashicorp/go-tfe/pull/924)
 
 # v1.57.0
 


### PR DESCRIPTION
## Description

This PR adds a missing changelog entry for https://github.com/hashicorp/go-tfe/pull/924. We're adding this changelog entry now to make this change more visible, in order to provide guidance for people who are interested in using go-tfe with integrated HCP Terraform organizations.

## External links

- [HCP Organization ID](https://developer.hashicorp.com/hcp/docs/hcp/admin/orgs#locate-the-organization-id)


