### PR TITLE
Add fields to githubAppInstallation

### DIFF
--- a/github_app_installation.go
+++ b/github_app_installation.go
@@ -37,9 +37,12 @@ type GHAInstallationList struct {
 
 // GHAInstallation represents a github app installation
 type GHAInstallation struct {
-	ID             *string `jsonapi:"primary,github-app-installations"`
-	InstallationID *int    `jsonapi:"attr,installation-id"`
-	Name           *string `jsonapi:"attr,name"`
+	ID               *string `jsonapi:"primary,github-app-installations"`
+	IconUrl          *string `jsonapi:"attr,icon-url"`
+	InstallationID   *int    `jsonapi:"attr,installation-id"`
+	InstallationType *string `jsonapi:"attr,installation-type"`
+	InstallationURL  *string `jsonapi:"attr,installation-url"`
+	Name             *string `jsonapi:"attr,name"`
 }
 
 // GHAInstallationListOptions represents the options for listing.
@@ -51,7 +54,6 @@ type GHAInstallationListOptions struct {
 func (s *gHAInstallations) List(ctx context.Context, options *GHAInstallationListOptions) (*GHAInstallationList, error) {
 	u := "github-app/installations"
 	req, err := s.client.NewRequest("GET", u, options)
-	fmt.Println(u)
 	if err != nil {
 		return nil, err
 	}

--- a/github_app_installation_integration_test.go
+++ b/github_app_installation_integration_test.go
@@ -5,10 +5,11 @@ package tfe
 
 import (
 	"context"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"os"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestGHAInstallationList(t *testing.T) {
@@ -39,8 +40,11 @@ func TestGHAInstallationRead(t *testing.T) {
 	t.Run("when installation id exists", func(t *testing.T) {
 		ghais, err := client.GHAInstallations.Read(ctx, GHAInstallationID)
 		require.NoError(t, err)
-		assert.NotEmpty(t, ghais.InstallationID)
+		assert.NotEmpty(t, ghais.IconUrl)
 		assert.NotEmpty(t, ghais.ID)
+		assert.NotEmpty(t, ghais.InstallationID)
+		assert.NotEmpty(t, ghais.InstallationType)
+		assert.NotEmpty(t, ghais.InstallationURL)
 		assert.NotEmpty(t, ghais.Name)
 		assert.Equal(t, *ghais.ID, gHAInstallationID)
 	})


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds fields of `GHAInstallation`. `GHAInstallation` now parses `IconUrl`, `InstallationType`, and `InstallationURL`.

The change aims to be part of automating notification configuration management for workspaces. This aligns with API's NotificationConfiguration return for List, Create, Read, Update, and Verify operations. 

curl
--header "Authorization: Bearer $TOKEN"
--request GET
 --data @payload.json
https://app.terraform.io/api/v2/github-app/installations

{"data":[{"id":"ghain-***","type":"github-app-installations","attributes":{"name":"***","installation-id":***,"icon-url":"https://avatars.githubusercontent.com/u/***?v=4","installation-type":"User","installation-url":"https://github.com/settings/installations/***"}}]}

Existing function `TestGHAInstallationRead` is updated to include new fields.

## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS`, `TFE_TOKEN`, and `GITHUB_APP_INSTALLATION_ID`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" GITHUB_APP_INSTALLATION_ID="ghain-***" go test -run TestGHAInstallation -v`. The new tests should pass.
1.  `IconUrl`, `InstallationType`, and `InstallationURL` is read for `GHAInstallation`.

1.  Generate the required environment variables for go test, `TFE_ADDRESS`, `TFE_TOKEN`, and `GITHUB_APP_INSTALLATION_ID`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" GITHUB_APP_INSTALLATION_ID="ghain-***" go test -run TestGHAInstallationList -v`. The new tests should pass.
1.  `IconUrl`, `InstallationType`, and `InstallationURL` is read for `GHAInstallation`.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example"  GITHUB_APP_INSTALLATION_ID="ghain-***"  go test -run TestGHAInstallationRead -v
=== RUN   TestGHAInstallationRead
=== RUN   TestGHAInstallationRead/when_installation_id_exists
--- PASS: TestGHAInstallationRead (1.54s)
    --- PASS: TestGHAInstallationRead/when_installation_id_exists (0.42s)
PASS
ok      github.com/hashicorp/go-tfe     1.613s

$ TFE_ADDRESS="https://example" TFE_TOKEN="example"  GITHUB_APP_INSTALLATION_ID="ghain-***"  go test -run TestGHAInstallationList -v
=== RUN   TestGHAInstallationList
=== RUN   TestGHAInstallationList/without_list_options
--- PASS: TestGHAInstallationList (1.70s)
    --- PASS: TestGHAInstallationList/without_list_options (0.43s)
PASS
ok      github.com/hashicorp/go-tfe     1.791s
```
