### PR TITLE
TF-26943 Adds support for RegistryModule VCS source_directory and tag_prefix options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 
 * Adds BETA support for reading, testing and updating Organization Audit Configuration by @glennsarti-hashi [#1151](https://github.com/hashicorp/go-tfe/pull/1151)
+* Adds support for `RegistryModule` VCS source_directory and tag_prefix options, by @jillrami [#1154] (https://github.com/hashicorp/go-tfe/pull/1154)
 
 # v1.87.0
 

--- a/helper_test.go
+++ b/helper_test.go
@@ -991,6 +991,15 @@ func createOrganization(t *testing.T, client *Client) (*Organization, func()) {
 	})
 }
 
+func createOrganizationWithMonorepoSupport(t *testing.T, client *Client) (*Organization, func()) {
+	return createOrganizationWithOptions(t, client, OrganizationCreateOptions{
+		Name:                           String("tst-" + randomString(t)),
+		Email:                          String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+		CostEstimationEnabled:          Bool(true),
+		RegistryMonorepoSupportEnabled: Bool(true),
+	})
+}
+
 func createOrganizationWithOptions(t *testing.T, client *Client, options OrganizationCreateOptions) (*Organization, func()) {
 	ctx := context.Background()
 	org, err := client.Organizations.Create(ctx, options)

--- a/organization.go
+++ b/organization.go
@@ -258,6 +258,9 @@ type OrganizationCreateOptions struct {
 	// Optional: StacksEnabled toggles whether stacks are enabled for the organization. This setting
 	// is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
 	StacksEnabled *bool `jsonapi:"attr,stacks-enabled,omitempty"`
+
+	// Optional: RegistryMonorepoSupportEnabled toggles whether monorepo support is enabled for the organization
+	RegistryMonorepoSupportEnabled *bool `jsonapi:"attr,registry-monorepo-support-enabled,omitempty"`
 }
 
 // OrganizationUpdateOptions represents the options for updating an organization.
@@ -313,6 +316,9 @@ type OrganizationUpdateOptions struct {
 	// Optional: StacksEnabled toggles whether stacks are enabled for the organization. This setting
 	// is considered BETA, SUBJECT TO CHANGE, and likely unavailable to most users.
 	StacksEnabled *bool `jsonapi:"attr,stacks-enabled,omitempty"`
+
+	// Optional: RegistryMonorepoSupportEnabled toggles whether monorepo support is enabled for the organization
+	RegistryMonorepoSupportEnabled *bool `jsonapi:"attr,registry-monorepo-support-enabled,omitempty"`
 }
 
 // ReadRunQueueOptions represents the options for showing the queue.

--- a/registry_module.go
+++ b/registry_module.go
@@ -370,6 +370,10 @@ type RegistryModuleVCSRepoOptions struct {
 	// **Note: This field is still in BETA and subject to change.**
 	Branch *string `json:"branch,omitempty"`
 	Tags   *bool   `json:"tags,omitempty"`
+
+	// Optional: If set, the registry module will be branch-based or tag-based
+	SourceDirectory *string `json:"source-directory,omitempty"`
+	TagPrefix       *string `json:"tag-prefix,omitempty"`
 }
 
 type RegistryModuleVCSRepoUpdateOptions struct {
@@ -380,6 +384,10 @@ type RegistryModuleVCSRepoUpdateOptions struct {
 	// **Note: This field is still in BETA and subject to change.**
 	Branch *string `json:"branch,omitempty"`
 	Tags   *bool   `json:"tags,omitempty"`
+
+	// Optional: If set, the registry module will be branch-based or tag-based
+	SourceDirectory *string `json:"source-directory,omitempty"`
+	TagPrefix       *string `json:"tag-prefix,omitempty"`
 }
 
 // List all the registry modules within an organization.

--- a/workspace.go
+++ b/workspace.go
@@ -273,6 +273,8 @@ type VCSRepo struct {
 	Tags              bool   `jsonapi:"attr,tags"`
 	TagsRegex         string `jsonapi:"attr,tags-regex"`
 	WebhookURL        string `jsonapi:"attr,webhook-url"`
+	SourceDirectory   string `jsonapi:"attr,source-directory"`
+	TagPrefix         string `jsonapi:"attr,tag-prefix"`
 }
 
 // Note: the fields of this struct are bool pointers instead of bool values, in order to simplify support for


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR introduces new fields to create a registry module with. The two fields are "source-directory" and "tag-prefix". If a source-directory is provided without a tag-prefix, the registry module is branch based. If a tag-prefix is provided with or without a source directory, it is branch based. The associated organization must have the setting `RegistryMonorepoSupportEnabled` enabled.

## Testing plan

Utilize registry module go-tfe client to create a registry module with branch based or tag based publishing. Enable RegistryMonorepoSupportEnabled setting to true on the associated organization.
Create the new registry module with either of these three conditions
- Source directory provided without a tag prefix (branch)
- Source directory provided with a tag prefix (tag)
- Tag prefix provided without a source directory (tag) 
<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/hashicorp/slug-ingress/pull/297)
- [RFC](https://docs.google.com/document/d/1D55RSQ0K7pn59tZg67sAPWklrgP11-Lt60hKyGGryQw/edit?usp=sharing)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-26943)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->

```
=== RUN   TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options_including_source_directory
--- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection (4.43s)
    --- PASS: TestRegistryModulesCreateBranchBasedWithVCSConnection/with_valid_options_including_source_directory (1.92s)
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->