### PR TITLE
Adds CanceledAt, RunEvents, TriggerReason fields to Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Adds `CanceledAt`, `RunEvents`, `TriggerReason` field to `Run` by @jpadrianoGo [#1161](https://github.com/hashicorp/go-tfe/pull/1161)
+
 # v1.87.0
 
 ## Bug Fixes

--- a/run.go
+++ b/run.go
@@ -135,6 +135,7 @@ type Run struct {
 	AutoApply              bool                 `jsonapi:"attr,auto-apply,omitempty"`
 	AllowConfigGeneration  *bool                `jsonapi:"attr,allow-config-generation,omitempty"`
 	AllowEmptyApply        bool                 `jsonapi:"attr,allow-empty-apply"`
+	CanceledAt             time.Time            `jsonapi:"attr,canceled-at,iso8601"`
 	CreatedAt              time.Time            `jsonapi:"attr,created-at,iso8601"`
 	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
@@ -153,6 +154,7 @@ type Run struct {
 	StatusTimestamps       *RunStatusTimestamps `jsonapi:"attr,status-timestamps"`
 	TargetAddrs            []string             `jsonapi:"attr,target-addrs,omitempty"`
 	TerraformVersion       string               `jsonapi:"attr,terraform-version"`
+	TriggerReason          string               `jsonapi:"attr,trigger-reason"`
 	Variables              []*RunVariableAttr   `jsonapi:"attr,variables"`
 
 	// Relations
@@ -163,6 +165,7 @@ type Run struct {
 	ConfirmedBy          *User                 `jsonapi:"relation,confirmed-by"`
 	Plan                 *Plan                 `jsonapi:"relation,plan"`
 	PolicyChecks         []*PolicyCheck        `jsonapi:"relation,policy-checks"`
+	RunEvents            []*RunEvent           `jsonapi:"relation,run-events"`
 	TaskStages           []*TaskStage          `jsonapi:"relation,task-stages,omitempty"`
 	Workspace            *Workspace            `jsonapi:"relation,workspace"`
 	Comments             []*Comment            `jsonapi:"relation,comments"`

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -473,6 +473,96 @@ func TestRunsConfirmedBy(t *testing.T) {
 	})
 }
 
+func TestRunsCanceledAt(t *testing.T) {
+	client := testClient(t)
+
+	ctx := context.Background()
+
+	wTest, wTestCleanup := createWorkspace(t, client, nil)
+	t.Cleanup(wTestCleanup)
+
+	// We need to create 2 runs here. The first run will automatically
+	// be planned so that one cannot be cancelled. The second one will
+	// be pending until the first one is confirmed or discarded, so we
+	// can cancel that one.
+	createRun(t, client, wTest)
+	rTest, _ := createRun(t, client, wTest)
+
+	t.Run("when the run is not canceled", func(t *testing.T) {
+		r, err := client.Runs.Read(ctx, rTest.ID)
+		require.NoError(t, err)
+
+		assert.Empty(t, r.CanceledAt)
+	})
+
+	t.Run("when the run is canceled", func(t *testing.T) {
+		err := client.Runs.Cancel(ctx, rTest.ID, RunCancelOptions{})
+		require.NoError(t, err)
+
+		for i := 1; ; i++ {
+			// Refresh the view of the run
+			rTest, err = client.Runs.Read(ctx, rTest.ID)
+			require.NoError(t, err)
+
+			// Check if the timestamp is present.
+			if !rTest.ForceCancelAvailableAt.IsZero() {
+				break
+			}
+
+			if i > 30 {
+				t.Fatal("Timeout waiting for run to be canceled")
+			}
+
+			time.Sleep(time.Second)
+		}
+
+		r, err := client.Runs.Read(ctx, rTest.ID)
+		require.NoError(t, err)
+
+		assert.NotEmpty(t, r.CanceledAt)
+	})
+}
+
+func TestRunsRunEvents(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	wTest, wTestCleanup := createWorkspace(t, client, nil)
+	defer wTestCleanup()
+
+	_, cvCleanup := createUploadedConfigurationVersion(t, client, wTest)
+	t.Cleanup(cvCleanup)
+
+	options := RunCreateOptions{
+		Workspace: wTest,
+	}
+
+	r, err := client.Runs.Create(ctx, options)
+	require.NoError(t, err)
+
+	assert.NotEmpty(t, r.RunEvents)
+}
+
+func TestRunsTriggerReason(t *testing.T) {
+	client := testClient(t)
+	ctx := context.Background()
+
+	wTest, wTestCleanup := createWorkspace(t, client, nil)
+	defer wTestCleanup()
+
+	_, cvCleanup := createUploadedConfigurationVersion(t, client, wTest)
+	t.Cleanup(cvCleanup)
+
+	options := RunCreateOptions{
+		Workspace: wTest,
+	}
+
+	r, err := client.Runs.Create(ctx, options)
+	require.NoError(t, err)
+
+	assert.NotNil(t, r.TriggerReason)
+}
+
 func TestRunsApply(t *testing.T) {
 	client := testClient(t)
 	ctx := context.Background()


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This PR adds `CanceledAt`, `RunEvents`, `TriggerReason` fields to `Run` struct.

## Testing plan

1.  Generate the required environment variables for go test, `TFE_ADDRESS` and `TFE_TOKEN`
1.  Run `TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestRunsCanceledAt`. The new tests should pass.
1.  `CanceledAt`, `RunEvents`, `TriggerReason` is read for `Run`.
```json
{
  "data": {
    "id": "run-***",
    "type": "runs",
    "attributes": {
      "actions": {
        "is-cancelable": false,
        "is-confirmable": false,
        "is-discardable": false,
        "is-force-cancelable": false
      },
      "allow-config-generation": false,
      "allow-empty-apply": false,
      "auto-apply": false,
      "canceled-at": "2025-07-21T08:42:10.617Z",
      "created-at": "2025-07-21T08:42:10.116Z",
      "has-changes": false,
      "is-destroy": false,
      "message": "Triggered via API",
      "plan-only": false,
      "refresh": true,
      "refresh-only": false,
      "replace-addrs": null,
      "save-plan": false,
      "source": "tfe-api",
      "status-timestamps": {
        "force-canceled-at": "2025-07-21T08:42:10+00:00"
      },
      "status": "canceled",
      "target-addrs": null,
      "trigger-reason": "manual",
      "terraform-version": "1.12.2",
      "updated-at": "2025-07-21T08:42:10.673Z",
      "permissions": {
        "can-apply": true,
        "can-cancel": true,
        "can-comment": true,
        "can-discard": true,
        "can-force-execute": true,
        "can-force-cancel": true,
        "can-override-policy-check": true
      },
      "variables": [],
      "force-cancel-available-at": "2025-07-21T08:43:10.617Z"
    },
    "relationships": {
      "workspace": {
        "data": {
          "id": "ws-***",
          "type": "workspaces"
        }
      },
      "apply": {
        "data": {
          "id": "apply-***",
          "type": "applies"
        },
        "links": {
          "related": "/api/v2/runs/run-***/apply"
        }
      },
      "canceled-by": {
        "data": {
          "id": "user-***",
          "type": "users"
        },
        "links": {
          "related": "/api/v2/runs/run-***/canceled-by"
        }
      },
      "configuration-version": {
        "data": {
          "id": "cv-***",
          "type": "configuration-versions"
        },
        "links": {
          "related": "/api/v2/runs/run-***/configuration-version"
        }
      },
      "created-by": {
        "data": {
          "id": "user-***",
          "type": "users"
        },
        "links": {
          "related": "/api/v2/runs/run-***/created-by"
        }
      },
      "plan": {
        "data": {
          "id": "plan-***",
          "type": "plans"
        },
        "links": {
          "related": "/api/v2/runs/run-***/plan"
        }
      },
      "run-events": {
        "data": [
          {
            "id": "re-***",
            "type": "run-events"
          },
          {
            "id": "re-***",
            "type": "run-events"
          },
          {
            "id": "re-***",
            "type": "run-events"
          }
        ],
        "links": {
          "related": "/api/v2/runs/run-***/run-events"
        }
      },
      "task-stages": {
        "data": [],
        "links": {
          "related": "/api/v2/runs/run-***/task-stages"
        }
      },
      "policy-checks": {
        "data": [],
        "links": {
          "related": "/api/v2/runs/run-***/policy-checks"
        }
      },
      "comments": {
        "data": [],
        "links": {
          "related": "/api/v2/runs/run-***/comments"
        }
      }
    },
    "links": {
      "self": "/api/v2/runs/run-***"
    }
  }
}
```


## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example"go test ./... -v -run TestRunsCanceledAt 

=== RUN   TestRunsCanceledAt
=== RUN   TestRunsCanceledAt/when_the_run_is_not_canceled
=== RUN   TestRunsCanceledAt/when_the_run_is_canceled
--- PASS: TestRunsCanceledAt (10.00s)
    --- PASS: TestRunsCanceledAt/when_the_run_is_not_canceled (0.38s)
    --- PASS: TestRunsCanceledAt/when_the_run_is_canceled (0.91s)
PASS
ok      github.com/hashicorp/go-tfe     10.059s

$ TFE_ADDRESS="https://example" TFE_TOKEN="example"go test ./... -v -run TestRunsRunEvents 

go test -run TestRunsRunEvents -v
=== RUN   TestRunsRunEvents
--- PASS: TestRunsRunEvents (4.86s)
PASS
ok      github.com/hashicorp/go-tfe     4.908s

$ TFE_ADDRESS="https://example" TFE_TOKEN="example"go test ./... -v -run TestRunsTriggerReason
=== RUN   TestRunsTriggerReason
--- PASS: TestRunsTriggerReason (5.01s)
PASS
ok      github.com/hashicorp/go-tfe     5.104s
```