### PR TITLE
Add default agent pool and execution mode support to projects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
 * Adds `CanceledAt`, `RunEvents`, `TriggerReason` field to `Run` by @jpadrianoGo [#1161](https://github.com/hashicorp/go-tfe/pull/1161)
 * Adds `CreatedAt` field to `AgentPool` by @jpadrianoGo [#1150](https://github.com/hashicorp/go-tfe/pull/1150)
 * Adds `CreatedBy` relation to `AgentToken` by @jpadrianoGo [#1149](https://github.com/hashicorp/go-tfe/pull/1149)
+* Adds `AllowedProjects` and `ExcludedWorkspaces` to `AgentPool` by @tylerwolf [#1185](https://github.com/hashicorp/go-tfe/pull/1185)
+* Adds `DefaultExecutionMode`, `DefaultAgentPool`, and `SettingOverwrites` to `Project` by @tylerwolf [#1185](https://github.com/hashicorp/go-tfe/pull/1185)
 
 # v1.90.0
 

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -290,63 +290,15 @@ func (s *agentPools) Update(ctx context.Context, agentPoolID string, options Age
 }
 
 func (s *agentPools) UpdateAllowedWorkspaces(ctx context.Context, agentPoolID string, options AgentPoolAllowedWorkspacesUpdateOptions) (*AgentPool, error) {
-	if !validStringID(&agentPoolID) {
-		return nil, ErrInvalidAgentPoolID
-	}
-
-	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentPoolID))
-	req, err := s.client.NewRequest("PATCH", u, &options)
-	if err != nil {
-		return nil, err
-	}
-
-	k := &AgentPool{}
-	err = req.Do(ctx, k)
-	if err != nil {
-		return nil, err
-	}
-
-	return k, nil
+	return s.updateArrayAttribute(ctx, agentPoolID, &options)
 }
 
 func (s *agentPools) UpdateAllowedProjects(ctx context.Context, agentPoolID string, options AgentPoolAllowedProjectsUpdateOptions) (*AgentPool, error) {
-	if !validStringID(&agentPoolID) {
-		return nil, ErrInvalidAgentPoolID
-	}
-
-	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentPoolID))
-	req, err := s.client.NewRequest("PATCH", u, &options)
-	if err != nil {
-		return nil, err
-	}
-
-	k := &AgentPool{}
-	err = req.Do(ctx, k)
-	if err != nil {
-		return nil, err
-	}
-
-	return k, nil
+	return s.updateArrayAttribute(ctx, agentPoolID, &options)
 }
 
 func (s *agentPools) UpdateExcludedWorkspaces(ctx context.Context, agentPoolID string, options AgentPoolExcludedWorkspacesUpdateOptions) (*AgentPool, error) {
-	if !validStringID(&agentPoolID) {
-		return nil, ErrInvalidAgentPoolID
-	}
-
-	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentPoolID))
-	req, err := s.client.NewRequest("PATCH", u, &options)
-	if err != nil {
-		return nil, err
-	}
-
-	k := &AgentPool{}
-	err = req.Do(ctx, k)
-	if err != nil {
-		return nil, err
-	}
-
-	return k, nil
+	return s.updateArrayAttribute(ctx, agentPoolID, &options)
 }
 
 // Delete an agent pool by its ID.
@@ -362,6 +314,26 @@ func (s *agentPools) Delete(ctx context.Context, agentPoolID string) error {
 	}
 
 	return req.Do(ctx, nil)
+}
+
+func (s *agentPools) updateArrayAttribute(ctx context.Context, agentPoolID string, options any) (*AgentPool, error) {
+	if !validStringID(&agentPoolID) {
+		return nil, ErrInvalidAgentPoolID
+	}
+
+	u := fmt.Sprintf("agent-pools/%s", url.PathEscape(agentPoolID))
+	req, err := s.client.NewRequest("PATCH", u, options)
+	if err != nil {
+		return nil, err
+	}
+
+	k := &AgentPool{}
+	err = req.Do(ctx, k)
+	if err != nil {
+		return nil, err
+	}
+
+	return k, nil
 }
 
 func (o AgentPoolCreateOptions) valid() error {

--- a/agent_pool.go
+++ b/agent_pool.go
@@ -316,6 +316,10 @@ func (s *agentPools) Delete(ctx context.Context, agentPoolID string) error {
 	return req.Do(ctx, nil)
 }
 
+// updateArrayAttribute is a helper function to update array attributes of an agent pool, such as allowed workspaces, allowed projects, or excluded workspaces.
+// Note: This function does not validate the options parameter, so it should be used with caution.  It is intended to be used with options structs
+// (e.g. AgentPoolAllowedWorkspacesUpdateOptions, AgentPoolAllowedProjectsUpdateOptions, AgentPoolExcludedWorkspacesUpdateOptions) whose array
+// attributes are NOT marked `omitempty`, so that an empty array is sent to the API to clear the existing values.
 func (s *agentPools) updateArrayAttribute(ctx context.Context, agentPoolID string, options any) (*AgentPool, error) {
 	if !validStringID(&agentPoolID) {
 		return nil, ErrInvalidAgentPoolID

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -16,12 +16,12 @@ func TestAgentPoolsList(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
 	agentPool, agentPoolCleanup := createAgentPool(t, client, orgTest)
-	defer agentPoolCleanup()
+	t.Cleanup(agentPoolCleanup)
 
 	t.Run("without list options", func(t *testing.T) {
 		pools, err := client.AgentPools.List(ctx, orgTest.Name, nil)
@@ -38,7 +38,7 @@ func TestAgentPoolsList(t *testing.T) {
 			ExecutionMode: String("agent"),
 			AgentPoolID:   String(agentPool.ID),
 		})
-		defer wTestCleanup()
+		t.Cleanup(wTestCleanup)
 
 		k, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
 			Include: []AgentPoolIncludeOpt{AgentPoolWorkspaces},
@@ -87,10 +87,10 @@ func TestAgentPoolsList(t *testing.T) {
 
 	t.Run("with allowed workspace name filter", func(t *testing.T) {
 		ws1, ws1TestCleanup := createWorkspace(t, client, orgTest)
-		defer ws1TestCleanup()
+		t.Cleanup(ws1TestCleanup)
 
 		ws2, ws2TestCleanup := createWorkspace(t, client, orgTest)
-		defer ws2TestCleanup()
+		t.Cleanup(ws2TestCleanup)
 
 		organizationScoped := false
 		ap, apCleanup := createAgentPoolWithOptions(t, client, orgTest, AgentPoolCreateOptions{
@@ -98,14 +98,14 @@ func TestAgentPoolsList(t *testing.T) {
 			OrganizationScoped: &organizationScoped,
 			AllowedWorkspaces:  []*Workspace{ws1},
 		})
-		defer apCleanup()
+		t.Cleanup(apCleanup)
 
 		ap2, ap2Cleanup := createAgentPoolWithOptions(t, client, orgTest, AgentPoolCreateOptions{
 			Name:               String("b-pool"),
 			OrganizationScoped: &organizationScoped,
 			AllowedWorkspaces:  []*Workspace{ws2},
 		})
-		defer ap2Cleanup()
+		t.Cleanup(ap2Cleanup)
 
 		pools, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
 			AllowedWorkspacesName: ws1.Name,
@@ -128,10 +128,10 @@ func TestAgentPoolsList(t *testing.T) {
 
 	t.Run("with allowed projects name filter", func(t *testing.T) {
 		proj1, proj1TestCleanup := createProject(t, client, orgTest)
-		defer proj1TestCleanup()
+		t.Cleanup(proj1TestCleanup)
 
 		proj2, proj2TestCleanup := createProject(t, client, orgTest)
-		defer proj2TestCleanup()
+		t.Cleanup(proj2TestCleanup)
 
 		organizationScoped := false
 		ap, apCleanup := createAgentPoolWithOptions(t, client, orgTest, AgentPoolCreateOptions{
@@ -139,14 +139,14 @@ func TestAgentPoolsList(t *testing.T) {
 			OrganizationScoped: &organizationScoped,
 			AllowedProjects:    []*Project{proj1},
 		})
-		defer apCleanup()
+		t.Cleanup(apCleanup)
 
 		ap2, ap2Cleanup := createAgentPoolWithOptions(t, client, orgTest, AgentPoolCreateOptions{
 			Name:               String("b-pool"),
 			OrganizationScoped: &organizationScoped,
 			AllowedProjects:    []*Project{proj2},
 		})
-		defer ap2Cleanup()
+		t.Cleanup(ap2Cleanup)
 
 		pools, err := client.AgentPools.List(ctx, orgTest.Name, &AgentPoolListOptions{
 			AllowedProjectsName: proj1.Name,
@@ -173,7 +173,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
@@ -213,7 +213,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 
 	t.Run("with allowed-workspaces options", func(t *testing.T) {
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		organizationScoped := false
 		options := AgentPoolCreateOptions{
@@ -244,7 +244,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 
 	t.Run("with allowed-projects options", func(t *testing.T) {
 		projectTest, projectTestCleanup := createProject(t, client, orgTest)
-		defer projectTestCleanup()
+		t.Cleanup(projectTestCleanup)
 
 		organizationScoped := false
 		options := AgentPoolCreateOptions{
@@ -275,7 +275,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 
 	t.Run("with excluded-workspaces options", func(t *testing.T) {
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		organizationScoped := false
 		options := AgentPoolCreateOptions{
@@ -310,12 +310,12 @@ func TestAgentPoolsRead(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
 	pool, poolCleanup := createAgentPool(t, client, orgTest)
-	defer poolCleanup()
+	t.Cleanup(poolCleanup)
 
 	t.Run("when the agent pool exists", func(t *testing.T) {
 		k, err := client.AgentPools.Read(ctx, pool.ID)
@@ -341,7 +341,7 @@ func TestAgentPoolsRead(t *testing.T) {
 			ExecutionMode: String("agent"),
 			AgentPoolID:   String(pool.ID),
 		})
-		defer wTestCleanup()
+		t.Cleanup(wTestCleanup)
 
 		k, err := client.AgentPools.ReadWithOptions(ctx, pool.ID, &AgentPoolReadOptions{
 			Include: []AgentPoolIncludeOpt{AgentPoolWorkspaces},
@@ -373,13 +373,13 @@ func TestAgentPoolsUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
 	t.Run("with valid options", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
 			Name: String(randomString(t)),
@@ -392,13 +392,13 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 	t.Run("when updating only the name", func(t *testing.T) {
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		projectTest, projectTestCleanup := createProject(t, client, orgTest)
-		defer projectTestCleanup()
+		t.Cleanup(projectTestCleanup)
 
 		excludedWorkspaceTest, excludedWorkspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer excludedWorkspaceTestCleanup()
+		t.Cleanup(excludedWorkspaceTestCleanup)
 
 		organizationScoped := false
 		options := AgentPoolCreateOptions{
@@ -440,7 +440,7 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 	t.Run("when updating organization scope", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		organizationScoped := false
 		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
@@ -455,10 +455,10 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 	t.Run("when updating allowed-workspaces", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
 			AllowedWorkspaces: []*Workspace{
@@ -475,10 +475,10 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 	t.Run("when updating allowed-projects", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		projectTest, projectTestCleanup := createProject(t, client, orgTest)
-		defer projectTestCleanup()
+		t.Cleanup(projectTestCleanup)
 
 		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
 			AllowedProjects: []*Project{
@@ -495,10 +495,10 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 	t.Run("when updating excluded-workspaces", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		kAfter, err := client.AgentPools.Update(ctx, kBefore.ID, AgentPoolUpdateOptions{
 			ExcludedWorkspaces: []*Workspace{
@@ -519,16 +519,16 @@ func TestAgentPoolsUpdateAllowedWorkspaces(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
 	t.Run("when updating allowed-workspaces", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		kAfter, err := client.AgentPools.UpdateAllowedWorkspaces(ctx, kBefore.ID, AgentPoolAllowedWorkspacesUpdateOptions{
 			AllowedWorkspaces: []*Workspace{
@@ -545,7 +545,7 @@ func TestAgentPoolsUpdateAllowedWorkspaces(t *testing.T) {
 
 	t.Run("when removing all the allowed-workspaces", func(t *testing.T) {
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		organizationScoped := false
 		options := AgentPoolCreateOptions{
@@ -557,7 +557,7 @@ func TestAgentPoolsUpdateAllowedWorkspaces(t *testing.T) {
 		}
 
 		kBefore, kTestCleanup := createAgentPoolWithOptions(t, client, orgTest, options)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		kAfter, err := client.AgentPools.UpdateAllowedWorkspaces(ctx, kBefore.ID, AgentPoolAllowedWorkspacesUpdateOptions{
 			AllowedWorkspaces: []*Workspace{},
@@ -575,16 +575,16 @@ func TestAgentPoolsUpdateAllowedProjects(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
 	t.Run("when updating allowed-projects", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		projectTest, projectTestCleanup := createProject(t, client, orgTest)
-		defer projectTestCleanup()
+		t.Cleanup(projectTestCleanup)
 
 		kAfter, err := client.AgentPools.UpdateAllowedProjects(ctx, kBefore.ID, AgentPoolAllowedProjectsUpdateOptions{
 			AllowedProjects: []*Project{
@@ -601,7 +601,7 @@ func TestAgentPoolsUpdateAllowedProjects(t *testing.T) {
 
 	t.Run("when removing all the allowed-projects", func(t *testing.T) {
 		projectTest, projectTestCleanup := createProject(t, client, orgTest)
-		defer projectTestCleanup()
+		t.Cleanup(projectTestCleanup)
 
 		organizationScoped := false
 		options := AgentPoolCreateOptions{
@@ -613,7 +613,7 @@ func TestAgentPoolsUpdateAllowedProjects(t *testing.T) {
 		}
 
 		kBefore, kTestCleanup := createAgentPoolWithOptions(t, client, orgTest, options)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		kAfter, err := client.AgentPools.UpdateAllowedProjects(ctx, kBefore.ID, AgentPoolAllowedProjectsUpdateOptions{
 			AllowedProjects: []*Project{},
@@ -631,16 +631,16 @@ func TestAgentPoolsUpdateExcludedWorkspaces(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 
 	t.Run("when updating excluded-workspaces", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		kAfter, err := client.AgentPools.UpdateExcludedWorkspaces(ctx, kBefore.ID, AgentPoolExcludedWorkspacesUpdateOptions{
 			ExcludedWorkspaces: []*Workspace{
@@ -657,7 +657,7 @@ func TestAgentPoolsUpdateExcludedWorkspaces(t *testing.T) {
 
 	t.Run("when removing all the excluded-workspaces", func(t *testing.T) {
 		workspaceTest, workspaceTestCleanup := createWorkspace(t, client, orgTest)
-		defer workspaceTestCleanup()
+		t.Cleanup(workspaceTestCleanup)
 
 		organizationScoped := false
 		options := AgentPoolCreateOptions{
@@ -669,7 +669,7 @@ func TestAgentPoolsUpdateExcludedWorkspaces(t *testing.T) {
 		}
 
 		kBefore, kTestCleanup := createAgentPoolWithOptions(t, client, orgTest, options)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		kAfter, err := client.AgentPools.UpdateExcludedWorkspaces(ctx, kBefore.ID, AgentPoolExcludedWorkspacesUpdateOptions{
 			ExcludedWorkspaces: []*Workspace{},
@@ -687,7 +687,7 @@ func TestAgentPoolsDelete(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	upgradeOrganizationSubscription(t, client, orgTest)
 

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -18,8 +18,6 @@ func TestAgentPoolsList(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	upgradeOrganizationSubscription(t, client, orgTest)
-
 	agentPool, agentPoolCleanup := createAgentPool(t, client, orgTest)
 	t.Cleanup(agentPoolCleanup)
 
@@ -175,8 +173,6 @@ func TestAgentPoolsCreate(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	upgradeOrganizationSubscription(t, client, orgTest)
-
 	t.Run("with valid options", func(t *testing.T) {
 		options := AgentPoolCreateOptions{
 			Name: String("cool-pool"),
@@ -312,8 +308,6 @@ func TestAgentPoolsRead(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	upgradeOrganizationSubscription(t, client, orgTest)
-
 	pool, poolCleanup := createAgentPool(t, client, orgTest)
 	t.Cleanup(poolCleanup)
 
@@ -374,8 +368,6 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
-
-	upgradeOrganizationSubscription(t, client, orgTest)
 
 	t.Run("with valid options", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
@@ -521,8 +513,6 @@ func TestAgentPoolsUpdateAllowedWorkspaces(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	upgradeOrganizationSubscription(t, client, orgTest)
-
 	t.Run("when updating allowed-workspaces", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
 		t.Cleanup(kTestCleanup)
@@ -576,8 +566,6 @@ func TestAgentPoolsUpdateAllowedProjects(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
-
-	upgradeOrganizationSubscription(t, client, orgTest)
 
 	t.Run("when updating allowed-projects", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
@@ -633,8 +621,6 @@ func TestAgentPoolsUpdateExcludedWorkspaces(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	upgradeOrganizationSubscription(t, client, orgTest)
-
 	t.Run("when updating excluded-workspaces", func(t *testing.T) {
 		kBefore, kTestCleanup := createAgentPool(t, client, orgTest)
 		t.Cleanup(kTestCleanup)
@@ -688,8 +674,6 @@ func TestAgentPoolsDelete(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
-
-	upgradeOrganizationSubscription(t, client, orgTest)
 
 	agentPool, _ := createAgentPool(t, client, orgTest)
 

--- a/agent_pool_integration_test.go
+++ b/agent_pool_integration_test.go
@@ -227,7 +227,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 		pool, err := client.AgentPools.Create(ctx, orgTest.Name, options)
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, len(pool.AllowedWorkspaces))
+		require.Equal(t, 1, len(pool.AllowedWorkspaces))
 		assert.Equal(t, workspaceTest.ID, pool.AllowedWorkspaces[0].ID)
 
 		// Get a refreshed view from the API.
@@ -258,7 +258,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 		pool, err := client.AgentPools.Create(ctx, orgTest.Name, options)
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, len(pool.AllowedProjects))
+		require.Equal(t, 1, len(pool.AllowedProjects))
 		assert.Equal(t, projectTest.ID, pool.AllowedProjects[0].ID)
 
 		// Get a refreshed view from the API.
@@ -289,7 +289,7 @@ func TestAgentPoolsCreate(t *testing.T) {
 		pool, err := client.AgentPools.Create(ctx, orgTest.Name, options)
 		require.NoError(t, err)
 
-		assert.Equal(t, 1, len(pool.ExcludedWorkspaces))
+		require.Equal(t, 1, len(pool.ExcludedWorkspaces))
 		assert.Equal(t, workspaceTest.ID, pool.ExcludedWorkspaces[0].ID)
 
 		// Get a refreshed view from the API.
@@ -424,11 +424,11 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 		assert.Equal(t, kBefore.ID, kAfter.ID)
 		assert.Equal(t, "updated-key-name", kAfter.Name)
-		assert.Equal(t, 1, len(kAfter.AllowedWorkspaces))
+		require.Equal(t, 1, len(kAfter.AllowedWorkspaces))
 		assert.Equal(t, workspaceTest.ID, kAfter.AllowedWorkspaces[0].ID)
-		assert.Equal(t, 1, len(kAfter.AllowedProjects))
+		require.Equal(t, 1, len(kAfter.AllowedProjects))
 		assert.Equal(t, projectTest.ID, kAfter.AllowedProjects[0].ID)
-		assert.Equal(t, 1, len(kAfter.ExcludedWorkspaces))
+		require.Equal(t, 1, len(kAfter.ExcludedWorkspaces))
 		assert.Equal(t, excludedWorkspaceTest.ID, kAfter.ExcludedWorkspaces[0].ID)
 	})
 
@@ -469,7 +469,7 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 		assert.Equal(t, kBefore.Name, kAfter.Name)
 		assert.NotEqual(t, kBefore.AllowedWorkspaces, kAfter.AllowedWorkspaces)
-		assert.Equal(t, 1, len(kAfter.AllowedWorkspaces))
+		require.Equal(t, 1, len(kAfter.AllowedWorkspaces))
 		assert.Equal(t, workspaceTest.ID, kAfter.AllowedWorkspaces[0].ID)
 	})
 
@@ -489,7 +489,7 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 		assert.Equal(t, kBefore.Name, kAfter.Name)
 		assert.NotEqual(t, kBefore.AllowedProjects, kAfter.AllowedProjects)
-		assert.Equal(t, 1, len(kAfter.AllowedProjects))
+		require.Equal(t, 1, len(kAfter.AllowedProjects))
 		assert.Equal(t, projectTest.ID, kAfter.AllowedProjects[0].ID)
 	})
 
@@ -509,7 +509,7 @@ func TestAgentPoolsUpdate(t *testing.T) {
 
 		assert.Equal(t, kBefore.Name, kAfter.Name)
 		assert.NotEqual(t, kBefore.ExcludedWorkspaces, kAfter.ExcludedWorkspaces)
-		assert.Equal(t, 1, len(kAfter.ExcludedWorkspaces))
+		require.Equal(t, 1, len(kAfter.ExcludedWorkspaces))
 		assert.Equal(t, workspaceTest.ID, kAfter.ExcludedWorkspaces[0].ID)
 	})
 }
@@ -539,7 +539,7 @@ func TestAgentPoolsUpdateAllowedWorkspaces(t *testing.T) {
 
 		assert.Equal(t, kBefore.Name, kAfter.Name)
 		assert.NotEqual(t, kBefore.AllowedWorkspaces, kAfter.AllowedWorkspaces)
-		assert.Equal(t, 1, len(kAfter.AllowedWorkspaces))
+		require.Equal(t, 1, len(kAfter.AllowedWorkspaces))
 		assert.Equal(t, workspaceTest.ID, kAfter.AllowedWorkspaces[0].ID)
 	})
 
@@ -595,7 +595,7 @@ func TestAgentPoolsUpdateAllowedProjects(t *testing.T) {
 
 		assert.Equal(t, kBefore.Name, kAfter.Name)
 		assert.NotEqual(t, kBefore.AllowedProjects, kAfter.AllowedProjects)
-		assert.Equal(t, 1, len(kAfter.AllowedProjects))
+		require.Equal(t, 1, len(kAfter.AllowedProjects))
 		assert.Equal(t, projectTest.ID, kAfter.AllowedProjects[0].ID)
 	})
 
@@ -651,7 +651,7 @@ func TestAgentPoolsUpdateExcludedWorkspaces(t *testing.T) {
 
 		assert.Equal(t, kBefore.Name, kAfter.Name)
 		assert.NotEqual(t, kBefore.ExcludedWorkspaces, kAfter.ExcludedWorkspaces)
-		assert.Equal(t, 1, len(kAfter.ExcludedWorkspaces))
+		require.Equal(t, 1, len(kAfter.ExcludedWorkspaces))
 		assert.Equal(t, workspaceTest.ID, kAfter.ExcludedWorkspaces[0].ID)
 	})
 

--- a/mocks/agent_pool_mocks.go
+++ b/mocks/agent_pool_mocks.go
@@ -129,6 +129,21 @@ func (mr *MockAgentPoolsMockRecorder) Update(ctx, agentPool, options any) *gomoc
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockAgentPools)(nil).Update), ctx, agentPool, options)
 }
 
+// UpdateAllowedProjects mocks base method.
+func (m *MockAgentPools) UpdateAllowedProjects(ctx context.Context, agentPool string, options tfe.AgentPoolAllowedProjectsUpdateOptions) (*tfe.AgentPool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateAllowedProjects", ctx, agentPool, options)
+	ret0, _ := ret[0].(*tfe.AgentPool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateAllowedProjects indicates an expected call of UpdateAllowedProjects.
+func (mr *MockAgentPoolsMockRecorder) UpdateAllowedProjects(ctx, agentPool, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAllowedProjects", reflect.TypeOf((*MockAgentPools)(nil).UpdateAllowedProjects), ctx, agentPool, options)
+}
+
 // UpdateAllowedWorkspaces mocks base method.
 func (m *MockAgentPools) UpdateAllowedWorkspaces(ctx context.Context, agentPool string, options tfe.AgentPoolAllowedWorkspacesUpdateOptions) (*tfe.AgentPool, error) {
 	m.ctrl.T.Helper()
@@ -142,4 +157,19 @@ func (m *MockAgentPools) UpdateAllowedWorkspaces(ctx context.Context, agentPool 
 func (mr *MockAgentPoolsMockRecorder) UpdateAllowedWorkspaces(ctx, agentPool, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateAllowedWorkspaces", reflect.TypeOf((*MockAgentPools)(nil).UpdateAllowedWorkspaces), ctx, agentPool, options)
+}
+
+// UpdateExcludedWorkspaces mocks base method.
+func (m *MockAgentPools) UpdateExcludedWorkspaces(ctx context.Context, agentPool string, options tfe.AgentPoolExcludedWorkspacesUpdateOptions) (*tfe.AgentPool, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateExcludedWorkspaces", ctx, agentPool, options)
+	ret0, _ := ret[0].(*tfe.AgentPool)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateExcludedWorkspaces indicates an expected call of UpdateExcludedWorkspaces.
+func (mr *MockAgentPoolsMockRecorder) UpdateExcludedWorkspaces(ctx, agentPool, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateExcludedWorkspaces", reflect.TypeOf((*MockAgentPools)(nil).UpdateExcludedWorkspaces), ctx, agentPool, options)
 }

--- a/project.go
+++ b/project.go
@@ -142,9 +142,9 @@ type ProjectCreateOptions struct {
 	// Optional: DefaultExecutionMode the default execution mode for workspaces in the project
 	DefaultExecutionMode *string `jsonapi:"attr,default-execution-mode,omitempty"`
 
-	// Optional: DefaultAgentPoolId default agent pool for workspaces in the project,
+	// Optional: DefaultAgentPoolID default agent pool for workspaces in the project,
 	// required when DefaultExecutionMode is set to `agent`
-	DefaultAgentPoolId *string `jsonapi:"attr,default-agent-pool-id,omitempty"`
+	DefaultAgentPoolID *string `jsonapi:"attr,default-agent-pool-id,omitempty"`
 
 	// Optional: Struct of booleans, which indicate whether the project
 	// specifies its own values for various settings. If you mark a setting as
@@ -185,9 +185,9 @@ type ProjectUpdateOptions struct {
 	// Optional: DefaultExecutionMode the default execution mode for workspaces
 	DefaultExecutionMode *string `jsonapi:"attr,default-execution-mode,omitempty"`
 
-	// Optional: DefaultAgentPoolId default agent pool for workspaces in the project,
+	// Optional: DefaultAgentPoolID default agent pool for workspaces in the project,
 	// required when DefaultExecutionMode is set to `agent`
-	DefaultAgentPoolId *string `jsonapi:"attr,default-agent-pool-id,omitempty"`
+	DefaultAgentPoolID *string `jsonapi:"attr,default-agent-pool-id,omitempty"`
 
 	// Optional: Struct of booleans, which indicate whether the project
 	// specifies its own values for various settings. If you mark a setting as

--- a/project.go
+++ b/project.go
@@ -65,17 +65,25 @@ type ProjectList struct {
 
 // Project represents a Terraform Enterprise project
 type Project struct {
-	ID        string `jsonapi:"primary,projects"`
-	IsUnified bool   `jsonapi:"attr,is-unified"`
-	Name      string `jsonapi:"attr,name"`
-
-	Description string `jsonapi:"attr,description"`
-
+	ID                          string                       `jsonapi:"primary,projects"`
 	AutoDestroyActivityDuration jsonapi.NullableAttr[string] `jsonapi:"attr,auto-destroy-activity-duration,omitempty"`
+	DefaultExecutionMode        string                       `jsonapi:"attr,default-execution-mode"`
+	Description                 string                       `jsonapi:"attr,description"`
+	IsUnified                   bool                         `jsonapi:"attr,is-unified"`
+	Name                        string                       `jsonapi:"attr,name"`
+	SettingOverwrites           *ProjectSettingOverwrites    `jsonapi:"attr,setting-overwrites"`
 
 	// Relations
-	Organization         *Organization          `jsonapi:"relation,organization"`
+	DefaultAgentPool     *AgentPool             `jsonapi:"relation,default-agent-pool"`
 	EffectiveTagBindings []*EffectiveTagBinding `jsonapi:"relation,effective-tag-bindings"`
+	Organization         *Organization          `jsonapi:"relation,organization"`
+}
+
+// Note: the fields of this struct are bool pointers instead of bool values, in order to simplify support for
+// future TFE versions that support *some but not all* of the inherited defaults that go-tfe knows about.
+type ProjectSettingOverwrites struct {
+	ExecutionMode *bool `jsonapi:"attr,default-execution-mode"`
+	AgentPool     *bool `jsonapi:"attr,default-agent-pool"`
 }
 
 type ProjectIncludeOpt string
@@ -130,6 +138,25 @@ type ProjectCreateOptions struct {
 	// after workspace activity to trigger a destroy run. The format should roughly
 	// match a Go duration string limited to days and hours, e.g. "24h" or "1d".
 	AutoDestroyActivityDuration jsonapi.NullableAttr[string] `jsonapi:"attr,auto-destroy-activity-duration,omitempty"`
+
+	// Optional: DefaultExecutionMode the default execution mode for workspaces in the project
+	DefaultExecutionMode *string `jsonapi:"attr,default-execution-mode,omitempty"`
+
+	// Optional: DefaultAgentPoolId default agent pool for workspaces in the project,
+	// required when DefaultExecutionMode is set to `agent`
+	DefaultAgentPoolId *string `jsonapi:"attr,default-agent-pool-id,omitempty"`
+
+	// Optional: Struct of booleans, which indicate whether the project
+	// specifies its own values for various settings. If you mark a setting as
+	// `false` in this struct, it will clear the project's existing value for
+	// that setting and defer to the default value that its organization provides.
+	//
+	// In general, it's not necessary to mark a setting as `true` in this
+	// struct; if you provide a literal value for a setting, HCP Terraform will
+	// automatically update its overwrites field to `true`. If you do choose to
+	// manually mark a setting as overwritten, you must provide a value for that
+	// setting at the same time.
+	SettingOverwrites *ProjectSettingOverwrites `jsonapi:"attr,setting-overwrites,omitempty"`
 }
 
 // ProjectUpdateOptions represents the options for updating a project
@@ -154,6 +181,25 @@ type ProjectUpdateOptions struct {
 	// after workspace activity to trigger a destroy run. The format should roughly
 	// match a Go duration string limited to days and hours, e.g. "24h" or "1d".
 	AutoDestroyActivityDuration jsonapi.NullableAttr[string] `jsonapi:"attr,auto-destroy-activity-duration,omitempty"`
+
+	// Optional: DefaultExecutionMode the default execution mode for workspaces
+	DefaultExecutionMode *string `jsonapi:"attr,default-execution-mode,omitempty"`
+
+	// Optional: DefaultAgentPoolId default agent pool for workspaces in the project,
+	// required when DefaultExecutionMode is set to `agent`
+	DefaultAgentPoolId *string `jsonapi:"attr,default-agent-pool-id,omitempty"`
+
+	// Optional: Struct of booleans, which indicate whether the project
+	// specifies its own values for various settings. If you mark a setting as
+	// `false` in this struct, it will clear the project's existing value for
+	// that setting and defer to the default value that its organization provides.
+	//
+	// In general, it's not necessary to mark a setting as `true` in this
+	// struct; if you provide a literal value for a setting, HCP Terraform will
+	// automatically update its overwrites field to `true`. If you do choose to
+	// manually mark a setting as overwritten, you must provide a value for that
+	// setting at the same time.
+	SettingOverwrites *ProjectSettingOverwrites `jsonapi:"attr,setting-overwrites,omitempty"`
 }
 
 // ProjectAddTagBindingsOptions represents the options for adding tag bindings

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -20,13 +20,13 @@ func TestProjectsList(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	pTest1, pTestCleanup := createProject(t, client, orgTest)
-	defer pTestCleanup()
+	t.Cleanup(pTestCleanup)
 
 	pTest2, pTestCleanup := createProject(t, client, orgTest)
-	defer pTestCleanup()
+	t.Cleanup(pTestCleanup)
 
 	t.Run("without list options", func(t *testing.T) {
 		pl, err := client.Projects.List(ctx, orgTest.Name, nil)
@@ -148,7 +148,7 @@ func TestProjectsReadWithOptions(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	pTest, pTestCleanup := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
 		Name: "project-with-tags",
@@ -156,7 +156,7 @@ func TestProjectsReadWithOptions(t *testing.T) {
 			{Key: "foo", Value: "bar"},
 		},
 	})
-	defer pTestCleanup()
+	t.Cleanup(pTestCleanup)
 
 	t.Run("when the project exists", func(t *testing.T) {
 		p, err := client.Projects.ReadWithOptions(ctx, pTest.ID, ProjectReadOptions{
@@ -177,10 +177,10 @@ func TestProjectsRead(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	pTest, pTestCleanup := createProject(t, client, orgTest)
-	defer pTestCleanup()
+	t.Cleanup(pTestCleanup)
 
 	t.Run("when the project exists", func(t *testing.T) {
 		w, err := client.Projects.Read(ctx, pTest.ID)
@@ -203,14 +203,14 @@ func TestProjectsRead(t *testing.T) {
 
 	t.Run("with default execution mode of 'agent'", func(t *testing.T) {
 		agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
-		defer agentPoolTestCleanup()
+		t.Cleanup(agentPoolTestCleanup)
 
 		proj, projCleanup := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
 			Name:                 "project-with-agent-pool",
 			DefaultExecutionMode: String("agent"),
 			DefaultAgentPoolID:   String(agentPoolTest.ID),
 		})
-		defer projCleanup()
+		t.Cleanup(projCleanup)
 
 		t.Run("execution mode and agent pool are properly decoded", func(t *testing.T) {
 			assert.Equal(t, "agent", proj.DefaultExecutionMode)
@@ -252,7 +252,7 @@ func TestProjectsCreate(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	newSubscriptionUpdater(orgTest).WithBusinessPlan().Update(t)
 
@@ -313,7 +313,7 @@ func TestProjectsCreate(t *testing.T) {
 
 	t.Run("when a default agent pool ID is specified without 'agent' execution mode", func(t *testing.T) {
 		agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
-		defer agentPoolTestCleanup()
+		t.Cleanup(agentPoolTestCleanup)
 
 		p, err := client.Projects.Create(ctx, orgTest.Name, ProjectCreateOptions{
 			Name:                 fmt.Sprintf("foo-%s", randomString(t)),
@@ -363,7 +363,7 @@ func TestProjectsCreate(t *testing.T) {
 
 	t.Run("when agent pool and execution mode setting overwrites do not match", func(t *testing.T) {
 		agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
-		defer agentPoolTestCleanup()
+		t.Cleanup(agentPoolTestCleanup)
 
 		p, err := client.Projects.Create(ctx, orgTest.Name, ProjectCreateOptions{
 			Name:                 fmt.Sprintf("foo-%s", randomString(t)),
@@ -430,10 +430,10 @@ func TestProjectsUpdate(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
-	defer agentPoolTestCleanup()
+	t.Cleanup(agentPoolTestCleanup)
 
 	t.Run("with valid options", func(t *testing.T) {
 		kBefore, kTestCleanup := createProject(t, client, orgTest)
@@ -507,7 +507,7 @@ func TestProjectsUpdate(t *testing.T) {
 
 	t.Run("when updating with invalid name", func(t *testing.T) {
 		kBefore, kTestCleanup := createProject(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		kAfter, err := client.Projects.Update(ctx, kBefore.ID, ProjectUpdateOptions{
 			Name: String(badIdentifier),
@@ -528,7 +528,7 @@ func TestProjectsUpdate(t *testing.T) {
 		newSubscriptionUpdater(orgTest).WithBusinessPlan().Update(t)
 
 		kBefore, kTestCleanup := createProject(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		w, err := client.Projects.Update(ctx, kBefore.ID, ProjectUpdateOptions{
 			AutoDestroyActivityDuration: jsonapi.NewNullableAttrWithValue("bar"),
@@ -539,7 +539,7 @@ func TestProjectsUpdate(t *testing.T) {
 
 	t.Run("with agent pool provided, but remote execution mode", func(t *testing.T) {
 		kBefore, kTestCleanup := createProject(t, client, orgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		pool, agentPoolCleanup := createAgentPool(t, client, orgTest)
 		t.Cleanup(agentPoolCleanup)
@@ -554,10 +554,10 @@ func TestProjectsUpdate(t *testing.T) {
 
 	t.Run("with different default execution modes", func(t *testing.T) {
 		proj, projCleanup := createProject(t, client, orgTest)
-		defer projCleanup()
+		t.Cleanup(projCleanup)
 
 		agentPool, agenPoolCleanup := createAgentPool(t, client, orgTest)
-		defer agenPoolCleanup()
+		t.Cleanup(agenPoolCleanup)
 
 		assert.Equal(t, "remote", proj.DefaultExecutionMode)
 		assert.Nil(t, proj.DefaultAgentPool)
@@ -593,7 +593,7 @@ func TestProjectsUpdate(t *testing.T) {
 		t.Cleanup(defaultExecutionOrgTestCleanup)
 
 		kBefore, kTestCleanup := createProject(t, client, defaultExecutionOrgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		options := ProjectUpdateOptions{
 			DefaultExecutionMode: String("local"),
@@ -613,7 +613,7 @@ func TestProjectsUpdate(t *testing.T) {
 		t.Cleanup(defaultExecutionOrgTestCleanup)
 
 		kBefore, kTestCleanup := createProject(t, client, defaultExecutionOrgTest)
-		defer kTestCleanup()
+		t.Cleanup(kTestCleanup)
 
 		options := ProjectUpdateOptions{
 			SettingOverwrites: &ProjectSettingOverwrites{
@@ -724,7 +724,7 @@ func TestProjectsDelete(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	pTest, _ := createProject(t, client, orgTest)
 
@@ -754,7 +754,7 @@ func TestProjectsAutoDestroy(t *testing.T) {
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
-	defer orgTestCleanup()
+	t.Cleanup(orgTestCleanup)
 
 	newSubscriptionUpdater(orgTest).WithBusinessPlan().Update(t)
 

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -166,7 +166,7 @@ func TestProjectsReadWithOptions(t *testing.T) {
 		assert.Equal(t, orgTest.Name, p.Organization.Name)
 
 		// Tag data is included
-		assert.Len(t, p.EffectiveTagBindings, 1)
+		require.Len(t, p.EffectiveTagBindings, 1)
 		assert.Equal(t, "foo", p.EffectiveTagBindings[0].Key)
 		assert.Equal(t, "bar", p.EffectiveTagBindings[0].Value)
 	})
@@ -240,7 +240,7 @@ func TestProjectsRead(t *testing.T) {
 			assert.NotEmpty(t, p)
 
 			assert.Equal(t, defaultExecutionOrgTest.DefaultExecutionMode, p.DefaultExecutionMode)
-			assert.NotEmpty(t, p.SettingOverwrites)
+			require.NotNil(t, p.SettingOverwrites)
 			assert.Equal(t, false, *p.SettingOverwrites.ExecutionMode)
 			assert.Equal(t, false, *p.SettingOverwrites.ExecutionMode)
 		})
@@ -460,14 +460,14 @@ func TestProjectsUpdate(t *testing.T) {
 			bindings, err := client.Projects.ListTagBindings(ctx, kAfter.ID)
 			require.NoError(t, err)
 
-			assert.Len(t, bindings, 1)
+			require.Len(t, bindings, 1)
 			assert.Equal(t, "foo", bindings[0].Key)
 			assert.Equal(t, "bar", bindings[0].Value)
 
 			effectiveBindings, err := client.Projects.ListEffectiveTagBindings(ctx, kAfter.ID)
 			require.NoError(t, err)
 
-			assert.Len(t, effectiveBindings, 1)
+			require.Len(t, effectiveBindings, 1)
 			assert.Equal(t, "foo", effectiveBindings[0].Key)
 			assert.Equal(t, "bar", effectiveBindings[0].Value)
 
@@ -648,7 +648,7 @@ func TestProjectsAddTagBindings(t *testing.T) {
 		})
 		require.NoError(t, err)
 
-		assert.Len(t, bindings, 2)
+		require.Len(t, bindings, 2)
 		assert.Equal(t, tagBindings[0].Key, bindings[0].Key)
 		assert.Equal(t, tagBindings[0].Value, bindings[0].Value)
 		assert.Equal(t, tagBindings[1].Key, bindings[1].Key)

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -199,6 +200,51 @@ func TestProjectsRead(t *testing.T) {
 		assert.Nil(t, w)
 		assert.EqualError(t, err, ErrInvalidProjectID.Error())
 	})
+
+	t.Run("with default execution mode of 'agent'", func(t *testing.T) {
+		agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
+		defer agentPoolTestCleanup()
+
+		proj, projCleanup := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
+			Name:                 "project-with-agent-pool",
+			DefaultExecutionMode: String("agent"),
+			DefaultAgentPoolId:   String(agentPoolTest.ID),
+		})
+		defer projCleanup()
+
+		t.Run("execution mode and agent pool are properly decoded", func(t *testing.T) {
+			assert.Equal(t, "agent", proj.DefaultExecutionMode)
+			assert.NotNil(t, proj.DefaultAgentPool)
+			assert.Equal(t, proj.DefaultAgentPool.ID, agentPoolTest.ID)
+		})
+	})
+
+	t.Run("when project is inheriting the default execution mode", func(t *testing.T) {
+		defaultExecutionOrgTest, defaultExecutionOrgTestCleanup := createOrganizationWithDefaultAgentPool(t, client)
+		t.Cleanup(defaultExecutionOrgTestCleanup)
+
+		options := ProjectCreateOptions{
+			Name: fmt.Sprintf("tst-" + randomString(t)[0:20]),
+			SettingOverwrites: &ProjectSettingOverwrites{
+				ExecutionMode: Bool(false),
+				AgentPool:     Bool(false),
+			},
+		}
+
+		pDefaultTest, pDefaultTestCleanup := createProjectWithOptions(t, client, defaultExecutionOrgTest, options)
+		t.Cleanup(pDefaultTestCleanup)
+
+		t.Run("and project execution mode is default", func(t *testing.T) {
+			p, err := client.Projects.Read(ctx, pDefaultTest.ID)
+			assert.NoError(t, err)
+			assert.NotEmpty(t, p)
+
+			assert.Equal(t, defaultExecutionOrgTest.DefaultExecutionMode, p.DefaultExecutionMode)
+			assert.NotEmpty(t, p.SettingOverwrites)
+			assert.Equal(t, false, *p.SettingOverwrites.ExecutionMode)
+			assert.Equal(t, false, *p.SettingOverwrites.ExecutionMode)
+		})
+	})
 }
 
 func TestProjectsCreate(t *testing.T) {
@@ -264,6 +310,119 @@ func TestProjectsCreate(t *testing.T) {
 		assert.Nil(t, w)
 		assert.Contains(t, err.Error(), "invalid attribute\n\nAuto destroy activity duration has an incorrect format, we expect up to 4 numeric digits and 1 unit ('d' or 'h')")
 	})
+
+	t.Run("when a default agent pool ID is specified without 'agent' execution mode", func(t *testing.T) {
+		agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
+		defer agentPoolTestCleanup()
+
+		p, err := client.Projects.Create(ctx, orgTest.Name, ProjectCreateOptions{
+			Name:                 fmt.Sprintf("foo-%s", randomString(t)),
+			DefaultExecutionMode: String("remote"),
+			DefaultAgentPoolId:   String(agentPoolTest.ID),
+		})
+
+		assert.Nil(t, p)
+		assert.Contains(t, err.Error(), "unprocessable entity\n\nAgent pool must not be specified unless using 'agent' execution mode")
+	})
+
+	t.Run("when 'agent' execution mode is specified without an a default agent pool ID", func(t *testing.T) {
+		p, err := client.Projects.Create(ctx, orgTest.Name, ProjectCreateOptions{
+			Name:                 fmt.Sprintf("foo-%s", randomString(t)),
+			DefaultExecutionMode: String("agent"),
+		})
+
+		assert.Nil(t, p)
+		assert.Contains(t, err.Error(), "invalid attribute\n\nDefault agent pool must be specified when using 'agent' execution mode")
+	})
+
+	t.Run("when no execution mode is specified, in an organization with local as default execution mode", func(t *testing.T) {
+		orgTest, orgTestCleanup := createOrganizationWithOptions(t, client, OrganizationCreateOptions{
+			Name:                 String("tst-" + randomString(t)[0:20]),
+			Email:                String(fmt.Sprintf("%s@tfe.local", randomString(t))),
+			DefaultExecutionMode: String("local"),
+		})
+		t.Cleanup(orgTestCleanup)
+
+		options := ProjectCreateOptions{
+			Name: fmt.Sprintf("foo-%s", randomString(t)),
+			SettingOverwrites: &ProjectSettingOverwrites{
+				ExecutionMode: Bool(false),
+				AgentPool:     Bool(false),
+			},
+		}
+
+		p, err := client.Projects.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		// Get a refreshed view from the API.
+		refreshed, err := client.Projects.Read(ctx, p.ID)
+		require.NoError(t, err)
+
+		assert.Equal(t, "local", refreshed.DefaultExecutionMode)
+	})
+
+	t.Run("when agent pool and execution mode setting overwrites do not match", func(t *testing.T) {
+		agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
+		defer agentPoolTestCleanup()
+
+		p, err := client.Projects.Create(ctx, orgTest.Name, ProjectCreateOptions{
+			Name:                 fmt.Sprintf("foo-%s", randomString(t)),
+			DefaultExecutionMode: String("agent"),
+			DefaultAgentPoolId:   String(agentPoolTest.ID),
+			SettingOverwrites: &ProjectSettingOverwrites{
+				AgentPool:     Bool(false),
+				ExecutionMode: Bool(true),
+			},
+		})
+
+		assert.Nil(t, p)
+		assert.Contains(t, err.Error(), "If agent-pool and execution-mode are both included in setting-overwrites, their values must be the same.")
+	})
+
+	t.Run("when organization has a default execution mode", func(t *testing.T) {
+		defaultExecutionOrgTest, defaultExecutionOrgTestCleanup := createOrganizationWithDefaultAgentPool(t, client)
+		t.Cleanup(defaultExecutionOrgTestCleanup)
+
+		t.Run("with setting overwrites set to false, project inherits the default execution mode", func(t *testing.T) {
+			options := ProjectCreateOptions{
+				Name: fmt.Sprintf("tst-proj-%s", randomString(t)[0:20]),
+				SettingOverwrites: &ProjectSettingOverwrites{
+					ExecutionMode: Bool(false),
+					AgentPool:     Bool(false),
+				},
+			}
+			p, err := client.Projects.Create(ctx, defaultExecutionOrgTest.Name, options)
+
+			require.NoError(t, err)
+			assert.Equal(t, "agent", p.DefaultExecutionMode)
+		})
+
+		t.Run("with setting overwrites set to true, project ignores the default execution mode", func(t *testing.T) {
+			options := ProjectCreateOptions{
+				Name:                 fmt.Sprintf("tst-proj-%s", randomString(t)[0:20]),
+				DefaultExecutionMode: String("local"),
+				SettingOverwrites: &ProjectSettingOverwrites{
+					ExecutionMode: Bool(true),
+					AgentPool:     Bool(true),
+				},
+			}
+			p, err := client.Projects.Create(ctx, defaultExecutionOrgTest.Name, options)
+
+			require.NoError(t, err)
+			assert.Equal(t, "local", p.DefaultExecutionMode)
+		})
+
+		t.Run("when explicitly setting default execution mode, project ignores the org default execution mode", func(t *testing.T) {
+			options := ProjectCreateOptions{
+				Name:                 fmt.Sprintf("tst-proj-%s", randomString(t)[0:20]),
+				DefaultExecutionMode: String("remote"),
+			}
+			p, err := client.Projects.Create(ctx, defaultExecutionOrgTest.Name, options)
+
+			require.NoError(t, err)
+			assert.Equal(t, "remote", p.DefaultExecutionMode)
+		})
+	})
 }
 
 func TestProjectsUpdate(t *testing.T) {
@@ -272,6 +431,9 @@ func TestProjectsUpdate(t *testing.T) {
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
+
+	agentPoolTest, agentPoolTestCleanup := createAgentPool(t, client, orgTest)
+	defer agentPoolTestCleanup()
 
 	t.Run("with valid options", func(t *testing.T) {
 		kBefore, kTestCleanup := createProject(t, client, orgTest)
@@ -283,12 +445,16 @@ func TestProjectsUpdate(t *testing.T) {
 			TagBindings: []*TagBinding{
 				{Key: "foo", Value: "bar"},
 			},
+			DefaultExecutionMode: String("agent"),
+			DefaultAgentPoolId:   String(agentPoolTest.ID),
 		})
 		require.NoError(t, err)
 
 		assert.Equal(t, kBefore.ID, kAfter.ID)
 		assert.NotEqual(t, kBefore.Name, kAfter.Name)
 		assert.NotEqual(t, kBefore.Description, kAfter.Description)
+		assert.NotEqual(t, kBefore.DefaultExecutionMode, kAfter.DefaultExecutionMode)
+		assert.NotEqual(t, kBefore.DefaultAgentPool, kAfter.DefaultAgentPool)
 
 		if betaFeaturesEnabled() {
 			bindings, err := client.Projects.ListTagBindings(ctx, kAfter.ID)
@@ -369,6 +535,95 @@ func TestProjectsUpdate(t *testing.T) {
 		})
 		assert.Nil(t, w)
 		assert.Contains(t, err.Error(), "invalid attribute\n\nAuto destroy activity duration has an incorrect format, we expect up to 4 numeric digits and 1 unit ('d' or 'h')")
+	})
+
+	t.Run("with agent pool provided, but remote execution mode", func(t *testing.T) {
+		kBefore, kTestCleanup := createProject(t, client, orgTest)
+		defer kTestCleanup()
+
+		pool, agentPoolCleanup := createAgentPool(t, client, orgTest)
+		t.Cleanup(agentPoolCleanup)
+
+		proj, err := client.Projects.Update(ctx, kBefore.ID, ProjectUpdateOptions{
+			DefaultExecutionMode: String("local"),
+			DefaultAgentPoolId:   String(pool.ID),
+		})
+		assert.Nil(t, proj)
+		assert.ErrorContains(t, err, "Agent pool must not be specified unless using 'agent' execution mode")
+	})
+
+	t.Run("with different default execution modes", func(t *testing.T) {
+		proj, projCleanup := createProject(t, client, orgTest)
+		defer projCleanup()
+
+		agentPool, agenPoolCleanup := createAgentPool(t, client, orgTest)
+		defer agenPoolCleanup()
+
+		assert.Equal(t, "remote", proj.DefaultExecutionMode)
+		assert.Nil(t, proj.DefaultAgentPool)
+
+		// assert that project's execution mode can be updated from 'remote' -> 'agent'
+		proj, err := client.Projects.Update(ctx, proj.ID, ProjectUpdateOptions{
+			DefaultExecutionMode: String("agent"),
+			DefaultAgentPoolId:   String(agentPool.ID),
+		})
+		assert.Equal(t, "agent", proj.DefaultExecutionMode)
+		assert.Equal(t, agentPool.ID, proj.DefaultAgentPool.ID)
+
+		// assert that project's execution mode can be updated from 'agent' -> 'remote'
+		proj, err = client.Projects.Update(ctx, proj.ID, ProjectUpdateOptions{
+			DefaultExecutionMode: String("remote"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "remote", proj.DefaultExecutionMode)
+		assert.Nil(t, proj.DefaultAgentPool)
+
+		// assert that project's execution mode can be updated from 'remote' -> 'local'
+		proj, err = client.Projects.Update(ctx, proj.ID, ProjectUpdateOptions{
+			DefaultExecutionMode: String("local"),
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "local", proj.DefaultExecutionMode)
+		assert.Nil(t, proj.DefaultAgentPool)
+	})
+
+	t.Run("with setting overwrites set to true, project ignores the default execution mode", func(t *testing.T) {
+		defaultExecutionOrgTest, defaultExecutionOrgTestCleanup := createOrganizationWithDefaultAgentPool(t, client)
+		t.Cleanup(defaultExecutionOrgTestCleanup)
+
+		kBefore, kTestCleanup := createProject(t, client, defaultExecutionOrgTest)
+		defer kTestCleanup()
+
+		options := ProjectUpdateOptions{
+			DefaultExecutionMode: String("local"),
+			SettingOverwrites: &ProjectSettingOverwrites{
+				ExecutionMode: Bool(true),
+				AgentPool:     Bool(true),
+			},
+		}
+		p, err := client.Projects.Update(ctx, kBefore.ID, options)
+
+		require.NoError(t, err)
+		assert.Equal(t, "local", p.DefaultExecutionMode)
+	})
+
+	t.Run("with setting overwrites set to false, project inherits the default execution mode", func(t *testing.T) {
+		defaultExecutionOrgTest, defaultExecutionOrgTestCleanup := createOrganizationWithDefaultAgentPool(t, client)
+		t.Cleanup(defaultExecutionOrgTestCleanup)
+
+		kBefore, kTestCleanup := createProject(t, client, defaultExecutionOrgTest)
+		defer kTestCleanup()
+
+		options := ProjectUpdateOptions{
+			SettingOverwrites: &ProjectSettingOverwrites{
+				ExecutionMode: Bool(false),
+				AgentPool:     Bool(false),
+			},
+		}
+		p, err := client.Projects.Update(ctx, kBefore.ID, options)
+
+		require.NoError(t, err)
+		assert.Equal(t, "agent", p.DefaultExecutionMode)
 	})
 }
 

--- a/projects_integration_test.go
+++ b/projects_integration_test.go
@@ -208,7 +208,7 @@ func TestProjectsRead(t *testing.T) {
 		proj, projCleanup := createProjectWithOptions(t, client, orgTest, ProjectCreateOptions{
 			Name:                 "project-with-agent-pool",
 			DefaultExecutionMode: String("agent"),
-			DefaultAgentPoolId:   String(agentPoolTest.ID),
+			DefaultAgentPoolID:   String(agentPoolTest.ID),
 		})
 		defer projCleanup()
 
@@ -318,7 +318,7 @@ func TestProjectsCreate(t *testing.T) {
 		p, err := client.Projects.Create(ctx, orgTest.Name, ProjectCreateOptions{
 			Name:                 fmt.Sprintf("foo-%s", randomString(t)),
 			DefaultExecutionMode: String("remote"),
-			DefaultAgentPoolId:   String(agentPoolTest.ID),
+			DefaultAgentPoolID:   String(agentPoolTest.ID),
 		})
 
 		assert.Nil(t, p)
@@ -368,7 +368,7 @@ func TestProjectsCreate(t *testing.T) {
 		p, err := client.Projects.Create(ctx, orgTest.Name, ProjectCreateOptions{
 			Name:                 fmt.Sprintf("foo-%s", randomString(t)),
 			DefaultExecutionMode: String("agent"),
-			DefaultAgentPoolId:   String(agentPoolTest.ID),
+			DefaultAgentPoolID:   String(agentPoolTest.ID),
 			SettingOverwrites: &ProjectSettingOverwrites{
 				AgentPool:     Bool(false),
 				ExecutionMode: Bool(true),
@@ -446,7 +446,7 @@ func TestProjectsUpdate(t *testing.T) {
 				{Key: "foo", Value: "bar"},
 			},
 			DefaultExecutionMode: String("agent"),
-			DefaultAgentPoolId:   String(agentPoolTest.ID),
+			DefaultAgentPoolID:   String(agentPoolTest.ID),
 		})
 		require.NoError(t, err)
 
@@ -546,7 +546,7 @@ func TestProjectsUpdate(t *testing.T) {
 
 		proj, err := client.Projects.Update(ctx, kBefore.ID, ProjectUpdateOptions{
 			DefaultExecutionMode: String("local"),
-			DefaultAgentPoolId:   String(pool.ID),
+			DefaultAgentPoolID:   String(pool.ID),
 		})
 		assert.Nil(t, proj)
 		assert.ErrorContains(t, err, "Agent pool must not be specified unless using 'agent' execution mode")
@@ -565,8 +565,9 @@ func TestProjectsUpdate(t *testing.T) {
 		// assert that project's execution mode can be updated from 'remote' -> 'agent'
 		proj, err := client.Projects.Update(ctx, proj.ID, ProjectUpdateOptions{
 			DefaultExecutionMode: String("agent"),
-			DefaultAgentPoolId:   String(agentPool.ID),
+			DefaultAgentPoolID:   String(agentPool.ID),
 		})
+		require.NoError(t, err)
 		assert.Equal(t, "agent", proj.DefaultExecutionMode)
 		assert.Equal(t, agentPool.ID, proj.DefaultAgentPool.ID)
 


### PR DESCRIPTION
## Description

This PR adds:
- `DefaultExecutionMode`, `DefaultAgentPool`, and `SettingOverwrites` support to `Project`
- `AllowedProjects` and `ExcludedWorkspaces` to `AgentPool`

## Testing plan

1. Generate required environment variables (i.e. TFE address and tokens).
2. Run tests in `agent_pool_integration_test.go` and `projects_integration_test.go`.  The new tests should pass.

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
=== RUN   TestProjectsList
=== RUN   TestProjectsList/without_list_options
--- PASS: TestProjectsList/without_list_options (0.19s)
=== RUN   TestProjectsList/with_pagination_list_options
--- PASS: TestProjectsList/with_pagination_list_options (0.19s)
=== RUN   TestProjectsList/with_query_list_option
--- PASS: TestProjectsList/with_query_list_option (0.20s)
=== RUN   TestProjectsList/without_a_valid_organization
--- PASS: TestProjectsList/without_a_valid_organization (0.00s)
=== RUN   TestProjectsList/when_using_a_tags_filter
    projects_integration_test.go:70: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestProjectsList/when_using_a_tags_filter (0.00s)

Test ignored.
=== RUN   TestProjectsList/when_including_effective_tags_relationship
    projects_integration_test.go:119: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestProjectsList/when_including_effective_tags_relationship (0.00s)

Test ignored.
--- PASS: TestProjectsList (2.07s)

Test ignored.
=== RUN   TestProjectsReadWithOptions
=== RUN   TestProjectsReadWithOptions/when_the_project_exists
--- PASS: TestProjectsReadWithOptions/when_the_project_exists (0.19s)
--- PASS: TestProjectsReadWithOptions (1.39s)
=== RUN   TestProjectsRead
=== RUN   TestProjectsRead/when_the_project_exists
--- PASS: TestProjectsRead/when_the_project_exists (0.29s)
=== RUN   TestProjectsRead/when_the_project_does_not_exist
--- PASS: TestProjectsRead/when_the_project_does_not_exist (0.22s)
=== RUN   TestProjectsRead/without_a_valid_project_ID
--- PASS: TestProjectsRead/without_a_valid_project_ID (0.00s)
=== RUN   TestProjectsRead/with_default_execution_mode_of_'agent'
=== RUN   TestProjectsRead/with_default_execution_mode_of_'agent'/execution_mode_and_agent_pool_are_properly_decoded
--- PASS: TestProjectsRead/with_default_execution_mode_of_'agent'/execution_mode_and_agent_pool_are_properly_decoded (0.00s)
--- PASS: TestProjectsRead/with_default_execution_mode_of_'agent' (0.84s)
=== RUN   TestProjectsRead/when_project_is_inheriting_the_default_execution_mode
=== RUN   TestProjectsRead/when_project_is_inheriting_the_default_execution_mode/and_project_execution_mode_is_default
--- PASS: TestProjectsRead/when_project_is_inheriting_the_default_execution_mode/and_project_execution_mode_is_default (0.19s)
--- PASS: TestProjectsRead/when_project_is_inheriting_the_default_execution_mode (1.60s)
--- PASS: TestProjectsRead (4.37s)
=== RUN   TestProjectsCreate
=== RUN   TestProjectsCreate/with_valid_options
--- PASS: TestProjectsCreate/with_valid_options (0.53s)
=== RUN   TestProjectsCreate/when_options_is_missing_name
--- PASS: TestProjectsCreate/when_options_is_missing_name (0.00s)
=== RUN   TestProjectsCreate/when_options_has_an_invalid_name
--- PASS: TestProjectsCreate/when_options_has_an_invalid_name (0.15s)
=== RUN   TestProjectsCreate/when_options_has_an_invalid_organization
--- PASS: TestProjectsCreate/when_options_has_an_invalid_organization (0.00s)
=== RUN   TestProjectsCreate/when_options_has_an_invalid_auto_destroy_activity_duration
    projects_integration_test.go:304: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestProjectsCreate/when_options_has_an_invalid_auto_destroy_activity_duration (0.00s)

Test ignored.
=== RUN   TestProjectsCreate/when_a_default_agent_pool_ID_is_specified_without_'agent'_execution_mode
--- PASS: TestProjectsCreate/when_a_default_agent_pool_ID_is_specified_without_'agent'_execution_mode (0.58s)
=== RUN   TestProjectsCreate/when_'agent'_execution_mode_is_specified_without_an_a_default_agent_pool_ID
--- PASS: TestProjectsCreate/when_'agent'_execution_mode_is_specified_without_an_a_default_agent_pool_ID (0.16s)
=== RUN   TestProjectsCreate/when_no_execution_mode_is_specified,_in_an_organization_with_local_as_default_execution_mode
--- PASS: TestProjectsCreate/when_no_execution_mode_is_specified,_in_an_organization_with_local_as_default_execution_mode (0.92s)
=== RUN   TestProjectsCreate/when_agent_pool_and_execution_mode_setting_overwrites_do_not_match
--- PASS: TestProjectsCreate/when_agent_pool_and_execution_mode_setting_overwrites_do_not_match (0.79s)
=== RUN   TestProjectsCreate/when_organization_has_a_default_execution_mode
=== RUN   TestProjectsCreate/when_organization_has_a_default_execution_mode/with_setting_overwrites_set_to_false,_project_inherits_the_default_execution_mode
--- PASS: TestProjectsCreate/when_organization_has_a_default_execution_mode/with_setting_overwrites_set_to_false,_project_inherits_the_default_execution_mode (0.18s)
=== RUN   TestProjectsCreate/when_organization_has_a_default_execution_mode/with_setting_overwrites_set_to_true,_project_ignores_the_default_execution_mode
--- PASS: TestProjectsCreate/when_organization_has_a_default_execution_mode/with_setting_overwrites_set_to_true,_project_ignores_the_default_execution_mode (0.18s)
=== RUN   TestProjectsCreate/when_organization_has_a_default_execution_mode/when_explicitly_setting_default_execution_mode,_project_ignores_the_org_default_execution_mode
--- PASS: TestProjectsCreate/when_organization_has_a_default_execution_mode/when_explicitly_setting_default_execution_mode,_project_ignores_the_org_default_execution_mode (0.18s)
--- PASS: TestProjectsCreate/when_organization_has_a_default_execution_mode (1.75s)
--- PASS: TestProjectsCreate (6.44s)

Test ignored.
=== RUN   TestProjectsUpdate
=== RUN   TestProjectsUpdate/with_valid_options
--- PASS: TestProjectsUpdate/with_valid_options (0.58s)
=== RUN   TestProjectsUpdate/when_updating_with_invalid_name
--- PASS: TestProjectsUpdate/when_updating_with_invalid_name (0.55s)
=== RUN   TestProjectsUpdate/without_a_valid_projects_ID
--- PASS: TestProjectsUpdate/without_a_valid_projects_ID (0.00s)
=== RUN   TestProjectsUpdate/without_a_valid_projects_auto_destroy_activity_duration
    projects_integration_test.go:526: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestProjectsUpdate/without_a_valid_projects_auto_destroy_activity_duration (0.00s)

Test ignored.
=== RUN   TestProjectsUpdate/with_agent_pool_provided,_but_remote_execution_mode
--- PASS: TestProjectsUpdate/with_agent_pool_provided,_but_remote_execution_mode (0.98s)
=== RUN   TestProjectsUpdate/with_different_default_execution_modes
--- PASS: TestProjectsUpdate/with_different_default_execution_modes (1.40s)
=== RUN   TestProjectsUpdate/with_setting_overwrites_set_to_true,_project_ignores_the_default_execution_mode
--- PASS: TestProjectsUpdate/with_setting_overwrites_set_to_true,_project_ignores_the_default_execution_mode (1.63s)
=== RUN   TestProjectsUpdate/with_setting_overwrites_set_to_false,_project_inherits_the_default_execution_mode
--- PASS: TestProjectsUpdate/with_setting_overwrites_set_to_false,_project_inherits_the_default_execution_mode (1.81s)
--- PASS: TestProjectsUpdate (8.62s)

Test ignored.
=== RUN   TestProjectsAddTagBindings
    projects_integration_test.go:631: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestProjectsAddTagBindings (0.00s)

Test ignored.
=== RUN   TestProjects_DeleteAllTagBindings
    projects_integration_test.go:695: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestProjects_DeleteAllTagBindings (0.00s)

Test ignored.
=== RUN   TestProjectsDelete
=== RUN   TestProjectsDelete/with_valid_options
--- PASS: TestProjectsDelete/with_valid_options (0.36s)
=== RUN   TestProjectsDelete/when_the_project_does_not_exist
--- PASS: TestProjectsDelete/when_the_project_does_not_exist (0.16s)
=== RUN   TestProjectsDelete/when_the_project_ID_is_invalid
--- PASS: TestProjectsDelete/when_the_project_ID_is_invalid (0.00s)
--- PASS: TestProjectsDelete (1.65s)
=== RUN   TestProjectsAutoDestroy
    projects_integration_test.go:751: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestProjectsAutoDestroy (0.00s)

Test ignored.
PASS

=== RUN   TestAgentPoolsList
=== RUN   TestAgentPoolsList/without_list_options
--- PASS: TestAgentPoolsList/without_list_options (0.26s)
=== RUN   TestAgentPoolsList/with_Include_option
    helper_test.go:944: Export a valid OAUTH_CLIENT_GITHUB_TOKEN before running this test!
--- SKIP: TestAgentPoolsList/with_Include_option (0.00s)

Test ignored.
=== RUN   TestAgentPoolsList/with_list_options
--- PASS: TestAgentPoolsList/with_list_options (0.20s)
=== RUN   TestAgentPoolsList/without_a_valid_organization
--- PASS: TestAgentPoolsList/without_a_valid_organization (0.00s)
=== RUN   TestAgentPoolsList/with_query_options
--- PASS: TestAgentPoolsList/with_query_options (0.48s)
=== RUN   TestAgentPoolsList/with_allowed_workspace_name_filter
--- PASS: TestAgentPoolsList/with_allowed_workspace_name_filter (2.68s)
=== RUN   TestAgentPoolsList/with_allowed_projects_name_filter
--- PASS: TestAgentPoolsList/with_allowed_projects_name_filter (2.40s)
--- PASS: TestAgentPoolsList (9.06s)

Test ignored.
=== RUN   TestAgentPoolsCreate
=== RUN   TestAgentPoolsCreate/with_valid_options
--- PASS: TestAgentPoolsCreate/with_valid_options (0.67s)
=== RUN   TestAgentPoolsCreate/when_options_is_missing_name
--- PASS: TestAgentPoolsCreate/when_options_is_missing_name (0.00s)
=== RUN   TestAgentPoolsCreate/with_an_invalid_organization
--- PASS: TestAgentPoolsCreate/with_an_invalid_organization (0.00s)
=== RUN   TestAgentPoolsCreate/with_allowed-workspaces_options
--- PASS: TestAgentPoolsCreate/with_allowed-workspaces_options (0.86s)
=== RUN   TestAgentPoolsCreate/with_allowed-projects_options
--- PASS: TestAgentPoolsCreate/with_allowed-projects_options (0.80s)
=== RUN   TestAgentPoolsCreate/with_excluded-workspaces_options
--- PASS: TestAgentPoolsCreate/with_excluded-workspaces_options (0.88s)
--- PASS: TestAgentPoolsCreate (4.89s)
=== RUN   TestAgentPoolsRead
=== RUN   TestAgentPoolsRead/when_the_agent_pool_exists
--- PASS: TestAgentPoolsRead/when_the_agent_pool_exists (0.23s)
=== RUN   TestAgentPoolsRead/when_the_agent_pool_does_not_exist
--- PASS: TestAgentPoolsRead/when_the_agent_pool_does_not_exist (0.14s)
=== RUN   TestAgentPoolsRead/without_a_valid_agent_pool_ID
--- PASS: TestAgentPoolsRead/without_a_valid_agent_pool_ID (0.00s)
=== RUN   TestAgentPoolsRead/with_Include_option
    helper_test.go:944: Export a valid OAUTH_CLIENT_GITHUB_TOKEN before running this test!
--- SKIP: TestAgentPoolsRead/with_Include_option (0.00s)

Test ignored.
--- PASS: TestAgentPoolsRead (2.57s)

Test ignored.
=== RUN   TestAgentPoolsUpdate
=== RUN   TestAgentPoolsUpdate/with_valid_options
--- PASS: TestAgentPoolsUpdate/with_valid_options (0.97s)
=== RUN   TestAgentPoolsUpdate/when_updating_only_the_name
--- PASS: TestAgentPoolsUpdate/when_updating_only_the_name (1.71s)
=== RUN   TestAgentPoolsUpdate/without_a_valid_agent_pool_ID
--- PASS: TestAgentPoolsUpdate/without_a_valid_agent_pool_ID (0.00s)
=== RUN   TestAgentPoolsUpdate/when_updating_organization_scope
--- PASS: TestAgentPoolsUpdate/when_updating_organization_scope (0.71s)
=== RUN   TestAgentPoolsUpdate/when_updating_allowed-workspaces
--- PASS: TestAgentPoolsUpdate/when_updating_allowed-workspaces (1.09s)
=== RUN   TestAgentPoolsUpdate/when_updating_allowed-projects
--- PASS: TestAgentPoolsUpdate/when_updating_allowed-projects (0.98s)
=== RUN   TestAgentPoolsUpdate/when_updating_excluded-workspaces
--- PASS: TestAgentPoolsUpdate/when_updating_excluded-workspaces (1.06s)
--- PASS: TestAgentPoolsUpdate (8.23s)
=== RUN   TestAgentPoolsUpdateAllowedWorkspaces
=== RUN   TestAgentPoolsUpdateAllowedWorkspaces/when_updating_allowed-workspaces
--- PASS: TestAgentPoolsUpdateAllowedWorkspaces/when_updating_allowed-workspaces (1.30s)
=== RUN   TestAgentPoolsUpdateAllowedWorkspaces/when_removing_all_the_allowed-workspaces
--- PASS: TestAgentPoolsUpdateAllowedWorkspaces/when_removing_all_the_allowed-workspaces (1.07s)
--- PASS: TestAgentPoolsUpdateAllowedWorkspaces (3.79s)
=== RUN   TestAgentPoolsUpdateAllowedProjects
=== RUN   TestAgentPoolsUpdateAllowedProjects/when_updating_allowed-projects
--- PASS: TestAgentPoolsUpdateAllowedProjects/when_updating_allowed-projects (1.18s)
=== RUN   TestAgentPoolsUpdateAllowedProjects/when_removing_all_the_allowed-projects
--- PASS: TestAgentPoolsUpdateAllowedProjects/when_removing_all_the_allowed-projects (1.13s)
--- PASS: TestAgentPoolsUpdateAllowedProjects (4.00s)
=== RUN   TestAgentPoolsUpdateExcludedWorkspaces
=== RUN   TestAgentPoolsUpdateExcludedWorkspaces/when_updating_excluded-workspaces
--- PASS: TestAgentPoolsUpdateExcludedWorkspaces/when_updating_excluded-workspaces (1.37s)
=== RUN   TestAgentPoolsUpdateExcludedWorkspaces/when_removing_all_the_excluded-workspaces
--- PASS: TestAgentPoolsUpdateExcludedWorkspaces/when_removing_all_the_excluded-workspaces (1.07s)
--- PASS: TestAgentPoolsUpdateExcludedWorkspaces (3.93s)
=== RUN   TestAgentPoolsDelete
=== RUN   TestAgentPoolsDelete/with_valid_options
--- PASS: TestAgentPoolsDelete/with_valid_options (0.40s)
=== RUN   TestAgentPoolsDelete/when_the_agent_pool_does_not_exist
--- PASS: TestAgentPoolsDelete/when_the_agent_pool_does_not_exist (0.18s)
=== RUN   TestAgentPoolsDelete/when_the_agent_pool_ID_is_invalid
--- PASS: TestAgentPoolsDelete/when_the_agent_pool_ID_is_invalid (0.00s)
--- PASS: TestAgentPoolsDelete (2.58s)
PASS
...
```
