### PR TITLE
Adds CreatedAt to AgentPool

### DIFF
--- a/agent_pool.go
+++ b/agent_pool.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // Compile-time proof of interface implementation.
@@ -52,10 +53,11 @@ type AgentPoolList struct {
 
 // AgentPool represents a HCP Terraform agent pool.
 type AgentPool struct {
-	ID                 string `jsonapi:"primary,agent-pools"`
-	Name               string `jsonapi:"attr,name"`
-	AgentCount         int    `jsonapi:"attr,agent-count"`
-	OrganizationScoped bool   `jsonapi:"attr,organization-scoped"`
+	ID                 string    `jsonapi:"primary,agent-pools"`
+	Name               string    `jsonapi:"attr,name"`
+	AgentCount         int       `jsonapi:"attr,agent-count"`
+	OrganizationScoped bool      `jsonapi:"attr,organization-scoped"`
+	CreatedAt          time.Time `jsonapi:"attr,created-at,iso8601"`
 
 	// Relations
 	Organization      *Organization `jsonapi:"relation,organization"`

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -248,6 +248,23 @@ func TestAgentPoolsRead(t *testing.T) {
 	})
 }
 
+func TestAgentPoolsReadCreatedAt(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
+
+	pool, poolCleanup := createAgentPool(t, client, orgTest)
+	defer poolCleanup()
+
+	k, err := client.AgentPools.Read(ctx, pool.ID)
+	assert.NotEmpty(t, k.CreatedAt)
+	require.NoError(t, err)
+}
+
 func TestAgentPoolsUpdate(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds `CreatedAt` field to `AgentPool` struct.

## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS` and `TFE_TOKEN`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestAgentPoolsReadCreatedAt`. The new tests should pass.
1.  `CreatedAt` is read for `AgentPool`.
```json
{
  "data": {
    "id": "apool-***",
    "type": "agent-pools",
    "attributes": {
      "name": "cool-pool",
      "created-at": "2025-06-01T03:35:11.339Z",
      "agent-count": 0,
      "organization-scoped": true
    },
    "relationships": {
      "organization": {
        "data": {
          "id": "orgTest",
          "type": "organizations"
        }
      },
      "agents": {
        "links": {
          "related": "/api/v2/agent-pools/apool-***/agents"
        }
      },
      "authentication-tokens": {
        "links": {
          "related": "/api/v2/agent-pools/apool-***/authentication-tokens"
        }
      },
      "oauth-clients": {
        "links": {
          "related": "/api/v2/organizations/orgTest/oauth-clients?filter[agent_pool]=apool-***"
        }
      },
      "workspaces": {
        "data": []
      },
      "allowed-workspaces": {
        "data": []
      }
    },
    "links": {
      "self": "/api/v2/agent-pools/apool-***"
    }
  }
}
```


## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example"go test ./... -v -run TestAgentPoolsReadCreatedAt

=== RUN   TestAgentPoolsReadCreatedAt
--- PASS: TestAgentPoolsReadCreatedAt (3.00s)
PASS
ok      github.com/hashicorp/go-tfe     3.067s
```