### PR TITLE
Adds DeliveryResponses parsing in NotificationConfiguration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Adds BETA support for approving all plans for a stack deployment run, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1136](https://github.com/hashicorp/go-tfe/pull/1136)
 * Adds BETA support for listing and reading `StackDeploymentSteps`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1133](https://github.com/hashicorp/go-tfe/pull/1133)
 * Adds BETA support for approving all plans in `StackDeploymentGroups`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1137](https://github.com/hashicorp/go-tfe/pull/1137)
+* Adds `DeliveryResponses` parsing in `NotificationConfiguration`, by @jpadrianoGo [#1129](https://github.com/hashicorp/go-tfe/pull/1129)
 
 # v1.83.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds `DeliveryResponses` parsing in `NotificationConfiguration`, by @jpadrianoGo [#1129](https://github.com/hashicorp/go-tfe/pull/1129)
+
 # v1.85.0
 
 ## Bug Fixes
@@ -18,7 +22,6 @@
 * Adds BETA support for approving all plans for a stack deployment run, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1136](https://github.com/hashicorp/go-tfe/pull/1136)
 * Adds BETA support for listing and reading `StackDeploymentSteps`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1133](https://github.com/hashicorp/go-tfe/pull/1133)
 * Adds BETA support for approving all plans in `StackDeploymentGroups`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1137](https://github.com/hashicorp/go-tfe/pull/1137)
-* Adds `DeliveryResponses` parsing in `NotificationConfiguration`, by @jpadrianoGo [#1129](https://github.com/hashicorp/go-tfe/pull/1129)
 
 ## Bug Fixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,10 +21,6 @@
 * Adds `PrivateRunTasks` field to Entitlements by @glennsarti [#944](https://github.com/hashicorp/go-tfe/pull/944)
 * Adds `AgentPool` relationship to options when creating and updating Run Tasks by @glennsarti [#944](https://github.com/hashicorp/go-tfe/pull/944)
 
-## Enhancements
-
-* Adds `DeliveryResponses` parsing in `NotificationConfiguration`, by @jpadrianoGo [#1129](https://github.com/hashicorp/go-tfe/pull/1129)
-
 # v1.82.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@
 * Adds `PrivateRunTasks` field to Entitlements by @glennsarti [#944](https://github.com/hashicorp/go-tfe/pull/944)
 * Adds `AgentPool` relationship to options when creating and updating Run Tasks by @glennsarti [#944](https://github.com/hashicorp/go-tfe/pull/944)
 
+## Enhancements
+
+* Adds `DeliveryResponses` parsing in `NotificationConfiguration`, by @jpadrianoGo [#1129](https://github.com/hashicorp/go-tfe/pull/1129)
+
 # v1.82.0
 
 ## Enhancements


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR updates DeliveryResponses field parsing of `NotificationConfiguration`. NotificationConfiguration now parses `DeliveryResponses`.

The change aims to be part of automating notification configuration management for workspaces. This aligns with API's NotificationConfiguration return for List, Create, Read, Update, and Verify operations. 

curl
--header "Authorization: Bearer $TOKEN"
--request POST
 --data @payload.json
https://app.terraform.io/api/v2/workspaces/ws-***/notification-configurations/

```json
{
  "data": {
    "id": "nc-***",
    "type": "notification-configurations",
    "attributes": {
      "enabled": true,
      "name": "Notify organization users about run",
      "destination-type": "generic",
      "triggers": [
        "run:applying",
        "run:completed",
        "run:created",
        "run:errored",
        "run:needs_attention",
        "run:planning"
      ],
      "delivery-responses": [
        {
          "code": "200",
          "body": "{\"code\":200,\"description\":\"OK\"}",
          "headers": {
            "content-length": ["31"],
            "content-type": ["application/json"],
            "date": ["Mon, 16 Jun 2025 01:42:05 GMT"]
          },
          "sent-at": "2025-06-16T01:42:06+00:00",
          "successful": "true",
          "url": "***"
        }
      ],
      "created-at": "2025-06-16T01:42:06.447Z",
      "updated-at": "2025-06-16T01:42:06.447Z",
      "url": "***",
      "token": null
    },
    "relationships": {
      "subscribable": {
        "data": {
          "id": "ws-***",
          "type": "workspaces"
        }
      }
    },
    "links": {
      "self": "/api/v2/notification-configurations/nc-***"
    }
  }
}
```


A new function is added to parse DeliveryResponse `func parseDeliveryResponses(nc *NotificationConfiguration)`.
The following functions have been updated to use parseDeliveryResponses:

- NotificationConfigurations.List(ctx context.Context, subscribableID string, options *NotificationConfigurationListOptions) (*NotificationConfigurationList, error)
- NotificationConfigurations.Create(ctx context.Context, subscribableID string, options NotificationConfigurationCreateOptions) (*NotificationConfiguration, error)
- NotificationConfigurations.Read(ctx context.Context, notificationConfigurationID string) (*NotificationConfiguration, error)
- NotificationConfigurations.Update(ctx context.Context, notificationConfigurationID string, options NotificationConfigurationUpdateOptions) (*NotificationConfiguration, error)

## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS`, `TFE_TOKEN`, and `TFC_RUN_TASK_URL`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" TFC_RUN_TASK_URL="working-URL" go test ./... -v -run TestNotificationConfigurationReadDeliveryResponses `. The new tests should pass.
1.  `DeliveryResponses` is read for NotificationConfigurations.
1.  Run all tests in notification_configuration_integration_test.go and existing tests should pass.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example"  TFC_RUN_TASK_URL="working-URL"  go test ./... -v -run TestNotificationConfigurationReadDeliveryResponses 
=== RUN   TestNotificationConfigurationReadDeliveryResponses
=== RUN   TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_create
=== RUN   TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_list
=== RUN   TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_read
=== RUN   TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_update
=== RUN   TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_verify
=== RUN   TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_disabled
--- PASS: TestNotificationConfigurationReadDeliveryResponses (17.20s)
    --- PASS: TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_create (2.28s)
    --- PASS: TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_list (3.35s)
    --- PASS: TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_read (2.45s)
    --- PASS: TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_update (2.74s)
    --- PASS: TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_verify (2.83s)
    --- PASS: TestNotificationConfigurationReadDeliveryResponses/with_notification_configuration_disabled (2.48s)
PASS
ok      github.com/hashicorp/go-tfe     17.211s
```
