### PR TITLE
Add Source and SourceModuleID to Workspace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds `Source` field to `Workspace`, by @jpadrianoGo [#1118](https://github.com/hashicorp/go-tfe/pull/1118)
+
 # v1.81.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-* Adds `Source` field to `Workspace`, by @jpadrianoGo [#1118](https://github.com/hashicorp/go-tfe/pull/1118)
+* Adds `Source` and `SourceModuleID` field to `Workspace`, by @jpadrianoGo [#1118](https://github.com/hashicorp/go-tfe/pull/1118)
 
 # v1.81.0
 

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -398,7 +398,7 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		r.Equal(WorkspaceSourceModule, w.Source)
 		r.Equal(sn, w.SourceName)
 		r.Equal(su, w.SourceURL)
-		r.NotEmpty(w.SourceModuleId)
+		r.NotEmpty(w.SourceModuleID)
 		r.Equal("remote", w.ExecutionMode)
 	})
 

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -395,8 +395,10 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		)
 		r.NoError(err)
 		r.Equal(wn, w.Name)
+		r.Equal(WorkspaceSourceModule, w.Source)
 		r.Equal(sn, w.SourceName)
 		r.Equal(su, w.SourceURL)
+		r.NotEmpty(w.SourceModuleId)
 		r.Equal("remote", w.ExecutionMode)
 	})
 

--- a/workspace.go
+++ b/workspace.go
@@ -211,6 +211,7 @@ type Workspace struct {
 	Source                      WorkspaceSource                 `jsonapi:"attr,source"`
 	SourceName                  string                          `jsonapi:"attr,source-name"`
 	SourceURL                   string                          `jsonapi:"attr,source-url"`
+	SourceModuleId              string                          `jsonapi:"attr,source-module-id"`
 	StructuredRunOutputEnabled  bool                            `jsonapi:"attr,structured-run-output-enabled"`
 	TerraformVersion            string                          `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes             []string                        `jsonapi:"attr,trigger-prefixes"`

--- a/workspace.go
+++ b/workspace.go
@@ -151,6 +151,16 @@ type workspaces struct {
 	client *Client
 }
 
+// WorkspaceSource represents a source type of a workspace.
+type WorkspaceSource string
+
+const (
+	WorkspaceSourceAPI       WorkspaceSource = "tfe-api"
+	WorkspaceSourceModule    WorkspaceSource = "tfe-module"
+	WorkspaceSourceUI        WorkspaceSource = "tfe-ui"
+	WorkspaceSourceTerraform WorkspaceSource = "terraform"
+)
+
 // WorkspaceList represents a list of workspaces.
 type WorkspaceList struct {
 	*Pagination
@@ -198,6 +208,7 @@ type Workspace struct {
 	Permissions                 *WorkspacePermissions           `jsonapi:"attr,permissions"`
 	QueueAllRuns                bool                            `jsonapi:"attr,queue-all-runs"`
 	SpeculativeEnabled          bool                            `jsonapi:"attr,speculative-enabled"`
+	Source                      WorkspaceSource                 `jsonapi:"attr,source"`
 	SourceName                  string                          `jsonapi:"attr,source-name"`
 	SourceURL                   string                          `jsonapi:"attr,source-url"`
 	StructuredRunOutputEnabled  bool                            `jsonapi:"attr,structured-run-output-enabled"`

--- a/workspace.go
+++ b/workspace.go
@@ -211,7 +211,7 @@ type Workspace struct {
 	Source                      WorkspaceSource                 `jsonapi:"attr,source"`
 	SourceName                  string                          `jsonapi:"attr,source-name"`
 	SourceURL                   string                          `jsonapi:"attr,source-url"`
-	SourceModuleId              string                          `jsonapi:"attr,source-module-id"`
+	SourceModuleID              string                          `jsonapi:"attr,source-module-id"`
 	StructuredRunOutputEnabled  bool                            `jsonapi:"attr,structured-run-output-enabled"`
 	TerraformVersion            string                          `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes             []string                        `jsonapi:"attr,trigger-prefixes"`

--- a/workspace.go
+++ b/workspace.go
@@ -209,9 +209,9 @@ type Workspace struct {
 	QueueAllRuns                bool                            `jsonapi:"attr,queue-all-runs"`
 	SpeculativeEnabled          bool                            `jsonapi:"attr,speculative-enabled"`
 	Source                      WorkspaceSource                 `jsonapi:"attr,source"`
+	SourceModuleID              string                          `jsonapi:"attr,source-module-id"`
 	SourceName                  string                          `jsonapi:"attr,source-name"`
 	SourceURL                   string                          `jsonapi:"attr,source-url"`
-	SourceModuleID              string                          `jsonapi:"attr,source-module-id"`
 	StructuredRunOutputEnabled  bool                            `jsonapi:"attr,structured-run-output-enabled"`
 	TerraformVersion            string                          `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes             []string                        `jsonapi:"attr,trigger-prefixes"`

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -1222,6 +1222,22 @@ func TestWorkspacesReadByID(t *testing.T) {
 	})
 }
 
+func TestWorkspacesReadSource(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+	t.Cleanup(wTestCleanup)
+
+	w, err := client.Workspaces.Read(ctx, orgTest.Name, wTest.Name)
+	require.NoError(t, err)
+
+	assert.Equal(t, WorkspaceSourceAPI, w.Source)
+}
+
 func TestWorkspacesAddTagBindings(t *testing.T) {
 	skipUnlessBeta(t)
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds `Source` and `SourceModuleID` field to `Workspace` struct.

## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS` and `TFE_TOKEN`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestWorkspacesReadSource`. The new tests should pass.
1.  `Source` is read for `Workspaces`.

{"data":{"id":"ws-***","type":"workspaces","attributes":{"allow-destroy-plan":true,"auto-apply":false,"auto-apply-run-trigger":false,"auto-destroy-activity-duration":null,"auto-destroy-at":null,"auto-destroy-status":null,"inherits-project-auto-destroy":true,"created-at":"2025-06-03T08:42:47.572Z","environment":"default","locked":false,"name":"wsTest","queue-all-runs":false,"speculative-enabled":true,"structured-run-output-enabled":true,"terraform-version":"1.12.1","working-directory":null,"global-remote-state":false,"updated-at":"2025-06-03T08:42:47.572Z","resource-count":0,"apply-duration-average":null,"plan-duration-average":null,"policy-check-failures":null,"run-failures":null,"workspace-kpis-runs-count":null,"unarchived-workspace-change-requests-count":0,"latest-change-at":"2025-06-03T08:42:47.572Z","operations":true,"execution-mode":"remote","vcs-repo":null,"vcs-repo-identifier":null,"permissions":{"can-update":true,"can-destroy":true,"can-queue-run":true,"can-read-run":true,"can-read-variable":true,"can-update-variable":true,"can-read-state-versions":true,"can-read-state-outputs":true,"can-create-state-versions":true,"can-queue-apply":true,"can-lock":true,"can-unlock":true,"can-force-unlock":true,"can-read-settings":true,"can-manage-tags":true,"can-manage-run-tasks":true,"can-force-delete":true,"can-manage-assessments":true,"can-manage-ephemeral-workspaces":false,"can-read-assessment-results":true,"can-read-change-requests":false,"can-update-change-requests":false,"can-queue-destroy":true},"actions":{"is-destroyable":true},"description":null,"file-triggers-enabled":true,"trigger-prefixes":[],"trigger-patterns":[],"assessments-enabled":false,"last-assessment-result-at":null,"locked-reason":"","source":"tfe-api","source-name":null,"source-url":null,"tag-names":[],"setting-overwrites":{"execution-mode":false,"agent-pool":false}},"relationships":{"organization":{"data":{"id":"orgTest","type":"organizations"}},"current-run":{"data":null},"latest-run":{"data":null},"outputs":{"data":[]},"remote-state-consumers":{"links":{"related":"/api/v2/workspaces/ws-***/relationships/remote-state-consumers"}},"current-state-version":{"data":null},"current-configuration-version":{"data":null},"agent-pool":{"data":null},"readme":{"data":null},"project":{"data":{"id":"prj-***","type":"projects"}},"current-assessment-result":{"data":null},"vars":{"data":[]}},"links":{"self":"/api/v2/organizations/orgTest/workspaces/wsTest","self-html":"/app/orgTest/workspaces/wsTest"}}}

1.  Generate the required environment variables for go test, `TFE_ADDRESS`, `TFE_TOKEN` and  `GITHUB_REGISTRY_MODULE_IDENTIFIER`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" GITHUB_REGISTRY_MODULE_IDENTIFIER="username/repository" go test ./... -v -run TestRegistryNoCodeModulesCreateWorkspace`. The new tests should pass.
1.  `Source` is read for `Workspaces`.
1.  `SourceModuleID` is read for no_code_module generated `Workspaces`.

{"data":{"id":"ws-***","type":"workspaces","attributes":{"allow-destroy-plan":true,"auto-apply":false,"auto-apply-run-trigger":false,"auto-destroy-activity-duration":null,"auto-destroy-at":null,"auto-destroy-status":null,"inherits-project-auto-destroy":true,"created-at":"2025-06-02T07:48:15.501Z","environment":"default","locked":true,"name":"foo-596bdc19-ff3e-2a31-1d7d-0f0bf3c5023e","queue-all-runs":false,"speculative-enabled":true,"structured-run-output-enabled":true,"terraform-version":"1.12.1","working-directory":null,"global-remote-state":false,"updated-at":"2025-06-02T07:48:19.377Z","resource-count":0,"apply-duration-average":null,"plan-duration-average":null,"policy-check-failures":null,"run-failures":null,"workspace-kpis-runs-count":null,"unarchived-workspace-change-requests-count":0,"latest-change-at":"2025-06-02T07:48:15.501Z","operations":true,"execution-mode":"remote","vcs-repo":null,"vcs-repo-identifier":null,"permissions":{"can-update":true,"can-destroy":true,"can-queue-run":true,"can-read-run":true,"can-read-variable":true,"can-update-variable":true,"can-read-state-versions":true,"can-read-state-outputs":true,"can-create-state-versions":true,"can-queue-apply":true,"can-lock":true,"can-unlock":true,"can-force-unlock":true,"can-read-settings":true,"can-manage-tags":true,"can-manage-run-tasks":true,"can-force-delete":true,"can-manage-assessments":true,"can-manage-ephemeral-workspaces":true,"can-read-assessment-results":true,"can-read-change-requests":true,"can-update-change-requests":true,"can-queue-destroy":true},"actions":{"is-destroyable":true},"description":null,"file-triggers-enabled":true,"trigger-prefixes":[],"trigger-patterns":[],"assessments-enabled":false,"last-assessment-result-at":null,"locked-reason":"","source":"tfe-module","source-name":"my-app","source-url":"my-app.com","source-module-id":"private/orgTest/moduleTest/random/1.0.0","no-code-upgrade-available":false,"tag-names":[],"setting-overwrites":{"execution-mode":true,"agent-pool":true}},"relationships":{"organization":{"data":{"id":"orgTest","type":"organizations"}},"locked-by":{"data":{"id":"run-***","type":"runs"},"links":{"related":"/api/v2/runs/run-***"}},"current-run":{"data":{"id":"run-***","type":"runs"},"links":{"related":"/api/v2/runs/run-***"}},"latest-run":{"data":{"id":"run-***","type":"runs"},"links":{"related":"/api/v2/runs/run-***"}},"outputs":{"data":[]},"remote-state-consumers":{"links":{"related":"/api/v2/workspaces/ws-***/relationships/remote-state-consumers"}},"current-state-version":{"data":null},"current-configuration-version":{"data":{"id":"cv-***","type":"configuration-versions"},"links":{"related":"/api/v2/configuration-versions/cv-***"}},"agent-pool":{"data":null},"readme":{"data":null},"project":{"data":{"id":"prj-***","type":"projects"}},"current-assessment-result":{"data":null},"moduleTest-version":{"data":{"id":"nocodever-***","type":"moduleTest-versions"}},"vars":{"data":[]}},"links":{"self":"/api/v2/organizations/orgTest/workspaces/***","self-html":"/app/orgTest/workspaces/***"}}}

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example"go test ./... -v -run TestWorkspacesReadSource

=== RUN   TestWorkspacesReadSource
--- PASS: TestWorkspacesReadSource (3.86s)
PASS
ok      github.com/hashicorp/go-tfe     3.910s
```
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" GITHUB_REGISTRY_MODULE_IDENTIFIER="username/repository" go test ./... -v -run TestRegistryNoCodeModulesCreateWorkspace`
go test ./... -v -run TestRegistryNoCodeModulesCreateWorkspace -count=1
=== RUN   TestRegistryNoCodeModulesCreateWorkspace
=== RUN   TestRegistryNoCodeModulesCreateWorkspace/test_creating_a_workspace_via_a_no-code_module
=== RUN   TestRegistryNoCodeModulesCreateWorkspace/fail_to_create_a_workspace_with_a_bad_module_ID
--- PASS: TestRegistryNoCodeModulesCreateWorkspace (15.44s)
    --- PASS: TestRegistryNoCodeModulesCreateWorkspace/test_creating_a_workspace_via_a_no-code_module (1.04s)
    --- PASS: TestRegistryNoCodeModulesCreateWorkspace/fail_to_create_a_workspace_with_a_bad_module_ID (0.27s)
PASS
ok      github.com/hashicorp/go-tfe     15.454s
```