### PR TITLE
Distinguish between empty and nil team token description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## BREAKING CHANGES
+
+* Updates team token `Description` to be a pointer, allowing for both nil descriptions and empty string descriptions. Team token descriptions and the ability to create multiple team tokens is in BETA, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users, by @mkam [#1088](https://github.com/hashicorp/go-tfe/pull/1088)
+
 # v1.78.0
 
 ## Enhancements

--- a/team_token.go
+++ b/team_token.go
@@ -50,7 +50,7 @@ type teamTokens struct {
 type TeamToken struct {
 	ID          string           `jsonapi:"primary,authentication-tokens"`
 	CreatedAt   time.Time        `jsonapi:"attr,created-at,iso8601"`
-	Description string           `jsonapi:"attr,description"`
+	Description *string          `jsonapi:"attr,description"`
 	LastUsedAt  time.Time        `jsonapi:"attr,last-used-at,iso8601"`
 	Token       string           `jsonapi:"attr,token"`
 	ExpiredAt   time.Time        `jsonapi:"attr,expired-at,iso8601"`
@@ -66,7 +66,7 @@ type TeamTokenCreateOptions struct {
 
 	// Optional: The token's description, which must unique per team.
 	// This feature is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
-	Description string `jsonapi:"attr,description,omitempty"`
+	Description *string `jsonapi:"attr,description,omitempty"`
 }
 
 // Create a new team token using the legacy creation behavior, which creates a token without a description
@@ -84,7 +84,7 @@ func (s *teamTokens) CreateWithOptions(ctx context.Context, teamID string, optio
 	}
 
 	var u string
-	if options.Description != "" {
+	if options.Description != nil {
 		u = fmt.Sprintf("teams/%s/authentication-tokens", url.PathEscape(teamID))
 	} else {
 		u = fmt.Sprintf("teams/%s/authentication-token", url.PathEscape(teamID))


### PR DESCRIPTION
## Description
An empty string for a description should be unique from an omitted, nil description, and only nil descriptions should use the legacy token API. This PR updates Description to be a string pointer to distinguish between these two values.

## Testing plan

1. Create a team token with a nil description
2. Create a second team token with an empty string description. This should not fail because it's considered unique from a nil description.

## Output from tests
<details><summary>Test output of all team token tests</summary>

```
-> % ENABLE_BETA=1 go test ./... -v -run "TestTeamTokens"
?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/projects	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
=== RUN   TestTeamTokensCreate
=== RUN   TestTeamTokensCreate/with_valid_options
=== RUN   TestTeamTokensCreate/when_a_token_already_exists
=== RUN   TestTeamTokensCreate/without_valid_team_ID
--- PASS: TestTeamTokensCreate (2.42s)
    --- PASS: TestTeamTokensCreate/with_valid_options (0.23s)
    --- PASS: TestTeamTokensCreate/when_a_token_already_exists (0.48s)
    --- PASS: TestTeamTokensCreate/without_valid_team_ID (0.00s)
=== RUN   TestTeamTokens_CreateWithOptions
=== RUN   TestTeamTokens_CreateWithOptions/with_valid_options
=== RUN   TestTeamTokens_CreateWithOptions/when_a_token_already_exists
=== RUN   TestTeamTokens_CreateWithOptions/without_valid_team_ID
=== RUN   TestTeamTokens_CreateWithOptions/without_an_expiration_date
=== RUN   TestTeamTokens_CreateWithOptions/with_an_expiration_date
--- PASS: TestTeamTokens_CreateWithOptions (3.79s)
    --- PASS: TestTeamTokens_CreateWithOptions/with_valid_options (0.22s)
    --- PASS: TestTeamTokens_CreateWithOptions/when_a_token_already_exists (0.61s)
    --- PASS: TestTeamTokens_CreateWithOptions/without_valid_team_ID (0.00s)
    --- PASS: TestTeamTokens_CreateWithOptions/without_an_expiration_date (0.58s)
    --- PASS: TestTeamTokens_CreateWithOptions/with_an_expiration_date (0.72s)
=== RUN   TestTeamTokens_CreateWithOptions_MultipleTokens
=== RUN   TestTeamTokens_CreateWithOptions_MultipleTokens/with_multiple_tokens
=== RUN   TestTeamTokens_CreateWithOptions_MultipleTokens/with_an_expiration_date
=== RUN   TestTeamTokens_CreateWithOptions_MultipleTokens/without_an_expiration_date
=== RUN   TestTeamTokens_CreateWithOptions_MultipleTokens/when_a_token_already_exists_with_the_same_description
=== RUN   TestTeamTokens_CreateWithOptions_MultipleTokens/without_valid_team_ID
--- PASS: TestTeamTokens_CreateWithOptions_MultipleTokens (5.55s)
    --- PASS: TestTeamTokens_CreateWithOptions_MultipleTokens/with_multiple_tokens (2.14s)
    --- PASS: TestTeamTokens_CreateWithOptions_MultipleTokens/with_an_expiration_date (0.66s)
    --- PASS: TestTeamTokens_CreateWithOptions_MultipleTokens/without_an_expiration_date (0.58s)
    --- PASS: TestTeamTokens_CreateWithOptions_MultipleTokens/when_a_token_already_exists_with_the_same_description (0.89s)
    --- PASS: TestTeamTokens_CreateWithOptions_MultipleTokens/without_valid_team_ID (0.00s)
=== RUN   TestTeamTokensRead
=== RUN   TestTeamTokensRead/with_valid_options
=== RUN   TestTeamTokensRead/with_an_expiration_date_passed_as_a_valid_option
=== RUN   TestTeamTokensRead/when_a_token_doesn't_exists
=== RUN   TestTeamTokensRead/without_valid_organization
--- PASS: TestTeamTokensRead (3.57s)
    --- PASS: TestTeamTokensRead/with_valid_options (1.00s)
    --- PASS: TestTeamTokensRead/with_an_expiration_date_passed_as_a_valid_option (1.08s)
    --- PASS: TestTeamTokensRead/when_a_token_doesn't_exists (0.21s)
    --- PASS: TestTeamTokensRead/without_valid_organization (0.00s)
=== RUN   TestTeamTokensReadByID
=== RUN   TestTeamTokensReadByID/with_legacy,_descriptionless_tokens
=== RUN   TestTeamTokensReadByID/with_multiple_team_tokens
=== RUN   TestTeamTokensReadByID/when_a_token_doesn't_exists
--- PASS: TestTeamTokensReadByID (4.68s)
    --- PASS: TestTeamTokensReadByID/with_legacy,_descriptionless_tokens (0.96s)
    --- PASS: TestTeamTokensReadByID/with_multiple_team_tokens (2.19s)
    --- PASS: TestTeamTokensReadByID/when_a_token_doesn't_exists (0.20s)
=== RUN   TestTeamTokensDelete
=== RUN   TestTeamTokensDelete/with_valid_options
=== RUN   TestTeamTokensDelete/when_a_token_does_not_exist
=== RUN   TestTeamTokensDelete/without_valid_team_ID
--- PASS: TestTeamTokensDelete (2.27s)
    --- PASS: TestTeamTokensDelete/with_valid_options (0.51s)
    --- PASS: TestTeamTokensDelete/when_a_token_does_not_exist (0.21s)
    --- PASS: TestTeamTokensDelete/without_valid_team_ID (0.00s)
=== RUN   TestTeamTokensDeleteByID
=== RUN   TestTeamTokensDeleteByID/with_legacy,_descriptionless_tokens
=== RUN   TestTeamTokensDeleteByID/with_multiple_team_tokens
=== RUN   TestTeamTokensDeleteByID/when_a_token_does_not_exist
=== RUN   TestTeamTokensDeleteByID/with_invalid_token_ID
--- PASS: TestTeamTokensDeleteByID (3.97s)
    --- PASS: TestTeamTokensDeleteByID/with_legacy,_descriptionless_tokens (0.77s)
    --- PASS: TestTeamTokensDeleteByID/with_multiple_team_tokens (1.68s)
    --- PASS: TestTeamTokensDeleteByID/when_a_token_does_not_exist (0.22s)
    --- PASS: TestTeamTokensDeleteByID/with_invalid_token_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	26.798s

...
```
</details>