### PR TITLE
[TF-24278] Remove Arch Tests

### DIFF
--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -137,13 +137,6 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		assert.Equal(t, *opts.DeprecatedReason, *tfv.DeprecatedReason)
 		assert.Equal(t, *opts.Enabled, tfv.Enabled)
 		assert.Equal(t, *opts.Beta, tfv.Beta)
-		assert.Equal(t, len(opts.Archs), len(tfv.Archs))
-		for i, arch := range opts.Archs {
-			assert.Equal(t, arch.URL, tfv.Archs[i].URL)
-			assert.Equal(t, arch.Sha, tfv.Archs[i].Sha)
-			assert.Equal(t, arch.OS, tfv.Archs[i].OS)
-			assert.Equal(t, arch.Arch, tfv.Archs[i].Arch)
-		}
 	})
 
 	t.Run("with valid options, url, and sha", func(t *testing.T) {
@@ -271,57 +264,6 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, *updateOpts.Deprecated, tfv.Deprecated)
 		assert.Equal(t, *opts.Enabled, tfv.Enabled)
 		assert.Equal(t, *opts.Beta, tfv.Beta)
-	})
-
-	t.Run("update with Archs", func(t *testing.T) {
-		version := genSafeRandomTerraformVersion()
-		sha := String(genSha(t))
-		opts := AdminTerraformVersionCreateOptions{
-			Version:          String(version),
-			URL:              String("https://www.hashicorp.com"),
-			Sha:              String(genSha(t)),
-			Official:         Bool(false),
-			Deprecated:       Bool(true),
-			DeprecatedReason: String("Test Reason"),
-			Enabled:          Bool(false),
-			Beta:             Bool(false),
-			Archs: []*ToolVersionArchitecture{{
-				URL:  "https://www.hashicorp.com",
-				Sha:  *sha,
-				OS:   linux,
-				Arch: amd64,
-			}},
-		}
-		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
-		require.NoError(t, err)
-		id := tfv.ID
-
-		defer func() {
-			deleteErr := client.Admin.TerraformVersions.Delete(ctx, id)
-			require.NoError(t, deleteErr)
-		}()
-
-		updateVersion := genSafeRandomTerraformVersion()
-		updateArchOpts := AdminTerraformVersionUpdateOptions{
-			Version:    String(updateVersion),
-			Deprecated: Bool(false),
-			Archs: []*ToolVersionArchitecture{{
-				URL:  "https://www.hashicorp.com",
-				Sha:  *sha,
-				OS:   linux,
-				Arch: amd64,
-			}},
-		}
-
-		tfv, err = client.Admin.TerraformVersions.Update(ctx, id, updateArchOpts)
-		require.NoError(t, err)
-
-		assert.Equal(t, len(tfv.Archs), 1)
-		assert.Equal(t, updateArchOpts.Archs[0].URL, tfv.Archs[0].URL)
-		assert.Equal(t, updateArchOpts.Archs[0].Sha, tfv.Archs[0].Sha)
-		assert.Equal(t, updateArchOpts.Archs[0].OS, tfv.Archs[0].OS)
-		assert.Equal(t, updateArchOpts.Archs[0].Arch, tfv.Archs[0].Arch)
-		assert.Equal(t, updateVersion, tfv.Version)
 	})
 
 	t.Run("with non-existent terraform version", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Removing Arch checks in response until flag is turned on.

**FLAG OFF IN LOCAL DEV**
```
go test -run TestAdminTerraformVersions_CreateDelete 
PASS
ok      github.com/hashicorp/go-tfe     1.936s

go test -run TestAdminTerraformVersions_ReadUpdate 
PASS
ok      github.com/hashicorp/go-tfe     1.537s
```