### PR TITLE
feat: add method to approve all plans for a stack deployment run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds BETA support for approving all plans for a stack deployment run, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1136](https://github.com/hashicorp/go-tfe/pull/1136)
+
 # v1.83.0
 
 ## Enhancements

--- a/stack_deployment_runs.go
+++ b/stack_deployment_runs.go
@@ -14,6 +14,7 @@ import (
 type StackDeploymentRuns interface {
 	// List returns a list of stack deployment runs for a given deployment group.
 	List(ctx context.Context, deploymentGroupID string, options *StackDeploymentRunListOptions) (*StackDeploymentRunList, error)
+	ApproveAllPlans(ctx context.Context, deploymentRunID string) error
 }
 
 // stackDeploymentRuns implements StackDeploymentRuns.
@@ -59,4 +60,13 @@ func (s *stackDeploymentRuns) List(ctx context.Context, deploymentGroupID string
 	}
 
 	return sdrl, nil
+}
+
+func (s stackDeploymentRuns) ApproveAllPlans(ctx context.Context, stackDeploymentRunID string) error {
+	req, err := s.client.NewRequest("POST", fmt.Sprintf("stack-deployment-runs/%s/approve-all-plans", url.PathEscape(stackDeploymentRunID)), nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
 }

--- a/stack_deployment_runs_integration_test.go
+++ b/stack_deployment_runs_integration_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestStackDeploymentRunList(t *testing.T) {
+func TestStackDeploymentRunsList(t *testing.T) {
 	skipUnlessBeta(t)
 
 	client := testClient(t)
@@ -70,5 +70,61 @@ func TestStackDeploymentRunList(t *testing.T) {
 		})
 		require.NoError(t, err)
 		assert.NotNil(t, runList)
+	})
+}
+
+func TestStackDeploymentRunsApproveAllPlans(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Name: "test-stack",
+		VCSRepo: &StackVCSRepoOptions{
+			// Identifier:   "hashicorp-guides/pet-nulls-stack",
+			Identifier:   "ctrombley/tf-stacks-pet-nulls",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+			Branch:       "main",
+		},
+		Project: &Project{
+			ID: orgTest.DefaultProject.ID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+
+	stackUpdated, err := client.Stacks.UpdateConfiguration(ctx, stack.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stackUpdated)
+
+	stack = pollStackDeployments(t, ctx, client, stackUpdated.ID)
+	require.NotNil(t, stack.LatestStackConfiguration)
+
+	// Get the deployment group ID from the stack configuration
+	deploymentGroups, err := client.StackDeploymentGroups.List(ctx, stack.LatestStackConfiguration.ID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, deploymentGroups)
+	require.NotEmpty(t, deploymentGroups.Items)
+
+	deploymentGroupID := deploymentGroups.Items[0].ID
+
+	runList, err := client.StackDeploymentRuns.List(ctx, deploymentGroupID, nil)
+	require.NoError(t, err)
+	assert.NotNil(t, runList)
+
+	deploymentRunID := runList.Items[0].ID
+
+	t.Run("Approve all plans", func(t *testing.T) {
+		t.Parallel()
+
+		err := client.StackDeploymentRuns.ApproveAllPlans(ctx, deploymentRunID)
+		require.NoError(t, err)
 	})
 }


### PR DESCRIPTION
## Description

This PR adds a method to approve all plans for a stack deployment run.

## Testing plan
Integration tests should be sufficient. Currently asserting for a 204 response is the best we can do, since plan approval has been temporarily disabled for the `stacks-ga` flag.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
❯ ENABLE_BETA=1 envchain local go test . -v -run StackDeploymentRunsApproveAllPlans
=== RUN   TestStackDeploymentRunsApproveAllPlans
    stack_deployment_runs_integration_test.go:108: Polling stack "st-dvmCjBFxaJnRTYkf" for deployments with deadline of 2025-06-17 15:39:33.791115 -0700 PDT m=+324.159602585
    stack_deployment_runs_integration_test.go:108: ...
    stack_deployment_runs_integration_test.go:108: Stack "st-dvmCjBFxaJnRTYkf" had 0 deployments
    stack_deployment_runs_integration_test.go:108: ...
    stack_deployment_runs_integration_test.go:108: Stack "st-dvmCjBFxaJnRTYkf" had 0 deployments
    stack_deployment_runs_integration_test.go:108: ...
    stack_deployment_runs_integration_test.go:108: Stack "st-dvmCjBFxaJnRTYkf" had 0 deployments
    stack_deployment_runs_integration_test.go:108: ...
    stack_deployment_runs_integration_test.go:108: Stack "st-dvmCjBFxaJnRTYkf" had 0 deployments
    stack_deployment_runs_integration_test.go:108: ...
    stack_deployment_runs_integration_test.go:108: Stack "st-dvmCjBFxaJnRTYkf" had 0 deployments
    stack_deployment_runs_integration_test.go:108: ...
    stack_deployment_runs_integration_test.go:108: Stack "st-dvmCjBFxaJnRTYkf" had 2 deployments
=== RUN   TestStackDeploymentRunsApproveAllPlans/Approve_all_plans
=== PAUSE TestStackDeploymentRunsApproveAllPlans/Approve_all_plans
=== CONT  TestStackDeploymentRunsApproveAllPlans/Approve_all_plans
--- PASS: TestStackDeploymentRunsApproveAllPlans (19.03s)
    --- PASS: TestStackDeploymentRunsApproveAllPlans/Approve_all_plans (0.23s)
PASS
ok      github.com/hashicorp/go-tfe     38.180s
```
