### PR TITLE
Fix validation of run status; add unit test [issue 1061]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@
 * Adds `CreatedAt` and `UpdatedAt` fields to `StackConfiguration` by @Maed223 [#1168](https://github.com/hashicorp/go-tfe/pull/1168)
 * Adds endpoint for advancing `StackDeploymentStep` by @hwatkins05-hashicorp [#1166](https://github.com/hashicorp/go-tfe/pull/1166)
 
+## Bug Fixes
+* Fixes issue [1061](https://github.com/hashicorp/go-tfe/issues/1061), validation accepts `"cost_estimated"`, by @KenCox-Hashicorp [#1170](https://github.com/hashicorp/go-tfe/pull/1170)
+
 # v1.88.0
 
 ## Enhancements

--- a/admin_run.go
+++ b/admin_run.go
@@ -167,7 +167,7 @@ func validateAdminRunFilterParams(runStatus string) error {
 				string(RunApplying),
 				string(RunCanceled),
 				string(RunConfirmed),
-				string(RunCostEstimate),
+				string(RunCostEstimated),
 				string(RunCostEstimating),
 				string(RunDiscarded),
 				string(RunErrored),

--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -1,0 +1,73 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_validateAdminRunFilterParams(t *testing.T) {
+	// RunStatus values accepted by validate
+	validRunStatuses := []string{
+		"applied",
+		"applying",
+		"apply_queued",
+		"canceled",
+		"confirmed",
+		"cost_estimated",
+		"cost_estimating",
+		"discarded",
+		"errored",
+		"pending",
+		"planned",
+		"planned_and_finished",
+		"planning",
+		"plan_queued",
+		"policy_checked",
+		"policy_checking",
+		"policy_override",
+		"policy_soft_failed",
+	}
+	for _, v := range validRunStatuses {
+		t.Run(v, func(t *testing.T) {
+			require.NoError(t, validateAdminRunFilterParams(v), fmt.Sprintf("'%s' should be valid", v))
+		})
+	}
+
+	// RunStatus values NOT accepted by validate - perhaps they should be?
+	invalidRunStatuses := []string{
+		"fetching",
+		"fetching_completed",
+		"planned_and_saved",
+		"post_plan_awaiting_decision",
+		"post_plan_completed",
+		"post_plan_running",
+		"pre_apply_running",
+		"pre_apply_completed",
+		"pre_plan_completed",
+		"pre_plan_running",
+		"queuing",
+		"queuing_apply",
+	}
+	for _, v := range invalidRunStatuses {
+		t.Run(v, func(t *testing.T) {
+			require.Error(t, validateAdminRunFilterParams(v), fmt.Sprintf("'%s' should be invalid", v))
+		})
+	}
+
+	// empty string is allowed
+	require.NoError(t, validateAdminRunFilterParams(""), "empty string should be valid")
+
+	// comma-separated list, all valid
+	require.NoError(t, validateAdminRunFilterParams("applied,planned,canceled"), "'applied,planned,canceled' should be valid)")
+
+	// invalid values
+	require.Error(t, validateAdminRunFilterParams("cost_estimate"), "invalid value: cost_estimate")
+
+	// comma-separated list, some invalid
+	require.Error(t, validateAdminRunFilterParams("applied,not-planned,canceled"), "'applied,not-planned,canceled' should be invalid)")
+}


### PR DESCRIPTION
## Description

Fixes https://github.com/hashicorp/go-tfe/issues/1061.  Note, that was reported in v1.75, the bug is still in head of code v1.88, so this may need backport.

`validateAdminRunFilterParams` in admin_run.go was using `RunCostEstimate`, a `RunIncludeOpt`. It should be using `RunCostEstimated`, a `RunStatus`. Adds unit test.

Some of the `RunStatus` values are not accepted by `validateAdminRunFilterParams` - this PR assumes that is intentional.

**Note:** Merge either this PR or #1171, which updates the validate function to add the missing RunStatus values.


## Testing plan

Code given in the issue should run, since "cost_estimated" is a RunStatus. This now works:

```
func main() {
     client, err := tfe.NewClient(&tfe.Config{
                Address:           "...",
                RetryServerErrors: true,
                Token:             "...",
        })
        if err != nil {
                log.Fatal("Error %v\n", err)
                os.Exit(1)
        }
        costEstimatedRuns, err := client.Admin.Runs.List(context.Background(), &tfe.AdminRunsListOptions{
                RunStatus: "cost_estimated",
        })
        if err != nil {
                log.Fatal(err)
        }
        log.Printf("Found %v runs in 'cost_estimated' state", len(costEstimatedRuns.Items))
}
```

## Related Links

- ILM team [JIRA](https://hashicorp.atlassian.net/browse/TF-24176)

## Output from tests

New unit test does not require TFE instance.

## Rollback Plan

Revert the PR.

## Changes to Security Controls

None.
