### PR TITLE
TF-26944 TF-26943 Support source_directory and tag_prefix for workspace options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
 # Unreleased
+* Adds support for `Workspace` VCSRepoOptions source_directory and tag_prefix, by @jillrami [#1194] (https://github.com/hashicorp/go-tfe/pull/1194)
 
 # v1.90.0
 

--- a/workspace.go
+++ b/workspace.go
@@ -517,6 +517,8 @@ type VCSRepoOptions struct {
 	OAuthTokenID      *string `json:"oauth-token-id,omitempty"`
 	TagsRegex         *string `json:"tags-regex,omitempty"`
 	GHAInstallationID *string `json:"github-app-installation-id,omitempty"`
+	SourceDirectory   *string `json:"source-directory,omitempty"`
+	TagPrefix         *string `json:"tag-prefix,omitempty"`
 }
 
 type WorkspaceSettingOverwritesOptions struct {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
Adds support for SourceDirectory and TagPrefix to VCSRepoOptions for workspaces. This PR is a follow-up to https://github.com/hashicorp/go-tfe/pull/1154.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->
End to end testing against https://github.com/hashicorp/terraform-provider-tfe/pull/1800 tfe-provider

## External links

- [Related PR](https://github.com/hashicorp/terraform-provider-tfe/pull/1800)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-26944)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
resolves errors in https://github.com/hashicorp/terraform-provider-tfe/pull/1800
```
Error: internal/provider/resource_tfe_workspace.go:517:20: options.VCSRepo.SourceDirectory undefined (type *tfe.VCSRepoOptions has no field or method SourceDirectory)
Error: internal/provider/resource_tfe_workspace.go:522:20: options.VCSRepo.TagPrefix undefined (type *tfe.VCSRepoOptions has no field or method TagPrefix)
Error: internal/provider/resource_tfe_workspace.go:888:5: unknown field SourceDirectory in struct literal of type tfe.VCSRepoOptions
Error: internal/provider/resource_tfe_workspace.go:889:5: unknown field TagPrefix in struct literal of type tfe.VCSRepoOptions
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->