### PR TITLE
Update feature set name Plus (entitlement) to Standard (entitlement)

### DIFF
--- a/notification_configuration_integration_test.go
+++ b/notification_configuration_integration_test.go
@@ -82,7 +82,7 @@ func TestNotificationConfigurationList_forTeams(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithStandardEntitlementPlan().Update(t)
 
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	t.Cleanup(tmTestCleanup)
@@ -314,7 +314,7 @@ func TestNotificationConfigurationCreate_forTeams(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithStandardEntitlementPlan().Update(t)
 
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	t.Cleanup(tmTestCleanup)
@@ -488,7 +488,7 @@ func TestNotificationConfigurationRead_forTeams(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithStandardEntitlementPlan().Update(t)
 
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	t.Cleanup(tmTestCleanup)
@@ -521,7 +521,7 @@ func TestNotificationConfigurationUpdate_forTeams(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithStandardEntitlementPlan().Update(t)
 
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	t.Cleanup(tmTestCleanup)
@@ -756,7 +756,7 @@ func TestNotificationConfigurationDelete_forTeams(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithStandardEntitlementPlan().Update(t)
 
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	t.Cleanup(tmTestCleanup)
@@ -813,7 +813,7 @@ func TestNotificationConfigurationVerify_forTeams(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithStandardEntitlementPlan().Update(t)
 
 	tmTest, tmTestCleanup := createTeam(t, client, orgTest)
 	t.Cleanup(tmTestCleanup)

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -474,7 +474,7 @@ func TestOrganizationsReadEntitlements(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	t.Cleanup(orgTestCleanup)
 
-	newSubscriptionUpdater(orgTest).WithPlusEntitlementPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithStandardEntitlementPlan().Update(t)
 
 	t.Run("when the org exists", func(t *testing.T) {
 		entitlements, err := client.Organizations.ReadEntitlements(ctx, orgTest.Name)

--- a/subscription_updater_test.go
+++ b/subscription_updater_test.go
@@ -72,8 +72,8 @@ func (b *organizationSubscriptionUpdater) WithTrialPlan() *organizationSubscript
 	return b
 }
 
-func (b *organizationSubscriptionUpdater) WithPlusEntitlementPlan() *organizationSubscriptionUpdater {
-	b.planName = "Plus (entitlement)"
+func (b *organizationSubscriptionUpdater) WithStandardEntitlementPlan() *organizationSubscriptionUpdater {
+	b.planName = "Standard (entitlement)"
 
 	start := time.Now()
 	ceiling := 1


### PR DESCRIPTION
## Description

The feature set name in HCP Terraform was recently changed from Plus (entitlement) to Standard (entitlement). This PR updates related tests to align with the new name.

## Testing plan
- Before the change, some acceptance tests failed
```
=== FAIL: . TestOrganizationsReadEntitlements (1.32s)
    subscription_updater_test.go:114: feature set response was empty
```

- After the change, the tests passes
```
=== RUN   TestOrganizationsReadEntitlements
=== RUN   TestOrganizationsReadEntitlements/when_the_org_exists
=== RUN   TestOrganizationsReadEntitlements/with_invalid_name
=== RUN   TestOrganizationsReadEntitlements/when_the_org_does_not_exist
--- PASS: TestOrganizationsReadEntitlements (1.10s)
    --- PASS: TestOrganizationsReadEntitlements/when_the_org_exists (0.09s)
    --- PASS: TestOrganizationsReadEntitlements/with_invalid_name (0.00s)
    --- PASS: TestOrganizationsReadEntitlements/when_the_org_does_not_exist (0.07s)
PASS
```

## External links

- [Related PR](https://github.com/hashicorp/atlas/pull/24571)