### PR TITLE
Added `SpeculativeEnabled` option to `CreateStackSourceOptions` for supporting speculative runs on manual stack uploads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds BETA support for speculative runs with `Stacks` resources, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1119](https://github.com/hashicorp/go-tfe/pull/1119)
+
 # v1.81.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Enhancements
 
-* Adds BETA support for speculative runs with `Stacks` resources, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1119](https://github.com/hashicorp/go-tfe/pull/1119)
+* Adds BETA support for speculative runs with `Stacks` resources and removes VCS repo validity check on `Stack` creation, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1119](https://github.com/hashicorp/go-tfe/pull/1119)
 
 # v1.81.0
 

--- a/examples/projects/main.go
+++ b/examples/projects/main.go
@@ -28,7 +28,7 @@ func main() {
 
 	// Create a new project
 	p, err := client.Projects.Create(ctx, "org-test", tfe.ProjectCreateOptions{
-		Name:          "my-app-tst",
+		Name: "my-app-tst",
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -36,7 +36,7 @@ func main() {
 
 	// Update the project auto destroy activity duration
 	p, err = client.Projects.Update(ctx, p.ID, tfe.ProjectUpdateOptions{
-		AutoDestroyActivityDuration:    jsonapi.NewNullableAttrWithValue("3d"),
+		AutoDestroyActivityDuration: jsonapi.NewNullableAttrWithValue("3d"),
 	})
 	if err != nil {
 		log.Fatal(err)
@@ -44,7 +44,7 @@ func main() {
 
 	// Disable auto destroy
 	p, err = client.Projects.Update(ctx, p.ID, tfe.ProjectUpdateOptions{
-		AutoDestroyActivityDuration:    jsonapi.NewNullNullableAttr[string](),
+		AutoDestroyActivityDuration: jsonapi.NewNullNullableAttr[string](),
 	})
 	if err != nil {
 		log.Fatal(err)

--- a/stack.go
+++ b/stack.go
@@ -331,14 +331,6 @@ func (s StackCreateOptions) valid() error {
 		return ErrRequiredProject
 	}
 
-	return s.VCSRepo.valid()
-}
-
-func (s StackVCSRepoOptions) valid() error {
-	if s.Identifier == "" {
-		return ErrRequiredVCSRepo
-	}
-
 	return nil
 }
 

--- a/stack_source.go
+++ b/stack_source.go
@@ -32,6 +32,7 @@ type StackSources interface {
 
 type CreateStackSourceOptions struct {
 	SelectedDeployments []string `jsonapi:"attr,selected-deployments,omitempty"`
+	SpeculativeEnabled  bool     `jsonapi:"attr,speculative-enabled"`
 }
 
 var _ StackSources = (*stackSources)(nil)

--- a/stack_source.go
+++ b/stack_source.go
@@ -32,7 +32,7 @@ type StackSources interface {
 
 type CreateStackSourceOptions struct {
 	SelectedDeployments []string `jsonapi:"attr,selected-deployments,omitempty"`
-	SpeculativeEnabled  bool     `jsonapi:"attr,speculative"`
+	SpeculativeEnabled  *bool     `jsonapi:"attr,speculative,omitempty"`
 }
 
 var _ StackSources = (*stackSources)(nil)

--- a/stack_source.go
+++ b/stack_source.go
@@ -32,7 +32,7 @@ type StackSources interface {
 
 type CreateStackSourceOptions struct {
 	SelectedDeployments []string `jsonapi:"attr,selected-deployments,omitempty"`
-	SpeculativeEnabled  *bool     `jsonapi:"attr,speculative,omitempty"`
+	SpeculativeEnabled  *bool    `jsonapi:"attr,speculative,omitempty"`
 }
 
 var _ StackSources = (*stackSources)(nil)

--- a/stack_source.go
+++ b/stack_source.go
@@ -32,7 +32,7 @@ type StackSources interface {
 
 type CreateStackSourceOptions struct {
 	SelectedDeployments []string `jsonapi:"attr,selected-deployments,omitempty"`
-	SpeculativeEnabled  bool     `jsonapi:"attr,speculative-enabled"`
+	SpeculativeEnabled  bool     `jsonapi:"attr,speculative"`
 }
 
 var _ StackSources = (*stackSources)(nil)

--- a/stack_source_integration_test.go
+++ b/stack_source_integration_test.go
@@ -28,7 +28,7 @@ func TestStackSourceCreateUploadAndRead(t *testing.T) {
 		Project: orgTest.DefaultProject,
 		Name:    "test-stack",
 		VCSRepo: &StackVCSRepoOptions{
-			Identifier:   "hwatkins05-hashicorp/pet-nulls-stack",
+			Identifier:   "hashicorp-guides/pet-nulls-stack",
 			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
 		},
 	})
@@ -87,7 +87,7 @@ func TestStackSourceSpeculativeVCSUpload(t *testing.T) {
 		Project: orgTest.DefaultProject,
 		Name:    "test-stack",
 		VCSRepo: &StackVCSRepoOptions{
-			Identifier:   "hwatkins05-hashicorp/pet-nulls-stack",
+			Identifier:   "hashicorp-guides/pet-nulls-stack",
 			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
 		},
 	})
@@ -121,7 +121,7 @@ func TestStackSourceNonSpeculativeVCSUpload(t *testing.T) {
 		Project: orgTest.DefaultProject,
 		Name:    "test-stack",
 		VCSRepo: &StackVCSRepoOptions{
-			Identifier:   "hwatkins05-hashicorp/pet-nulls-stack",
+			Identifier:   "hashicorp-guides/pet-nulls-stack",
 			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
 		},
 	})

--- a/stack_source_integration_test.go
+++ b/stack_source_integration_test.go
@@ -79,9 +79,9 @@ func TestStackSourceSpeculatives(t *testing.T) {
 	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
 	t.Cleanup(cleanup)
 
-	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+	stackVCS, err := client.Stacks.Create(ctx, StackCreateOptions{
 		Project: orgTest.DefaultProject,
-		Name:    "test-stack",
+		Name:    "test-stack-vcs",
 		VCSRepo: &StackVCSRepoOptions{
 			Identifier:   "hashicorp-guides/pet-nulls-stack",
 			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
@@ -89,16 +89,16 @@ func TestStackSourceSpeculatives(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	stackHCP, err := client.Stacks.Create(ctx, StackCreateOptions{
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
 		Project: &Project{
 			ID: orgTest.DefaultProject.ID,
 		},
-		Name: "test-stack-hcp",
+		Name: "test-stack",
 	})
 	require.NoError(t, err)
 
 	t.Run("with speculative run enabled for VCS upload", func(t *testing.T) {
-		ss, err := client.StackSources.CreateAndUpload(ctx, stack.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
+		ss, err := client.StackSources.CreateAndUpload(ctx, stackVCS.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
 			SelectedDeployments: []string{"simple"},
 			SpeculativeEnabled:  Bool(true),
 		})
@@ -108,7 +108,7 @@ func TestStackSourceSpeculatives(t *testing.T) {
 	})
 
 	t.Run("with speculative run disabled for manual upload", func(t *testing.T) {
-		ss, err := client.StackSources.CreateAndUpload(ctx, stackHCP.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
+		ss, err := client.StackSources.CreateAndUpload(ctx, stack.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
 			SelectedDeployments: []string{"simple"},
 			SpeculativeEnabled:  Bool(false),
 		})
@@ -118,7 +118,7 @@ func TestStackSourceSpeculatives(t *testing.T) {
 	})
 
 	t.Run("with invalid speculative run option for VCS upload", func(t *testing.T) {
-		ss, err := client.StackSources.CreateAndUpload(ctx, stack.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
+		ss, err := client.StackSources.CreateAndUpload(ctx, stackVCS.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
 			SelectedDeployments: []string{"simple"},
 			SpeculativeEnabled:  Bool(false),
 		})

--- a/stack_source_integration_test.go
+++ b/stack_source_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -27,12 +28,13 @@ func TestStackSourceCreateUploadAndRead(t *testing.T) {
 		Project: orgTest.DefaultProject,
 		Name:    "test-stack",
 		VCSRepo: &StackVCSRepoOptions{
-			Identifier:   "hashicorp-guides/pet-nulls-stack",
+			Identifier:   "hwatkins05-hashicorp/pet-nulls-stack",
 			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
 		},
 	})
 	require.NoError(t, err)
 
+	// Should I modify create stack source options to include speculative enabled?
 	ss, err := client.StackSources.CreateAndUpload(ctx, stack.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
 		SelectedDeployments: []string{"simple"},
 	})
@@ -65,4 +67,95 @@ func TestStackSourceCreateUploadAndRead(t *testing.T) {
 	case <-ctx.Done():
 		require.Fail(t, "timed out waiting for stack source to be processed")
 	}
+}
+
+// TO-DO: Can I just add a function here to test the stack source upload? Specifically speculative uploads?
+// This should not have errors, since it is a speculative run on a VCS upload.
+func TestStackSourceSpeculativeVCSUpload(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Project: orgTest.DefaultProject,
+		Name:    "test-stack",
+		VCSRepo: &StackVCSRepoOptions{
+			Identifier:   "hwatkins05-hashicorp/pet-nulls-stack",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+		},
+	})
+	require.NoError(t, err)
+
+	options := &CreateStackSourceOptions{
+		SelectedDeployments: []string{"simple"},
+		SpeculativeEnabled:  true,
+	}
+	ss, err := client.StackSources.CreateAndUpload(ctx, stack.ID, "test-fixtures/stack-source", options)
+	require.NoError(t, err)
+	require.NotNil(t, ss)
+	require.NotNil(t, ss.UploadURL)
+	assert.Equal(t, options.SpeculativeEnabled, ss.Stack.SpeculativeEnabled)
+}
+
+// This should fail because it is a non-speculative run on a VCS upload.
+func TestStackSourceNonSpeculativeVCSUpload(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Project: orgTest.DefaultProject,
+		Name:    "test-stack",
+		VCSRepo: &StackVCSRepoOptions{
+			Identifier:   "hwatkins05-hashicorp/pet-nulls-stack",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+		},
+	})
+	require.NoError(t, err)
+
+	_, err = client.StackSources.CreateAndUpload(ctx, stack.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
+		SelectedDeployments: []string{"simple"},
+		SpeculativeEnabled: false,
+	})
+	require.Error(t, err)
+}
+
+// This is a speculative run to HCP Terraform Cloud, so it should not error.
+func TestStackSourceSpeculativeManualUpload(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Project: &Project{
+			ID: orgTest.DefaultProject.ID,
+		},
+	})
+	require.NoError(t, err)
+
+	ss, err := client.StackSources.CreateAndUpload(ctx, stack.ID, "test-fixtures/stack-source", &CreateStackSourceOptions{
+		SelectedDeployments: []string{"simple"},
+		SpeculativeEnabled:  true,
+	})
+	require.NoError(t, err)
+	require.NotNil(t, ss)
+	require.NotNil(t, ss.UploadURL)
 }

--- a/stack_source_integration_test.go
+++ b/stack_source_integration_test.go
@@ -93,7 +93,7 @@ func TestStackSourceSpeculatives(t *testing.T) {
 		Project: &Project{
 			ID: orgTest.DefaultProject.ID,
 		},
-		Name:   "test-stack-hcp",
+		Name: "test-stack-hcp",
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
Added `SpeculativeEnabled` option to `CreateStackSourceOptions` for supporting speculative runs on manual stack uploads.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
1. Create a VCS-backed stack
2. Attempt to create and upload a stack source with `SpeculativeEnabled` field set to false to ensure it errors
3. Create and upload a stack source without the `SpeculativeEnabled` field to ensure previous versions will not break

## External links

- [Related PR for API](https://github.com/hashicorp/atlas/pull/23359/)
- [Jira Ticket](https://hashicorp.atlassian.net/browse/TF-25643)

## Output from tests
<!--Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.-->

```
% envchain go-tfe go test -run TestStackSource -v
=== RUN   TestStackSourceCreateUploadAndRead
    stack_source_integration_test.go:63: Found stack source configuration "stc-FZL5zVJZS3bvdZHj"
--- PASS: TestStackSourceCreateUploadAndRead (3.47s)
=== RUN   TestStackSourceSpeculatives
=== RUN   TestStackSourceSpeculatives/with_speculative_run_enabled_for_VCS_upload
=== RUN   TestStackSourceSpeculatives/with_speculative_run_disabled_for_manual_upload
=== RUN   TestStackSourceSpeculatives/with_invalid_speculative_run_option_for_VCS_upload
--- PASS: TestStackSourceSpeculatives (4.85s)
    --- PASS: TestStackSourceSpeculatives/with_speculative_run_enabled_for_VCS_upload (0.27s)
    --- PASS: TestStackSourceSpeculatives/with_speculative_run_disabled_for_manual_upload (0.56s)
    --- PASS: TestStackSourceSpeculatives/with_invalid_speculative_run_option_for_VCS_upload (0.31s)
PASS
ok      github.com/hashicorp/go-tfe     8.743s
```

<!--
_Please run the tests locally for any files you changes and include the output here._

```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```
-->

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->


<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
