### PR TITLE
Update agent_token_integration_test.go

### DIFF
--- a/agent_token_integration_test.go
+++ b/agent_token_integration_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -13,6 +14,7 @@ import (
 
 func TestAgentTokensList(t *testing.T) {
 	skipIfEnterprise(t)
+	skipUnlessAfterDate(t, time.Date(2025, 5, 28, 0, 0, 0, 0, time.UTC))
 
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
skip test that is failing due to a bug in the platform