### PR TITLE
`Includes` option for stack deployment runs Read/List

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds option for `Includes` for `StackDeploymentRuns` Read/List, by @Maed223 [#1152](https://github.com/hashicorp/go-tfe/pull/1152)
+
 # v1.85.0
 
 ## Bug Fixes

--- a/stack_deployment_runs.go
+++ b/stack_deployment_runs.go
@@ -15,6 +15,7 @@ type StackDeploymentRuns interface {
 	// List returns a list of stack deployment runs for a given deployment group.
 	List(ctx context.Context, deploymentGroupID string, options *StackDeploymentRunListOptions) (*StackDeploymentRunList, error)
 	Read(ctx context.Context, stackDeploymentRunID string) (*StackDeploymentRun, error)
+	ReadWithOptions(ctx context.Context, stackDeploymentRunID string, options *StackDeploymentRunReadOptions) (*StackDeploymentRun, error)
 	ApproveAllPlans(ctx context.Context, deploymentRunID string) error
 }
 
@@ -36,15 +37,28 @@ type StackDeploymentRun struct {
 	StackDeploymentGroup *StackDeploymentGroup `jsonapi:"relation,stack-deployment-group"`
 }
 
+type SDRIncludeOpt string
+
+const (
+	SDRDeploymentGroup SDRIncludeOpt = "stack-deployment-group"
+)
+
 // StackDeploymentRunList represents a list of stack deployment runs.
 type StackDeploymentRunList struct {
 	*Pagination
 	Items []*StackDeploymentRun
 }
 
+type StackDeploymentRunReadOptions struct {
+	// Optional: A list of relations to include.
+	Include []SDRIncludeOpt `url:"include,omitempty"`
+}
+
 // StackDeploymentRunListOptions represents the options for listing stack deployment runs.
 type StackDeploymentRunListOptions struct {
 	ListOptions
+	// Optional: A list of relations to include.
+	Include []SDRIncludeOpt `url:"include,omitempty"`
 }
 
 // List returns a list of stack deployment runs for a given deployment group.
@@ -78,6 +92,25 @@ func (s stackDeploymentRuns) Read(ctx context.Context, stackDeploymentRunID stri
 	return &run, nil
 }
 
+func (s stackDeploymentRuns) ReadWithOptions(ctx context.Context, stackDeploymentRunID string, options *StackDeploymentRunReadOptions) (*StackDeploymentRun, error) {
+	if err := options.valid(); err != nil {
+		return nil, err
+	}
+
+	req, err := s.client.NewRequest("GET", fmt.Sprintf("stack-deployment-runs/%s", url.PathEscape(stackDeploymentRunID)), options)
+	if err != nil {
+		return nil, err
+	}
+
+	run := StackDeploymentRun{}
+	err = req.Do(ctx, &run)
+	if err != nil {
+		return nil, err
+	}
+
+	return &run, nil
+}
+
 func (s stackDeploymentRuns) ApproveAllPlans(ctx context.Context, stackDeploymentRunID string) error {
 	req, err := s.client.NewRequest("POST", fmt.Sprintf("stack-deployment-runs/%s/approve-all-plans", url.PathEscape(stackDeploymentRunID)), nil)
 	if err != nil {
@@ -85,4 +118,16 @@ func (s stackDeploymentRuns) ApproveAllPlans(ctx context.Context, stackDeploymen
 	}
 
 	return req.Do(ctx, nil)
+}
+
+func (o *StackDeploymentRunReadOptions) valid() error {
+	for _, include := range o.Include {
+		switch include {
+		case SDRDeploymentGroup:
+			// Valid option, do nothing.
+		default:
+			return fmt.Errorf("invalid include option: %s", include)
+		}
+	}
+	return nil
 }

--- a/stack_deployment_runs_integration_test.go
+++ b/stack_deployment_runs_integration_test.go
@@ -71,6 +71,28 @@ func TestStackDeploymentRunsList(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotNil(t, runList)
 	})
+
+	t.Run("With include option", func(t *testing.T) {
+		t.Parallel()
+
+		runList, err := client.StackDeploymentRuns.List(ctx, deploymentGroupID, &StackDeploymentRunListOptions{
+			Include: []SDRIncludeOpt{"stack-deployment-group"},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, runList)
+		for _, run := range runList.Items {
+			assert.NotNil(t, run.StackDeploymentGroup.ID)
+		}
+	})
+
+	t.Run("With invalid include option", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := client.StackDeploymentRuns.List(ctx, deploymentGroupID, &StackDeploymentRunListOptions{
+			Include: []SDRIncludeOpt{"invalid-option"},
+		})
+		assert.Error(t, err)
+	})
 }
 
 func TestStackDeploymentRunsRead(t *testing.T) {
@@ -124,6 +146,20 @@ func TestStackDeploymentRunsRead(t *testing.T) {
 
 	t.Run("Read with invalid ID", func(t *testing.T) {
 		_, err := client.StackDeploymentRuns.Read(ctx, "")
+		assert.Error(t, err)
+	})
+	t.Run("Read with options", func(t *testing.T) {
+		run, err := client.StackDeploymentRuns.ReadWithOptions(ctx, sdr.ID, &StackDeploymentRunReadOptions{
+			Include: []SDRIncludeOpt{"stack-deployment-group"},
+		})
+		assert.NoError(t, err)
+		assert.NotNil(t, run)
+		assert.NotNil(t, run.StackDeploymentGroup.ID)
+	})
+	t.Run("Read with invalid options", func(t *testing.T) {
+		_, err := client.StackDeploymentRuns.ReadWithOptions(ctx, sdr.ID, &StackDeploymentRunReadOptions{
+			Include: []SDRIncludeOpt{"invalid-option"},
+		})
 		assert.Error(t, err)
 	})
 }


### PR DESCRIPTION
## Description

We unintentionally omitted the ability to specify inclusions for stack deployment runs, this PR adds such an option for Read/List.

## Testing plan

Added unit tests pertaining to the new option.

## External links

JIRA: https://hashicorp.atlassian.net/browse/TF-27398?atlOrigin=eyJpIjoiNTQzYzY4YTBkOGJiNDg2MGI4NmU4YWVhYzQ0NTMyMzIiLCJwIjoiaiJ9

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
