### PR TITLE
Add invoke-action-addrs to CreateRun

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,6 @@
 # Unreleased
 
-## Enhancements
-
-* Add `invoke-action-addrs` to `CreateRunOptions` by @mutahhir [#1206](https://github.com/hashicorp/go-tfe/pull/1206)
+* Add BETA support for Action invocations via `CreateRunOptions` by @mutahhir [#1206](https://github.com/hashicorp/go-tfe/pull/1206)
 
 # v1.93.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Enhancements
+
+* Add `invoke-action-addrs` to `CreateRunOptions` by @mutahhir [#1206](https://github.com/hashicorp/go-tfe/pull/1206)
+
 # v1.93.0
 
 ## Enhancements

--- a/run.go
+++ b/run.go
@@ -140,6 +140,7 @@ type Run struct {
 	ForceCancelAvailableAt time.Time            `jsonapi:"attr,force-cancel-available-at,iso8601"`
 	HasChanges             bool                 `jsonapi:"attr,has-changes"`
 	IsDestroy              bool                 `jsonapi:"attr,is-destroy"`
+	InvokeActionAddrs      []string             `jsonapi:"attr,invoke-action-addrs,omitempty"`
 	Message                string               `jsonapi:"attr,message"`
 	Permissions            *RunPermissions      `jsonapi:"attr,permissions"`
 	PolicyPaths            []string             `jsonapi:"attr,policy-paths,omitempty"`
@@ -403,6 +404,9 @@ type RunCreateOptions struct {
 	// Variables allows you to specify terraform input variables for
 	// a particular run, prioritized over variables defined on the workspace.
 	Variables []*RunVariable `jsonapi:"attr,variables,omitempty"`
+
+	// Action Addresses to invoke.
+	InvokeActionAddrs []string `jsonapi:"attr,invoke-action-addrs,omitempty"`
 }
 
 // RunApplyOptions represents the options for applying a run.

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -304,12 +304,11 @@ func TestRunsCreate(t *testing.T) {
 
 	t.Run("with additional attributes", func(t *testing.T) {
 		options := RunCreateOptions{
-			Message:           String("yo"),
-			Workspace:         wTest,
-			Refresh:           Bool(false),
-			ReplaceAddrs:      []string{"null_resource.example"},
-			TargetAddrs:       []string{"null_resource.example"},
-			InvokeActionAddrs: []string{"actions.foo.bar"},
+			Message:      String("yo"),
+			Workspace:    wTest,
+			Refresh:      Bool(false),
+			ReplaceAddrs: []string{"null_resource.example"},
+			TargetAddrs:  []string{"null_resource.example"},
 		}
 
 		r, err := client.Runs.Create(ctx, options)
@@ -318,7 +317,6 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, *options.Refresh, r.Refresh)
 		assert.Equal(t, options.ReplaceAddrs, r.ReplaceAddrs)
 		assert.Equal(t, options.TargetAddrs, r.TargetAddrs)
-		assert.Equal(t, options.InvokeActionAddrs, r.InvokeActionAddrs)
 		assert.Nil(t, r.Variables)
 	})
 

--- a/run_integration_test.go
+++ b/run_integration_test.go
@@ -304,11 +304,12 @@ func TestRunsCreate(t *testing.T) {
 
 	t.Run("with additional attributes", func(t *testing.T) {
 		options := RunCreateOptions{
-			Message:      String("yo"),
-			Workspace:    wTest,
-			Refresh:      Bool(false),
-			ReplaceAddrs: []string{"null_resource.example"},
-			TargetAddrs:  []string{"null_resource.example"},
+			Message:           String("yo"),
+			Workspace:         wTest,
+			Refresh:           Bool(false),
+			ReplaceAddrs:      []string{"null_resource.example"},
+			TargetAddrs:       []string{"null_resource.example"},
+			InvokeActionAddrs: []string{"actions.foo.bar"},
 		}
 
 		r, err := client.Runs.Create(ctx, options)
@@ -317,6 +318,7 @@ func TestRunsCreate(t *testing.T) {
 		assert.Equal(t, *options.Refresh, r.Refresh)
 		assert.Equal(t, options.ReplaceAddrs, r.ReplaceAddrs)
 		assert.Equal(t, options.TargetAddrs, r.TargetAddrs)
+		assert.Equal(t, options.InvokeActionAddrs, r.InvokeActionAddrs)
 		assert.Nil(t, r.Variables)
 	})
 
@@ -370,6 +372,23 @@ func TestRunsCreate(t *testing.T) {
 		assert.Len(t, r.PolicyPaths, 2)
 		assert.Contains(t, r.PolicyPaths, "./path/to/dir1")
 		assert.Contains(t, r.PolicyPaths, "./path/to/dir2")
+	})
+
+	t.Run("with action invocations", func(t *testing.T) {
+		skipUnlessBeta(t)
+
+		opts := RunCreateOptions{
+			Message:           String("creating with policy paths"),
+			Workspace:         wTest,
+			InvokeActionAddrs: []string{"actions.foo.bar"},
+		}
+
+		r, err := client.Runs.Create(ctx, opts)
+		require.NoError(t, err)
+		require.NotEmpty(t, r.InvokeActionAddrs)
+
+		assert.Len(t, r.InvokeActionAddrs, 1)
+		assert.Contains(t, r.InvokeActionAddrs, "actions.foo.bar")
 	})
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description
Counterpart to https://github.com/hashicorp/atlas/pull/24700 where we're adding support for Action invocation addresses within the CreateRun API.

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->



## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

-->

- [Atlas PR with API change](https://github.com/hashicorp/atlas/pull/24700)
- [Eventual Consumer PR from Terraform](https://github.com/hashicorp/terraform/pull/37544)

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run  TestRunsCreate/with_action_invocations

=== RUN   TestRunsCreate
=== RUN   TestRunsCreate/with_action_invocations
--- PASS: TestRunsCreate (1.47s)
    --- PASS: TestRunsCreate/with_action_invocations (0.43s)
=== RUN   TestTestRunsCreate
    helper_test.go:1688: Export a valid GITHUB_REGISTRY_MODULE_IDENTIFIER before running this test
--- SKIP: TestTestRunsCreate (0.48s)
PASS
ok      github.com/hashicorp/go-tfe     2.203s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
