### PR TITLE
Fix relation tags in PolicySetVersion struct for IngressAttributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Bug Fixes
+
+* Fixes `IngressAttributes` field decoding in `PolicySetVersion` by @rageshganeshkumar [#1164](https://github.com/hashicorp/go-tfe/pull/1164)
+
 ## Enhancements
 * Add support for querying and filtering private registry modules based on a search query, `provider`, `registry_name` and `organization_name`, by @gautambaghel [#1179](https://github.com/hashicorp/go-tfe/pull/1179) 
 * Adds support for `RegistryModule` VCS source_directory and tag_prefix options, by @jillrami [#1154] (https://github.com/hashicorp/go-tfe/pull/1154)

--- a/policy_set_version.go
+++ b/policy_set_version.go
@@ -67,6 +67,12 @@ type PolicySetVersionStatusTimestamps struct {
 	ErroredAt    time.Time `jsonapi:"attr,errored-at,rfc3339"`
 }
 
+type PolicySetIngressAttributes struct {
+	CommitSHA  string `jsonapi:"attr,commit-sha"`
+	CommitURL  string `jsonapi:"attr,commit-url"`
+	Identifier string `jsonapi:"attr,identifier"`
+}
+
 // PolicySetVersion represents a Terraform Enterprise Policy Set Version
 type PolicySetVersion struct {
 	ID                string                           `jsonapi:"primary,policy-set-versions"`
@@ -77,7 +83,7 @@ type PolicySetVersion struct {
 	ErrorMessage      string                           `jsonapi:"attr,error-message"`
 	CreatedAt         time.Time                        `jsonapi:"attr,created-at,iso8601"`
 	UpdatedAt         time.Time                        `jsonapi:"attr,updated-at,iso8601"`
-	IngressAttributes *IngressAttributes               `jsonapi:"attr,ingress-attributes"`
+	IngressAttributes *PolicySetIngressAttributes      `jsonapi:"attr,ingress-attributes"`
 
 	// Relations
 	PolicySet *PolicySet `jsonapi:"relation,policy-set"`


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->

This pull request modifies the `PolicySetVersion` struct in `policy_set_version.go` to improve the representation of `IngressAttributes`. The change updates its JSON:API tag to correctly indicate it as a relation rather than an attribute.

### Changes to `PolicySetVersion` struct:
* Updated the `IngressAttributes` field to use the `jsonapi:"relation,ingress-attributes"` tag instead of `jsonapi:"attr,ingress-attributes"`, ensuring it is treated as a relationship in the JSON:API specification.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

Try reading a policy set version

```
policySetVersion, err := client.PolicySetVersions.Read(ctx, policySetVersionID)
```

### Before Change

```
ragesh.ganeshkumar@ragesh gotfe-samples % go run read_policy.go
2025/07/29 14:31:11 Error reading policy set version: jsonapi: Can't unmarshal map[commit-sha:6c12753ef1621f2ec0bd85f970733067a3e96b9d commit-url:https://github.com/rageshganeshkumar/sleepy-space/commit/6c12753ef1621f2ec0bd85f970733067a3e96b9d identifier:rageshganeshkumar/sleepy-space] (map) to struct field `IngressAttributes`, which is a pointer to `IngressAttributes (struct)`
exit status 1
```

### After Change
```
ragesh.ganeshkumar@ragesh gotfe-samples % go run read_policy.go
Policy Set Version ID: polsetver-Jvhes6ZWnJdUam5s
Status: ready
Source: github
Created At: 2025-07-29 08:52:07.005 +0000 UTC
```

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->
N/A
## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
N/A