### PR TITLE
Stack configuration list endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 
+* Adds BETA support for listing `StackConfigurationList`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @shwetamurali [#1138](https://github.com/hashicorp/go-tfe/pull/1138)
 * Adds BETA support for approving all plans for a stack deployment run, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1136](https://github.com/hashicorp/go-tfe/pull/1136)
 * Adds BETA support for listing and reading `StackDeploymentSteps`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @ctrombley [#1133](https://github.com/hashicorp/go-tfe/pull/1133)
 * Adds BETA support for approving all plans in `StackDeploymentGroups`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @hwatkins05-hashicorp [#1137](https://github.com/hashicorp/go-tfe/pull/1137)

--- a/stack.go
+++ b/stack.go
@@ -131,6 +131,8 @@ type StackConfiguration struct {
 	ErrorMessage         *string                             `jsonapi:"attr,error-message"`
 	EventStreamURL       string                              `jsonapi:"attr,event-stream-url"`
 	Diagnostics          []*StackDiagnostic                  `jsonapi:"attr,diags"`
+
+	Relationships map[string]interface{} `json:"relationships"`
 }
 
 // StackDeployment represents a stack deployment, specified by configuration

--- a/stack.go
+++ b/stack.go
@@ -132,7 +132,7 @@ type StackConfiguration struct {
 	EventStreamURL       string                              `jsonapi:"attr,event-stream-url"`
 	Diagnostics          []*StackDiagnostic                  `jsonapi:"attr,diags"`
 
-	Relationships map[string]interface{} `json:"relationships"`
+	Stack *Stack `jsonapi:"relation,stack"`
 }
 
 // StackDeployment represents a stack deployment, specified by configuration

--- a/stack_configuration_integration_test.go
+++ b/stack_configuration_integration_test.go
@@ -55,6 +55,15 @@ func TestStackConfigurationList(t *testing.T) {
 		require.NotEmpty(t, cfg.ID)
 		require.NotEmpty(t, cfg.Status)
 		require.GreaterOrEqual(t, cfg.SequenceNumber, 1)
+
+		if cfg.Relationships != nil {
+			stackRel, ok := cfg.Relationships["stack"].(map[string]interface{})
+			require.True(t, ok)
+			data, ok := stackRel["data"].(map[string]interface{})
+			require.True(t, ok)
+			assert.NotEmpty(t, data["id"])
+			assert.Equal(t, "stacks", data["type"])
+		}
 	}
 
 	// Test with pagination options

--- a/stack_configuration_integration_test.go
+++ b/stack_configuration_integration_test.go
@@ -1,0 +1,51 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/stretchr/testify/require"
+)
+
+func TestStackConfigurationList(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Name: "test-stack-list",
+		VCSRepo: &StackVCSRepoOptions{
+			Identifier:   "shwetamurali/pet-nulls-stack",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+		},
+		Project: &Project{
+			ID: orgTest.DefaultProject.ID,
+		},
+	})
+	NoError(t, err)
+
+	// Trigger a stack configuration by updating configuration
+	_, err = client.Stacks.UpdateConfiguration(ctx, stack.ID)
+	NoError(t, err)
+
+	// List stack configurations
+	list, err := client.StackConfigurations.List(ctx, stack.ID, nil)
+	NoError(t, err)
+	NotNil(t, list)
+	GreaterOrEqual(t, len(list.Items), 1)
+
+	for _, cfg := range list.Items {
+		NotEmpty(t, cfg.ID)
+		// Optionally, check other fields that relate the configuration to the stack, if available
+	}
+}

--- a/stack_configuration_integration_test.go
+++ b/stack_configuration_integration_test.go
@@ -8,7 +8,8 @@ import (
 	"testing"
 	"time"
 
-	. "github.com/stretchr/testify/require"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestStackConfigurationList(t *testing.T) {
@@ -33,27 +34,27 @@ func TestStackConfigurationList(t *testing.T) {
 			ID: orgTest.DefaultProject.ID,
 		},
 	})
-	NoError(t, err)
+	require.NoError(t, err)
 
 	// Trigger first stack configuration by updating configuration
 	_, err = client.Stacks.UpdateConfiguration(ctx, stack.ID)
-	NoError(t, err)
+	require.NoError(t, err)
 
 	// Wait a bit and trigger second stack configuration
 	time.Sleep(2 * time.Second)
 	_, err = client.Stacks.UpdateConfiguration(ctx, stack.ID)
-	NoError(t, err)
+	require.NoError(t, err)
 
 	list, err := client.StackConfigurations.List(ctx, stack.ID, nil)
-	NoError(t, err)
-	NotNil(t, list)
-	Equal(t, len(list.Items), 2)
+	require.NoError(t, err)
+	require.NotNil(t, list)
+	assert.Equal(t, len(list.Items), 2)
 
 	// Assert attributes for each configuration
 	for _, cfg := range list.Items {
-		NotEmpty(t, cfg.ID)
-		NotEmpty(t, cfg.Status)
-		GreaterOrEqual(t, cfg.SequenceNumber, 1)
+		require.NotEmpty(t, cfg.ID)
+		require.NotEmpty(t, cfg.Status)
+		require.GreaterOrEqual(t, cfg.SequenceNumber, 1)
 	}
 
 	// Test with pagination options
@@ -66,9 +67,11 @@ func TestStackConfigurationList(t *testing.T) {
 		}
 
 		listWithOptions, err := client.StackConfigurations.List(ctx, stack.ID, options)
-		NoError(t, err)
-		NotNil(t, listWithOptions)
-		Equal(t, len(listWithOptions.Items), 2)
-		NotNil(t, listWithOptions.Pagination)
+		require.NoError(t, err)
+		require.NotNil(t, listWithOptions)
+		assert.GreaterOrEqual(t, len(listWithOptions.Items), 2)
+
+		require.NotNil(t, listWithOptions.Pagination)
+		assert.GreaterOrEqual(t, listWithOptions.Pagination.TotalCount, 2)
 	})
 }

--- a/stack_configuration_integration_test.go
+++ b/stack_configuration_integration_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"context"
 	"testing"
+	"time"
 
 	. "github.com/stretchr/testify/require"
 )
@@ -34,18 +35,40 @@ func TestStackConfigurationList(t *testing.T) {
 	})
 	NoError(t, err)
 
-	// Trigger a stack configuration by updating configuration
+	// Trigger first stack configuration by updating configuration
 	_, err = client.Stacks.UpdateConfiguration(ctx, stack.ID)
 	NoError(t, err)
 
-	// List stack configurations
+	// Wait a bit and trigger second stack configuration
+	time.Sleep(2 * time.Second)
+	_, err = client.Stacks.UpdateConfiguration(ctx, stack.ID)
+	NoError(t, err)
+
 	list, err := client.StackConfigurations.List(ctx, stack.ID, nil)
 	NoError(t, err)
 	NotNil(t, list)
-	GreaterOrEqual(t, len(list.Items), 1)
+	Equal(t, len(list.Items), 2)
 
+	// Assert attributes for each configuration
 	for _, cfg := range list.Items {
 		NotEmpty(t, cfg.ID)
-		// Optionally, check other fields that relate the configuration to the stack, if available
+		NotEmpty(t, cfg.Status)
+		GreaterOrEqual(t, cfg.SequenceNumber, 1)
 	}
+
+	// Test with pagination options
+	t.Run("with pagination options", func(t *testing.T) {
+		options := &StackConfigurationListOptions{
+			ListOptions: ListOptions{
+				PageNumber: 1,
+				PageSize:   10,
+			},
+		}
+
+		listWithOptions, err := client.StackConfigurations.List(ctx, stack.ID, options)
+		NoError(t, err)
+		NotNil(t, listWithOptions)
+		Equal(t, len(listWithOptions.Items), 2)
+		NotNil(t, listWithOptions.Pagination)
+	})
 }

--- a/stack_configuration_integration_test.go
+++ b/stack_configuration_integration_test.go
@@ -56,14 +56,8 @@ func TestStackConfigurationList(t *testing.T) {
 		require.NotEmpty(t, cfg.Status)
 		require.GreaterOrEqual(t, cfg.SequenceNumber, 1)
 
-		if cfg.Relationships != nil {
-			stackRel, ok := cfg.Relationships["stack"].(map[string]interface{})
-			require.True(t, ok)
-			data, ok := stackRel["data"].(map[string]interface{})
-			require.True(t, ok)
-			assert.NotEmpty(t, data["id"])
-			assert.Equal(t, "stacks", data["type"])
-		}
+		require.NotNil(t, cfg.Stack)
+		require.NotEmpty(t, cfg.Stack.ID)
 	}
 
 	// Test with pagination options

--- a/stack_configuration_integration_test.go
+++ b/stack_configuration_integration_test.go
@@ -27,7 +27,7 @@ func TestStackConfigurationList(t *testing.T) {
 	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
 		Name: "test-stack-list",
 		VCSRepo: &StackVCSRepoOptions{
-			Identifier:   "shwetamurali/pet-nulls-stack",
+			Identifier:   "hashicorp-guides/pet-nulls-stack",
 			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
 		},
 		Project: &Project{


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adding an endpoint to get the list of corresponding configurations for a given `stack ID` per the [OpenAPI Spec](https://github.com/hashicorp/atlas/blob/main/openapi/spec/resources/stacks/stack-configurations/collection.yml)

## Testing plan

1. Fork `pet-nulls-stack` or any repo with stacks
2. Disable stacks-ga flag in local atlas
3. Run test


<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
`go test -v -run TestStackConfigurationList`
```
=== RUN   TestStackConfigurationList
=== RUN   TestStackConfigurationList/with_pagination_options
--- PASS: TestStackConfigurationList (8.50s)
    --- PASS: TestStackConfigurationList/with_pagination_options (0.13s)
PASS
ok      github.com/hashicorp/go-tfe     8.894s
```