### PR TITLE
Add createdAt and updatedAt timestamps to stack config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 
 * Adds BETA support for reading, testing and updating Organization Audit Configuration by @glennsarti-hashi [#1151](https://github.com/hashicorp/go-tfe/pull/1151)
 * Adds `Completed` status to `StackConfiguration` by @hwatkins05-hashicorp [#1163](https://github.com/hashicorp/go-tfe/pull/1163)
+* Adds `CreatedAt` and `UpdatedAt` fields to `StackConfiguration` by @Maed223 [#1168](https://github.com/hashicorp/go-tfe/pull/1168)
 
 # v1.87.0
 

--- a/stack.go
+++ b/stack.go
@@ -131,6 +131,8 @@ type StackConfiguration struct {
 	ErrorMessage         *string                             `jsonapi:"attr,error-message"`
 	EventStreamURL       string                              `jsonapi:"attr,event-stream-url"`
 	Diagnostics          []*StackDiagnostic                  `jsonapi:"attr,diags"`
+	CreatedAt            time.Time                           `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt            time.Time                           `jsonapi:"attr,updated-at,iso8601"`
 
 	Stack *Stack `jsonapi:"relation,stack"`
 }


### PR DESCRIPTION
## Description

Adds `CreatedAt` and `UpdatedAt` fields to `StackConfiguration`.


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
