### PR TITLE
chore: prep changelog for 1.97 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+# v1.97.0
+
 ## Enhancements
 
 * Add variable set support for stacks with `ApplyToStacks`, `RemoveFromStacks`, and `UpdateStacks` API methods by @nithishravindra [#1251](https://github.com/hashicorp/go-tfe/pull/1251)


### PR DESCRIPTION
This PR preps the changelog for the 1.97.0 weekly release.