### PR TITLE
StackConfiguration's `CreateAndUpload` 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v1.90.0
+
 ## Bug Fixes
 
 * Fixes `IngressAttributes` field decoding in `PolicySetVersion` by @rageshganeshkumar [#1164](https://github.com/hashicorp/go-tfe/pull/1164)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Adds endpoint for reruning a stack deployment by @hwatkins05-hashicorp/@Maed223 [#1176](https://github.com/hashicorp/go-tfe/pull/1176)
 * Adds `ReadByName` for `StackDeploymentGroup` by @Maed223 [#1181](https://github.com/hashicorp/go-tfe/pull/1181)
 * Adds BETA support for listing `QueryRuns`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @brandonc [#1177](https://github.com/hashicorp/go-tfe/pull/1177)
+* Adds BETA support for `CreateAndUpload` for `StackConfiguration`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @Maed223 [#1184](https://github.com/hashicorp/go-tfe/pull/1184)
 
 
 # v1.89.0

--- a/stack_configuration.go
+++ b/stack_configuration.go
@@ -195,7 +195,7 @@ func (s stackConfigurations) CreateAndUpload(ctx context.Context, stackID, path 
 		return nil, err
 	}
 
-	err = s.UploadTarGzip(ctx, uploadURL, body)
+	err = s.uploadTarGzip(ctx, uploadURL, body)
 	if err != nil {
 		return nil, err
 	}
@@ -250,6 +250,6 @@ func (s stackConfigurations) pollForUploadURL(ctx context.Context, stackConfigur
 //
 // **Note**: This method does not validate the content being uploaded and is therefore the caller's
 // responsibility to ensure the raw content is a valid Terraform configuration.
-func (s stackConfigurations) UploadTarGzip(ctx context.Context, uploadURL string, archive io.Reader) error {
+func (s stackConfigurations) uploadTarGzip(ctx context.Context, uploadURL string, archive io.Reader) error {
 	return s.client.doForeignPUTRequest(ctx, uploadURL, archive)
 }

--- a/stack_configuration.go
+++ b/stack_configuration.go
@@ -7,7 +7,9 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"net/url"
+	"time"
 )
 
 // StackConfigurations describes all the stacks configurations-related methods that the
@@ -15,6 +17,10 @@ import (
 // NOTE WELL: This is a beta feature and is subject to change until noted otherwise in the
 // release notes.
 type StackConfigurations interface {
+	// CreateAndUpload packages and uploads the specified Terraform Stacks
+	// configuration files in association with a Stack.
+	CreateAndUpload(ctx context.Context, stackID string, path string, opts *CreateStackConfigurationOptions) (*StackConfiguration, error)
+
 	// ReadConfiguration returns a stack configuration by its ID.
 	Read(ctx context.Context, id string) (*StackConfiguration, error)
 
@@ -154,4 +160,96 @@ func (s stackConfigurations) List(ctx context.Context, stackID string, options *
 	}
 
 	return result, nil
+}
+
+type CreateStackConfigurationOptions struct {
+	SelectedDeployments []string `jsonapi:"attr,selected-deployments,omitempty"`
+	SpeculativeEnabled  *bool    `jsonapi:"attr,speculative,omitempty"`
+}
+
+// CreateAndUpload packages and uploads the specified Terraform Stacks
+// configuration files in association with a Stack.
+func (s stackConfigurations) CreateAndUpload(ctx context.Context, stackID, path string, opts *CreateStackConfigurationOptions) (*StackConfiguration, error) {
+	if opts == nil {
+		opts = &CreateStackConfigurationOptions{}
+	}
+	u := fmt.Sprintf("stacks/%s/stack-configurations", url.PathEscape(stackID))
+	req, err := s.client.NewRequest("POST", u, opts)
+	if err != nil {
+		return nil, fmt.Errorf("error creating stack configuration request for stack %q: %w", stackID, err)
+	}
+
+	sc := &StackConfiguration{}
+	err = req.Do(ctx, sc)
+	if err != nil {
+		return nil, fmt.Errorf("error creating stack configuration for stack %q: %w", stackID, err)
+	}
+
+	uploadURL, err := s.pollForUploadURL(ctx, sc.ID)
+	if err != nil {
+		return nil, fmt.Errorf("error retrieving upload URL for stack configuration %q: %w", sc.ID, err)
+	}
+
+	body, err := packContents(path)
+	if err != nil {
+		return nil, err
+	}
+
+	err = s.UploadTarGzip(ctx, uploadURL, body)
+	if err != nil {
+		return nil, err
+	}
+
+	return sc, nil
+}
+
+// PollForUploadURL polls for the upload URL of a stack configuration until it becomes available.
+// It makes a request every 2 seconds until the upload URL is present in the response.
+// It will timeout after 10 seconds.
+func (s stackConfigurations) pollForUploadURL(ctx context.Context, stackConfigurationID string) (string, error) {
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	timeout := time.NewTimer(15 * time.Second)
+	defer timeout.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-timeout.C:
+			return "", fmt.Errorf("timeout waiting for upload URL for stack configuration %q", stackConfigurationID)
+		case <-ticker.C:
+			urlReq, err := s.client.NewRequest("GET", fmt.Sprintf("stack-configurations/%s/upload-url", stackConfigurationID), nil)
+			if err != nil {
+				return "", fmt.Errorf("error creating upload URL request for stack configuration %q: %w", stackConfigurationID, err)
+			}
+
+			type UploadURLResponse struct {
+				Data struct {
+					SourceUploadURL *string `json:"source-upload-url"`
+				} `json:"data"`
+			}
+
+			uploadResp := &UploadURLResponse{}
+			err = urlReq.DoJSON(ctx, uploadResp)
+			if err != nil {
+				return "", fmt.Errorf("error getting upload URL for stack configuration %q: %w", stackConfigurationID, err)
+			}
+
+			if uploadResp.Data.SourceUploadURL != nil {
+				return *uploadResp.Data.SourceUploadURL, nil
+			}
+		}
+	}
+}
+
+// UploadTarGzip is used to upload Terraform configuration files contained a tar gzip archive.
+// Any stream implementing io.Reader can be passed into this method. This method is also
+// particularly useful for tar streams created by non-default go-slug configurations.
+//
+// **Note**: This method does not validate the content being uploaded and is therefore the caller's
+// responsibility to ensure the raw content is a valid Terraform configuration.
+func (s stackConfigurations) UploadTarGzip(ctx context.Context, uploadURL string, archive io.Reader) error {
+	return s.client.doForeignPUTRequest(ctx, uploadURL, archive)
 }


### PR DESCRIPTION
## Description

For Stacks GA the `CreateAndUpload` endpoints are now on the stack configuration, this PR makes the needed addition to support this in go-tfe.

## Testing plan

Added new test for associated endpoint.

## Output from tests

<img width="970" height="97" alt="Screenshot 2025-08-13 at 4 03 20 PM" src="https://github.com/user-attachments/assets/b8b069c0-6992-495e-9e8c-d398cf335e33" />

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
