### PR TITLE
Fix validation check for "cost_estimated" [TF-24176]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Adds BETA support for reading, testing and updating Organization Audit Configuration by @glennsarti-hashi [#1151](https://github.com/hashicorp/go-tfe/pull/1151)
 * Adds `Completed` status to `StackConfiguration` by @hwatkins05-hashicorp [#1163](https://github.com/hashicorp/go-tfe/pull/1163)
 * Adds `CreatedAt` and `UpdatedAt` fields to `StackConfiguration` by @Maed223 [#1168](https://github.com/hashicorp/go-tfe/pull/1168)
+* Bug fix for RunStatus value `"cost_estimate"` by @KenCox-Hashicorp [#1169](https://github.com/hashicorp/go-tfe/pull/1169)
 
 # v1.87.0
 

--- a/admin_run.go
+++ b/admin_run.go
@@ -167,7 +167,7 @@ func validateAdminRunFilterParams(runStatus string) error {
 				string(RunApplying),
 				string(RunCanceled),
 				string(RunConfirmed),
-				string(RunCostEstimate),
+				string(RunCostEstimated),
 				string(RunCostEstimating),
 				string(RunDiscarded),
 				string(RunErrored),

--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateAdminRunFilterParams(t *testing.T) {
+	// RunStatus values accepted by validate
+	validRunStatuses := []string{
+		"applied",
+		"applying",
+		"apply_queued",
+		"canceled",
+		"confirmed",
+		"cost_estimated",
+		"cost_estimating",
+		"discarded",
+		"errored",
+		"pending",
+		"planned",
+		"planned_and_finished",
+		"planning",
+		"plan_queued",
+		"policy_checked",
+		"policy_checking",
+		"policy_override",
+		"policy_soft_failed",
+	}
+	for _, v := range validRunStatuses {
+		t.Run(v, func(t *testing.T) {
+			require.NoError(t, validateAdminRunFilterParams(v), fmt.Sprintf("'%s' should be valid", v))
+		})
+	}
+
+	// RunStatus values NOT accepted by validate - perhaps they should be?
+	invalidRunStatuses := []string{
+		"fetching",
+		"fetching_completed",
+		"planned_and_saved",
+		"post_plan_awaiting_decision",
+		"post_plan_completed",
+		"post_plan_running",
+		"pre_apply_running",
+		"pre_apply_completed",
+		"pre_plan_completed",
+		"pre_plan_running",
+		"queuing",
+		"queuing_apply",
+	}
+	for _, v := range invalidRunStatuses {
+		t.Run(v, func(t *testing.T) {
+			require.Error(t, validateAdminRunFilterParams(v), fmt.Sprintf("'%s' should be invalid", v))
+		})
+	}
+
+	// empty string is allowed
+	require.NoError(t, validateAdminRunFilterParams(""), "empty string should be valid")
+
+	// comma-separated list, all valid
+	require.NoError(t, validateAdminRunFilterParams("applied,planned,canceled"), "'applied,planned,canceled' should be valid)")
+
+	// invalid values
+	require.Error(t, validateAdminRunFilterParams("cost_estimate"), "invalid value: cost_estimate")
+
+	// comma-separated list, some invalid
+	require.Error(t, validateAdminRunFilterParams("applied,not-planned,canceled"), "'applied,not-planned,canceled' should be invalid)")
+}


### PR DESCRIPTION
## Description

Customer-reported error in [TF-24176](https://hashicorp.atlassian.net/browse/TF-24176) - `"cost_estimated"` is not accepted as a filter value.

The validation check should have `RunCostEstimated`, a `RunStatus` defined as "cost_estimated". `RunCostEstimate` is a `RunIncludeOpt`.

I added a unit test for `validateAdminRunFilterParams`, and found that some of the `RunStatus` values are not accepted. I've moved those to a separate check for invalid values, but possibly `validateAdminRunFilterParams` should be changed to accept them too? If so I can update this PR.

Note the ticket [TF-24176](https://hashicorp.atlassian.net/browse/TF-24176) refers to https://pkg.go.dev/github.com/hashicorp/go-tfe#RunStatus, which does list all the RunStatus strings, so customers are under the impression they can all be used as filters.

This was reported against version 75, but is in head of code version 88. **It may need backport.**

## Testing plan

Code given in JIRA ticket should run - "cost_estimated" is a RunStatus.

```
     client, err := tfe.NewClient(&tfe.Config{
                Address:           "...",
                RetryServerErrors: true,
                Token:             "...",
        })
        if err != nil {
                log.Fatal("Error %v\n", err)
                os.Exit(1)
        }
        costEstimatedRuns, err := client.Admin.Runs.List(context.Background(), &tfe.AdminRunsListOptions{
                RunStatus: "cost_estimated",
        })
        if err != nil {
                log.Fatal(err)
        }
        log.Printf("Found %v runs in 'cost_estimated' state", len(costEstimatedRuns.Items))
```

## External links

- [JIRA bug report](https://hashicorp.atlassian.net/browse/TF-24176)

## Output from tests

Added a unit test which does not require access to TFE instance.

## Rollback Plan

Should not need rollback.

## Changes to Security Controls

No changes.


[TF-24176]: https://hashicorp.atlassian.net/browse/TF-24176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[TF-24176]: https://hashicorp.atlassian.net/browse/TF-24176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ