### PR TITLE
Add AgentPool to OAuthClientUpdateOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Add `AgentPool` field to the OAuthClientUpdateOptions struct, which is used to associate a VCS Provider with an AgentPool for PrivateVCS support  by @jpogran [#1075](https://github.com/hashicorp/go-tfe/pull/1075)
+
 # v1.78.0
 
 ## Enhancements
@@ -16,6 +18,7 @@
 ## BREAKING CHANGES
 
 In the last release, Runs interface method `ListForOrganization` included pagination fields `TotalCount` and `TotalPages`, but these are being removed as this feature approaches general availablity by @brandonc [#1074](https://github.com/hashicorp/go-tfe/pull/1074)
+
 
 # v1.76.0
 

--- a/oauth_client.go
+++ b/oauth_client.go
@@ -196,6 +196,9 @@ type OAuthClientUpdateOptions struct {
 	// Optional: The token string you were given by your VCS provider.
 	OAuthToken *string `jsonapi:"attr,oauth-token-string,omitempty"`
 
+	// Optional: AgentPool to associate the VCS Provider with, for PrivateVCS support
+	AgentPool *AgentPool `jsonapi:"relation,agent-pool,omitempty"`
+
 	// Optional: Whether the OAuthClient is available to all workspaces in the organization.
 	// True if the oauth client is organization scoped, false otherwise.
 	OrganizationScoped *bool `jsonapi:"attr,organization-scoped,omitempty"`

--- a/oauth_client_integration_test.go
+++ b/oauth_client_integration_test.go
@@ -640,6 +640,36 @@ func TestOAuthClientsUpdate(t *testing.T) {
 		assert.NotEmpty(t, oc.ID)
 		assert.NotEqual(t, origOC.OrganizationScoped, oc.OrganizationScoped)
 	})
+
+	t.Run("updates agent pool", func(t *testing.T) {
+		testAgentPool1, agentPoolCleanup := createAgentPool(t, client, orgTest)
+		defer agentPoolCleanup()
+		testAgentPool2, agentPoolCleanup2 := createAgentPool(t, client, orgTest)
+		defer agentPoolCleanup2()
+
+		organizationScopedTrue := true
+		options := OAuthClientCreateOptions{
+			APIURL:             String("https://bbdc.com"),
+			HTTPURL:            String("https://bbdc.com"),
+			ServiceProvider:    ServiceProvider(ServiceProviderBitbucketDataCenter),
+			OrganizationScoped: &organizationScopedTrue,
+			AgentPool:          testAgentPool1,
+		}
+
+		origOC, err := client.OAuthClients.Create(ctx, orgTest.Name, options)
+
+		require.NoError(t, err)
+		assert.NotEmpty(t, origOC.ID)
+
+		updateOpts := OAuthClientUpdateOptions{
+			AgentPool: testAgentPool2,
+		}
+		oc, err := client.OAuthClients.Update(ctx, origOC.ID, updateOpts)
+		require.NoError(t, err)
+		assert.NotEmpty(t, oc.ID)
+		assert.Equal(t, oc.AgentPool.ID, testAgentPool2.ID)
+		assert.NotEqual(t, origOC.AgentPool.ID, oc.AgentPool.ID)
+	})
 }
 
 const publicKey = `


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description


This change adds an AgentPool field to the OAuthClientUpdateOptions struct, which is used to associate a VCS Provider with an AgentPool for PrivateVCS support.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```