### PR TITLE
Add ConfirmedBy to Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 * Adds `IngressAttributes` field to `PolicySetVersion` by @jpadrianoGo [#1092](https://github.com/hashicorp/go-tfe/pull/1092)
+* Adds `ConfirmedBy` field to `Run` by @jpadrianoGo [#1110](https://github.com/hashicorp/go-tfe/pull/1110)
 
 # v1.80.0
 

--- a/run.go
+++ b/run.go
@@ -160,6 +160,7 @@ type Run struct {
 	ConfigurationVersion *ConfigurationVersion `jsonapi:"relation,configuration-version"`
 	CostEstimate         *CostEstimate         `jsonapi:"relation,cost-estimate"`
 	CreatedBy            *User                 `jsonapi:"relation,created-by"`
+	ConfirmedBy          *User                 `jsonapi:"relation,confirmed-by"`
 	Plan                 *Plan                 `jsonapi:"relation,plan"`
 	PolicyChecks         []*PolicyCheck        `jsonapi:"relation,policy-checks"`
 	TaskStages           []*TaskStage          `jsonapi:"relation,task-stages,omitempty"`

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -446,6 +446,33 @@ func TestRunsReadWithPolicyPaths(t *testing.T) {
 	assert.Contains(t, r.PolicyPaths, "./foo")
 }
 
+func TestRunsConfirmedBy(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("with apply", func(t *testing.T) {
+		rTest, rTestCleanup := createRunApply(t, client, nil)
+		t.Cleanup(rTestCleanup)
+
+		r, err := client.Runs.Read(ctx, rTest.ID)
+		require.NoError(t, err)
+
+		assert.NotNil(t, r.ConfirmedBy)
+		assert.NotZero(t, r.ConfirmedBy.ID)
+	})
+
+	t.Run("without apply", func(t *testing.T) {
+		rTest, rTestCleanup := createPlannedRun(t, client, nil)
+		t.Cleanup(rTestCleanup)
+
+		r, err := client.Runs.Read(ctx, rTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, rTest, r)
+
+		assert.Nil(t, r.ConfirmedBy)
+	})
+}
+
 func TestRunsApply(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds `ConfirmedBy *User` relation field to `Run` struct. Run now includes `ConfirmedBy`.

The change aims to be part of automating terraform plan/apply verification. This aligns Run.Read return with the API's.

curl
--header "Authorization: Bearer $TOKEN"
--request GET
https://app.terraform.io/api/v2/runs/run-Hukccoek3V9yXb6h

Runs.Read(ctx context.Context, runID string) (*Run, error)

 {"data":{"id":"run-***","type":"runs","attributes":{"actions":{"is-cancelable":false,"is-confirmable":false,"is-discardable":false,"is-force-cancelable":false},"allow-config-generation":true,"allow-empty-apply":false,"auto-apply":false,"canceled-at":null,"created-at":"2025-04-29T06:05:13.747Z","has-changes":true,"is-destroy":false,"message":"Triggered via UI","plan-only":false,"refresh":true,"refresh-only":false,"replace-addrs":[],"save-plan":false,"source":"tfe-ui","status-timestamps":{"applied-at":"2025-04-29T06:26:05+00:00","planned-at":"2025-04-29T06:11:59+00:00","queuing-at":"2025-04-29T06:11:15+00:00","applying-at":"2025-04-29T06:25:43+00:00","planning-at":"2025-04-29T06:11:33+00:00","confirmed-at":"2025-04-29T06:25:27+00:00","plan-queued-at":"2025-04-29T06:11:16+00:00","apply-queued-at":"2025-04-29T06:25:27+00:00","queuing-apply-at":"2025-04-29T06:25:27+00:00","cost-estimated-at":"2025-04-29T06:12:00+00:00","plan-queueable-at":"2025-04-29T06:11:15+00:00","policy-checked-at":"2025-04-29T06:12:06+00:00","cost-estimating-at":"2025-04-29T06:11:59+00:00"},"status":"applied","target-addrs":null,"trigger-reason":"manual","terraform-version":"*.*.*","updated-at":"2025-04-29T06:26:05.994Z","permissions":{"can-apply":true,"can-cancel":true,"can-comment":true,"can-discard":true,"can-force-execute":true,"can-force-cancel":true,"can-override-policy-check":true},"variables":[]},"relationships":{"workspace":{"data":{"id":"ws-***","type":"workspaces"}},"apply":{"data":{"id":"apply-***","type":"applies"},"links":{"related":"/api/v2/runs/run-***/apply"}},"configuration-version":{"data":{"id":"cv-***","type":"configuration-versions"},"links":{"related":"/api/v2/runs/run-***/configuration-version"}},"confirmed-by":{"data":{"id":"user-***","type":"users"},"links":{"related":"/api/v2/runs/run-***/confirmed-by"}},"cost-estimate":{"data":{"id":"ce-***","type":"cost-estimates"},"links":{"related":"/api/v2/cost-estimates/ce-***"}},"created-by":{"data":{"id":"user-***","type":"users"},"links":{"related":"/api/v2/runs/run-***/created-by"}},"plan":{"data":{"id":"plan-***","type":"plans"},"links":{"related":"/api/v2/runs/run-***/plan"}},"run-events":{"data":[{"id":"re-***","type":"run-events"}],"links":{"related":"/api/v2/runs/run-***/run-events"}},"task-stages":{"data":[],"links":{"related":"/api/v2/runs/run-***/task-stages"}},"policy-checks":{"data":[{"id":"polchk-***","type":"policy-checks"}],"links":{"related":"/api/v2/runs/run-***/policy-checks"}},"comments":{"data":[],"links":{"related":"/api/v2/runs/run-***/comments"}}},"links":{"self":"/api/v2/runs/run-***"}}}
 
## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS` and `TFE_TOKEN`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestRunsConfirmedBy`. The new tests should pass.
1.  `ConfirmedBy` is read for Run.


## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestRunsConfirmedBy

go test -run TestRunsConfirmedBy -v ./... -count=1 -timeout=0
 === RUN TestRunsConfirmedBy
 === RUN TestRunsConfirmedBy/with_apply
     helper_test.go:1267: Polling run "run-Hukccoek3V9yXb6h" for status included in ["planned" "errored"] with deadline of 2025-05-19 12:29:18.9216227 +0800 PST m=+123.214070107
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-Hukccoek3V9yXb6h"
     helper_test.go:1279: Run "run-Hukccoek3V9yXb6h" had status "plan_queued"
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-Hukccoek3V9yXb6h"
     helper_test.go:1279: Run "run-Hukccoek3V9yXb6h" had status "planning"
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-Hukccoek3V9yXb6h"
     helper_test.go:1279: Run "run-Hukccoek3V9yXb6h" had status "planned"
     helper_test.go:1343: Applying run "run-Hukccoek3V9yXb6h"
     helper_test.go:1267: Polling run "run-Hukccoek3V9yXb6h" for status included in ["applied" "errored"] with deadline of 2025-05-19 12:29:27.390930802 +0800 PST m=+131.683378232
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-Hukccoek3V9yXb6h"
     helper_test.go:1279: Run "run-Hukccoek3V9yXb6h" had status "apply_queued"
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-Hukccoek3V9yXb6h"
     helper_test.go:1279: Run "run-Hukccoek3V9yXb6h" had status "applying"
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-Hukccoek3V9yXb6h"
     helper_test.go:1279: Run "run-Hukccoek3V9yXb6h" had status "applied"
 === RUN TestRunsConfirmedBy/without_apply
     helper_test.go:1267: Polling run "run-RZoBTvF9PfpWdBjz" for status included in ["cost_estimated" "planned" "errored"] with deadline of 2025-05-19 12:32:43.041909365 +0800 PST m=+327.334356774
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-RZoBTvF9PfpWdBjz"
     helper_test.go:1279: Run "run-RZoBTvF9PfpWdBjz" had status "plan_queued"
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-RZoBTvF9PfpWdBjz"
     helper_test.go:1279: Run "run-RZoBTvF9PfpWdBjz" had status "planning"
     helper_test.go:1273: ...
     helper_test.go:1331: Reading run "run-RZoBTvF9PfpWdBjz"
     helper_test.go:1279: Run "run-RZoBTvF9PfpWdBjz" had status "planned"
 --- PASS: TestRunsConfirmedBy (40.42s)
     --- PASS: TestRunsConfirmedBy/with_apply (22.56s)
     --- PASS: TestRunsConfirmedBy/without_apply (16.84s)
 PASS
 ok [github.com/hashicorp/go-tfe](http://github.com/hashicorp/go-tfe) 40.422
```
