### PR TITLE
set OAUTH_CLIENT_GITHUB_TOKEN to GITHUB_TOKEN in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
           admin_subscription_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.subscription }}
           admin_support_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.support }}
           admin_version_maintenance_token: ${{ fromJSON(steps.tflocal.outputs.workspace-outputs-json).tfe_admin_token_by_role.version-maintenance }}
-          oauth-client-github-token: ${{ secrets.OAUTH_CLIENT_GITHUB_TOKEN }}
+          oauth-client-github-token: ${{ secrets.GITHUB_TOKEN }}
 
   tests-combine-summaries:
     name: Combine Test Reports


### PR DESCRIPTION
This secret is missing in the repo. Not sure if the action token is sufficient or not