### PR TITLE
BREAKING: removes TotalCount/TotalPages from ListForOrganization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## BREAKING CHANGES
+
+In the last release, Runs interface method `ListForOrganization` included pagination fields `TotalCount` and `TotalPages`, but these are being removed as this feature approaches general availablity by @brandonc [#1074](https://github.com/hashicorp/go-tfe/pull/1074)
+
 # v1.76.0
 
 ## Enhancements

--- a/mocks/run_mocks.go
+++ b/mocks/run_mocks.go
@@ -141,10 +141,10 @@ func (mr *MockRunsMockRecorder) List(ctx, workspaceID, options any) *gomock.Call
 }
 
 // ListForOrganization mocks base method.
-func (m *MockRuns) ListForOrganization(ctx context.Context, organization string, options *tfe.RunListForOrganizationOptions) (*tfe.RunList, error) {
+func (m *MockRuns) ListForOrganization(ctx context.Context, organization string, options *tfe.RunListForOrganizationOptions) (*tfe.OrganizationRunList, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "ListForOrganization", ctx, organization, options)
-	ret0, _ := ret[0].(*tfe.RunList)
+	ret0, _ := ret[0].(*tfe.OrganizationRunList)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }

--- a/run.go
+++ b/run.go
@@ -22,7 +22,7 @@ type Runs interface {
 	List(ctx context.Context, workspaceID string, options *RunListOptions) (*RunList, error)
 
 	// List all the runs of the given organization.
-	ListForOrganization(ctx context.Context, organization string, options *RunListForOrganizationOptions) (*RunList, error)
+	ListForOrganization(ctx context.Context, organization string, options *RunListForOrganizationOptions) (*OrganizationRunList, error)
 
 	// Create a new run with the given options.
 	Create(ctx context.Context, options RunCreateOptions) (*Run, error)
@@ -117,6 +117,14 @@ const (
 // RunList represents a list of runs.
 type RunList struct {
 	*Pagination
+	Items []*Run
+}
+
+// OrganizationRunList represents a list of runs across an organization. It
+// differs from the RunList in that it does not include a TotalCount of records
+// in the pagination details
+type OrganizationRunList struct {
+	*PaginationNextPrev
 	Items []*Run
 }
 
@@ -448,7 +456,7 @@ func (s *runs) List(ctx context.Context, workspaceID string, options *RunListOpt
 }
 
 // List all the runs of the given workspace.
-func (s *runs) ListForOrganization(ctx context.Context, organization string, options *RunListForOrganizationOptions) (*RunList, error) {
+func (s *runs) ListForOrganization(ctx context.Context, organization string, options *RunListForOrganizationOptions) (*OrganizationRunList, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
 	}
@@ -462,7 +470,7 @@ func (s *runs) ListForOrganization(ctx context.Context, organization string, opt
 		return nil, err
 	}
 
-	rl := &RunList{}
+	rl := &OrganizationRunList{}
 	err = req.Do(ctx, rl)
 	if err != nil {
 		return nil, err

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -750,7 +750,7 @@ func TestRunsListForOrganization(t *testing.T) {
 		assert.Contains(t, found, rTest1.ID)
 		assert.Contains(t, found, rTest2.ID)
 		assert.Equal(t, 1, rl.CurrentPage)
-		assert.Equal(t, 2, rl.TotalCount)
+		assert.Empty(t, rl.NextPage)
 	})
 
 	t.Run("without list options and include as nil", func(t *testing.T) {
@@ -768,7 +768,7 @@ func TestRunsListForOrganization(t *testing.T) {
 		assert.Contains(t, found, rTest1.ID)
 		assert.Contains(t, found, rTest2.ID)
 		assert.Equal(t, 1, rl.CurrentPage)
-		assert.Equal(t, 2, rl.TotalCount)
+		assert.Empty(t, rl.NextPage)
 	})
 
 	t.Run("with list options", func(t *testing.T) {
@@ -784,7 +784,7 @@ func TestRunsListForOrganization(t *testing.T) {
 		require.NoError(t, err)
 		assert.Empty(t, rl.Items)
 		assert.Equal(t, 999, rl.CurrentPage)
-		assert.Equal(t, 2, rl.TotalCount)
+		assert.Empty(t, rl.NextPage)
 	})
 
 	t.Run("with workspace included", func(t *testing.T) {
@@ -818,7 +818,7 @@ func TestRunsListForOrganization(t *testing.T) {
 		assert.Contains(t, found, rTest1.ID)
 		assert.Contains(t, found, rTest2.ID)
 		assert.Equal(t, 1, rl.CurrentPage)
-		assert.Equal(t, 2, rl.TotalCount)
+		assert.Empty(t, rl.NextPage)
 	})
 
 	t.Run("with filter by workspace", func(t *testing.T) {
@@ -840,6 +840,6 @@ func TestRunsListForOrganization(t *testing.T) {
 		require.NotNil(t, rl.Items[1].Workspace)
 		assert.NotEmpty(t, rl.Items[1].Workspace.Name)
 		assert.Equal(t, 1, rl.CurrentPage)
-		assert.Equal(t, 2, rl.TotalCount)
+		assert.Empty(t, rl.NextPage)
 	})
 }


### PR DESCRIPTION
Closes #1073 

## Description

As we seek to release the Organization Runs feature more widely, it needs to be modified to remove the TotalCount/TotalPages pagination attributes. This feature was added in the last release of go-tfe.

## Testing plan

Today, you'll find that the TotalCount/TotalPages are still in the API response but will be removed very soon.

## Notes

The unmarshaler had to be modified to check for a struct field called "PaginationPrevNext" and preferring that with the missing fields. The implicit assumption is that any `Items` struct will either define `*Pagination` _or_ `*PaginationNextPrev`
