### PR TITLE
Fix state version test timeout issues

### DIFF
--- a/state_version_integration_test.go
+++ b/state_version_integration_test.go
@@ -422,7 +422,7 @@ func TestStateVersionsRead(t *testing.T) {
 		require.NoError(t, err)
 
 		if !sv.ResourcesProcessed {
-			svRetry, err := retry(func() (interface{}, error) {
+			svRetry, err := retryPatiently(func() (interface{}, error) {
 				svTest, err := client.StateVersions.Read(ctx, svTest.ID)
 				require.NoError(t, err)
 
@@ -436,6 +436,8 @@ func TestStateVersionsRead(t *testing.T) {
 			if err != nil {
 				t.Fatalf("error retrying state version read, err=%s", err)
 			}
+
+			require.NotNil(t, svRetry, "timed out waiting for resources to finish processing")
 
 			sv, ok = svRetry.(*StateVersion)
 			if !ok {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

The `TestStateVersionsRead` test was failing intermittently on our nightly test suite with `require.NotNil(t, sv.BillableRUMCount)` errors due to race conditions in the retry mechanism. This PR:
- **Increased timeout**: Changed from `retry` (30 seconds) to `retryPatiently` (120 seconds) to give backend more processing time
- **Improved error handling**: Added `require.NotNil` check with descriptive error message for clearer debugging

## Testing plan

Hard to test the benefits of this right now since this test is currently passing on my local instance with and without the change (it is flaky) - although this does show that it doesn't break anything. In a week after this is merged, I will go through the nightlies results on Datadog to see how it is performing.