### PR TITLE
fix(stacks): fixes to support atlas integration tests

### DIFF
--- a/stack.go
+++ b/stack.go
@@ -149,7 +149,7 @@ const (
 // StackListOptions represents the options for listing stacks.
 type StackListOptions struct {
 	ListOptions
-	ProjectID    string          `url:"filter[project[id]],omitempty"`
+	ProjectID    string          `url:"filter[project][id],omitempty"`
 	Sort         StackSortColumn `url:"sort,omitempty"`
 	SearchByName string          `url:"search[name],omitempty"`
 }

--- a/stack_deployment_groups_summary.go
+++ b/stack_deployment_groups_summary.go
@@ -7,7 +7,7 @@ import (
 )
 
 type StackDeploymentGroupSummaries interface {
-	// List lists all the stack configuration summaries for a stack.
+	// List lists all the stack deployment group summaries for a stack.
 	List(ctx context.Context, configurationID string, options *StackDeploymentGroupSummaryListOptions) (*StackDeploymentGroupSummaryList, error)
 }
 

--- a/stack_deployment_steps.go
+++ b/stack_deployment_steps.go
@@ -43,10 +43,11 @@ const (
 // StackDeploymentStep represents a step from a stack deployment
 type StackDeploymentStep struct {
 	// Attributes
-	ID        string    `jsonapi:"primary,stack-deployment-steps"`
-	Status    string    `jsonapi:"attr,status"`
-	CreatedAt time.Time `jsonapi:"attr,created-at,iso8601"`
-	UpdatedAt time.Time `jsonapi:"attr,updated-at,iso8601"`
+	ID            string    `jsonapi:"primary,stack-deployment-steps"`
+	Status        string    `jsonapi:"attr,status"`
+	OperationType string    `jsonapi:"attr,operation-type"`
+	CreatedAt     time.Time `jsonapi:"attr,created-at,iso8601"`
+	UpdatedAt     time.Time `jsonapi:"attr,updated-at,iso8601"`
 
 	// Links
 	Links map[string]interface{} `jsonapi:"links,omitempty"`

--- a/stack_deployment_steps_integration_test.go
+++ b/stack_deployment_steps_integration_test.go
@@ -157,6 +157,7 @@ func TestStackDeploymentStepsRead(t *testing.T) {
 		assert.NoError(t, err)
 		assert.NotEmpty(t, sds.ID)
 		assert.NotEmpty(t, sds.Status)
+		assert.NotEmpty(t, sds.OperationType)
 	})
 
 	t.Run("Read with invalid ID", func(t *testing.T) {


### PR DESCRIPTION
This PR implements a couple fixes for the stacks resources:

- "List stacks by project" `filter` param was not working properly and has now been fixed
- Add `OperationType` to deployment step resource
- Fix docs

This PR supports hashicorp/atlas#25379.