### PR TITLE
chore: limit concurrency scope for CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,9 +4,6 @@ on:
     branches: [main]
   pull_request:
 
-concurrency:
-  group: "one"
-
 jobs:
   lint:
     name: Lint
@@ -60,6 +57,9 @@ jobs:
   tests-run-dependent:
     name: Run Dependent Tests
     runs-on: ubuntu-latest
+    concurrency:
+      group: "one"
+
     steps:
       - name: terraform-cloud-outputs
         id: tflocal


### PR DESCRIPTION

## Description

This PR reduces the scope of the concurrency used by the CI workflow.
Concurrency will now be scoped only to the "critical section" of our test suite (aka run-dependent tests).

## Testing plan

1. Run the test suite from this PR
