### PR TITLE
Adds CreatedBy to AgentToken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds `CreatedBy` relation to `AgentToken` by @jpadrianoGo [#1149](https://github.com/hashicorp/go-tfe/pull/1149)
+
 # v1.90.0
 
 ## Bug Fixes

--- a/agent_token.go
+++ b/agent_token.go
@@ -44,6 +44,9 @@ type AgentToken struct {
 	Description string    `jsonapi:"attr,description"`
 	LastUsedAt  time.Time `jsonapi:"attr,last-used-at,iso8601"`
 	Token       string    `jsonapi:"attr,token"`
+
+	// Relations
+	CreatedBy *User `jsonapi:"relation,created-by"`
 }
 
 // AgentTokenList represents a list of agent tokens.

--- a/agent_token_integration_test.go
+++ b/agent_token_integration_test.go
@@ -108,6 +108,23 @@ func TestAgentTokensRead(t *testing.T) {
 	})
 }
 
+func TestAgentTokensReadCreatedBy(t *testing.T) {
+	skipIfEnterprise(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	apTest, apTestCleanup := createAgentPool(t, client, nil)
+	defer apTestCleanup()
+
+	token, tokenTestCleanup := createAgentToken(t, client, apTest)
+	defer tokenTestCleanup()
+
+	at, err := client.AgentTokens.Read(ctx, token.ID)
+	require.NoError(t, err)
+	require.NotNil(t, at.CreatedBy)
+}
+
 func TestAgentTokensDelete(t *testing.T) {
 	skipIfEnterprise(t)
 


### PR DESCRIPTION
## Description

This PR adds `CreatedBy` relation to `AgentToken` struct, originally by @jpAdrianoGo (#1149).

## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS` and `TFE_TOKEN`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestAgentTokensReadCreatedBy`. The new tests should pass.
1.  `CreatedBy` relation is read for `AgentToken`.
```json
{
  "data": {
    "id": "at-***",
    "type": "authentication-tokens",
    "attributes": {
      "created-at": "2025-07-05T01:50:16.218Z",
      "last-used-at": null,
      "description": "this agent token is created by user-***",
      "token": null,
      "expired-at": null
    },
    "relationships": {
      "team": {
        "data": null
      },
      "created-by": {
        "data": {
          "id": "user-***",
          "type": "users"
        }
      }
    }
  }
}
```



## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example"go test ./... -v -run TestAgentTokensReadCreatedBy

=== RUN   TestAgentTokensReadCreatedBy
--- PASS: TestAgentTokensReadCreatedBy (3.56s)
PASS
ok      github.com/hashicorp/go-tfe     3.614s
```
