### PR TITLE
Token test takes account of default token expiration date

### DIFF
--- a/helper_test.go
+++ b/helper_test.go
@@ -37,6 +37,7 @@ const badIdentifier = "! / nope" //nolint
 const agentVersion = "1.3.0"
 const testInitialClientToken = "insert-your-token-here"
 const testTaskResultCallbackToken = "this-is-task-result-callback-token"
+const defaultTokenExpirationYears = 2
 
 var _testAccountDetails *TestAccountDetails
 

--- a/organization_token_integration_test.go
+++ b/organization_token_integration_test.go
@@ -78,7 +78,10 @@ func TestOrganizationTokens_CreateWithOptions(t *testing.T) {
 		ot, err := client.OrganizationTokens.CreateWithOptions(ctx, orgTest.Name, OrganizationTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, ot.Token)
-		assert.Empty(t, ot.ExpiredAt)
+		assert.NotZero(t, ot.ExpiredAt)
+		expectedExpiry := ot.CreatedAt.AddDate(defaultTokenExpirationYears, 0, 0)
+		// Allow a small buffer (1 minute) for timestamp precision differences.
+		assert.WithinDuration(t, expectedExpiry, ot.ExpiredAt, time.Minute)
 		tkToken = ot.Token
 	})
 

--- a/team_token_integration_test.go
+++ b/team_token_integration_test.go
@@ -78,7 +78,10 @@ func TestTeamTokens_CreateWithOptions(t *testing.T) {
 		tt, err := client.TeamTokens.CreateWithOptions(ctx, tmTest.ID, TeamTokenCreateOptions{})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
-		assert.Empty(t, tt.ExpiredAt)
+		assert.NotZero(t, tt.ExpiredAt)
+		expectedExpiry := tt.CreatedAt.AddDate(defaultTokenExpirationYears, 0, 0)
+		// Allow a small buffer (1 minute) for timestamp precision differences.
+		assert.WithinDuration(t, expectedExpiry, tt.ExpiredAt, time.Minute)
 		tmToken = tt.Token
 	})
 
@@ -161,7 +164,10 @@ func TestTeamTokens_CreateWithOptions_MultipleTokens(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotEmpty(t, tt.Token)
-		assert.Empty(t, tt.ExpiredAt)
+		assert.NotZero(t, tt.ExpiredAt)
+		expectedExpiry := tt.CreatedAt.AddDate(defaultTokenExpirationYears, 0, 0)
+		// Allow a small buffer (1 minute) for timestamp precision differences.
+		assert.WithinDuration(t, expectedExpiry, tt.ExpiredAt, time.Minute)
 		require.NotNil(t, tt.Description)
 		require.Equal(t, *tt.Description, desc)
 	})
@@ -277,7 +283,10 @@ func TestTeamTokensReadByID(t *testing.T) {
 		require.NotEmpty(t, tt)
 		require.NotNil(t, tt.Description)
 		assert.Equal(t, *tt.Description, desc1)
-		assert.Empty(t, tt.ExpiredAt)
+		assert.NotZero(t, tt.ExpiredAt)
+		expectedExpiry := tt.CreatedAt.AddDate(defaultTokenExpirationYears, 0, 0)
+		// Allow a small buffer (1 minute) for timestamp precision differences.
+		assert.WithinDuration(t, expectedExpiry, tt.ExpiredAt, time.Minute)
 		require.NotEmpty(t, tt.Team)
 		assert.Equal(t, tt.Team.ID, tmTest.ID)
 

--- a/user_token_integration_test.go
+++ b/user_token_integration_test.go
@@ -88,7 +88,10 @@ func TestUserTokens_Create(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		assert.Empty(t, token.ExpiredAt)
+		assert.NotZero(t, token.ExpiredAt)
+		expectedExpiry := token.CreatedAt.AddDate(defaultTokenExpirationYears, 0, 0)
+		// Allow a small buffer (1 minute) for timestamp precision differences.
+		assert.WithinDuration(t, expectedExpiry, token.ExpiredAt, time.Minute)
 	})
 
 	t.Run("create token with an expiration date", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Token test now takes account of default token expiration date

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->
- Revert PR

## Changes to Security Controls

None
