### PR TITLE
tests(agent_pool): add skip reason for integration test

### DIFF
--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -272,7 +272,7 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 	t.Run("when updating only the name", func(t *testing.T) {
 		// TODO: Fix failing assertion on AllowedWorkspaces and un-skip
-		t.Skip()
+		t.Skip("Skipping test until we know why the API is no longer returning AllowedWorkspaces on update")
 
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
 		defer workspaceTestCleanup()


### PR DESCRIPTION
This PR adds a reason for a skipped integration test.