### PR TITLE
Add IngressAttributes to PolicySetVersion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,5 @@
 # Unreleased
 
-<<<<<<< HEAD
 ## Enhancements
 * Adds `IngressAttributes` field to `PolicySetVersion` by @jpadrianoGo [#1092](https://github.com/hashicorp/go-tfe/pull/1092)
 
@@ -10,10 +9,6 @@
 * Adds BETA support for `PolicyPaths` to the `Runs` interface, by sebasslash [#1104](https://github.com/hashicorp/go-tfe/pull/1104)
 
 # v1.79.0
-=======
-* Adds `AgentPool` field to the OAuthClientUpdateOptions struct, which is used to associate a VCS Provider with an AgentPool for PrivateVCS support  by @jpogran [#1075](https://github.com/hashicorp/go-tfe/pull/1075)
-* Adds `IngressAttributes` field to `PolicySetVersion` by @jpadrianoGo [#1092](https://github.com/hashicorp/go-tfe/pull/1092)
->>>>>>> Updated changelog
 
 ## BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+<<<<<<< HEAD
 ## Enhancements
 * Adds `IngressAttributes` field to `PolicySetVersion` by @jpadrianoGo [#1092](https://github.com/hashicorp/go-tfe/pull/1092)
 
@@ -9,6 +10,10 @@
 * Adds BETA support for `PolicyPaths` to the `Runs` interface, by sebasslash [#1104](https://github.com/hashicorp/go-tfe/pull/1104)
 
 # v1.79.0
+=======
+* Adds `AgentPool` field to the OAuthClientUpdateOptions struct, which is used to associate a VCS Provider with an AgentPool for PrivateVCS support  by @jpogran [#1075](https://github.com/hashicorp/go-tfe/pull/1075)
+* Adds `IngressAttributes` field to `PolicySetVersion` by @jpadrianoGo [#1092](https://github.com/hashicorp/go-tfe/pull/1092)
+>>>>>>> Updated changelog
 
 ## BREAKING CHANGES
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Enhancements
+* Adds `IngressAttributes` field to `PolicySetVersion` by @jpadrianoGo [#1092](https://github.com/hashicorp/go-tfe/pull/1092)
+
 # v1.80.0
 
 ## Enhancements

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -78,6 +78,13 @@ type PolicySetVersion struct {
 	CreatedAt        time.Time                        `jsonapi:"attr,created-at,iso8601"`
 	UpdatedAt        time.Time                        `jsonapi:"attr,updated-at,iso8601"`
 
+	// Ingress-attributes
+	IngressAttributes struct {
+		CommitSHA  string `jsonapi:"attr,commit-sha"`
+		CommitURL  string `jsonapi:"attr,commit-url"`
+		Identifier string `jsonapi:"attr,identifier"`
+	} `jsonapi:"attr,ingress-attributes"`
+
 	// Relations
 	PolicySet *PolicySet `jsonapi:"relation,policy-set"`
 

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -69,21 +69,15 @@ type PolicySetVersionStatusTimestamps struct {
 
 // PolicySetVersion represents a Terraform Enterprise Policy Set Version
 type PolicySetVersion struct {
-	ID               string                           `jsonapi:"primary,policy-set-versions"`
-	Source           PolicySetVersionSource           `jsonapi:"attr,source"`
-	Status           PolicySetVersionStatus           `jsonapi:"attr,status"`
-	StatusTimestamps PolicySetVersionStatusTimestamps `jsonapi:"attr,status-timestamps"`
-	Error            string                           `jsonapi:"attr,error"`
-	ErrorMessage     string                           `jsonapi:"attr,error-message"`
-	CreatedAt        time.Time                        `jsonapi:"attr,created-at,iso8601"`
-	UpdatedAt        time.Time                        `jsonapi:"attr,updated-at,iso8601"`
-
-	// Ingress-attributes
-	IngressAttributes struct {
-		CommitSHA  string `jsonapi:"attr,commit-sha"`
-		CommitURL  string `jsonapi:"attr,commit-url"`
-		Identifier string `jsonapi:"attr,identifier"`
-	} `jsonapi:"attr,ingress-attributes"`
+	ID                string                           `jsonapi:"primary,policy-set-versions"`
+	Source            PolicySetVersionSource           `jsonapi:"attr,source"`
+	Status            PolicySetVersionStatus           `jsonapi:"attr,status"`
+	StatusTimestamps  PolicySetVersionStatusTimestamps `jsonapi:"attr,status-timestamps"`
+	Error             string                           `jsonapi:"attr,error"`
+	ErrorMessage      string                           `jsonapi:"attr,error-message"`
+	CreatedAt         time.Time                        `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt         time.Time                        `jsonapi:"attr,updated-at,iso8601"`
+	IngressAttributes *IngressAttributes               `jsonapi:"attr,ingress-attributes"`
 
 	// Relations
 	PolicySet *PolicySet `jsonapi:"relation,policy-set"`

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -184,7 +184,6 @@ func TestPolicySetVersionsIngressAttributes(t *testing.T) {
 		psv, err := client.PolicySetVersions.Read(ctx, ps.NewestVersion.ID)
 		require.NoError(t, err)
 
-		require.NotNil(t, psv.IngressAttributes)
 		assert.NotZero(t, psv.IngressAttributes.CommitSHA)
 		assert.NotZero(t, psv.IngressAttributes.CommitURL)
 		assert.NotZero(t, psv.IngressAttributes.Identifier)

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -148,6 +148,8 @@ func TestPolicySetVersionsIngressAttributes(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
+	upgradeOrganizationSubscription(t, client, orgTest)
+
 	t.Run("with vcs", func(t *testing.T) {
 		githubIdentifier := os.Getenv("GITHUB_POLICY_SET_IDENTIFIER")
 		if githubIdentifier == "" {

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -184,6 +184,7 @@ func TestPolicySetVersionsIngressAttributes(t *testing.T) {
 		psv, err := client.PolicySetVersions.Read(ctx, ps.NewestVersion.ID)
 		require.NoError(t, err)
 
+		require.NotNil(t, psv.IngressAttributes)
 		assert.NotZero(t, psv.IngressAttributes.CommitSHA)
 		assert.NotZero(t, psv.IngressAttributes.CommitURL)
 		assert.NotZero(t, psv.IngressAttributes.Identifier)

--- a/policy_set_version_integration_test.go
+++ b/policy_set_version_integration_test.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"os"
 	"testing"
 	"time"
 
@@ -137,5 +138,64 @@ func TestPolicySetVersionsUploadURL(t *testing.T) {
 
 		_, err := psv.uploadURL()
 		assert.EqualError(t, err, "the Policy Set Version upload URL is empty")
+	})
+}
+
+func TestPolicySetVersionsIngressAttributes(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	t.Run("with vcs", func(t *testing.T) {
+		githubIdentifier := os.Getenv("GITHUB_POLICY_SET_IDENTIFIER")
+		if githubIdentifier == "" {
+			t.Skip("Export a valid GITHUB_POLICY_SET_IDENTIFIER before running this test")
+		}
+
+		otTest, otTestCleanup := createOAuthToken(t, client, orgTest)
+		defer otTestCleanup()
+
+		options := PolicySetCreateOptions{
+			Name:         String("vcs-policy-set"),
+			Kind:         Sentinel,
+			PoliciesPath: String("policy-sets/foo"),
+			VCSRepo: &VCSRepoOptions{
+				Branch:            String("policies"),
+				Identifier:        String(githubIdentifier),
+				OAuthTokenID:      String(otTest.ID),
+				IngressSubmodules: Bool(true),
+			},
+		}
+
+		ps, err := client.PolicySets.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		ps, err = client.PolicySets.ReadWithOptions(ctx, ps.ID, &PolicySetReadOptions{
+			Include: []PolicySetIncludeOpt{
+				PolicySetNewestVersion,
+			},
+		})
+		require.NoError(t, err)
+
+		psv, err := client.PolicySetVersions.Read(ctx, ps.NewestVersion.ID)
+		require.NoError(t, err)
+		require.NotNil(t, psv.IngressAttributes)
+		assert.NotZero(t, psv.IngressAttributes.CommitSHA)
+		assert.NotZero(t, psv.IngressAttributes.CommitURL)
+		assert.NotZero(t, psv.IngressAttributes.Identifier)
+	})
+
+	t.Run("without vcs", func(t *testing.T) {
+		psTest, psTestCleanup := createPolicySet(t, client, nil, nil, nil, nil, nil, "")
+		defer psTestCleanup()
+
+		psv, err := client.PolicySetVersions.Create(ctx, psTest.ID)
+		require.NoError(t, err)
+		require.NotNil(t, psv.IngressAttributes)
+		assert.Zero(t, psv.IngressAttributes.CommitSHA)
+		assert.Zero(t, psv.IngressAttributes.CommitURL)
+		assert.Zero(t, psv.IngressAttributes.Identifier)
 	})
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds an new PolicySetVersion field, `IngressAttributes` struct with `commit-sha`,`commit-url`, and `identifier` fields. PolicySetVersion now includes `IngressAttributes`.

The change aims to be part of automating policy-set creation and testing. This aligns PolicySetVersions.Read return with curl's return.

curl
--header "Authorization: Bearer $TOKEN"
--request GET
https://app.terraform.io/api/v2/policy-set-versions/polsetver-cXciu9nQwmk9Cfrn

PolicySetVersions.Read(ctx context.Context, policySetVersionID string) (*PolicySetVersion, error)

{ "data": { "id": "polsetver-***", "type": "policy-set-versions", "attributes": { "source": "github", "status": "ready", "status-timestamps": { "ready-at": "2024-11-10T00:14:59+00:00", "ingressing-at": "2024-11-10T00:14:54+00:00" }, "error": null, "error-message": null, "ingress-attributes": { "commit-sha": "***", "commit-url": "***", "identifier": "***" }, "created-at": "2024-11-10T00:14:54.604Z", "updated-at": "2024-11-10T00:14:59.500Z" }, "relationships": { "policy-set": { "data": { "id": "polset-***", "type": "policy-sets" } } }, "links": { "self": "/api/v2/policy-set-versions/polsetver-***" } } }

## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS` and `TFE_TOKEN`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" GITHUB_POLICY_SET_IDENTIFIER="username/repository" OAUTH_CLIENT_GITHUB_TOKEN="githubtoken" go test ./... -v -run TestPolicySetVersionsIngressAttributes`. The new tests should pass.
1.  `IngressAttributes` is read for PolicySetVersion.


## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" GITHUB_POLICY_SET_IDENTIFIER="username/repository" OAUTH_CLIENT_GITHUB_TOKEN="githubtoken" go test ./... -v -run TestPolicySetVersionsIngressAttributes

=== RUN   TestPolicySetVersionsIngressAttributes
=== RUN   TestPolicySetVersionsIngressAttributes/with_vcs
=== RUN   TestPolicySetVersionsIngressAttributes/without_vcs
--- PASS: TestPolicySetVersionsIngressAttributes (12.48s)
    --- PASS: TestPolicySetVersionsIngressAttributes/with_vcs (4.52s)
    --- PASS: TestPolicySetVersionsIngressAttributes/without_vcs (1.87s)
PASS
ok      github.com/hashicorp/go-tfe     12.482s
```
