### PR TITLE
Add support for Customer Key Version and Encrypted Data Keys

### DIFF
--- a/aws_oidc_configuration.go
+++ b/aws_oidc_configuration.go
@@ -8,6 +8,9 @@ import (
 
 const OIDCConfigPathFormat = "oidc-configurations/%s"
 
+// AWSOIDCConfigurations describes all the AWS OIDC configuration related methods that the HCP Terraform API supports.
+// HCP Terraform API docs:
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/oidc-configurations/aws
 type AWSOIDCConfigurations interface {
 	Create(ctx context.Context, organization string, options AWSOIDCConfigurationCreateOptions) (*AWSOIDCConfiguration, error)
 

--- a/azure_oidc_configuration.go
+++ b/azure_oidc_configuration.go
@@ -6,6 +6,9 @@ import (
 	"net/url"
 )
 
+// AzureOIDCConfigurations describes all the Azure OIDC configuration related methods that the HCP Terraform API supports.
+// HCP Terraform API docs:
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/oidc-configurations/azure
 type AzureOIDCConfigurations interface {
 	Create(ctx context.Context, organization string, options AzureOIDCConfigurationCreateOptions) (*AzureOIDCConfiguration, error)
 

--- a/errors.go
+++ b/errors.go
@@ -244,6 +244,10 @@ var (
 	ErrInvalidOIDC = errors.New("invalid value for OIDC configuration ID")
 
 	ErrInvalidHYOK = errors.New("invalid value for HYOK configuration ID")
+
+	ErrInvalidHYOKCustomerKeyVersion = errors.New("invalid value for HYOK Customer key version ID")
+
+	ErrInvalidHYOKEncryptedDataKey = errors.New("invalid value for HYOK encrypted data key ID")
 )
 
 var (

--- a/gcp_oidc_configuration.go
+++ b/gcp_oidc_configuration.go
@@ -6,6 +6,9 @@ import (
 	"net/url"
 )
 
+// GCPOIDCConfigurations describes all the GCP OIDC configuration related methods that the HCP Terraform API supports.
+// HCP Terraform API docs:
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/oidc-configurations/gcp
 type GCPOIDCConfigurations interface {
 	Create(ctx context.Context, organization string, options GCPOIDCConfigurationCreateOptions) (*GCPOIDCConfiguration, error)
 

--- a/hyok_configuration.go
+++ b/hyok_configuration.go
@@ -108,6 +108,7 @@ type HYOKConfigurationsCreateOptions struct {
 	// Relationships
 	OIDCConfiguration *OIDCConfigurationTypeChoice `jsonapi:"polyrelation,oidc-configuration"`
 	AgentPool         *AgentPool                   `jsonapi:"relation,agent-pool"`
+	KeyVersions       []*HYOKCustomerKeyVersions   `jsonapi:"relation,hyok-customer-key-versions"`
 }
 
 type HYOKConfigurationsReadOptions struct {

--- a/hyok_configuration.go
+++ b/hyok_configuration.go
@@ -72,7 +72,7 @@ type HYOKConfiguration struct {
 	Organization      *Organization                `jsonapi:"relation,organization"`
 	OIDCConfiguration *OIDCConfigurationTypeChoice `jsonapi:"polyrelation,oidc-configuration"`
 	AgentPool         *AgentPool                   `jsonapi:"relation,agent-pool"`
-	KeyVersions       []*HYOKCustomerKeyVersions   `jsonapi:"relation,hyok-customer-key-versions"`
+	KeyVersions       []*HYOKCustomerKeyVersion    `jsonapi:"relation,hyok-customer-key-versions"`
 }
 
 type HYOKConfigurationsList struct {

--- a/hyok_configuration.go
+++ b/hyok_configuration.go
@@ -108,7 +108,6 @@ type HYOKConfigurationsCreateOptions struct {
 	// Relationships
 	OIDCConfiguration *OIDCConfigurationTypeChoice `jsonapi:"polyrelation,oidc-configuration"`
 	AgentPool         *AgentPool                   `jsonapi:"relation,agent-pool"`
-	KeyVersions       []*HYOKCustomerKeyVersions   `jsonapi:"relation,hyok-customer-key-versions"`
 }
 
 type HYOKConfigurationsReadOptions struct {

--- a/hyok_configuration.go
+++ b/hyok_configuration.go
@@ -72,6 +72,7 @@ type HYOKConfiguration struct {
 	Organization      *Organization                `jsonapi:"relation,organization"`
 	OIDCConfiguration *OIDCConfigurationTypeChoice `jsonapi:"polyrelation,oidc-configuration"`
 	AgentPool         *AgentPool                   `jsonapi:"relation,agent-pool"`
+	KeyVersions       []*HYOKCustomerKeyVersions   `jsonapi:"relation,hyok-customer-key-versions"`
 }
 
 type HYOKConfigurationsList struct {

--- a/hyok_configuration.go
+++ b/hyok_configuration.go
@@ -6,6 +6,9 @@ import (
 	"net/url"
 )
 
+// HYOKConfigurations describes all the HYOK configuration related methods that the HCP Terraform API supports.
+// HCP Terraform API docs:
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/configurations
 type HYOKConfigurations interface {
 	List(ctx context.Context, organization string, options *HYOKConfigurationsListOptions) (*HYOKConfigurationsList, error)
 

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -1,0 +1,159 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+// HyokCustomerKeyVersions describes all the hyok customer key version related methods that the HCP Terraform API supports.
+//
+// TFE API docs: (TODO: ADD DOCS URL)
+type HyokCustomerKeyVersions interface {
+	// List all hyok customer key versions associated to a HYOK configuration.
+	List(ctx context.Context, hyokConfiguration string, options *HyokCustomerKeyVersionListOptions) (*HyokCustomerKeyVersionList, error)
+
+	// Read a hyok customer key version by its ID.
+	Read(ctx context.Context, HyokCustomerKeyVersionID string) (*HyokCustomerKeyVersion, error)
+
+	// Revoke a hyok customer key version.
+	Revoke(ctx context.Context, HyokCustomerKeyVersionID string) error
+
+	// Delete a hyok customer key version.
+	Delete(ctx context.Context, HyokCustomerKeyVersionID string) error
+}
+
+// hyokCustomerKeyVersions implements HyokCustomerKeyVersions
+type hyokCustomerKeyVersions struct {
+	client *Client
+}
+
+// HyokCustomerKeyVersionList represents a list of hyok customer key versions
+type HyokCustomerKeyVersionList struct {
+	*Pagination
+	Items []*HyokCustomerKeyVersion
+}
+
+// HyokCustomerKeyVersion represents a Terraform Enterprise $resource
+type HyokCustomerKeyVersion struct {
+	ID         string           `jsonapi:"primary,hyok-customer-key-version"`
+	KeyVersion string           `jsonapi:"attr,key-version"`
+	CreatedAt  time.Time        `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt  time.Time        `jsonapi:"attr,updated-at,iso8601"`
+	RevokedAt  time.Time        `jsonapi:"attr,revoked-at,iso8601"`
+	Status     KeyVersionStatus `jsonapi:"attr,status"`
+	Error      string           `jsonapi:"attr,error"`
+}
+
+// KeyVersionStatus represents a key version status.
+type KeyVersionStatus string
+
+// List all available configuration version statuses.
+const (
+	KeyVersionStatusAvailable        KeyVersionStatus = "available"
+	KeyVersionStatusRevoking         KeyVersionStatus = "revoking"
+	KeyVersionStatusRevoked          KeyVersionStatus = "revoked"
+	KeyVersionStatusRevocationFailed KeyVersionStatus = "revocation_failed"
+)
+
+// HyokCustomerKeyVersionListOptions represents the options for listing hyok customer key versions
+type HyokCustomerKeyVersionListOptions struct {
+	ListOptions
+	Refresh bool `query:"refresh"`
+}
+
+func (o *HyokCustomerKeyVersionListOptions) valid() error {
+	return nil
+}
+
+// HyokCustomerKeyVersionCreateOptions represents the options for creating a hyok customer key version
+type HyokCustomerKeyVersionCreateOptions struct {
+	Type string `jsonapi:"primary,hyok-customer-key-version"`
+	// Add more create options here
+}
+
+// HyokCustomerKeyVersionUpdateOptions represents the options for updating a hyok customer key version
+type HyokCustomerKeyVersionUpdateOptions struct {
+	ID string `jsonapi:"primary,hyok-customer-key-version"`
+
+	// Add more update options here
+}
+
+// List all hyok customer key versions.
+func (s *hyokCustomerKeyVersions) List(ctx context.Context, hyokConfiguration string, options *HyokCustomerKeyVersionListOptions) (*HyokCustomerKeyVersionList, error) {
+	if !validStringID(&hyokConfiguration) {
+		return nil, ErrInvalidHyokConfigID
+	}
+
+	// TODO: DO I NEED TO CHECK THIS?
+	//if err := options.valid(); err != nil {
+	//	return nil, err
+	//}
+
+	path := fmt.Sprintf("hyok-configurations/%s/hyok-customer-key-versions", url.PathEscape(hyokConfiguration))
+	req, err := s.client.NewRequest("GET", path, options)
+	if err != nil {
+		return nil, err
+	}
+
+	kvs := &HyokCustomerKeyVersionList{}
+	err = req.Do(ctx, kvs)
+	if err != nil {
+		return nil, err
+	}
+
+	return kvs, nil
+}
+
+// Read a hyok customer key version by its ID.
+func (s *hyokCustomerKeyVersions) Read(ctx context.Context, HyokCustomerKeyVersionID string) (*HyokCustomerKeyVersion, error) {
+	if !validStringID(&HyokCustomerKeyVersionID) {
+		return nil, ErrInvalidHyokConfigID
+	}
+
+	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(HyokCustomerKeyVersionID))
+	req, err := s.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	kv := &HyokCustomerKeyVersion{}
+	err = req.Do(ctx, kv)
+	if err != nil {
+		return nil, err
+	}
+
+	return kv, nil
+
+}
+
+// Revoke a hyok customer key version.
+func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, HyokCustomerKeyVersionID string) error {
+	if !validStringID(&HyokCustomerKeyVersionID) {
+		return ErrInvalidHyokConfigID
+	}
+
+	path := fmt.Sprintf("hyok-customer-key-versions/%s/actions/revoke", url.PathEscape(HyokCustomerKeyVersionID))
+	req, err := s.client.NewRequest("POST", path, nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// Delete a hyok customer key version.
+func (s *hyokCustomerKeyVersions) Delete(ctx context.Context, HyokCustomerKeyVersionID string) error {
+	if !validStringID(&HyokCustomerKeyVersionID) {
+		return ErrInvalidHyokConfigID
+	}
+
+	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(HyokCustomerKeyVersionID))
+	req, err := s.client.NewRequest("DELETE", path, nil)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -111,7 +111,8 @@ func (s *hyokCustomerKeyVersions) Read(ctx context.Context, hyokCustomerKeyVersi
 	return kv, nil
 }
 
-// Revoke a hyok customer key version.
+// Revoke a hyok customer key version. This process is asynchronous.
+// Returns `error` if there was a problem triggering the revocation. Otherwise revocation has been triggered successfully.
 func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, hyokCustomerKeyVersionID string) error {
 	if !validStringID(&hyokCustomerKeyVersionID) {
 		return ErrInvalidHYOK

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -38,7 +38,7 @@ type HYOKCustomerKeyVersionList struct {
 // HYOKCustomerKeyVersion represents the resource
 type HYOKCustomerKeyVersion struct {
 	// Attributes
-	ID         string               `jsonapi:"primary,hyok-customer-key-version"`
+	ID         string               `jsonapi:"primary,hyok-customer-key-versions"`
 	KeyVersion string               `jsonapi:"attr,key-version"`
 	CreatedAt  time.Time            `jsonapi:"attr,created-at,iso8601"`
 	UpdatedAt  time.Time            `jsonapi:"attr,updated-at,iso8601"`

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -7,6 +7,8 @@ import (
 	"time"
 )
 
+var _ HYOKCustomerKeyVersions = (*hyokCustomerKeyVersions)(nil)
+
 // HYOKCustomerKeyVersions describes all the hyok customer key version related methods that the HCP Terraform API supports.
 type HYOKCustomerKeyVersions interface {
 	// List all hyok customer key versions associated to a HYOK configuration.
@@ -58,7 +60,7 @@ const (
 // HYOKCustomerKeyVersionListOptions represents the options for listing hyok customer key versions
 type HYOKCustomerKeyVersionListOptions struct {
 	ListOptions
-	Refresh bool `query:"refresh"`
+	Refresh string `url:"refresh,omitempty"`
 }
 
 // List all hyok customer key versions.

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -7,73 +7,73 @@ import (
 	"time"
 )
 
-// HyokCustomerKeyVersions describes all the hyok customer key version related methods that the HCP Terraform API supports.
-type HyokCustomerKeyVersions interface {
+// HYOKCustomerKeyVersions describes all the hyok customer key version related methods that the HCP Terraform API supports.
+type HYOKCustomerKeyVersions interface {
 	// List all hyok customer key versions associated to a HYOK configuration.
-	List(ctx context.Context, hyokConfiguration string, options *HyokCustomerKeyVersionListOptions) (*HyokCustomerKeyVersionList, error)
+	List(ctx context.Context, hyokConfigurationID string, options *HYOKCustomerKeyVersionListOptions) (*HYOKCustomerKeyVersionList, error)
 
 	// Read a hyok customer key version by its ID.
-	Read(ctx context.Context, HyokCustomerKeyVersionID string) (*HyokCustomerKeyVersion, error)
+	Read(ctx context.Context, hyokCustomerKeyVersionID string) (*HYOKCustomerKeyVersion, error)
 
 	// Revoke a hyok customer key version.
-	Revoke(ctx context.Context, HyokCustomerKeyVersionID string) error
+	Revoke(ctx context.Context, hyokCustomerKeyVersionID string) error
 
 	// Delete a hyok customer key version.
-	Delete(ctx context.Context, HyokCustomerKeyVersionID string) error
+	Delete(ctx context.Context, hyokCustomerKeyVersionID string) error
 }
 
-// hyokCustomerKeyVersions implements HyokCustomerKeyVersions
+// hyokCustomerKeyVersions implements HYOKCustomerKeyVersions
 type hyokCustomerKeyVersions struct {
 	client *Client
 }
 
-// HyokCustomerKeyVersionList represents a list of hyok customer key versions
-type HyokCustomerKeyVersionList struct {
+// HYOKCustomerKeyVersionList represents a list of hyok customer key versions
+type HYOKCustomerKeyVersionList struct {
 	*Pagination
-	Items []*HyokCustomerKeyVersion
+	Items []*HYOKCustomerKeyVersion
 }
 
-// HyokCustomerKeyVersion represents a Terraform Enterprise $resource
-type HyokCustomerKeyVersion struct {
-	ID         string           `jsonapi:"primary,hyok-customer-key-version"`
-	KeyVersion string           `jsonapi:"attr,key-version"`
-	CreatedAt  time.Time        `jsonapi:"attr,created-at,iso8601"`
-	UpdatedAt  time.Time        `jsonapi:"attr,updated-at,iso8601"`
-	RevokedAt  time.Time        `jsonapi:"attr,revoked-at,iso8601"`
-	Status     KeyVersionStatus `jsonapi:"attr,status"`
-	Error      string           `jsonapi:"attr,error"`
+// HYOKCustomerKeyVersion represents a Terraform Enterprise $resource
+type HYOKCustomerKeyVersion struct {
+	ID         string               `jsonapi:"primary,hyok-customer-key-version"`
+	KeyVersion string               `jsonapi:"attr,key-version"`
+	CreatedAt  time.Time            `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt  time.Time            `jsonapi:"attr,updated-at,iso8601"`
+	RevokedAt  time.Time            `jsonapi:"attr,revoked-at,iso8601"`
+	Status     HYOKKeyVersionStatus `jsonapi:"attr,status"`
+	Error      string               `jsonapi:"attr,error"`
 }
 
-// KeyVersionStatus represents a key version status.
-type KeyVersionStatus string
+// HYOKKeyVersionStatus represents a key version status.
+type HYOKKeyVersionStatus string
 
 // List all available configuration version statuses.
 const (
-	KeyVersionStatusAvailable        KeyVersionStatus = "available"
-	KeyVersionStatusRevoking         KeyVersionStatus = "revoking"
-	KeyVersionStatusRevoked          KeyVersionStatus = "revoked"
-	KeyVersionStatusRevocationFailed KeyVersionStatus = "revocation_failed"
+	KeyVersionStatusAvailable        HYOKKeyVersionStatus = "available"
+	KeyVersionStatusRevoking         HYOKKeyVersionStatus = "revoking"
+	KeyVersionStatusRevoked          HYOKKeyVersionStatus = "revoked"
+	KeyVersionStatusRevocationFailed HYOKKeyVersionStatus = "revocation_failed"
 )
 
-// HyokCustomerKeyVersionListOptions represents the options for listing hyok customer key versions
-type HyokCustomerKeyVersionListOptions struct {
+// HYOKCustomerKeyVersionListOptions represents the options for listing hyok customer key versions
+type HYOKCustomerKeyVersionListOptions struct {
 	ListOptions
 	Refresh bool `query:"refresh"`
 }
 
 // List all hyok customer key versions.
-func (s *hyokCustomerKeyVersions) List(ctx context.Context, hyokConfiguration string, options *HyokCustomerKeyVersionListOptions) (*HyokCustomerKeyVersionList, error) {
-	if !validStringID(&hyokConfiguration) {
+func (s *hyokCustomerKeyVersions) List(ctx context.Context, hyokConfigurationID string, options *HYOKCustomerKeyVersionListOptions) (*HYOKCustomerKeyVersionList, error) {
+	if !validStringID(&hyokConfigurationID) {
 		return nil, ErrInvalidHYOK
 	}
 
-	path := fmt.Sprintf("hyok-configurations/%s/hyok-customer-key-versions", url.PathEscape(hyokConfiguration))
+	path := fmt.Sprintf("hyok-configurations/%s/hyok-customer-key-versions", url.PathEscape(hyokConfigurationID))
 	req, err := s.client.NewRequest("GET", path, options)
 	if err != nil {
 		return nil, err
 	}
 
-	kvs := &HyokCustomerKeyVersionList{}
+	kvs := &HYOKCustomerKeyVersionList{}
 	err = req.Do(ctx, kvs)
 	if err != nil {
 		return nil, err
@@ -83,18 +83,18 @@ func (s *hyokCustomerKeyVersions) List(ctx context.Context, hyokConfiguration st
 }
 
 // Read a hyok customer key version by its ID.
-func (s *hyokCustomerKeyVersions) Read(ctx context.Context, HyokCustomerKeyVersionID string) (*HyokCustomerKeyVersion, error) {
-	if !validStringID(&HyokCustomerKeyVersionID) {
+func (s *hyokCustomerKeyVersions) Read(ctx context.Context, hyokCustomerKeyVersionID string) (*HYOKCustomerKeyVersion, error) {
+	if !validStringID(&hyokCustomerKeyVersionID) {
 		return nil, ErrInvalidHYOK
 	}
 
-	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(HyokCustomerKeyVersionID))
+	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(hyokCustomerKeyVersionID))
 	req, err := s.client.NewRequest("GET", path, nil)
 	if err != nil {
 		return nil, err
 	}
 
-	kv := &HyokCustomerKeyVersion{}
+	kv := &HYOKCustomerKeyVersion{}
 	err = req.Do(ctx, kv)
 	if err != nil {
 		return nil, err
@@ -104,12 +104,12 @@ func (s *hyokCustomerKeyVersions) Read(ctx context.Context, HyokCustomerKeyVersi
 }
 
 // Revoke a hyok customer key version.
-func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, HyokCustomerKeyVersionID string) error {
-	if !validStringID(&HyokCustomerKeyVersionID) {
+func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, hyokCustomerKeyVersionID string) error {
+	if !validStringID(&hyokCustomerKeyVersionID) {
 		return ErrInvalidHYOK
 	}
 
-	path := fmt.Sprintf("hyok-customer-key-versions/%s/actions/revoke", url.PathEscape(HyokCustomerKeyVersionID))
+	path := fmt.Sprintf("hyok-customer-key-versions/%s/actions/revoke", url.PathEscape(hyokCustomerKeyVersionID))
 	req, err := s.client.NewRequest("POST", path, nil)
 	if err != nil {
 		return err
@@ -119,12 +119,12 @@ func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, HyokCustomerKeyVer
 }
 
 // Delete a hyok customer key version.
-func (s *hyokCustomerKeyVersions) Delete(ctx context.Context, HyokCustomerKeyVersionID string) error {
-	if !validStringID(&HyokCustomerKeyVersionID) {
+func (s *hyokCustomerKeyVersions) Delete(ctx context.Context, hyokCustomerKeyVersionID string) error {
+	if !validStringID(&hyokCustomerKeyVersionID) {
 		return ErrInvalidHYOK
 	}
 
-	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(HyokCustomerKeyVersionID))
+	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(hyokCustomerKeyVersionID))
 	req, err := s.client.NewRequest("DELETE", path, nil)
 	if err != nil {
 		return err

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -93,7 +93,7 @@ func (s *hyokCustomerKeyVersions) List(ctx context.Context, hyokConfigurationID 
 // Read a hyok customer key version by its ID.
 func (s *hyokCustomerKeyVersions) Read(ctx context.Context, hyokCustomerKeyVersionID string) (*HYOKCustomerKeyVersion, error) {
 	if !validStringID(&hyokCustomerKeyVersionID) {
-		return nil, ErrInvalidHYOK
+		return nil, ErrInvalidHYOKCustomerKeyVersion
 	}
 
 	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(hyokCustomerKeyVersionID))
@@ -115,7 +115,7 @@ func (s *hyokCustomerKeyVersions) Read(ctx context.Context, hyokCustomerKeyVersi
 // Returns `error` if there was a problem triggering the revocation. Otherwise revocation has been triggered successfully.
 func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, hyokCustomerKeyVersionID string) error {
 	if !validStringID(&hyokCustomerKeyVersionID) {
-		return ErrInvalidHYOK
+		return ErrInvalidHYOKCustomerKeyVersion
 	}
 
 	path := fmt.Sprintf("hyok-customer-key-versions/%s/actions/revoke", url.PathEscape(hyokCustomerKeyVersionID))
@@ -130,7 +130,7 @@ func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, hyokCustomerKeyVer
 // Delete a hyok customer key version.
 func (s *hyokCustomerKeyVersions) Delete(ctx context.Context, hyokCustomerKeyVersionID string) error {
 	if !validStringID(&hyokCustomerKeyVersionID) {
-		return ErrInvalidHYOK
+		return ErrInvalidHYOKCustomerKeyVersion
 	}
 
 	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(hyokCustomerKeyVersionID))

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -8,8 +8,6 @@ import (
 )
 
 // HyokCustomerKeyVersions describes all the hyok customer key version related methods that the HCP Terraform API supports.
-//
-// TFE API docs: (TODO: ADD DOCS URL)
 type HyokCustomerKeyVersions interface {
 	// List all hyok customer key versions associated to a HYOK configuration.
 	List(ctx context.Context, hyokConfiguration string, options *HyokCustomerKeyVersionListOptions) (*HyokCustomerKeyVersionList, error)
@@ -63,33 +61,11 @@ type HyokCustomerKeyVersionListOptions struct {
 	Refresh bool `query:"refresh"`
 }
 
-func (o *HyokCustomerKeyVersionListOptions) valid() error {
-	return nil
-}
-
-// HyokCustomerKeyVersionCreateOptions represents the options for creating a hyok customer key version
-type HyokCustomerKeyVersionCreateOptions struct {
-	Type string `jsonapi:"primary,hyok-customer-key-version"`
-	// Add more create options here
-}
-
-// HyokCustomerKeyVersionUpdateOptions represents the options for updating a hyok customer key version
-type HyokCustomerKeyVersionUpdateOptions struct {
-	ID string `jsonapi:"primary,hyok-customer-key-version"`
-
-	// Add more update options here
-}
-
 // List all hyok customer key versions.
 func (s *hyokCustomerKeyVersions) List(ctx context.Context, hyokConfiguration string, options *HyokCustomerKeyVersionListOptions) (*HyokCustomerKeyVersionList, error) {
 	if !validStringID(&hyokConfiguration) {
-		return nil, ErrInvalidHyokConfigID
+		return nil, ErrInvalidHYOK
 	}
-
-	// TODO: DO I NEED TO CHECK THIS?
-	//if err := options.valid(); err != nil {
-	//	return nil, err
-	//}
 
 	path := fmt.Sprintf("hyok-configurations/%s/hyok-customer-key-versions", url.PathEscape(hyokConfiguration))
 	req, err := s.client.NewRequest("GET", path, options)
@@ -109,7 +85,7 @@ func (s *hyokCustomerKeyVersions) List(ctx context.Context, hyokConfiguration st
 // Read a hyok customer key version by its ID.
 func (s *hyokCustomerKeyVersions) Read(ctx context.Context, HyokCustomerKeyVersionID string) (*HyokCustomerKeyVersion, error) {
 	if !validStringID(&HyokCustomerKeyVersionID) {
-		return nil, ErrInvalidHyokConfigID
+		return nil, ErrInvalidHYOK
 	}
 
 	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(HyokCustomerKeyVersionID))
@@ -125,13 +101,12 @@ func (s *hyokCustomerKeyVersions) Read(ctx context.Context, HyokCustomerKeyVersi
 	}
 
 	return kv, nil
-
 }
 
 // Revoke a hyok customer key version.
 func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, HyokCustomerKeyVersionID string) error {
 	if !validStringID(&HyokCustomerKeyVersionID) {
-		return ErrInvalidHyokConfigID
+		return ErrInvalidHYOK
 	}
 
 	path := fmt.Sprintf("hyok-customer-key-versions/%s/actions/revoke", url.PathEscape(HyokCustomerKeyVersionID))
@@ -146,7 +121,7 @@ func (s *hyokCustomerKeyVersions) Revoke(ctx context.Context, HyokCustomerKeyVer
 // Delete a hyok customer key version.
 func (s *hyokCustomerKeyVersions) Delete(ctx context.Context, HyokCustomerKeyVersionID string) error {
 	if !validStringID(&HyokCustomerKeyVersionID) {
-		return ErrInvalidHyokConfigID
+		return ErrInvalidHYOK
 	}
 
 	path := fmt.Sprintf("hyok-customer-key-versions/%s", url.PathEscape(HyokCustomerKeyVersionID))

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -66,7 +66,7 @@ const (
 // HYOKCustomerKeyVersionListOptions represents the options for listing hyok customer key versions
 type HYOKCustomerKeyVersionListOptions struct {
 	ListOptions
-	Refresh string `url:"refresh,omitempty"`
+	Refresh bool `url:"refresh,omitempty"`
 }
 
 // List all hyok customer key versions.

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -10,6 +10,8 @@ import (
 var _ HYOKCustomerKeyVersions = (*hyokCustomerKeyVersions)(nil)
 
 // HYOKCustomerKeyVersions describes all the hyok customer key version related methods that the HCP Terraform API supports.
+// HCP Terraform API docs:
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/key-versions
 type HYOKCustomerKeyVersions interface {
 	// List all hyok customer key versions associated to a HYOK configuration.
 	List(ctx context.Context, hyokConfigurationID string, options *HYOKCustomerKeyVersionListOptions) (*HYOKCustomerKeyVersionList, error)

--- a/hyok_customer_key_version.go
+++ b/hyok_customer_key_version.go
@@ -35,8 +35,9 @@ type HYOKCustomerKeyVersionList struct {
 	Items []*HYOKCustomerKeyVersion
 }
 
-// HYOKCustomerKeyVersion represents a Terraform Enterprise $resource
+// HYOKCustomerKeyVersion represents the resource
 type HYOKCustomerKeyVersion struct {
+	// Attributes
 	ID         string               `jsonapi:"primary,hyok-customer-key-version"`
 	KeyVersion string               `jsonapi:"attr,key-version"`
 	CreatedAt  time.Time            `jsonapi:"attr,created-at,iso8601"`
@@ -44,6 +45,9 @@ type HYOKCustomerKeyVersion struct {
 	RevokedAt  time.Time            `jsonapi:"attr,revoked-at,iso8601"`
 	Status     HYOKKeyVersionStatus `jsonapi:"attr,status"`
 	Error      string               `jsonapi:"attr,error"`
+
+	// Relationships
+	HYOKConfiguration *HYOKConfiguration `jsonapi:"relation,hyok-configuration"`
 }
 
 // HYOKKeyVersionStatus represents a key version status.

--- a/hyok_customer_key_version_integration_test.go
+++ b/hyok_customer_key_version_integration_test.go
@@ -7,8 +7,10 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// These tests are intended for local execution only, as OIDC configurations for HYOK requires specific conditions.
-// To run them locally, follow the instructions outlined in hyok_configuration_integration_test.go
+// These tests are intended for local execution only, as key versions for HYOK requires specific conditions
+// for tests to run successfully. To test locally:
+// 1. Follow the instructions outlined in hyok_configuration_integration_test.go.
+// 2. Set hyokCustomerKeyVersionID to the ID of an existing HYOK customer key version
 
 func TestHYOKCustomerKeyVersionsList(t *testing.T) {
 	if skipHYOKIntegrationTests {
@@ -33,6 +35,21 @@ func TestHYOKCustomerKeyVersionsList(t *testing.T) {
 
 	t.Run("with no list options", func(t *testing.T) {
 		_, err := client.HYOKCustomerKeyVersions.List(ctx, hyok.ID, nil)
+		require.NoError(t, err)
+	})
+}
+
+func TestHYOKCustomerKeyVersionsRead(t *testing.T) {
+	if skipHYOKIntegrationTests {
+		t.Skip()
+	}
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("read an existing key version", func(t *testing.T) {
+		hyokCustomerKeyVersionID := ""
+		_, err := client.HYOKCustomerKeyVersions.Read(ctx, hyokCustomerKeyVersionID)
 		require.NoError(t, err)
 	})
 }

--- a/hyok_customer_key_version_integration_test.go
+++ b/hyok_customer_key_version_integration_test.go
@@ -1,0 +1,38 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests are intended for local execution only, as OIDC configurations for HYOK requires specific conditions.
+// To run them locally, follow the instructions outlined in hyok_configuration_integration_test.go
+
+func TestHYOKCustomerKeyVersionsList(t *testing.T) {
+	if skipHYOKIntegrationTests {
+		t.Skip()
+	}
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, err := client.Organizations.Read(ctx, hyokOrganizationName)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	agentPool, agentPoolCleanup := createAgentPool(t, client, orgTest)
+	t.Cleanup(agentPoolCleanup)
+
+	oidc, oidcCleanup := createGCPOIDCConfiguration(t, client, orgTest)
+	t.Cleanup(oidcCleanup)
+	hyok, hyokCleanup := oidc.createHYOKConfiguration(t, client, orgTest, agentPool)
+	t.Cleanup(hyokCleanup)
+
+	t.Run("with no list options", func(t *testing.T) {
+		_, err := client.HYOKCustomerKeyVersions.List(ctx, hyok.ID, nil)
+		require.NoError(t, err)
+	})
+}

--- a/hyok_encrypted_data_key.go
+++ b/hyok_encrypted_data_key.go
@@ -37,7 +37,7 @@ type HYOKEncryptedDataKey struct {
 // Read a HYOK encrypted data key by its ID.
 func (h hyokEncryptedDataKeys) Read(ctx context.Context, hyokEncryptedDataKeyID string) (*HYOKEncryptedDataKey, error) {
 	if !validStringID(&hyokEncryptedDataKeyID) {
-		return nil, ErrInvalidHYOK
+		return nil, ErrInvalidHYOKEncryptedDataKey
 	}
 
 	path := fmt.Sprintf("hyok-encrypted-data-keys/%s", url.PathEscape(hyokEncryptedDataKeyID))

--- a/hyok_encrypted_data_key.go
+++ b/hyok_encrypted_data_key.go
@@ -1,0 +1,54 @@
+package tfe
+
+import (
+	"context"
+	"fmt"
+	"net/url"
+	"time"
+)
+
+var _ HYOKEncryptedDataKeys = (*hyokEncryptedDataKeys)(nil)
+
+// HYOKEncryptedDataKeys describes all the hyok customer key version related methods that the HCP Terraform API supports.
+type HYOKEncryptedDataKeys interface {
+	// Read a HYOK encrypted data key by its ID.
+	Read(ctx context.Context, hyokEncryptedDataKeyID string) (*HYOKEncryptedDataKey, error)
+}
+
+// hyokEncryptedDataKeys implements HYOKEncryptedDataKeys
+type hyokEncryptedDataKeys struct {
+	client *Client
+}
+
+// HYOKEncryptedDataKey represents the resource
+type HYOKEncryptedDataKey struct {
+	// Attributes
+	ID              string    `jsonapi:"primary,hyok-encrypted-data-key"`
+	EncryptedDEK    string    `jsonapi:"attr,encrypted-dek"`
+	CustomerKeyName string    `jsonapi:"attr,customer-key-name"`
+	CreatedAt       time.Time `jsonapi:"attr,created-at,iso8601"`
+
+	// Relationships
+	KeyVersion *HYOKCustomerKeyVersions `jsonapi:"relation,hyok-customer-key-version"`
+}
+
+// Read a HYOK encrypted data key by its ID.
+func (h hyokEncryptedDataKeys) Read(ctx context.Context, hyokEncryptedDataKeyID string) (*HYOKEncryptedDataKey, error) {
+	if !validStringID(&hyokEncryptedDataKeyID) {
+		return nil, ErrInvalidHYOK
+	}
+
+	path := fmt.Sprintf("hyok-encrypted-data-keys/%s", url.PathEscape(hyokEncryptedDataKeyID))
+	req, err := h.client.NewRequest("GET", path, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	dek := &HYOKEncryptedDataKey{}
+	err = req.Do(ctx, dek)
+	if err != nil {
+		return nil, err
+	}
+
+	return dek, nil
+}

--- a/hyok_encrypted_data_key.go
+++ b/hyok_encrypted_data_key.go
@@ -10,6 +10,8 @@ import (
 var _ HYOKEncryptedDataKeys = (*hyokEncryptedDataKeys)(nil)
 
 // HYOKEncryptedDataKeys describes all the hyok customer key version related methods that the HCP Terraform API supports.
+// HCP Terraform API docs:
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/encrypted-data-keys
 type HYOKEncryptedDataKeys interface {
 	// Read a HYOK encrypted data key by its ID.
 	Read(ctx context.Context, hyokEncryptedDataKeyID string) (*HYOKEncryptedDataKey, error)

--- a/hyok_encrypted_data_key.go
+++ b/hyok_encrypted_data_key.go
@@ -23,13 +23,13 @@ type hyokEncryptedDataKeys struct {
 // HYOKEncryptedDataKey represents the resource
 type HYOKEncryptedDataKey struct {
 	// Attributes
-	ID              string    `jsonapi:"primary,hyok-encrypted-data-key"`
+	ID              string    `jsonapi:"primary,hyok-encrypted-data-keys"`
 	EncryptedDEK    string    `jsonapi:"attr,encrypted-dek"`
 	CustomerKeyName string    `jsonapi:"attr,customer-key-name"`
 	CreatedAt       time.Time `jsonapi:"attr,created-at,iso8601"`
 
 	// Relationships
-	KeyVersion *HYOKCustomerKeyVersions `jsonapi:"relation,hyok-customer-key-version"`
+	KeyVersion *HYOKCustomerKeyVersion `jsonapi:"relation,hyok-customer-key-versions"`
 }
 
 // Read a HYOK encrypted data key by its ID.

--- a/hyok_encrypted_data_key_integration_test.go
+++ b/hyok_encrypted_data_key_integration_test.go
@@ -1,0 +1,28 @@
+package tfe
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// These tests are intended for local execution only, as data encryption keys for HYOK requires specific conditions
+// for tests to run successfully. To test locally:
+// 1. Follow the instructions outlined in hyok_configuration_integration_test.go.
+// 2. Set hyokEncryptedDataKeyID to the ID of an existing data encryption key
+
+func TestHYOKEncryptedDataKeyRead(t *testing.T) {
+	if skipHYOKIntegrationTests {
+		t.Skip()
+	}
+
+	client := testClient(t)
+	ctx := context.Background()
+
+	t.Run("read an existing encrypted data key", func(t *testing.T) {
+		hyokEncryptedDataKeyID := ""
+		_, err := client.HYOKEncryptedDataKeys.Read(ctx, hyokEncryptedDataKeyID)
+		require.NoError(t, err)
+	})
+}

--- a/tfe.go
+++ b/tfe.go
@@ -170,6 +170,7 @@ type Client struct {
 	SSHKeys                         SSHKeys
 	Stacks                          Stacks
 	HYOKConfigurations              HYOKConfigurations
+	HyokCustomerKeyVersions         HyokCustomerKeyVersions
 	StackConfigurations             StackConfigurations
 	StackDeployments                StackDeployments
 	StackDeploymentGroups           StackDeploymentGroups

--- a/tfe.go
+++ b/tfe.go
@@ -171,6 +171,7 @@ type Client struct {
 	Stacks                          Stacks
 	HYOKConfigurations              HYOKConfigurations
 	HYOKCustomerKeyVersions         HYOKCustomerKeyVersions
+	HYOKEncryptedDataKeys           HYOKEncryptedDataKeys
 	StackConfigurations             StackConfigurations
 	StackDeployments                StackDeployments
 	StackDeploymentGroups           StackDeploymentGroups
@@ -510,6 +511,8 @@ func NewClient(cfg *Config) (*Client, error) {
 	client.SSHKeys = &sshKeys{client: client}
 	client.Stacks = &stacks{client: client}
 	client.HYOKConfigurations = &hyokConfigurations{client: client}
+	client.HYOKCustomerKeyVersions = &hyokCustomerKeyVersions{client: client}
+	client.HYOKEncryptedDataKeys = &hyokEncryptedDataKeys{client: client}
 	client.StackConfigurations = &stackConfigurations{client: client}
 	client.StackDeployments = &stackDeployments{client: client}
 	client.StackDeploymentGroups = &stackDeploymentGroups{client: client}

--- a/tfe.go
+++ b/tfe.go
@@ -170,7 +170,7 @@ type Client struct {
 	SSHKeys                         SSHKeys
 	Stacks                          Stacks
 	HYOKConfigurations              HYOKConfigurations
-	HyokCustomerKeyVersions         HyokCustomerKeyVersions
+	HYOKCustomerKeyVersions         HYOKCustomerKeyVersions
 	StackConfigurations             StackConfigurations
 	StackDeployments                StackDeployments
 	StackDeploymentGroups           StackDeploymentGroups

--- a/vault_oidc_configuration.go
+++ b/vault_oidc_configuration.go
@@ -6,6 +6,9 @@ import (
 	"net/url"
 )
 
+// VaultOIDCConfigurations describes all the Vault OIDC configuration related methods that the HCP Terraform API supports.
+// HCP Terraform API docs:
+// https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/oidc-configurations/vault
 type VaultOIDCConfigurations interface {
 	Create(ctx context.Context, organization string, options VaultOIDCConfigurationCreateOptions) (*VaultOIDCConfiguration, error)
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Add support for HYOK customer key versions and HYOK encrypted data keys.

Supported operations for `HYOKCustomerKeyVersions`:
- List
- Read
- Revoke
- Delete

Supported operations for `HYOKEncryptedDataKey`:
- Read

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/key-versions)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

- [Key Version API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/key-versions)
- [Encrypted Data Keys API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/hold-your-own-key/encrypted-data-keys)
- [JIRA](https://hashicorp.atlassian.net/browse/TF-27660)

## Output from tests
<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```shell
envchain local-go-tfe go test -run TestHYOKEncryptedDataKeyRead -v           16:46:44   29ms
=== RUN   TestHYOKEncryptedDataKeyRead
=== RUN   TestHYOKEncryptedDataKeyRead/read_an_existing_encrypted_data_key
--- PASS: TestHYOKEncryptedDataKeyRead (0.42s)
    --- PASS: TestHYOKEncryptedDataKeyRead/read_an_existing_encrypted_data_key (0.17s)
PASS
ok  	github.com/hashicorp/go-tfe	0.983s
```

```shell
envchain local-go-tfe go test -run TestHYOKCustomerKeyVersions -v          16:46:55   3.019s
=== RUN   TestHYOKCustomerKeyVersionsList
=== RUN   TestHYOKCustomerKeyVersionsList/with_no_list_options
--- PASS: TestHYOKCustomerKeyVersionsList (7.76s)
    --- PASS: TestHYOKCustomerKeyVersionsList/with_no_list_options (0.10s)
=== RUN   TestHYOKCustomerKeyVersionsRead
=== RUN   TestHYOKCustomerKeyVersionsRead/read_an_existing_key_version
--- PASS: TestHYOKCustomerKeyVersionsRead (0.34s)
    --- PASS: TestHYOKCustomerKeyVersionsRead/read_an_existing_key_version (0.12s)
PASS
ok  	github.com/hashicorp/go-tfe	8.630s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
