### PR TITLE
Rerun deployment group

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Enhancements
 * Adds support for `RegistryModule` VCS source_directory and tag_prefix options, by @jillrami [#1154] (https://github.com/hashicorp/go-tfe/pull/1154)
 * Adds `GroupName` filter option for `StackDeploymentGroup` by @Maed223 [#1175](https://github.com/hashicorp/go-tfe/pull/1175)
+* Adds endpoint for reruning a stack deployment by @hwatkins05-hashicorp/@Maed223 [#1176](https://github.com/hashicorp/go-tfe/pull/1176)
+
 
 ## Bug Fixes
 * Fixes issue [1061](https://github.com/hashicorp/go-tfe/issues/1061), validation accepts all RunStatus including `"cost_estimated"` by @KenCox-Hashicorp [#1171](https://github.com/hashicorp/go-tfe/pull/1171)

--- a/stack_deployment_groups_integration_test.go
+++ b/stack_deployment_groups_integration_test.go
@@ -186,3 +186,73 @@ func TestStackDeploymentGroupsApproveAllPlans(t *testing.T) {
 		require.NoError(t, err)
 	})
 }
+
+func TestStackDeploymentGroupsRerun(t *testing.T) {
+	skipUnlessBeta(t)
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	t.Cleanup(orgTestCleanup)
+
+	oauthClient, cleanup := createOAuthClient(t, client, orgTest, nil)
+	t.Cleanup(cleanup)
+
+	stack, err := client.Stacks.Create(ctx, StackCreateOptions{
+		Name: "test-stack",
+		VCSRepo: &StackVCSRepoOptions{
+			Identifier:   "hashicorp-guides/pet-nulls-stack",
+			OAuthTokenID: oauthClient.OAuthTokens[0].ID,
+			Branch:       "main",
+		},
+		Project: &Project{
+			ID: orgTest.DefaultProject.ID,
+		},
+	})
+	require.NoError(t, err)
+	require.NotNil(t, stack)
+
+	stackUpdated, err := client.Stacks.UpdateConfiguration(ctx, stack.ID)
+	require.NoError(t, err)
+	require.NotNil(t, stackUpdated)
+
+	stack = pollStackDeployments(t, ctx, client, stackUpdated.ID)
+	require.NotNil(t, stack.LatestStackConfiguration)
+
+	deploymentGroups, err := client.StackDeploymentGroups.List(ctx, stack.LatestStackConfiguration.ID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, deploymentGroups)
+	require.NotEmpty(t, deploymentGroups.Items)
+
+	deploymentGroupID := deploymentGroups.Items[0].ID
+
+	deploymentRuns, err := client.StackDeploymentRuns.List(ctx, deploymentGroupID, nil)
+	require.NoError(t, err)
+	require.NotNil(t, deploymentRuns)
+	require.NotEmpty(t, deploymentRuns.Items)
+
+	err = client.StackDeploymentGroups.ApproveAllPlans(ctx, deploymentGroupID)
+	require.NoError(t, err)
+
+	pollStackDeploymentRunForDeployingStatus(t, ctx, client, deploymentRuns.Items[0].ID)
+
+	deploymentRunIds := []string{deploymentRuns.Items[0].ID}
+	for _, dr := range deploymentRuns.Items {
+		deploymentRunIds = append(deploymentRunIds, dr.ID)
+	}
+
+	t.Run("No deployments specified for rerun", func(t *testing.T) {
+		err := client.StackDeploymentGroups.Rerun(ctx, deploymentGroupID, nil)
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "no deployments specified for rerun")
+	})
+
+	t.Run("Rerun with invalid ID", func(t *testing.T) {
+		err := client.StackDeploymentGroups.Rerun(ctx, "", &StackDeploymentGroupRerunOptions{
+			Deployments: deploymentRunIds,
+		})
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "invalid stack deployment group ID")
+	})
+}


### PR DESCRIPTION
## Description

Adds support for rerun stack deployment group endpoint.

## Testing plan

Basic tests for the endpoint are included. Due to the difficult nature of providing a failing deployment here, testing for the actual rerun of the deployment has been omitted, though we shouldn't have to concern ourselves with validation of correct API behavior here.

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-25667)

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
