### PR TITLE
chore: add read and list methods for retrieving stack deployment steps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 * Adds BETA support for approving all plans for a stack deployment run, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1136](https://github.com/hashicorp/go-tfe/pull/1136)
+* Adds BETA support for listing and reading `StackDeploymentSteps`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1133](https://github.com/hashicorp/go-tfe/pull/1133)
 
 # v1.83.0
 
@@ -10,7 +11,6 @@
 
 * Adds BETA support for listing `StackDeploymentRuns`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @shwetamurali [#1134](https://github.com/hashicorp/go-tfe/pull/1134)
 * Add support for HCP Terraform `/api/v2/workspaces/{external_id}/all-vars` API endpoint to fetch the list of all variables available to a workspace (include inherited variables from varsets) by @debrin-hc [#1105](https://github.com/hashicorp/go-tfe/pull/1105)
-* Adds BETA support for listing and reading `StackDeploymentSteps`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1133](https://github.com/hashicorp/go-tfe/pull/1133)
 * Adds BETA support for listing `StackDeploymentGroups`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1128](https://github.com/hashicorp/go-tfe/pull/1128)
 * Adds BETA support for removing/adding VCS backing for a Stack, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @Maed223 [#1131](https://github.com/hashicorp/go-tfe/pull/1131)
 * Adds BETA support for reading a `StackDeploymentGroup`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1132](https://github.com/hashicorp-go-tfe/pull/1132)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 
 * Adds BETA support for listing `StackDeploymentRuns`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @shwetamurali [#1134](https://github.com/hashicorp/go-tfe/pull/1134)
 * Add support for HCP Terraform `/api/v2/workspaces/{external_id}/all-vars` API endpoint to fetch the list of all variables available to a workspace (include inherited variables from varsets) by @debrin-hc [#1105](https://github.com/hashicorp/go-tfe/pull/1105)
+* Adds BETA support for listing and reading `StackDeploymentSteps`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1133](https://github.com/hashicorp/go-tfe/pull/1133)
 * Adds BETA support for listing `StackDeploymentGroups`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1128](https://github.com/hashicorp/go-tfe/pull/1128)
 * Adds BETA support for removing/adding VCS backing for a Stack, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @Maed223 [#1131](https://github.com/hashicorp/go-tfe/pull/1131)
 * Adds BETA support for reading a `StackDeploymentGroup`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1132](https://github.com/hashicorp-go-tfe/pull/1132)

--- a/stack.go
+++ b/stack.go
@@ -148,6 +148,42 @@ type StackDeployment struct {
 	CurrentStackState *StackState `jsonapi:"relation,current-stack-state"`
 }
 
+type StackDeploymentRun struct {
+	// Attributes
+	ID         string    `jsonapi:"primary,stacks-deployment-runs"`
+	Status     string    `jsonapi:"attr,status"`
+	Deployment string    `jsonapi:"attr,deployment"`
+	CreatedAt  time.Time `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt  time.Time `jsonapi:"attr,updated-at,iso8601"`
+
+	// Relationships
+	StackDeploymentGroup *StackDeploymentGroup `jsonapi:"relation,stacks-deployment-group"`
+}
+
+// StackDeploymentRunList represents a list of stack deployment runs
+type StackDeploymentRunList struct {
+	*Pagination
+	Items []*StackDeploymentRun
+}
+
+// StackDeploymentStep represents a step from a stack deployment
+type StackDeploymentStep struct {
+	// Attributes
+	ID        string    `jsonapi:"primary,stacks-deployment-steps"`
+	Status    string    `jsonapi:"attr,status"`
+	CreatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
+
+	// Relationships
+	StackDeploymentRun *StackDeploymentRun `jsonapi:"relation,stacks-deployment-run"`
+}
+
+// StackDeploymentStepList represents a list of stack deployment steps
+type StackDeploymentStepList struct {
+	*Pagination
+	Items []*StackDeploymentStep
+}
+
 // StackState represents a stack state
 type StackState struct {
 	// Attributes

--- a/stack.go
+++ b/stack.go
@@ -148,42 +148,6 @@ type StackDeployment struct {
 	CurrentStackState *StackState `jsonapi:"relation,current-stack-state"`
 }
 
-type StackDeploymentRun struct {
-	// Attributes
-	ID         string    `jsonapi:"primary,stacks-deployment-runs"`
-	Status     string    `jsonapi:"attr,status"`
-	Deployment string    `jsonapi:"attr,deployment"`
-	CreatedAt  time.Time `jsonapi:"attr,created-at,iso8601"`
-	UpdatedAt  time.Time `jsonapi:"attr,updated-at,iso8601"`
-
-	// Relationships
-	StackDeploymentGroup *StackDeploymentGroup `jsonapi:"relation,stacks-deployment-group"`
-}
-
-// StackDeploymentRunList represents a list of stack deployment runs
-type StackDeploymentRunList struct {
-	*Pagination
-	Items []*StackDeploymentRun
-}
-
-// StackDeploymentStep represents a step from a stack deployment
-type StackDeploymentStep struct {
-	// Attributes
-	ID        string    `jsonapi:"primary,stacks-deployment-steps"`
-	Status    string    `jsonapi:"attr,status"`
-	CreatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
-	UpdatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
-
-	// Relationships
-	StackDeploymentRun *StackDeploymentRun `jsonapi:"relation,stacks-deployment-run"`
-}
-
-// StackDeploymentStepList represents a list of stack deployment steps
-type StackDeploymentStepList struct {
-	*Pagination
-	Items []*StackDeploymentStep
-}
-
 // StackState represents a stack state
 type StackState struct {
 	// Attributes

--- a/stack_deployment_groups.go
+++ b/stack_deployment_groups.go
@@ -1,3 +1,6 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
 package tfe
 
 import (
@@ -7,7 +10,6 @@ import (
 	"time"
 )
 
-// StackDeploymentGroups describes all the stack-deployment-groups related methods that the HCP Terraform API supports.
 type StackDeploymentGroups interface {
 	// List returns a list of Deployment Groups in a stack.
 	List(ctx context.Context, stackConfigID string, options *StackDeploymentGroupListOptions) (*StackDeploymentGroupList, error)
@@ -35,6 +37,7 @@ var _ StackDeploymentGroups = &stackDeploymentGroups{}
 
 // StackDeploymentGroup represents a stack deployment group.
 type StackDeploymentGroup struct {
+	// Attributes
 	ID        string    `jsonapi:"primary,stacks-deployment-groups"`
 	Name      string    `jsonapi:"attr,name"`
 	Status    string    `jsonapi:"attr,status"`

--- a/stack_deployment_groups.go
+++ b/stack_deployment_groups.go
@@ -10,6 +10,7 @@ import (
 	"time"
 )
 
+// StackDeploymentGroups describes all the stack-deployment-groups related methods that the HCP Terraform API supports.
 type StackDeploymentGroups interface {
 	// List returns a list of Deployment Groups in a stack.
 	List(ctx context.Context, stackConfigID string, options *StackDeploymentGroupListOptions) (*StackDeploymentGroupList, error)

--- a/stack_deployment_runs.go
+++ b/stack_deployment_runs.go
@@ -14,6 +14,7 @@ import (
 type StackDeploymentRuns interface {
 	// List returns a list of stack deployment runs for a given deployment group.
 	List(ctx context.Context, deploymentGroupID string, options *StackDeploymentRunListOptions) (*StackDeploymentRunList, error)
+	Read(ctx context.Context, stackDeploymentRunID string) (*StackDeploymentRun, error)
 	ApproveAllPlans(ctx context.Context, deploymentRunID string) error
 }
 
@@ -60,6 +61,21 @@ func (s *stackDeploymentRuns) List(ctx context.Context, deploymentGroupID string
 	}
 
 	return sdrl, nil
+}
+
+func (s stackDeploymentRuns) Read(ctx context.Context, stackDeploymentRunID string) (*StackDeploymentRun, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("stack-deployment-runs/%s", url.PathEscape(stackDeploymentRunID)), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	run := StackDeploymentRun{}
+	err = req.Do(ctx, &run)
+	if err != nil {
+		return nil, err
+	}
+
+	return &run, nil
 }
 
 func (s stackDeploymentRuns) ApproveAllPlans(ctx context.Context, stackDeploymentRunID string) error {

--- a/stack_deployment_steps.go
+++ b/stack_deployment_steps.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // StackDeploymentSteps describes all the stacks deployment step-related methods that the
@@ -15,16 +16,40 @@ import (
 // release notes.
 type StackDeploymentSteps interface {
 	// List returns the stack deployment steps for a stack deployment run.
-	List(ctx context.Context, stackDeploymentRunID string) (*StackDeploymentStepList, error)
+	List(ctx context.Context, stackDeploymentRunID string, opts *StackDeploymentStepsListOptions) (*StackDeploymentStepList, error)
 	Read(ctx context.Context, stackDeploymentStepID string) (*StackDeploymentStep, error)
+}
+
+// StackDeploymentStep represents a step from a stack deployment
+type StackDeploymentStep struct {
+	// Attributes
+	ID        string    `jsonapi:"primary,stacks-deployment-steps"`
+	Status    string    `jsonapi:"attr,status"`
+	CreatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
+
+	// Relationships
+	StackDeploymentRun *StackDeploymentRun `jsonapi:"relation,stack-deployment-run"`
+}
+
+// StackDeploymentStepList represents a list of stack deployment steps
+type StackDeploymentStepList struct {
+	*Pagination
+	Items []*StackDeploymentStep
 }
 
 type stackDeploymentSteps struct {
 	client *Client
 }
 
-func (s stackDeploymentSteps) List(ctx context.Context, stackDeploymentRunID string) (*StackDeploymentStepList, error) {
-	req, err := s.client.NewRequest("GET", fmt.Sprintf("stack-deployment-runs/%s/stack-deployment-steps", url.PathEscape(stackDeploymentRunID)), nil)
+// StackDeploymentStepsListOptions represents the options for listing stack
+// deployment steps.
+type StackDeploymentStepsListOptions struct {
+	ListOptions
+}
+
+func (s stackDeploymentSteps) List(ctx context.Context, stackDeploymentRunID string, opts *StackDeploymentStepsListOptions) (*StackDeploymentStepList, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("stack-deployment-runs/%s/stack-deployment-steps", url.PathEscape(stackDeploymentRunID)), opts)
 	if err != nil {
 		return nil, err
 	}

--- a/stack_deployment_steps.go
+++ b/stack_deployment_steps.go
@@ -29,7 +29,7 @@ type StackDeploymentStep struct {
 	UpdatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
 
 	// Relationships
-	StackDeploymentGroup *StackDeploymentGroup `jsonapi:"relation,stack-deployment-group"`
+	StackDeploymentRun *StackDeploymentRun `jsonapi:"relation,stack-deployment-run"`
 }
 
 // StackDeploymentStepList represents a list of stack deployment steps

--- a/stack_deployment_steps.go
+++ b/stack_deployment_steps.go
@@ -29,7 +29,7 @@ type StackDeploymentStep struct {
 	UpdatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
 
 	// Relationships
-	StackDeploymentRun *StackDeploymentRun `jsonapi:"relation,stack-deployment-run"`
+	StackDeploymentGroup *StackDeploymentGroup `jsonapi:"relation,stack-deployment-group"`
 }
 
 // StackDeploymentStepList represents a list of stack deployment steps

--- a/stack_deployment_steps.go
+++ b/stack_deployment_steps.go
@@ -1,0 +1,54 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+)
+
+// StackDeploymentSteps describes all the stacks deployment step-related methods that the
+// HCP Terraform API supports.
+// NOTE WELL: This is a beta feature and is subject to change until noted otherwise in the
+// release notes.
+type StackDeploymentSteps interface {
+	// List returns the stack deployment steps for a stack deployment run.
+	List(ctx context.Context, stackDeploymentRunID string) (*StackDeploymentStepList, error)
+	Read(ctx context.Context, stackDeploymentStepID string) (*StackDeploymentStep, error)
+}
+
+type stackDeploymentSteps struct {
+	client *Client
+}
+
+func (s stackDeploymentSteps) List(ctx context.Context, stackDeploymentRunID string) (*StackDeploymentStepList, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("stack-deployment-runs/%s/stack-deployment-steps", url.PathEscape(stackDeploymentRunID)), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	steps := StackDeploymentStepList{}
+	err = req.Do(ctx, &steps)
+	if err != nil {
+		return nil, err
+	}
+
+	return &steps, nil
+}
+
+func (s stackDeploymentSteps) Read(ctx context.Context, stackDeploymentStepID string) (*StackDeploymentStep, error) {
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("stack-deployment-steps/%s", url.PathEscape(stackDeploymentStepID)), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	step := StackDeploymentStep{}
+	err = req.Do(ctx, &step)
+	if err != nil {
+		return nil, err
+	}
+
+	return &step, nil
+}

--- a/stack_deployment_steps_integration_test.go
+++ b/stack_deployment_steps_integration_test.go
@@ -74,10 +74,8 @@ func TestStackDeploymentStepsList(t *testing.T) {
 		assert.NotNil(t, step.ID)
 		assert.NotNil(t, step.Status)
 
-		require.NotNil(t, step.StackDeploymentRun)
-		assert.Equal(t, step.StackDeploymentRun.ID, sdr.ID)
-		assert.Equal(t, step.StackDeploymentRun.Status, sdr.Status)
-		assert.Equal(t, step.StackDeploymentRun.Deployment, sdr.Deployment)
+		require.NotNil(t, step.StackDeploymentGroup)
+		assert.Equal(t, sdg.ID, step.StackDeploymentGroup.ID)
 	})
 
 	t.Run("List with pagination", func(t *testing.T) {
@@ -98,10 +96,8 @@ func TestStackDeploymentStepsList(t *testing.T) {
 		assert.NotNil(t, step.ID)
 		assert.NotNil(t, step.Status)
 
-		require.NotNil(t, step.StackDeploymentRun)
-		assert.Equal(t, step.StackDeploymentRun.ID, sdr.ID)
-		assert.Equal(t, step.StackDeploymentRun.Status, sdr.Status)
-		assert.Equal(t, step.StackDeploymentRun.Deployment, sdr.Deployment)
+		require.NotNil(t, step.StackDeploymentGroup)
+		assert.Equal(t, sdg.ID, step.StackDeploymentGroup.ID)
 	})
 }
 
@@ -148,15 +144,21 @@ func TestStackDeploymentStepsRead(t *testing.T) {
 
 	sdr := stackDeploymentRuns.Items[0]
 
+	steps, err := client.StackDeploymentSteps.List(ctx, sdr.ID, nil)
+	assert.NoError(t, err)
+	assert.NotEmpty(t, steps)
+
+	step := steps.Items[0]
+
 	t.Run("Read with valid ID", func(t *testing.T) {
-		step, err := client.StackDeploymentSteps.Read(ctx, sdr.ID)
+		sds, err := client.StackDeploymentSteps.Read(ctx, step.ID)
 		assert.NoError(t, err)
-		assert.Equal(t, step.ID, sdg.ID)
-		assert.Equal(t, step.Status, sdg.Status)
+		assert.NotEmpty(t, sds.ID)
+		assert.NotEmpty(t, sds.Status)
 	})
 
 	t.Run("Read with invalid ID", func(t *testing.T) {
-		_, err := client.StackDeploymentGroups.Read(ctx, "")
+		_, err := client.StackDeploymentSteps.Read(ctx, "")
 		require.Error(t, err)
 	})
 }

--- a/stack_deployment_steps_integration_test.go
+++ b/stack_deployment_steps_integration_test.go
@@ -74,8 +74,8 @@ func TestStackDeploymentStepsList(t *testing.T) {
 		assert.NotNil(t, step.ID)
 		assert.NotNil(t, step.Status)
 
-		require.NotNil(t, step.StackDeploymentGroup)
-		assert.Equal(t, sdg.ID, step.StackDeploymentGroup.ID)
+		require.NotNil(t, step.StackDeploymentRun)
+		assert.Equal(t, sdg.ID, step.StackDeploymentRun.ID)
 	})
 
 	t.Run("List with pagination", func(t *testing.T) {
@@ -96,8 +96,8 @@ func TestStackDeploymentStepsList(t *testing.T) {
 		assert.NotNil(t, step.ID)
 		assert.NotNil(t, step.Status)
 
-		require.NotNil(t, step.StackDeploymentGroup)
-		assert.Equal(t, sdg.ID, step.StackDeploymentGroup.ID)
+		require.NotNil(t, step.StackDeploymentRun)
+		assert.Equal(t, sdg.ID, step.StackDeploymentRun.ID)
 	})
 }
 

--- a/stack_deployment_steps_integration_test.go
+++ b/stack_deployment_steps_integration_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -47,15 +48,115 @@ func TestStackDeploymentStepsList(t *testing.T) {
 
 	sdg := stackDeploymentGroups.Items[0]
 
-	stackDeploymentRuns, err := client.StackDeploymentRuns.List(ctx, sdg.ID)
+	stackDeploymentRuns, err := client.StackDeploymentRuns.List(ctx, sdg.ID, nil)
 	require.NoError(t, err)
 	require.NotEmpty(t, stackDeploymentRuns)
 
 	sdr := stackDeploymentRuns.Items[0]
-	steps, err := client.StackDeploymentSteps.List(ctx, sdr.ID)
-	require.NoError(t, err)
-	require.NotEmpty(t, steps)
 
-	step := steps.Items[0]
-	require.NotNil(t, step)
+	t.Run("List with invalid stack deployment run ID", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := client.StackDeploymentSteps.List(ctx, "", nil)
+		assert.Error(t, err)
+	})
+
+	t.Run("List without options", func(t *testing.T) {
+		t.Parallel()
+
+		steps, err := client.StackDeploymentSteps.List(ctx, sdr.ID, nil)
+		assert.NoError(t, err)
+		assert.NotEmpty(t, steps)
+
+		step := steps.Items[0]
+
+		assert.NotNil(t, step)
+		assert.NotNil(t, step.ID)
+		assert.NotNil(t, step.Status)
+
+		require.NotNil(t, step.StackDeploymentRun)
+		assert.Equal(t, step.StackDeploymentRun.ID, sdr.ID)
+		assert.Equal(t, step.StackDeploymentRun.Status, sdr.Status)
+		assert.Equal(t, step.StackDeploymentRun.Deployment, sdr.Deployment)
+	})
+
+	t.Run("List with pagination", func(t *testing.T) {
+		t.Parallel()
+
+		steps, err := client.StackDeploymentSteps.List(ctx, sdr.ID, &StackDeploymentStepsListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 1,
+				PageSize:   10,
+			},
+		})
+		assert.NoError(t, err)
+		assert.NotEmpty(t, steps)
+
+		step := steps.Items[0]
+
+		assert.NotNil(t, step)
+		assert.NotNil(t, step.ID)
+		assert.NotNil(t, step.Status)
+
+		require.NotNil(t, step.StackDeploymentRun)
+		assert.Equal(t, step.StackDeploymentRun.ID, sdr.ID)
+		assert.Equal(t, step.StackDeploymentRun.Status, sdr.Status)
+		assert.Equal(t, step.StackDeploymentRun.Deployment, sdr.Deployment)
+	})
+}
+
+func TestStackDeploymentStepsRead(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Project: orgTest.DefaultProject,
+		Name:    "test-stack",
+		VCSRepo: &StackVCSRepoOptions{
+			Identifier:   "hashicorp-guides/pet-nulls-stack",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+			Branch:       "main",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+
+	stackUpdated, err := client.Stacks.UpdateConfiguration(ctx, stack.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stackUpdated)
+
+	stack = pollStackDeployments(t, ctx, client, stackUpdated.ID)
+	require.NotNil(t, stack.LatestStackConfiguration)
+
+	stackDeploymentGroups, err := client.StackDeploymentGroups.List(ctx, stack.LatestStackConfiguration.ID, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, stackDeploymentGroups)
+
+	sdg := stackDeploymentGroups.Items[0]
+
+	stackDeploymentRuns, err := client.StackDeploymentRuns.List(ctx, sdg.ID, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, stackDeploymentRuns)
+
+	sdr := stackDeploymentRuns.Items[0]
+
+	t.Run("Read with valid ID", func(t *testing.T) {
+		step, err := client.StackDeploymentSteps.Read(ctx, sdr.ID)
+		assert.NoError(t, err)
+		assert.Equal(t, step.ID, sdg.ID)
+		assert.Equal(t, step.Status, sdg.Status)
+	})
+
+	t.Run("Read with invalid ID", func(t *testing.T) {
+		_, err := client.StackDeploymentGroups.Read(ctx, "")
+		require.Error(t, err)
+	})
 }

--- a/stack_deployment_steps_integration_test.go
+++ b/stack_deployment_steps_integration_test.go
@@ -1,0 +1,61 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestStackDeploymentStepsList(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Project: orgTest.DefaultProject,
+		Name:    "test-stack",
+		VCSRepo: &StackVCSRepoOptions{
+			Identifier:   "hashicorp-guides/pet-nulls-stack",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+			Branch:       "main",
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+
+	stackUpdated, err := client.Stacks.UpdateConfiguration(ctx, stack.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stackUpdated)
+
+	stack = pollStackDeployments(t, ctx, client, stackUpdated.ID)
+	require.NotNil(t, stack.LatestStackConfiguration)
+
+	stackDeploymentGroups, err := client.StackDeploymentGroups.List(ctx, stack.LatestStackConfiguration.ID, nil)
+	require.NoError(t, err)
+	require.NotEmpty(t, stackDeploymentGroups)
+
+	sdg := stackDeploymentGroups.Items[0]
+
+	stackDeploymentRuns, err := client.StackDeploymentRuns.List(ctx, sdg.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, stackDeploymentRuns)
+
+	sdr := stackDeploymentRuns.Items[0]
+	steps, err := client.StackDeploymentSteps.List(ctx, sdr.ID)
+	require.NoError(t, err)
+	require.NotEmpty(t, steps)
+
+	step := steps.Items[0]
+	require.NotNil(t, step)
+}

--- a/tfe.go
+++ b/tfe.go
@@ -165,6 +165,8 @@ type Client struct {
 	StackConfigurations        StackConfigurations
 	StackDeployments           StackDeployments
 	StackDeploymentGroups      StackDeploymentGroups
+	StackDeploymentRuns        StackDeploymentRuns
+	StackDeploymentSteps       StackDeploymentSteps
 	StackPlans                 StackPlans
 	StackPlanOperations        StackPlanOperations
 	StackSources               StackSources
@@ -496,6 +498,8 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.StackConfigurations = &stackConfigurations{client: client}
 	client.StackDeployments = &stackDeployments{client: client}
 	client.StackDeploymentGroups = &stackDeploymentGroups{client: client}
+	client.StackDeploymentRuns = &stackDeploymentRuns{client: client}
+	client.StackDeploymentSteps = &stackDeploymentSteps{client: client}
 	client.StackPlans = &stackPlans{client: client}
 	client.StackPlanOperations = &stackPlanOperations{client: client}
 	client.StackSources = &stackSources{client: client}

--- a/tfe.go
+++ b/tfe.go
@@ -192,8 +192,6 @@ type Client struct {
 	Projects                   Projects
 
 	Meta Meta
-
-	StackDeploymentRuns StackDeploymentRuns
 }
 
 // Admin is the the Terraform Enterprise Admin API. It provides access to site


### PR DESCRIPTION
## Description

This PR adds `List` and `Read` methods for retrieving stack deployment steps. It additionally adds a `Read` method for retrieving single stack deployment runs.

The new tests will not pass until hashicorp/atlas#23652 has been merged and deployed.

## Testing plan
Integration tests should be coverage enough.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$  ENABLE_BETA=1 envchain local go test . -v -run StackDeploymentSteps
=== RUN   TestStackDeploymentStepsList
    stack_deployment_steps_integration_test.go:43: Polling stack "st-9n3hm3sRiMr6nYif" for deployments with deadline of 2025-06-17 14:09:40.150549 -0700 PDT m=+304.318793876
    stack_deployment_steps_integration_test.go:43: ...
    stack_deployment_steps_integration_test.go:43: Stack "st-9n3hm3sRiMr6nYif" had 0 deployments
    stack_deployment_steps_integration_test.go:43: ...
    stack_deployment_steps_integration_test.go:43: Stack "st-9n3hm3sRiMr6nYif" had 0 deployments
    stack_deployment_steps_integration_test.go:43: ...
    stack_deployment_steps_integration_test.go:43: Stack "st-9n3hm3sRiMr6nYif" had 0 deployments
    stack_deployment_steps_integration_test.go:43: ...
    stack_deployment_steps_integration_test.go:43: Stack "st-9n3hm3sRiMr6nYif" had 0 deployments
    stack_deployment_steps_integration_test.go:43: ...
    stack_deployment_steps_integration_test.go:43: Stack "st-9n3hm3sRiMr6nYif" had 0 deployments
    stack_deployment_steps_integration_test.go:43: ...
    stack_deployment_steps_integration_test.go:43: Stack "st-9n3hm3sRiMr6nYif" had 2 deployments
=== RUN   TestStackDeploymentStepsList/List_with_invalid_stack_deployment_run_ID
=== PAUSE TestStackDeploymentStepsList/List_with_invalid_stack_deployment_run_ID
=== RUN   TestStackDeploymentStepsList/List_without_options
=== PAUSE TestStackDeploymentStepsList/List_without_options
=== RUN   TestStackDeploymentStepsList/List_with_pagination
=== PAUSE TestStackDeploymentStepsList/List_with_pagination
=== CONT  TestStackDeploymentStepsList/List_with_invalid_stack_deployment_run_ID
=== CONT  TestStackDeploymentStepsList/List_with_pagination
=== CONT  TestStackDeploymentStepsList/List_without_options
--- PASS: TestStackDeploymentStepsList (18.96s)
    --- PASS: TestStackDeploymentStepsList/List_with_invalid_stack_deployment_run_ID (0.90s)
    --- PASS: TestStackDeploymentStepsList/List_with_pagination (1.57s)
    --- PASS: TestStackDeploymentStepsList/List_without_options (1.80s)
=== RUN   TestStackDeploymentStepsRead
    stack_deployment_steps_integration_test.go:134: Polling stack "st-G15ZX7uZfwEy2HZb" for deployments with deadline of 2025-06-17 14:10:02.476038 -0700 PDT m=+326.644364085
    stack_deployment_steps_integration_test.go:134: ...
    stack_deployment_steps_integration_test.go:134: Stack "st-G15ZX7uZfwEy2HZb" had 0 deployments
    stack_deployment_steps_integration_test.go:134: ...
    stack_deployment_steps_integration_test.go:134: Stack "st-G15ZX7uZfwEy2HZb" had 0 deployments
    stack_deployment_steps_integration_test.go:134: ...
    stack_deployment_steps_integration_test.go:134: Stack "st-G15ZX7uZfwEy2HZb" had 0 deployments
    stack_deployment_steps_integration_test.go:134: ...
    stack_deployment_steps_integration_test.go:134: Stack "st-G15ZX7uZfwEy2HZb" had 0 deployments
    stack_deployment_steps_integration_test.go:134: ...
    stack_deployment_steps_integration_test.go:134: Stack "st-G15ZX7uZfwEy2HZb" had 0 deployments
    stack_deployment_steps_integration_test.go:134: ...
    stack_deployment_steps_integration_test.go:134: Stack "st-G15ZX7uZfwEy2HZb" had 2 deployments
=== RUN   TestStackDeploymentStepsRead/Read_with_valid_ID
=== RUN   TestStackDeploymentStepsRead/Read_with_invalid_ID
--- PASS: TestStackDeploymentStepsRead (22.34s)
    --- PASS: TestStackDeploymentStepsRead/Read_with_valid_ID (0.25s)
    --- PASS: TestStackDeploymentStepsRead/Read_with_invalid_ID (1.07s)
PASS
ok      github.com/hashicorp/go-tfe     43.661s
```
