### PR TITLE
Remove omission of vcs_repo in stack update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Unreleased
-* Add support for HCP Terraform `/api/v2/workspaces/{external_id}/all-vars` API endpoint to fetch the list of all variables available to a workspace (include inherited variables from varsets) by @debrin-hc [#1105](https://github.com/hashicorp/go-tfe/pull/1105)
 
+## Enhancements
+
+* Add support for HCP Terraform `/api/v2/workspaces/{external_id}/all-vars` API endpoint to fetch the list of all variables available to a workspace (include inherited variables from varsets) by @debrin-hc [#1105](https://github.com/hashicorp/go-tfe/pull/1105)
 * Adds BETA support for listing `StackDeploymentGroups`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1128](https://github.com/hashicorp/go-tfe/pull/1128)
+* Adds BETA support for removing/adding VCS backing for a Stack, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @Maed223 [#1131](https://github.com/hashicorp/go-tfe/pull/1131)
 
 # v1.82.0
 

--- a/stack.go
+++ b/stack.go
@@ -191,7 +191,7 @@ type StackCreateOptions struct {
 type StackUpdateOptions struct {
 	Name        *string              `jsonapi:"attr,name,omitempty"`
 	Description *string              `jsonapi:"attr,description,omitempty"`
-	VCSRepo     *StackVCSRepoOptions `jsonapi:"attr,vcs-repo,omitempty"`
+	VCSRepo     *StackVCSRepoOptions `jsonapi:"attr,vcs-repo"`
 }
 
 // WaitForStatusResult is the data structure that is sent over the channel


### PR DESCRIPTION
## Description

Previously forgotten in the PR removing the VCS repo validation was to remove the `omit-empty` jsonapi tag in the `StackUpdateOptions`. This is needed as we need to explicitly give `nil` in the request to remove the VCS backing of a Stack. Before this wouldn't work as the nil was being omitted from the request. This is a requirement for the tfe provider work.

## Testing plan

Added a test to cover this change

## Output from tests
![Screenshot 2025-06-16 at 4 25 16 PM](https://github.com/user-attachments/assets/894602c4-6857-41af-b385-4c3fd32a142a)
![Screenshot 2025-06-16 at 4 34 20 PM](https://github.com/user-attachments/assets/abf17128-f40c-4946-a590-67c04e8a635b)
![Screenshot 2025-06-16 at 4 35 06 PM](https://github.com/user-attachments/assets/78fca7b9-3261-4b76-ae5c-ba11552c4de6)


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->
