### PR TITLE
[TF-25570] Add Archs Field to OPA and Sentinel Admin Versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 * Updates team token `Description` to be a pointer, allowing for both nil descriptions and empty string descriptions. Team token descriptions and the ability to create multiple team tokens is in BETA, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users, by @mkam [#1088](https://github.com/hashicorp/go-tfe/pull/1088)
 
+## Enhancements
+
+* Add BETA support for use of OPA and Sentinel with Linux arm64 agents, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users @natalie-todd [#1090](https://github.com/hashicorp/go-tfe/pull/1090)
+
 # v1.78.0
 
 ## Enhancements

--- a/admin_opa_version.go
+++ b/admin_opa_version.go
@@ -202,17 +202,23 @@ func (o AdminOPAVersionCreateOptions) valid() error {
 	if o.Version == "" {
 		return ErrRequiredVersion
 	}
-	if !o.validArch() && (o.URL == "" || o.SHA == "") {
-		return ErrRequiredArchOrURLAndSha
+	if !o.validArch() {
+		return ErrRequiredArchsOrURLAndSha
 	}
 	return nil
 }
 
 func (o AdminOPAVersionCreateOptions) validArch() bool {
+	if o.Archs == nil && o.URL != "" && o.SHA != "" {
+		return true
+	}
+
+	emptyToolVersionFields := o.URL == "" && o.SHA == ""
+
 	for _, a := range o.Archs {
-		if a.URL != "" && a.Sha != "" && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64) {
-			return true
+		if !validArch(a) || !emptyToolVersionFields && (o.URL != a.URL || o.SHA != a.Sha) {
+			return false
 		}
 	}
-	return false
+	return true
 }

--- a/admin_opa_version.go
+++ b/admin_opa_version.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 	"time"
 )
 
@@ -42,17 +43,18 @@ type adminOPAVersions struct {
 
 // AdminOPAVersion represents a OPA Version
 type AdminOPAVersion struct {
-	ID               string    `jsonapi:"primary,opa-versions"`
-	Version          string    `jsonapi:"attr,version"`
-	URL              string    `jsonapi:"attr,url"`
-	SHA              string    `jsonapi:"attr,sha"`
-	Deprecated       bool      `jsonapi:"attr,deprecated"`
-	DeprecatedReason *string   `jsonapi:"attr,deprecated-reason,omitempty"`
-	Official         bool      `jsonapi:"attr,official"`
-	Enabled          bool      `jsonapi:"attr,enabled"`
-	Beta             bool      `jsonapi:"attr,beta"`
-	Usage            int       `jsonapi:"attr,usage"`
-	CreatedAt        time.Time `jsonapi:"attr,created-at,iso8601"`
+	ID               string                     `jsonapi:"primary,opa-versions"`
+	Version          string                     `jsonapi:"attr,version"`
+	URL              string                     `jsonapi:"attr,url,omitempty"`
+	SHA              string                     `jsonapi:"attr,sha,omitempty"`
+	Deprecated       bool                       `jsonapi:"attr,deprecated"`
+	DeprecatedReason *string                    `jsonapi:"attr,deprecated-reason,omitempty"`
+	Official         bool                       `jsonapi:"attr,official"`
+	Enabled          bool                       `jsonapi:"attr,enabled"`
+	Beta             bool                       `jsonapi:"attr,beta"`
+	Usage            int                        `jsonapi:"attr,usage"`
+	CreatedAt        time.Time                  `jsonapi:"attr,created-at,iso8601"`
+	Archs            []*ToolVersionArchitecture `jsonapi:"attr,archs,omitempty"`
 }
 
 // AdminOPAVersionsListOptions represents the options for listing
@@ -69,28 +71,30 @@ type AdminOPAVersionsListOptions struct {
 
 // AdminOPAVersionCreateOptions for creating an OPA version.
 type AdminOPAVersionCreateOptions struct {
-	Type             string  `jsonapi:"primary,opa-versions"`
-	Version          string  `jsonapi:"attr,version"` // Required
-	URL              string  `jsonapi:"attr,url"`     // Required
-	SHA              string  `jsonapi:"attr,sha"`     // Required
-	Official         *bool   `jsonapi:"attr,official,omitempty"`
-	Deprecated       *bool   `jsonapi:"attr,deprecated,omitempty"`
-	DeprecatedReason *string `jsonapi:"attr,deprecated-reason,omitempty"`
-	Enabled          *bool   `jsonapi:"attr,enabled,omitempty"`
-	Beta             *bool   `jsonapi:"attr,beta,omitempty"`
+	Type             string                     `jsonapi:"primary,opa-versions"`
+	Version          string                     `jsonapi:"attr,version"`       // Required
+	URL              string                     `jsonapi:"attr,url,omitempty"` // Required w/ SHA unless Archs are provided
+	SHA              string                     `jsonapi:"attr,sha,omitempty"` // Required w/ URL unless Archs are provided
+	Official         *bool                      `jsonapi:"attr,official,omitempty"`
+	Deprecated       *bool                      `jsonapi:"attr,deprecated,omitempty"`
+	DeprecatedReason *string                    `jsonapi:"attr,deprecated-reason,omitempty"`
+	Enabled          *bool                      `jsonapi:"attr,enabled,omitempty"`
+	Beta             *bool                      `jsonapi:"attr,beta,omitempty"`
+	Archs            []*ToolVersionArchitecture `jsonapi:"attr,archs,omitempty"` // Required unless URL and SHA are provided
 }
 
 // AdminOPAVersionUpdateOptions for updating OPA version.
 type AdminOPAVersionUpdateOptions struct {
-	Type             string  `jsonapi:"primary,opa-versions"`
-	Version          *string `jsonapi:"attr,version,omitempty"`
-	URL              *string `jsonapi:"attr,url,omitempty"`
-	SHA              *string `jsonapi:"attr,sha,omitempty"`
-	Official         *bool   `jsonapi:"attr,official,omitempty"`
-	Deprecated       *bool   `jsonapi:"attr,deprecated,omitempty"`
-	DeprecatedReason *string `jsonapi:"attr,deprecated-reason,omitempty"`
-	Enabled          *bool   `jsonapi:"attr,enabled,omitempty"`
-	Beta             *bool   `jsonapi:"attr,beta,omitempty"`
+	Type             string                     `jsonapi:"primary,opa-versions"`
+	Version          *string                    `jsonapi:"attr,version,omitempty"`
+	URL              *string                    `jsonapi:"attr,url,omitempty"`
+	SHA              *string                    `jsonapi:"attr,sha,omitempty"`
+	Official         *bool                      `jsonapi:"attr,official,omitempty"`
+	Deprecated       *bool                      `jsonapi:"attr,deprecated,omitempty"`
+	DeprecatedReason *string                    `jsonapi:"attr,deprecated-reason,omitempty"`
+	Enabled          *bool                      `jsonapi:"attr,enabled,omitempty"`
+	Beta             *bool                      `jsonapi:"attr,beta,omitempty"`
+	Archs            []*ToolVersionArchitecture `jsonapi:"attr,archs,omitempty"`
 }
 
 // AdminOPAVersionsList represents a list of OPA versions.
@@ -192,18 +196,23 @@ func (a *adminOPAVersions) Delete(ctx context.Context, id string) error {
 }
 
 func (o AdminOPAVersionCreateOptions) valid() error {
-	if (o == AdminOPAVersionCreateOptions{}) {
+	if (reflect.DeepEqual(o, AdminOPAVersionCreateOptions{})) {
 		return ErrRequiredOPAVerCreateOps
 	}
 	if o.Version == "" {
 		return ErrRequiredVersion
 	}
-	if o.URL == "" {
-		return ErrRequiredURL
+	if !o.validArch() && (o.URL == "" || o.SHA == "") {
+		return ErrRequiredArchOrURLAndSha
 	}
-	if o.SHA == "" {
-		return ErrRequiredSha
-	}
-
 	return nil
+}
+
+func (o AdminOPAVersionCreateOptions) validArch() bool {
+	for _, a := range o.Archs {
+		if a.URL != "" && a.Sha != "" && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64) {
+			return true
+		}
+	}
+	return false
 }

--- a/admin_opa_version_integration_test.go
+++ b/admin_opa_version_integration_test.go
@@ -102,7 +102,46 @@ func TestAdminOPAVersions_CreateDelete(t *testing.T) {
 	ctx := context.Background()
 	version := createAdminOPAVersion()
 
-	t.Run("with valid options", func(t *testing.T) {
+	t.Run("with valid options including archs", func(t *testing.T) {
+		opts := AdminOPAVersionCreateOptions{
+			Version:          version,
+			Deprecated:       Bool(true),
+			DeprecatedReason: String("Test Reason"),
+			Official:         Bool(false),
+			Enabled:          Bool(false),
+			Beta:             Bool(false),
+			Archs: []*ToolVersionArchitecture{
+				{
+					URL:  "https://www.hashicorp.com",
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: amd64,
+				},
+				{
+					URL:  "https://www.hashicorp.com",
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: arm64,
+				}},
+		}
+		ov, err := client.Admin.OPAVersions.Create(ctx, opts)
+		require.NoError(t, err)
+
+		defer func() {
+			deleteErr := client.Admin.OPAVersions.Delete(ctx, ov.ID)
+			require.NoError(t, deleteErr)
+		}()
+
+		assert.Equal(t, opts.Version, ov.Version)
+		assert.ElementsMatch(t, opts.Archs, ov.Archs)
+		assert.Equal(t, *opts.Official, ov.Official)
+		assert.Equal(t, *opts.Deprecated, ov.Deprecated)
+		assert.Equal(t, *opts.DeprecatedReason, *ov.DeprecatedReason)
+		assert.Equal(t, *opts.Enabled, ov.Enabled)
+		assert.Equal(t, *opts.Beta, ov.Beta)
+	})
+
+	t.Run("with valid options including, url, and sha", func(t *testing.T) {
 		opts := AdminOPAVersionCreateOptions{
 			Version:          version,
 			URL:              "https://www.hashicorp.com",
@@ -131,8 +170,8 @@ func TestAdminOPAVersions_CreateDelete(t *testing.T) {
 		assert.Equal(t, *opts.Beta, ov.Beta)
 	})
 
-	t.Run("with only required options", func(t *testing.T) {
-		version := createAdminOPAVersion()
+	t.Run("with only required options including tool version url and sha", func(t *testing.T) {
+		version = createAdminOPAVersion()
 		opts := AdminOPAVersionCreateOptions{
 			Version: version,
 			URL:     "https://www.hashicorp.com",
@@ -156,6 +195,41 @@ func TestAdminOPAVersions_CreateDelete(t *testing.T) {
 		assert.Equal(t, false, ov.Beta)
 	})
 
+	t.Run("with only required options including archs", func(t *testing.T) {
+		version = createAdminOPAVersion()
+		opts := AdminOPAVersionCreateOptions{
+			Version: version,
+			Archs: []*ToolVersionArchitecture{
+				{
+					URL:  "https://www.hashicorp.com",
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: amd64,
+				},
+				{
+					URL:  "https://www.hashicorp.com",
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: arm64,
+				}},
+		}
+		ov, err := client.Admin.OPAVersions.Create(ctx, opts)
+		require.NoError(t, err)
+
+		defer func() {
+			deleteErr := client.Admin.OPAVersions.Delete(ctx, ov.ID)
+			require.NoError(t, deleteErr)
+		}()
+
+		assert.Equal(t, opts.Version, ov.Version)
+		assert.ElementsMatch(t, opts.Archs, ov.Archs)
+		assert.Equal(t, false, ov.Official)
+		assert.Equal(t, false, ov.Deprecated)
+		assert.Nil(t, ov.DeprecatedReason)
+		assert.Equal(t, true, ov.Enabled)
+		assert.Equal(t, false, ov.Beta)
+	})
+
 	t.Run("with empty options", func(t *testing.T) {
 		_, err := client.Admin.OPAVersions.Create(ctx, AdminOPAVersionCreateOptions{})
 		require.Equal(t, err, ErrRequiredOPAVerCreateOps)
@@ -170,6 +244,7 @@ func TestAdminOPAVersions_ReadUpdate(t *testing.T) {
 
 	t.Run("reads and updates", func(t *testing.T) {
 		version := createAdminOPAVersion()
+		sha := String(genSha(t))
 		opts := AdminOPAVersionCreateOptions{
 			Version:          version,
 			URL:              "https://www.hashicorp.com",
@@ -179,6 +254,12 @@ func TestAdminOPAVersions_ReadUpdate(t *testing.T) {
 			DeprecatedReason: String("Test Reason"),
 			Enabled:          Bool(false),
 			Beta:             Bool(false),
+			Archs: []*ToolVersionArchitecture{{
+				URL:  "https://www.hashicorp.com",
+				Sha:  *sha,
+				OS:   linux,
+				Arch: amd64,
+			}},
 		}
 		ov, err := client.Admin.OPAVersions.Create(ctx, opts)
 		require.NoError(t, err)
@@ -193,8 +274,9 @@ func TestAdminOPAVersions_ReadUpdate(t *testing.T) {
 		require.NoError(t, err)
 
 		assert.Equal(t, opts.Version, ov.Version)
-		assert.Equal(t, opts.URL, ov.URL)
-		assert.Equal(t, opts.SHA, ov.SHA)
+		assert.Equal(t, opts.Archs[0].URL, ov.URL)
+		assert.Equal(t, opts.Archs[0].Sha, ov.SHA)
+		assert.ElementsMatch(t, opts.Archs, ov.Archs)
 		assert.Equal(t, *opts.Official, ov.Official)
 		assert.Equal(t, *opts.Deprecated, ov.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *ov.DeprecatedReason)
@@ -215,10 +297,36 @@ func TestAdminOPAVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, updateVersion, ov.Version)
 		assert.Equal(t, updateURL, ov.URL)
 		assert.Equal(t, opts.SHA, ov.SHA)
+		assert.Equal(t, updateURL, ov.Archs[0].URL)
+		assert.Equal(t, opts.SHA, ov.Archs[0].Sha)
 		assert.Equal(t, *opts.Official, ov.Official)
 		assert.Equal(t, *updateOpts.Deprecated, ov.Deprecated)
 		assert.Equal(t, *opts.Enabled, ov.Enabled)
 		assert.Equal(t, *opts.Beta, ov.Beta)
+
+		updateOpts = AdminOPAVersionUpdateOptions{
+			Archs: []*ToolVersionArchitecture{
+				{
+					URL:  "https://www.hashicorp.com/update",
+					Sha:  *sha,
+					OS:   linux,
+					Arch: amd64,
+				},
+				{
+					URL:  "https://www.hashicorp.com/update/arm64",
+					Sha:  *sha,
+					OS:   linux,
+					Arch: arm64,
+				},
+			},
+		}
+
+		ov, err = client.Admin.OPAVersions.Update(ctx, id, updateOpts)
+		require.NoError(t, err)
+
+		assert.Equal(t, "https://www.hashicorp.com/update", ov.URL)
+		assert.Equal(t, opts.SHA, ov.SHA)
+		assert.ElementsMatch(t, updateOpts.Archs, ov.Archs)
 	})
 
 	t.Run("with non-existent OPA version", func(t *testing.T) {

--- a/admin_opa_version_integration_test.go
+++ b/admin_opa_version_integration_test.go
@@ -133,7 +133,6 @@ func TestAdminOPAVersions_CreateDelete(t *testing.T) {
 		}()
 
 		assert.Equal(t, opts.Version, ov.Version)
-		assert.ElementsMatch(t, opts.Archs, ov.Archs)
 		assert.Equal(t, *opts.Official, ov.Official)
 		assert.Equal(t, *opts.Deprecated, ov.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *ov.DeprecatedReason)
@@ -222,7 +221,6 @@ func TestAdminOPAVersions_CreateDelete(t *testing.T) {
 		}()
 
 		assert.Equal(t, opts.Version, ov.Version)
-		assert.ElementsMatch(t, opts.Archs, ov.Archs)
 		assert.Equal(t, false, ov.Official)
 		assert.Equal(t, false, ov.Deprecated)
 		assert.Nil(t, ov.DeprecatedReason)
@@ -276,7 +274,6 @@ func TestAdminOPAVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, opts.Version, ov.Version)
 		assert.Equal(t, opts.Archs[0].URL, ov.URL)
 		assert.Equal(t, opts.Archs[0].Sha, ov.SHA)
-		assert.ElementsMatch(t, opts.Archs, ov.Archs)
 		assert.Equal(t, *opts.Official, ov.Official)
 		assert.Equal(t, *opts.Deprecated, ov.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *ov.DeprecatedReason)
@@ -297,36 +294,10 @@ func TestAdminOPAVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, updateVersion, ov.Version)
 		assert.Equal(t, updateURL, ov.URL)
 		assert.Equal(t, opts.SHA, ov.SHA)
-		assert.Equal(t, updateURL, ov.Archs[0].URL)
-		assert.Equal(t, opts.SHA, ov.Archs[0].Sha)
 		assert.Equal(t, *opts.Official, ov.Official)
 		assert.Equal(t, *updateOpts.Deprecated, ov.Deprecated)
 		assert.Equal(t, *opts.Enabled, ov.Enabled)
 		assert.Equal(t, *opts.Beta, ov.Beta)
-
-		updateOpts = AdminOPAVersionUpdateOptions{
-			Archs: []*ToolVersionArchitecture{
-				{
-					URL:  "https://www.hashicorp.com/update",
-					Sha:  *sha,
-					OS:   linux,
-					Arch: amd64,
-				},
-				{
-					URL:  "https://www.hashicorp.com/update/arm64",
-					Sha:  *sha,
-					OS:   linux,
-					Arch: arm64,
-				},
-			},
-		}
-
-		ov, err = client.Admin.OPAVersions.Update(ctx, id, updateOpts)
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://www.hashicorp.com/update", ov.URL)
-		assert.Equal(t, opts.SHA, ov.SHA)
-		assert.ElementsMatch(t, updateOpts.Archs, ov.Archs)
 	})
 
 	t.Run("with non-existent OPA version", func(t *testing.T) {

--- a/admin_sentinel_version.go
+++ b/admin_sentinel_version.go
@@ -202,17 +202,23 @@ func (o AdminSentinelVersionCreateOptions) valid() error {
 	if o.Version == "" {
 		return ErrRequiredVersion
 	}
-	if !o.validArch() && (o.URL == "" || o.SHA == "") {
-		return ErrRequiredArchOrURLAndSha
+	if !o.validArch() {
+		return ErrRequiredArchsOrURLAndSha
 	}
 	return nil
 }
 
 func (o AdminSentinelVersionCreateOptions) validArch() bool {
+	if o.Archs == nil && o.URL != "" && o.SHA != "" {
+		return true
+	}
+
+	emptyToolVersionFields := o.URL == "" && o.SHA == ""
+
 	for _, a := range o.Archs {
-		if a.URL != "" && a.Sha != "" && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64) {
-			return true
+		if !validArch(a) || !emptyToolVersionFields && (o.URL != a.URL || o.SHA != a.Sha) {
+			return false
 		}
 	}
-	return false
+	return true
 }

--- a/admin_sentinel_version.go
+++ b/admin_sentinel_version.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"reflect"
 	"time"
 )
 
@@ -42,17 +43,18 @@ type adminSentinelVersions struct {
 
 // AdminSentinelVersion represents a Sentinel Version
 type AdminSentinelVersion struct {
-	ID               string    `jsonapi:"primary,sentinel-versions"`
-	Version          string    `jsonapi:"attr,version"`
-	URL              string    `jsonapi:"attr,url"`
-	SHA              string    `jsonapi:"attr,sha"`
-	Deprecated       bool      `jsonapi:"attr,deprecated"`
-	DeprecatedReason *string   `jsonapi:"attr,deprecated-reason,omitempty"`
-	Official         bool      `jsonapi:"attr,official"`
-	Enabled          bool      `jsonapi:"attr,enabled"`
-	Beta             bool      `jsonapi:"attr,beta"`
-	Usage            int       `jsonapi:"attr,usage"`
-	CreatedAt        time.Time `jsonapi:"attr,created-at,iso8601"`
+	ID               string                     `jsonapi:"primary,sentinel-versions"`
+	Version          string                     `jsonapi:"attr,version"`
+	URL              string                     `jsonapi:"attr,url,omitempty"`
+	SHA              string                     `jsonapi:"attr,sha,omitempty"`
+	Deprecated       bool                       `jsonapi:"attr,deprecated"`
+	DeprecatedReason *string                    `jsonapi:"attr,deprecated-reason,omitempty"`
+	Official         bool                       `jsonapi:"attr,official"`
+	Enabled          bool                       `jsonapi:"attr,enabled"`
+	Beta             bool                       `jsonapi:"attr,beta"`
+	Usage            int                        `jsonapi:"attr,usage"`
+	CreatedAt        time.Time                  `jsonapi:"attr,created-at,iso8601"`
+	Archs            []*ToolVersionArchitecture `jsonapi:"attr,archs,omitempty"`
 }
 
 // AdminSentinelVersionsListOptions represents the options for listing
@@ -69,28 +71,30 @@ type AdminSentinelVersionsListOptions struct {
 
 // AdminSentinelVersionCreateOptions for creating an Sentinel version.
 type AdminSentinelVersionCreateOptions struct {
-	Type             string  `jsonapi:"primary,sentinel-versions"`
-	Version          string  `jsonapi:"attr,version"` // Required
-	URL              string  `jsonapi:"attr,url"`     // Required
-	SHA              string  `jsonapi:"attr,sha"`     // Required
-	Official         *bool   `jsonapi:"attr,official,omitempty"`
-	Deprecated       *bool   `jsonapi:"attr,deprecated,omitempty"`
-	DeprecatedReason *string `jsonapi:"attr,deprecated-reason,omitempty"`
-	Enabled          *bool   `jsonapi:"attr,enabled,omitempty"`
-	Beta             *bool   `jsonapi:"attr,beta,omitempty"`
+	Type             string                     `jsonapi:"primary,sentinel-versions"`
+	Version          string                     `jsonapi:"attr,version"`       // Required
+	URL              string                     `jsonapi:"attr,url,omitempty"` // Required w/ SHA unless Archs are provided
+	SHA              string                     `jsonapi:"attr,sha,omitempty"` // Required w/ URL unless Archs are provided
+	Official         *bool                      `jsonapi:"attr,official,omitempty"`
+	Deprecated       *bool                      `jsonapi:"attr,deprecated,omitempty"`
+	DeprecatedReason *string                    `jsonapi:"attr,deprecated-reason,omitempty"`
+	Enabled          *bool                      `jsonapi:"attr,enabled,omitempty"`
+	Beta             *bool                      `jsonapi:"attr,beta,omitempty"`
+	Archs            []*ToolVersionArchitecture `jsonapi:"attr,archs,omitempty"` // Required unless URL and SHA are provided
 }
 
 // AdminSentinelVersionUpdateOptions for updating Sentinel version.
 type AdminSentinelVersionUpdateOptions struct {
-	Type             string  `jsonapi:"primary,sentinel-versions"`
-	Version          *string `jsonapi:"attr,version,omitempty"`
-	URL              *string `jsonapi:"attr,url,omitempty"`
-	SHA              *string `jsonapi:"attr,sha,omitempty"`
-	Official         *bool   `jsonapi:"attr,official,omitempty"`
-	Deprecated       *bool   `jsonapi:"attr,deprecated,omitempty"`
-	DeprecatedReason *string `jsonapi:"attr,deprecated-reason,omitempty"`
-	Enabled          *bool   `jsonapi:"attr,enabled,omitempty"`
-	Beta             *bool   `jsonapi:"attr,beta,omitempty"`
+	Type             string                     `jsonapi:"primary,sentinel-versions"`
+	Version          *string                    `jsonapi:"attr,version,omitempty"`
+	URL              *string                    `jsonapi:"attr,url,omitempty"`
+	SHA              *string                    `jsonapi:"attr,sha,omitempty"`
+	Official         *bool                      `jsonapi:"attr,official,omitempty"`
+	Deprecated       *bool                      `jsonapi:"attr,deprecated,omitempty"`
+	DeprecatedReason *string                    `jsonapi:"attr,deprecated-reason,omitempty"`
+	Enabled          *bool                      `jsonapi:"attr,enabled,omitempty"`
+	Beta             *bool                      `jsonapi:"attr,beta,omitempty"`
+	Archs            []*ToolVersionArchitecture `jsonapi:"attr,archs,omitempty"`
 }
 
 // AdminSentinelVersionsList represents a list of Sentinel versions.
@@ -192,18 +196,23 @@ func (a *adminSentinelVersions) Delete(ctx context.Context, id string) error {
 }
 
 func (o AdminSentinelVersionCreateOptions) valid() error {
-	if (o == AdminSentinelVersionCreateOptions{}) {
+	if (reflect.DeepEqual(o, AdminSentinelVersionCreateOptions{})) {
 		return ErrRequiredSentinelVerCreateOps
 	}
 	if o.Version == "" {
 		return ErrRequiredVersion
 	}
-	if o.URL == "" {
-		return ErrRequiredURL
+	if !o.validArch() && (o.URL == "" || o.SHA == "") {
+		return ErrRequiredArchOrURLAndSha
 	}
-	if o.SHA == "" {
-		return ErrRequiredSha
-	}
-
 	return nil
+}
+
+func (o AdminSentinelVersionCreateOptions) validArch() bool {
+	for _, a := range o.Archs {
+		if a.URL != "" && a.Sha != "" && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64) {
+			return true
+		}
+	}
+	return false
 }

--- a/admin_sentinel_version_integration_test.go
+++ b/admin_sentinel_version_integration_test.go
@@ -133,7 +133,6 @@ func TestAdminSentinelVersions_CreateDelete(t *testing.T) {
 		}()
 
 		assert.Equal(t, opts.Version, sv.Version)
-		assert.ElementsMatch(t, opts.Archs, sv.Archs)
 		assert.Equal(t, *opts.Official, sv.Official)
 		assert.Equal(t, *opts.Deprecated, sv.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *sv.DeprecatedReason)
@@ -222,7 +221,6 @@ func TestAdminSentinelVersions_CreateDelete(t *testing.T) {
 		}()
 
 		assert.Equal(t, opts.Version, sv.Version)
-		assert.ElementsMatch(t, opts.Archs, sv.Archs)
 		assert.Equal(t, false, sv.Official)
 		assert.Equal(t, false, sv.Deprecated)
 		assert.Nil(t, sv.DeprecatedReason)
@@ -276,7 +274,6 @@ func TestAdminSentinelVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, opts.Version, sv.Version)
 		assert.Equal(t, opts.Archs[0].URL, sv.URL)
 		assert.Equal(t, opts.Archs[0].Sha, sv.SHA)
-		assert.ElementsMatch(t, opts.Archs, sv.Archs)
 		assert.Equal(t, *opts.Official, sv.Official)
 		assert.Equal(t, *opts.Deprecated, sv.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *sv.DeprecatedReason)
@@ -297,37 +294,10 @@ func TestAdminSentinelVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, updateVersion, sv.Version)
 		assert.Equal(t, updateURL, sv.URL)
 		assert.Equal(t, opts.SHA, sv.SHA)
-		assert.Equal(t, updateURL, sv.Archs[0].URL)
-		assert.Equal(t, opts.SHA, sv.Archs[0].Sha)
 		assert.Equal(t, *opts.Official, sv.Official)
 		assert.Equal(t, *updateOpts.Deprecated, sv.Deprecated)
 		assert.Equal(t, *opts.Enabled, sv.Enabled)
 		assert.Equal(t, *opts.Beta, sv.Beta)
-
-		updateOpts = AdminSentinelVersionUpdateOptions{
-			Archs: []*ToolVersionArchitecture{
-				{
-					URL:  "https://www.hashicorp.com/update",
-					Sha:  *sha,
-					OS:   linux,
-					Arch: amd64,
-				},
-				{
-					URL:  "https://www.hashicorp.com/update/arm64",
-					Sha:  *sha,
-					OS:   linux,
-					Arch: arm64,
-				},
-			},
-		}
-
-		sv, err = client.Admin.SentinelVersions.Update(ctx, id, updateOpts)
-
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://www.hashicorp.com/update", sv.URL)
-		assert.Equal(t, opts.SHA, sv.SHA)
-		assert.ElementsMatch(t, updateOpts.Archs, sv.Archs)
 	})
 
 	t.Run("with non-existent Sentinel version", func(t *testing.T) {

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -223,12 +223,10 @@ func (o AdminTerraformVersionCreateOptions) valid() error {
 }
 
 func (o AdminTerraformVersionCreateOptions) validArch() bool {
-	var valid bool
 	for _, a := range o.Archs {
-		valid = validString(&a.URL) && validString(&a.Sha) && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64)
-		if valid {
-			break
+		if a.URL != "" && a.Sha != "" && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64) {
+			return true
 		}
 	}
-	return valid
+	return false
 }

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -102,7 +102,7 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()
 
-	t.Run("with valid options and archs", func(t *testing.T) {
+	t.Run("with valid options including archs", func(t *testing.T) {
 		opts := AdminTerraformVersionCreateOptions{
 			Version:          String(genSafeRandomTerraformVersion()),
 			Deprecated:       Bool(true),
@@ -293,7 +293,6 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		}
 
 		tfv, err = client.Admin.TerraformVersions.Update(ctx, id, updateOpts)
-
 		require.NoError(t, err)
 
 		assert.Equal(t, updateVersion, tfv.Version)

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -133,7 +133,6 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		}()
 
 		assert.Equal(t, *opts.Version, tfv.Version)
-		assert.ElementsMatch(t, opts.Archs, tfv.Archs)
 		assert.Equal(t, *opts.Official, tfv.Official)
 		assert.Equal(t, *opts.Deprecated, tfv.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *tfv.DeprecatedReason)
@@ -222,7 +221,6 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 		}()
 
 		assert.Equal(t, *opts.Version, tfv.Version)
-		assert.ElementsMatch(t, opts.Archs, tfv.Archs)
 		assert.Equal(t, false, tfv.Official)
 		assert.Equal(t, false, tfv.Deprecated)
 		assert.Nil(t, tfv.DeprecatedReason)
@@ -276,7 +274,6 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, *opts.Version, tfv.Version)
 		assert.Equal(t, opts.Archs[0].URL, tfv.URL)
 		assert.Equal(t, opts.Archs[0].Sha, tfv.Sha)
-		assert.ElementsMatch(t, opts.Archs, tfv.Archs)
 		assert.Equal(t, *opts.Official, tfv.Official)
 		assert.Equal(t, *opts.Deprecated, tfv.Deprecated)
 		assert.Equal(t, *opts.DeprecatedReason, *tfv.DeprecatedReason)
@@ -298,37 +295,10 @@ func TestAdminTerraformVersions_ReadUpdate(t *testing.T) {
 		assert.Equal(t, updateVersion, tfv.Version)
 		assert.Equal(t, updateURL, tfv.URL)
 		assert.Equal(t, *opts.Sha, tfv.Sha)
-		assert.Equal(t, updateURL, tfv.Archs[0].URL)
-		assert.Equal(t, *opts.Sha, tfv.Archs[0].Sha)
 		assert.Equal(t, *opts.Official, tfv.Official)
 		assert.Equal(t, *updateOpts.Deprecated, tfv.Deprecated)
 		assert.Equal(t, *opts.Enabled, tfv.Enabled)
 		assert.Equal(t, *opts.Beta, tfv.Beta)
-
-		updateOpts = AdminTerraformVersionUpdateOptions{
-			Archs: []*ToolVersionArchitecture{
-				{
-					URL:  "https://www.hashicorp.com/update",
-					Sha:  *sha,
-					OS:   linux,
-					Arch: amd64,
-				},
-				{
-					URL:  "https://www.hashicorp.com/update/arm64",
-					Sha:  *sha,
-					OS:   linux,
-					Arch: arm64,
-				},
-			},
-		}
-
-		tfv, err = client.Admin.TerraformVersions.Update(ctx, id, updateOpts)
-
-		require.NoError(t, err)
-
-		assert.Equal(t, "https://www.hashicorp.com/update", tfv.URL)
-		assert.Equal(t, *opts.Sha, tfv.Sha)
-		assert.ElementsMatch(t, updateOpts.Archs, tfv.Archs)
 	})
 
 	t.Run("with non-existent terraform version", func(t *testing.T) {

--- a/errors.go
+++ b/errors.go
@@ -276,7 +276,7 @@ var (
 
 	ErrRequiredURL = errors.New("url is required")
 
-	ErrRequiredArchOrURLAndSha = errors.New("valid arch or url and sha is required")
+	ErrRequiredArchsOrURLAndSha = errors.New("valid archs or url and sha are required")
 
 	ErrRequiredAPIURL = errors.New("API URL is required")
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

This PR updates the OPA and Sentinel admin versions to use the Archs field which was added to the tool version APIs as a part of the Arm64 Agent Support project. 

## External links

- [Jira](https://hashicorp.atlassian.net/browse/TFDN-245?atlOrigin=eyJpIjoiMWQ0ZDcwMDBiZGQ1NDFjN2JlNTM1OGEyYzljMzAxODUiLCJwIjoiaiJ9)
- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/1714)

