### PR TITLE
Add Organization Audit Configuration classes which are in limited beta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds BETA support for reading, testing and updating Organization Audit Configuration by @glennsarti-hashi [#1151](https://github.com/hashicorp/go-tfe/pull/1151)
+
 # v1.87.0
 
 ## Bug Fixes

--- a/entitlement_helper_test.go
+++ b/entitlement_helper_test.go
@@ -1,0 +1,45 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"errors"
+)
+
+func getOrgEntitlements(client *Client, organizationName string) (*Entitlements, error) {
+	ctx := context.Background()
+	orgEntitlements, err := client.Organizations.ReadEntitlements(ctx, organizationName)
+	if err != nil {
+		return nil, err
+	}
+	if orgEntitlements == nil {
+		return nil, errors.New("The organization entitlements are empty.")
+	}
+	return orgEntitlements, nil
+}
+
+func hasGlobalRunTasks(client *Client, organizationName string) (bool, error) {
+	oe, err := getOrgEntitlements(client, organizationName)
+	if err != nil {
+		return false, err
+	}
+	return oe.GlobalRunTasks, nil
+}
+
+func hasPrivateRunTasks(client *Client, organizationName string) (bool, error) {
+	oe, err := getOrgEntitlements(client, organizationName)
+	if err != nil {
+		return false, err
+	}
+	return oe.PrivateRunTasks, nil
+}
+
+func hasAuditLogging(client *Client, organizationName string) (bool, error) {
+	oe, err := getOrgEntitlements(client, organizationName)
+	if err != nil {
+		return false, err
+	}
+	return oe.AuditLogging, nil
+}

--- a/organization.go
+++ b/organization.go
@@ -189,6 +189,7 @@ type OrganizationPermissions struct {
 	CanCreateWorkspaceMigration bool `jsonapi:"attr,can-create-workspace-migration"`
 	CanDeployNoCodeModules      bool `jsonapi:"attr,can-deploy-no-code-modules"`
 	CanDestroy                  bool `jsonapi:"attr,can-destroy"`
+	CanManageAuditing           bool `jsonapi:"attr,can-manage-auditing"`
 	CanManageNoCodeModules      bool `jsonapi:"attr,can-manage-no-code-modules"`
 	CanManageRunTasks           bool `jsonapi:"attr,can-manage-run-tasks"`
 	CanTraverse                 bool `jsonapi:"attr,can-traverse"`

--- a/organization_audit_configuration.go
+++ b/organization_audit_configuration.go
@@ -1,0 +1,140 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+var _ OrganizationAuditConfigurations = (*organizationAuditConfigurations)(nil)
+
+// OrganizationAuditConfigurations describes the configuration for auditing events for the organization.
+type OrganizationAuditConfigurations interface {
+	// Read the audit configuration of an organization by its name.
+	Read(ctx context.Context, organization string) (*OrganizationAuditConfiguration, error)
+
+	// Send a test audit event for an organization by its name.
+	Test(ctx context.Context, organization string) (*OrganizationAuditConfigurationTest, error)
+
+	// Update the audit configuration of an organization by its name.
+	Update(ctx context.Context, organization string, options OrganizationAuditConfigurationOptions) (*OrganizationAuditConfiguration, error)
+}
+
+// OrganizationAuditConfiguration represents the auditing configuration for a HCP Terraform Organization.
+type OrganizationAuditConfiguration struct {
+	AuditTrails          *OrganizationAuditConfigAuditTrails    `jsonapi:"attr,audit-trails,omitempty"`
+	HCPAuditLogStreaming *OrganizationAuditConfigAuditStreaming `jsonapi:"attr,hcp-audit-log-streaming,omitempty"`
+	ID                   string                                 `jsonapi:"primary,audit-configurations"`
+	Permissions          *OrganizationAuditConfigPermissions    `jsonapi:"attr,permissions,omitempty"`
+	Timestamps           *OrganizationAuditConfigTimestamps     `jsonapi:"attr,timestamps,omitempty"`
+	UpdatedAt            time.Time                              `jsonapi:"attr,updated-at,iso8601"`
+
+	Organization *Organization `jsonapi:"relation,organization"`
+}
+
+type OrganizationAuditConfigAuditTrails struct {
+	Enabled bool `jsonapi:"attr,enabled"`
+}
+
+type OrganizationAuditConfigAuditStreaming struct {
+	Enabled                bool   `jsonapi:"attr,enabled"`
+	OrganizationID         string `jsonapi:"attr,organization-id"`
+	UseDefaultOrganization bool   `jsonapi:"attr,use-default-organization"`
+}
+
+type OrganizationAuditConfigPermissions struct {
+	CanEnableHCPAuditLogStreaming              bool `jsonapi:"attr,can-enable-hcp-audit-log-streaming"`
+	CanSetHCPAuditLogStreamingOrganization     bool `jsonapi:"attr,can-set-hcp-audit-log-streaming-organization-id"`
+	CanUseDefaultAuditLogStreamingOrganization bool `jsonapi:"attr,can-use-default-audit-log-streaming-organization"`
+}
+
+type OrganizationAuditConfigTimestamps struct {
+	AuditTrailsDisabledAt           *time.Time `jsonapi:"attr,audit-trails-disabled-at,iso8601,omitempty"`
+	AuditTrailsEnabledAt            *time.Time `jsonapi:"attr,audit-trails-enabled-at,iso8601,omitempty"`
+	AuditTrailsLastFailure          *time.Time `jsonapi:"attr,audit-trails-last-failure,iso8601,omitempty"`
+	AuditTrailsLastSuccess          *time.Time `jsonapi:"attr,audit-trails-last-success,iso8601,omitempty"`
+	HCPAuditLogStreamingDisabledAt  *time.Time `jsonapi:"attr,hcp-audit-log-streaming-disabled-at,iso8601,omitempty"`
+	HCPAuditLogStreamingEnabledAt   *time.Time `jsonapi:"attr,hcp-audit-log-streaming-enabled-at,iso8601,omitempty"`
+	HCPAuditLogStreamingLastFailure *time.Time `jsonapi:"attr,hcp-audit-log-streaming-last-failure,iso8601,omitempty"`
+	HCPAuditLogStreamingLastSuccess *time.Time `jsonapi:"attr,hcp-audit-log-streaming-last-success,iso8601,omitempty"`
+}
+
+type OrganizationAuditConfigurationTest struct {
+	RequestID *string `json:"request-id,omitempty"`
+}
+
+type OrganizationAuditConfigurationOptions struct {
+	AuditTrails          *OrganizationAuditConfigAuditTrails    `jsonapi:"attr,audit-trails,omitempty"`
+	HCPAuditLogStreaming *OrganizationAuditConfigAuditStreaming `jsonapi:"attr,hcp-audit-log-streaming,omitempty"`
+}
+
+type organizationAuditConfigurations struct {
+	client *Client
+}
+
+// Read the audit configuration of an organization by its name.
+func (s *organizationAuditConfigurations) Read(ctx context.Context, organization string) (*OrganizationAuditConfiguration, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+
+	u := fmt.Sprintf("organizations/%s/audit-configuration", url.PathEscape(organization))
+	req, err := s.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ac := &OrganizationAuditConfiguration{}
+	err = req.Do(ctx, ac)
+	if err != nil {
+		return nil, err
+	}
+
+	return ac, err
+}
+
+// Send a test audit event for an organization by its name.
+func (s *organizationAuditConfigurations) Test(ctx context.Context, organization string) (*OrganizationAuditConfigurationTest, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+
+	u := fmt.Sprintf("organizations/%s/audit-configuration/test", url.PathEscape(organization))
+	req, err := s.client.NewRequest("POST", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	result := &OrganizationAuditConfigurationTest{}
+	err = req.DoJSON(ctx, result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, err
+}
+
+// Update the audit configuration of an organization by its name.
+func (s *organizationAuditConfigurations) Update(ctx context.Context, organization string, options OrganizationAuditConfigurationOptions) (*OrganizationAuditConfiguration, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+
+	u := fmt.Sprintf("organizations/%s/audit-configuration", url.PathEscape(organization))
+	req, err := s.client.NewRequest("PATCH", u, &options)
+	if err != nil {
+		return nil, err
+	}
+
+	ac := &OrganizationAuditConfiguration{}
+	err = req.Do(ctx, ac)
+	if err != nil {
+		return nil, err
+	}
+
+	return ac, err
+}

--- a/organization_audit_configuration_integration_test.go
+++ b/organization_audit_configuration_integration_test.go
@@ -1,0 +1,104 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestOrganizationAuditConfigurationRead(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	newSubscriptionUpdater(orgTest).WithBusinessPlan().Update(t)
+
+	if v, err := hasAuditLogging(client, orgTest.Name); err != nil {
+		t.Fatalf("Could not retrieve the entitlements for the test organization.: %s", err)
+	} else if !v {
+		t.Fatal("The test organization requires the audit-logging entitlement but is not entitled.")
+		return
+	}
+
+	ac, err := client.OrganizationAuditConfigurations.Read(ctx, orgTest.Name)
+	require.NoError(t, err)
+
+	// By default audit trails is enabled
+	assert.Equal(t, ac.AuditTrails.Enabled, true)
+	assert.NotNil(t, ac.Organization)
+	assert.Equal(t, orgTest.Name, ac.Organization.Name)
+}
+
+func TestOrganizationAuditConfigurationTest(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	newSubscriptionUpdater(orgTest).WithBusinessPlan().Update(t)
+
+	if v, err := hasAuditLogging(client, orgTest.Name); err != nil {
+		t.Fatalf("Could not retrieve the entitlements for the test organization.: %s", err)
+	} else if !v {
+		t.Fatal("The test organization requires the audit-logging entitlement but is not entitled.")
+		return
+	}
+
+	result, err := client.OrganizationAuditConfigurations.Test(ctx, orgTest.Name)
+	require.NoError(t, err)
+
+	// Expect a Request ID is returned
+	assert.NotNil(t, result.RequestID)
+}
+
+func TestOrganizationAuditConfigurationUpdate(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	newSubscriptionUpdater(orgTest).WithBusinessPlan().Update(t)
+
+	if v, err := hasAuditLogging(client, orgTest.Name); err != nil {
+		t.Fatalf("Could not retrieve the entitlements for the test organization.: %s", err)
+	} else if !v {
+		t.Fatal("The test organization requires the audit-logging entitlement but is not entitled.")
+		return
+	}
+
+	ac, err := client.OrganizationAuditConfigurations.Read(ctx, orgTest.Name)
+	require.NoError(t, err)
+
+	// Unfortunately we can't really test the HCP Log Streaming because it requires either an integrated HCP organization,
+	// or a valid HCP login session. Neither of which are setup for the test organization. Instead we just "update" the settings
+	// with the existing ones. This doesn't prove that the endpoint behaves properly, but just tests that we can at least send
+	// a payload to the expected API route.
+	newCfg, err := client.OrganizationAuditConfigurations.Update(ctx, orgTest.Name, OrganizationAuditConfigurationOptions{
+		AuditTrails: &OrganizationAuditConfigAuditTrails{
+			Enabled: ac.AuditTrails.Enabled,
+		},
+		HCPAuditLogStreaming: &OrganizationAuditConfigAuditStreaming{
+			Enabled: ac.HCPAuditLogStreaming.Enabled,
+		},
+	})
+
+	require.NoError(t, err)
+
+	assert.Equal(t, ac.AuditTrails.Enabled, newCfg.AuditTrails.Enabled)
+	assert.Equal(t, ac.HCPAuditLogStreaming.Enabled, newCfg.HCPAuditLogStreaming.Enabled)
+}

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -5,41 +5,12 @@ package tfe
 
 import (
 	"context"
-	"errors"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-func getOrgEntitlements(client *Client, organizationName string) (*Entitlements, error) {
-	ctx := context.Background()
-	orgEntitlements, err := client.Organizations.ReadEntitlements(ctx, organizationName)
-	if err != nil {
-		return nil, err
-	}
-	if orgEntitlements == nil {
-		return nil, errors.New("The organization entitlements are empty.")
-	}
-	return orgEntitlements, nil
-}
-
-func hasGlobalRunTasks(client *Client, organizationName string) (bool, error) {
-	oe, err := getOrgEntitlements(client, organizationName)
-	if err != nil {
-		return false, err
-	}
-	return oe.GlobalRunTasks, nil
-}
-
-func hasPrivateRunTasks(client *Client, organizationName string) (bool, error) {
-	oe, err := getOrgEntitlements(client, organizationName)
-	if err != nil {
-		return false, err
-	}
-	return oe.PrivateRunTasks, nil
-}
 
 func TestRunTasksCreate(t *testing.T) {
 	client := testClient(t)

--- a/tfe.go
+++ b/tfe.go
@@ -123,74 +123,75 @@ type Client struct {
 	remoteTFEVersion  string
 	appName           string
 
-	Admin                      Admin
-	Agents                     Agents
-	AgentPools                 AgentPools
-	AgentTokens                AgentTokens
-	Applies                    Applies
-	AuditTrails                AuditTrails
-	Comments                   Comments
-	ConfigurationVersions      ConfigurationVersions
-	CostEstimates              CostEstimates
-	GHAInstallations           GHAInstallations
-	GPGKeys                    GPGKeys
-	NotificationConfigurations NotificationConfigurations
-	OAuthClients               OAuthClients
-	OAuthTokens                OAuthTokens
-	Organizations              Organizations
-	OrganizationMemberships    OrganizationMemberships
-	OrganizationTags           OrganizationTags
-	OrganizationTokens         OrganizationTokens
-	Plans                      Plans
-	PlanExports                PlanExports
-	Policies                   Policies
-	PolicyChecks               PolicyChecks
-	PolicyEvaluations          PolicyEvaluations
-	PolicySetOutcomes          PolicySetOutcomes
-	PolicySetParameters        PolicySetParameters
-	PolicySetVersions          PolicySetVersions
-	PolicySets                 PolicySets
-	RegistryModules            RegistryModules
-	RegistryNoCodeModules      RegistryNoCodeModules
-	RegistryProviders          RegistryProviders
-	RegistryProviderPlatforms  RegistryProviderPlatforms
-	RegistryProviderVersions   RegistryProviderVersions
-	ReservedTagKeys            ReservedTagKeys
-	Runs                       Runs
-	RunEvents                  RunEvents
-	RunTasks                   RunTasks
-	RunTasksIntegration        RunTasksIntegration
-	RunTriggers                RunTriggers
-	SSHKeys                    SSHKeys
-	Stacks                     Stacks
-	StackConfigurations        StackConfigurations
-	StackDeployments           StackDeployments
-	StackDeploymentGroups      StackDeploymentGroups
-	StackDeploymentRuns        StackDeploymentRuns
-	StackDeploymentSteps       StackDeploymentSteps
-	StackPlans                 StackPlans
-	StackPlanOperations        StackPlanOperations
-	StackSources               StackSources
-	StateVersionOutputs        StateVersionOutputs
-	StateVersions              StateVersions
-	TaskResults                TaskResults
-	TaskStages                 TaskStages
-	Teams                      Teams
-	TeamAccess                 TeamAccesses
-	TeamMembers                TeamMembers
-	TeamProjectAccess          TeamProjectAccesses
-	TeamTokens                 TeamTokens
-	TestRuns                   TestRuns
-	TestVariables              TestVariables
-	Users                      Users
-	UserTokens                 UserTokens
-	Variables                  Variables
-	VariableSets               VariableSets
-	VariableSetVariables       VariableSetVariables
-	Workspaces                 Workspaces
-	WorkspaceResources         WorkspaceResources
-	WorkspaceRunTasks          WorkspaceRunTasks
-	Projects                   Projects
+	Admin                           Admin
+	Agents                          Agents
+	AgentPools                      AgentPools
+	AgentTokens                     AgentTokens
+	Applies                         Applies
+	AuditTrails                     AuditTrails
+	Comments                        Comments
+	ConfigurationVersions           ConfigurationVersions
+	CostEstimates                   CostEstimates
+	GHAInstallations                GHAInstallations
+	GPGKeys                         GPGKeys
+	NotificationConfigurations      NotificationConfigurations
+	OAuthClients                    OAuthClients
+	OAuthTokens                     OAuthTokens
+	OrganizationAuditConfigurations OrganizationAuditConfigurations
+	OrganizationMemberships         OrganizationMemberships
+	Organizations                   Organizations
+	OrganizationTags                OrganizationTags
+	OrganizationTokens              OrganizationTokens
+	Plans                           Plans
+	PlanExports                     PlanExports
+	Policies                        Policies
+	PolicyChecks                    PolicyChecks
+	PolicyEvaluations               PolicyEvaluations
+	PolicySetOutcomes               PolicySetOutcomes
+	PolicySetParameters             PolicySetParameters
+	PolicySetVersions               PolicySetVersions
+	PolicySets                      PolicySets
+	RegistryModules                 RegistryModules
+	RegistryNoCodeModules           RegistryNoCodeModules
+	RegistryProviders               RegistryProviders
+	RegistryProviderPlatforms       RegistryProviderPlatforms
+	RegistryProviderVersions        RegistryProviderVersions
+	ReservedTagKeys                 ReservedTagKeys
+	Runs                            Runs
+	RunEvents                       RunEvents
+	RunTasks                        RunTasks
+	RunTasksIntegration             RunTasksIntegration
+	RunTriggers                     RunTriggers
+	SSHKeys                         SSHKeys
+	Stacks                          Stacks
+	StackConfigurations             StackConfigurations
+	StackDeployments                StackDeployments
+	StackDeploymentGroups           StackDeploymentGroups
+	StackDeploymentRuns             StackDeploymentRuns
+	StackDeploymentSteps            StackDeploymentSteps
+	StackPlans                      StackPlans
+	StackPlanOperations             StackPlanOperations
+	StackSources                    StackSources
+	StateVersionOutputs             StateVersionOutputs
+	StateVersions                   StateVersions
+	TaskResults                     TaskResults
+	TaskStages                      TaskStages
+	Teams                           Teams
+	TeamAccess                      TeamAccesses
+	TeamMembers                     TeamMembers
+	TeamProjectAccess               TeamProjectAccesses
+	TeamTokens                      TeamTokens
+	TestRuns                        TestRuns
+	TestVariables                   TestVariables
+	Users                           Users
+	UserTokens                      UserTokens
+	Variables                       Variables
+	VariableSets                    VariableSets
+	VariableSetVariables            VariableSetVariables
+	Workspaces                      Workspaces
+	WorkspaceResources              WorkspaceResources
+	WorkspaceRunTasks               WorkspaceRunTasks
+	Projects                        Projects
 
 	Meta Meta
 }
@@ -473,6 +474,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.Organizations = &organizations{client: client}
 	client.OrganizationTags = &organizationTags{client: client}
 	client.OrganizationTokens = &organizationTokens{client: client}
+	client.OrganizationAuditConfigurations = &organizationAuditConfigurations{client: client}
 	client.PlanExports = &planExports{client: client}
 	client.Plans = &plans{client: client}
 	client.Policies = &policies{client: client}


### PR DESCRIPTION
## Description

This PR adds the new Organization Audit Configuration classes and API routes which are in limited Beta in HashiCorp Terraform. Note here that the API is stable

## Testing plan

Via acceptance tests

## External links

API documentation is currently a Work In Progress.

## Output from tests

```text
=== RUN   TestOrganizationAuditConfigurationRead
--- PASS: TestOrganizationAuditConfigurationRead (3.28s)
=== RUN   TestOrganizationAuditConfigurationTest
--- PASS: TestOrganizationAuditConfigurationTest (2.49s)
=== RUN   TestOrganizationAuditConfigurationUpdate
--- PASS: TestOrganizationAuditConfigurationUpdate (2.77s)
PASS
ok  	github.com/hashicorp/go-tfe	8.778s
?   	github.com/hashicorp/go-tfe/examples/backing_data	[no test files]
?   	github.com/hashicorp/go-tfe/examples/configuration_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/organizations	[no test files]
?   	github.com/hashicorp/go-tfe/examples/projects	[no test files]
?   	github.com/hashicorp/go-tfe/examples/registry_modules	[no test files]
?   	github.com/hashicorp/go-tfe/examples/run_errors	[no test files]
?   	github.com/hashicorp/go-tfe/examples/state_versions	[no test files]
?   	github.com/hashicorp/go-tfe/examples/users	[no test files]
?   	github.com/hashicorp/go-tfe/examples/workspaces	[no test files]
?   	github.com/hashicorp/go-tfe/mocks	[no test files]
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

N/A

## Changes to Security Controls

N/A
