### PR TITLE
[IPL-7725] Adding Support for Calls to `/workspaces/{external_id}/all-vars` API Endpoint on HCP Terraform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Add support for HCP Terraform `/api/v2/workspaces/{external_id}/all-vars` API endpoint to fetch the list of all variables available to a workspace (include inherited variables from varsets) by @debrin-hc [#1105](https://github.com/hashicorp/go-tfe/pull/1105)
 
 ## Enhancements
 
@@ -27,8 +28,6 @@
 * Adds `AgentPool` field to the OAuthClientUpdateOptions struct, which is used to associate a VCS Provider with an AgentPool for PrivateVCS support  by @jpogran [#1075](https://github.com/hashicorp/go-tfe/pull/1075)
 
 * Add BETA support for use of OPA and Sentinel with Linux arm64 agents, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users @natalie-todd [#1090](https://github.com/hashicorp/go-tfe/pull/1090)
-
-* Add support for HCP Terraform `/api/v2/workspaces/{external_id}/all-vars` API endpoint to fetch the list of all variables available to a workspce (include inherited variables from varsets) by @debrin-hc [#1105](https://github.com/hashicorp/go-tfe/pull/1105)
 
 # v1.78.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 
 * Add BETA support for use of OPA and Sentinel with Linux arm64 agents, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users @natalie-todd [#1090](https://github.com/hashicorp/go-tfe/pull/1090)
 
+* Add support for HCP Terraform `/api/v2/workspaces/{external_id}/all-vars` API endpoint to fetch the list of all variables available to a workspce (include inherited variables from varsets) by @debrin-hc [#1105](https://github.com/hashicorp/go-tfe/pull/1105)
+
 # v1.78.0
 
 ## Enhancements

--- a/helper_test.go
+++ b/helper_test.go
@@ -2209,19 +2209,48 @@ func createTeamTokenWithOptions(t *testing.T, client *Client, tm *Team, options 
 }
 
 func createVariable(t *testing.T, client *Client, w *Workspace) (*Variable, func()) {
+	options := VariableCreateOptions{
+		Key:         String(randomString(t)),
+		Value:       String(randomString(t)),
+		Category:    Category(CategoryTerraform),
+		Description: String(randomString(t)),
+	}
+	return createVariableWithOptions(t, client, w, options)
+}
+
+func createVariableWithOptions(t *testing.T, client *Client, w *Workspace, options VariableCreateOptions) (*Variable, func()) {
 	var wCleanup func()
 
 	if w == nil {
 		w, wCleanup = createWorkspace(t, client, nil)
 	}
 
+	if options.Key == nil {
+		options.Key = String(randomString(t))
+	}
+
+	if options.Value == nil {
+		options.Value = String(randomString(t))
+	}
+
+	if options.Description == nil {
+		options.Description = String(randomString(t))
+	}
+
+	if options.Category == nil {
+		options.Category = Category(CategoryTerraform)
+	}
+
+	if options.HCL == nil {
+		options.HCL = Bool(false)
+	}
+
+	if options.Sensitive == nil {
+		options.Sensitive = Bool(false)
+	}
+
 	ctx := context.Background()
-	v, err := client.Variables.Create(ctx, w.ID, VariableCreateOptions{
-		Key:         String(randomString(t)),
-		Value:       String(randomString(t)),
-		Category:    Category(CategoryTerraform),
-		Description: String(randomString(t)),
-	})
+	v, err := client.Variables.Create(ctx, w.ID, options)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/mocks/variable_mocks.go
+++ b/mocks/variable_mocks.go
@@ -84,6 +84,21 @@ func (mr *MockVariablesMockRecorder) List(ctx, workspaceID, options any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockVariables)(nil).List), ctx, workspaceID, options)
 }
 
+// ListAll mocks base method.
+func (m *MockVariables) ListAll(ctx context.Context, workspaceID string, options *tfe.VariableListOptions) (*tfe.VariableList, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ListAll", ctx, workspaceID, options)
+	ret0, _ := ret[0].(*tfe.VariableList)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ListAll indicates an expected call of ListAll.
+func (mr *MockVariablesMockRecorder) ListAll(ctx, workspaceID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListAll", reflect.TypeOf((*MockVariables)(nil).ListAll), ctx, workspaceID, options)
+}
+
 // Read mocks base method.
 func (m *MockVariables) Read(ctx context.Context, workspaceID, variableID string) (*tfe.Variable, error) {
 	m.ctrl.T.Helper()

--- a/variable.go
+++ b/variable.go
@@ -17,7 +17,7 @@ var _ Variables = (*variables)(nil)
 //
 // TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspace-variables
 type Variables interface {
-	// List all the variables associated with the given workspace (doesn't include variables inherited variables from varsets).
+	// List all the variables associated with the given workspace (doesn't include variables inherited from varsets).
 	List(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error)
 
 	// ListAll all the variables associated with the given workspace including variables inherited from varsets.

--- a/variable.go
+++ b/variable.go
@@ -138,7 +138,6 @@ func (s *variables) List(ctx context.Context, workspaceID string, options *Varia
 
 // ListAll the variables associated with the given workspace including inherited variables from varsets.
 func (s *variables) ListAll(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error) {
-	fmt.Printf("Workspace ID: %s\n", workspaceID)
 	return s.getList(ctx, workspaceID, options, "workspaces/%s/all-vars")
 }
 

--- a/variable.go
+++ b/variable.go
@@ -20,7 +20,7 @@ type Variables interface {
 	// List all the variables associated with the given workspace (doesn't include variables inherited variables from varsets).
 	List(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error)
 
-	// List all the variables associated with the given workspace including variables inherited from varsets.
+	// ListAll all the variables associated with the given workspace including variables inherited from varsets.
 	ListAll(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error)
 
 	// Create is used to create a new variable.
@@ -138,7 +138,8 @@ func (s *variables) List(ctx context.Context, workspaceID string, options *Varia
 
 // ListAll the variables associated with the given workspace including inherited variables from varsets.
 func (s *variables) ListAll(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error) {
-	return s.getList(ctx, workspaceID, options, "workspaces/%s/vars/all")
+	fmt.Printf("Workspace ID: %s\n", workspaceID)
+	return s.getList(ctx, workspaceID, options, "workspaces/%s/all-vars")
 }
 
 func (s *variables) getList(ctx context.Context, workspaceID string, options *VariableListOptions, path string) (*VariableList, error) {

--- a/variable.go
+++ b/variable.go
@@ -131,12 +131,12 @@ type VariableUpdateOptions struct {
 	Sensitive *bool `jsonapi:"attr,sensitive,omitempty"`
 }
 
-// List all the variables associated with the given workspace (doesn't include inherited variables from varsets).
+// List all the variables associated with the given workspace (doesn't include variables inherited from varsets).
 func (s *variables) List(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error) {
 	return s.getList(ctx, workspaceID, options, "workspaces/%s/vars")
 }
 
-// ListAll the variables associated with the given workspace including inherited variables from varsets.
+// ListAll the variables associated with the given workspace including variables inherited from varsets.
 func (s *variables) ListAll(ctx context.Context, workspaceID string, options *VariableListOptions) (*VariableList, error) {
 	return s.getList(ctx, workspaceID, options, "workspaces/%s/all-vars")
 }

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -147,26 +147,34 @@ func TestVariablesListAll(t *testing.T) {
 	applyVariableSetToWorkspace(t, client, orgVarset.ID, wTest.ID)
 	applyVariableSetToWorkspace(t, client, prjVarset.ID, wTest.ID)
 
-	t.Run("without list all-vars options", func(t *testing.T) {
+	t.Run("when /workspace/{external_id}/all-vars API is called", func(t *testing.T) {
 		vl, err := client.Variables.ListAll(ctx, wTest.ID, nil)
-		variableIdToValueMap := make(map[string]string)
+		assert.NotNilf(t, vl, "expected to get variables list")
+
+		variableIDToValueMap := make(map[string]string)
 		for _, variable := range vl.Items {
-			variableIdToValueMap[variable.ID] = variable.Value
+			variableIDToValueMap[variable.ID] = variable.Value
 		}
 		require.NoError(t, err)
 		assert.Equal(t, len(vl.Items), 5)
-		assert.NotContains(t, variableIdToValueMap, glVarOverwrite.ID)
-		assert.NotContains(t, variableIdToValueMap, prjVarOverwrite.ID)
-		assert.Contains(t, variableIdToValueMap, glVar.ID)
-		assert.Contains(t, variableIdToValueMap, prjVar.ID)
-		assert.Contains(t, variableIdToValueMap, wsVar1.ID)
-		assert.Contains(t, variableIdToValueMap, wsVar2.ID)
-		assert.Contains(t, variableIdToValueMap, wsVar3.ID)
-		assert.Equal(t, glVar.Value, variableIdToValueMap[glVar.ID])
-		assert.Equal(t, prjVar.Value, variableIdToValueMap[prjVar.ID])
-		assert.Equal(t, wsVar1.Value, variableIdToValueMap[wsVar1.ID])
-		assert.Equal(t, wsVar2.Value, variableIdToValueMap[wsVar2.ID])
-		assert.Equal(t, wsVar3.Value, variableIdToValueMap[wsVar3.ID])
+		assert.NotContains(t, variableIDToValueMap, glVarOverwrite.ID)
+		assert.NotContains(t, variableIDToValueMap, prjVarOverwrite.ID)
+		assert.Contains(t, variableIDToValueMap, glVar.ID)
+		assert.Contains(t, variableIDToValueMap, prjVar.ID)
+		assert.Contains(t, variableIDToValueMap, wsVar1.ID)
+		assert.Contains(t, variableIDToValueMap, wsVar2.ID)
+		assert.Contains(t, variableIDToValueMap, wsVar3.ID)
+		assert.Equal(t, glVar.Value, variableIDToValueMap[glVar.ID])
+		assert.Equal(t, prjVar.Value, variableIDToValueMap[prjVar.ID])
+		assert.Equal(t, wsVar1.Value, variableIDToValueMap[wsVar1.ID])
+		assert.Equal(t, wsVar2.Value, variableIDToValueMap[wsVar2.ID])
+		assert.Equal(t, wsVar3.Value, variableIDToValueMap[wsVar3.ID])
+	})
+
+	t.Run("when workspace ID is invalid ID", func(t *testing.T) {
+		vl, err := client.Variables.ListAll(ctx, badIdentifier, nil)
+		assert.Nilf(t, vl, "expected variables list to be nil")
+		assert.EqualError(t, err, ErrInvalidWorkspaceID.Error())
 	})
 }
 

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -149,8 +150,8 @@ func TestVariablesListAll(t *testing.T) {
 
 	t.Run("when /workspaces/{external_id}/all-vars API is called", func(t *testing.T) {
 		vl, err := client.Variables.ListAll(ctx, wTest.ID, nil)
-		require.NoError(t, err)
-		assert.NotNilf(t, vl, "expected to get variables list")
+		require.NoErrorf(t, err, fmt.Sprintf("received unexpected error: %v", err.Error()))
+		assert.NotNilf(t, vl, "expected to get a non-empty variables list")
 
 		variableIDToValueMap := make(map[string]string)
 		for _, variable := range vl.Items {

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -149,13 +149,13 @@ func TestVariablesListAll(t *testing.T) {
 
 	t.Run("when /workspaces/{external_id}/all-vars API is called", func(t *testing.T) {
 		vl, err := client.Variables.ListAll(ctx, wTest.ID, nil)
+		require.NoError(t, err)
 		assert.NotNilf(t, vl, "expected to get variables list")
 
 		variableIDToValueMap := make(map[string]string)
 		for _, variable := range vl.Items {
 			variableIDToValueMap[variable.ID] = variable.Value
 		}
-		require.NoError(t, err)
 		assert.Equal(t, len(vl.Items), 5)
 		assert.NotContains(t, variableIDToValueMap, glVarOverwrite.ID)
 		assert.NotContains(t, variableIDToValueMap, prjVarOverwrite.ID)

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -5,7 +5,6 @@ package tfe
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -150,7 +149,7 @@ func TestVariablesListAll(t *testing.T) {
 
 	t.Run("when /workspaces/{external_id}/all-vars API is called", func(t *testing.T) {
 		vl, err := client.Variables.ListAll(ctx, wTest.ID, nil)
-		require.NoErrorf(t, err, fmt.Sprintf("received unexpected error: %v", err.Error()))
+		require.NoError(t, err)
 		assert.NotNilf(t, vl, "expected to get a non-empty variables list")
 
 		variableIDToValueMap := make(map[string]string)

--- a/variable_integration_test.go
+++ b/variable_integration_test.go
@@ -147,7 +147,7 @@ func TestVariablesListAll(t *testing.T) {
 	applyVariableSetToWorkspace(t, client, orgVarset.ID, wTest.ID)
 	applyVariableSetToWorkspace(t, client, prjVarset.ID, wTest.ID)
 
-	t.Run("when /workspace/{external_id}/all-vars API is called", func(t *testing.T) {
+	t.Run("when /workspaces/{external_id}/all-vars API is called", func(t *testing.T) {
 		vl, err := client.Variables.ListAll(ctx, wTest.ID, nil)
 		assert.NotNilf(t, vl, "expected to get variables list")
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description
<!-- Describe why you're making this change. -->
This PR adds the support to make calls to the `/workspaces/{external_id}/all-vars` V2 API, which now returns the list of all variables accessible in a workspace. This list now includes all variables inherited from organization and project level variable sets in HCP Terraform. The existing V2 API `/workspaces/{external_id}/vars` only returns the list of variables defined in a workspace, and excludes inherited but not overwritten variables from varsets.

With this change, the remote / backend context in terraform core can effectively call this API to fetch the list of accessible variables, effectively fixing the bug mentioned in [IPL-7725](https://hashicorp.atlassian.net/browse/IPL-7725). The bug talks about such inherited but not overwritten variables defined in a terraform configuration, which causes a "No value for required variable" error while doing a `terraform import` from the CLI. 

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._
-->

- [JIRA](https://hashicorp.atlassian.net/browse/IPL-7725)
- [ADR](https://go.hashi.co/adr/tf-033)
- [Related PR (Atlas)](https://github.com/hashicorp/atlas/pull/22817)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
(base) amartyamajumdar@amartyamajumdar-FGXW6P4DYL go-tfe % envchain go-tfe go test -run TestVariablesListAll -v ./...
?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/projects	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]


=== RUN   TestVariablesListAll
=== RUN   TestVariablesListAll/when_/workspaces/{external_id}/all-vars_API_is_called
=== RUN   TestVariablesListAll/when_workspace_ID_is_invalid_ID
--- PASS: TestVariablesListAll (5.34s)
    --- PASS: TestVariablesListAll/when_/workspaces/{external_id}/all-vars_API_is_called (0.18s)
    --- PASS: TestVariablesListAll/when_workspace_ID_is_invalid_ID (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	6.246s
(base) amartyamajumdar@amartyamajumdar-FGXW6P4DYL go-tfe %
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

Not required. This adds support for a new V2 API and does not affect any existing workflows.


[IPL-7725]: https://hashicorp.atlassian.net/browse/IPL-7725?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ