### PR TITLE
Rolling `gotestsum` in CI back to previous version

### DIFF
--- a/.github/actions/test-go-tfe/action.yml
+++ b/.github/actions/test-go-tfe/action.yml
@@ -61,7 +61,7 @@ runs:
 
     - name: Install gotestsum
       shell: bash
-      run: go install gotest.tools/gotestsum@latest
+      run: go install gotest.tools/gotestsum@5768fec807c3a620b209c79845e80fb4befa5857 # v1.12.2
 
     - name: Download artifact
       id: download-artifact


### PR DESCRIPTION
## Description

In CI we are always use the latest version, but it looks like the new latest has some issues.

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
