### PR TITLE
Added `ProviderType` attribute in saml settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Enhancements
+* Adds the `ProviderType` field to `AdminSAMLSetting` and `AdminSAMLSettingsUpdateOptions` to support the `provider-type` SAML setting.
+
 # v1.103.0
 
 ## Enhancements

--- a/admin_setting_saml.go
+++ b/admin_setting_saml.go
@@ -28,30 +28,41 @@ type adminSAMLSettings struct {
 	client *Client
 }
 
+// SAMLProviderType represents the SAML identity provider type.
+type SAMLProviderType string
+
+// SAMLProviderType constants define the supported SAML identity provider types.
+const (
+	SAMLProviderTypeOkta    SAMLProviderType = "okta"
+	SAMLProviderTypeEntra   SAMLProviderType = "entra"
+	SAMLProviderTypeGeneric SAMLProviderType = "saml"
+	SAMLProviderTypeUnknown SAMLProviderType = "unknown"
+)
+
 // AdminSAMLSetting represents the SAML settings in Terraform Enterprise.
 type AdminSAMLSetting struct {
-	ID                        string `jsonapi:"primary,saml-settings"`
-	Enabled                   bool   `jsonapi:"attr,enabled"`
-	Debug                     bool   `jsonapi:"attr,debug"`
-	AuthnRequestsSigned       bool   `jsonapi:"attr,authn-requests-signed"`
-	WantAssertionsSigned      bool   `jsonapi:"attr,want-assertions-signed"`
-	TeamManagementEnabled     bool   `jsonapi:"attr,team-management-enabled"`
-	OldIDPCert                string `jsonapi:"attr,old-idp-cert"`
-	IDPCert                   string `jsonapi:"attr,idp-cert"`
-	SLOEndpointURL            string `jsonapi:"attr,slo-endpoint-url"`
-	SSOEndpointURL            string `jsonapi:"attr,sso-endpoint-url"`
-	AttrUsername              string `jsonapi:"attr,attr-username"`
-	AttrGroups                string `jsonapi:"attr,attr-groups"`
-	AttrSiteAdmin             string `jsonapi:"attr,attr-site-admin"`
-	SiteAdminRole             string `jsonapi:"attr,site-admin-role"`
-	SSOAPITokenSessionTimeout int    `jsonapi:"attr,sso-api-token-session-timeout"`
-	ACSConsumerURL            string `jsonapi:"attr,acs-consumer-url"`
-	MetadataURL               string `jsonapi:"attr,metadata-url"`
-	Certificate               string `jsonapi:"attr,certificate"`
-	PrivateKey                string `jsonapi:"attr,private-key"`
-	SignatureSigningMethod    string `jsonapi:"attr,signature-signing-method"`
-	SignatureDigestMethod     string `jsonapi:"attr,signature-digest-method"`
-	ProviderType              string `jsonapi:"attr,provider-type"`
+	ID                        string           `jsonapi:"primary,saml-settings"`
+	Enabled                   bool             `jsonapi:"attr,enabled"`
+	Debug                     bool             `jsonapi:"attr,debug"`
+	AuthnRequestsSigned       bool             `jsonapi:"attr,authn-requests-signed"`
+	WantAssertionsSigned      bool             `jsonapi:"attr,want-assertions-signed"`
+	TeamManagementEnabled     bool             `jsonapi:"attr,team-management-enabled"`
+	OldIDPCert                string           `jsonapi:"attr,old-idp-cert"`
+	IDPCert                   string           `jsonapi:"attr,idp-cert"`
+	SLOEndpointURL            string           `jsonapi:"attr,slo-endpoint-url"`
+	SSOEndpointURL            string           `jsonapi:"attr,sso-endpoint-url"`
+	AttrUsername              string           `jsonapi:"attr,attr-username"`
+	AttrGroups                string           `jsonapi:"attr,attr-groups"`
+	AttrSiteAdmin             string           `jsonapi:"attr,attr-site-admin"`
+	SiteAdminRole             string           `jsonapi:"attr,site-admin-role"`
+	SSOAPITokenSessionTimeout int              `jsonapi:"attr,sso-api-token-session-timeout"`
+	ACSConsumerURL            string           `jsonapi:"attr,acs-consumer-url"`
+	MetadataURL               string           `jsonapi:"attr,metadata-url"`
+	Certificate               string           `jsonapi:"attr,certificate"`
+	PrivateKey                string           `jsonapi:"attr,private-key"`
+	SignatureSigningMethod    string           `jsonapi:"attr,signature-signing-method"`
+	SignatureDigestMethod     string           `jsonapi:"attr,signature-digest-method"`
+	ProviderType              SAMLProviderType `jsonapi:"attr,provider-type"`
 }
 
 // Read returns the SAML settings.
@@ -74,24 +85,24 @@ func (a *adminSAMLSettings) Read(ctx context.Context) (*AdminSAMLSetting, error)
 // SAML settings.
 // https://developer.hashicorp.com/terraform/enterprise/api-docs/admin/settings#request-body-2
 type AdminSAMLSettingsUpdateOptions struct {
-	Enabled                   *bool   `jsonapi:"attr,enabled,omitempty"`
-	Debug                     *bool   `jsonapi:"attr,debug,omitempty"`
-	IDPCert                   *string `jsonapi:"attr,idp-cert,omitempty"`
-	Certificate               *string `jsonapi:"attr,certificate,omitempty"`
-	PrivateKey                *string `jsonapi:"attr,private-key,omitempty"`
-	SLOEndpointURL            *string `jsonapi:"attr,slo-endpoint-url,omitempty"`
-	SSOEndpointURL            *string `jsonapi:"attr,sso-endpoint-url,omitempty"`
-	AttrUsername              *string `jsonapi:"attr,attr-username,omitempty"`
-	AttrGroups                *string `jsonapi:"attr,attr-groups,omitempty"`
-	AttrSiteAdmin             *string `jsonapi:"attr,attr-site-admin,omitempty"`
-	SiteAdminRole             *string `jsonapi:"attr,site-admin-role,omitempty"`
-	SSOAPITokenSessionTimeout *int    `jsonapi:"attr,sso-api-token-session-timeout,omitempty"`
-	TeamManagementEnabled     *bool   `jsonapi:"attr,team-management-enabled,omitempty"`
-	AuthnRequestsSigned       *bool   `jsonapi:"attr,authn-requests-signed,omitempty"`
-	WantAssertionsSigned      *bool   `jsonapi:"attr,want-assertions-signed,omitempty"`
-	SignatureSigningMethod    *string `jsonapi:"attr,signature-signing-method,omitempty"`
-	SignatureDigestMethod     *string `jsonapi:"attr,signature-digest-method,omitempty"`
-	ProviderType              *string `jsonapi:"attr,provider-type,omitempty"`
+	Enabled                   *bool             `jsonapi:"attr,enabled,omitempty"`
+	Debug                     *bool             `jsonapi:"attr,debug,omitempty"`
+	IDPCert                   *string           `jsonapi:"attr,idp-cert,omitempty"`
+	Certificate               *string           `jsonapi:"attr,certificate,omitempty"`
+	PrivateKey                *string           `jsonapi:"attr,private-key,omitempty"`
+	SLOEndpointURL            *string           `jsonapi:"attr,slo-endpoint-url,omitempty"`
+	SSOEndpointURL            *string           `jsonapi:"attr,sso-endpoint-url,omitempty"`
+	AttrUsername              *string           `jsonapi:"attr,attr-username,omitempty"`
+	AttrGroups                *string           `jsonapi:"attr,attr-groups,omitempty"`
+	AttrSiteAdmin             *string           `jsonapi:"attr,attr-site-admin,omitempty"`
+	SiteAdminRole             *string           `jsonapi:"attr,site-admin-role,omitempty"`
+	SSOAPITokenSessionTimeout *int              `jsonapi:"attr,sso-api-token-session-timeout,omitempty"`
+	TeamManagementEnabled     *bool             `jsonapi:"attr,team-management-enabled,omitempty"`
+	AuthnRequestsSigned       *bool             `jsonapi:"attr,authn-requests-signed,omitempty"`
+	WantAssertionsSigned      *bool             `jsonapi:"attr,want-assertions-signed,omitempty"`
+	SignatureSigningMethod    *string           `jsonapi:"attr,signature-signing-method,omitempty"`
+	SignatureDigestMethod     *string           `jsonapi:"attr,signature-digest-method,omitempty"`
+	ProviderType              *SAMLProviderType `jsonapi:"attr,provider-type,omitempty"`
 }
 
 // Update updates the SAML settings.

--- a/admin_setting_saml.go
+++ b/admin_setting_saml.go
@@ -51,6 +51,7 @@ type AdminSAMLSetting struct {
 	PrivateKey                string `jsonapi:"attr,private-key"`
 	SignatureSigningMethod    string `jsonapi:"attr,signature-signing-method"`
 	SignatureDigestMethod     string `jsonapi:"attr,signature-digest-method"`
+	ProviderType              string `jsonapi:"attr,provider-type"`
 }
 
 // Read returns the SAML settings.
@@ -90,6 +91,7 @@ type AdminSAMLSettingsUpdateOptions struct {
 	WantAssertionsSigned      *bool   `jsonapi:"attr,want-assertions-signed,omitempty"`
 	SignatureSigningMethod    *string `jsonapi:"attr,signature-signing-method,omitempty"`
 	SignatureDigestMethod     *string `jsonapi:"attr,signature-digest-method,omitempty"`
+	ProviderType              *string `jsonapi:"attr,provider-type,omitempty"`
 }
 
 // Update updates the SAML settings.

--- a/admin_setting_saml.go
+++ b/admin_setting_saml.go
@@ -107,7 +107,6 @@ type AdminSAMLSettingsUpdateOptions struct {
 
 // Update updates the SAML settings.
 func (a *adminSAMLSettings) Update(ctx context.Context, options AdminSAMLSettingsUpdateOptions) (*AdminSAMLSetting, error) {
-
 	if options.ProviderType != nil {
 		switch *options.ProviderType {
 		case SAMLProviderTypeOkta, SAMLProviderTypeEntra, SAMLProviderTypeGeneric, SAMLProviderTypeUnknown:

--- a/admin_setting_saml.go
+++ b/admin_setting_saml.go
@@ -107,6 +107,15 @@ type AdminSAMLSettingsUpdateOptions struct {
 
 // Update updates the SAML settings.
 func (a *adminSAMLSettings) Update(ctx context.Context, options AdminSAMLSettingsUpdateOptions) (*AdminSAMLSetting, error) {
+
+	if options.ProviderType != nil {
+		switch *options.ProviderType {
+		case SAMLProviderTypeOkta, SAMLProviderTypeEntra, SAMLProviderTypeGeneric, SAMLProviderTypeUnknown:
+		default:
+			return nil, ErrInvalidSAMLProviderType
+		}
+	}
+
 	req, err := a.client.NewRequest("PATCH", "admin/saml-settings", &options)
 	if err != nil {
 		return nil, err

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -133,21 +133,34 @@ func TestAdminSettings_SAML_Update(t *testing.T) {
 	})
 
 	t.Run("with provider type defined", func(t *testing.T) {
-		providerTypesForTesting := []string{"okta", "entra", "saml", "unknown", "error"}
-		for _, providerType := range providerTypesForTesting {
-			_, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
-				Enabled:      Bool(true),
-				ProviderType: String(providerType),
-			})
-			if providerType == "error" {
-				require.Error(t, err)
-				continue
-			}
-			require.NoError(t, err)
+		testCases := []struct {
+			name         string
+			providerType SAMLProviderType
+			raiseError   bool
+		}{
+			{"valid okta", SAMLProviderTypeOkta, false},
+			{"valid entra", SAMLProviderTypeEntra, false},
+			{"valid saml", SAMLProviderTypeGeneric, false},
+			{"valid unknown - for backward compatibility", SAMLProviderTypeUnknown, false},
+			{"invalid provider type", "error", true},
+		}
+		for _, tc := range testCases {
+			t.Run(tc.name, func(t *testing.T) {
+				_, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
+					Enabled:      Bool(true),
+					ProviderType: SAMLProvider(tc.providerType),
+				})
 
-			samlSettings, err = client.Admin.Settings.SAML.Read(ctx)
-			require.NoError(t, err)
-			assert.Equal(t, providerType, samlSettings.ProviderType)
+				if tc.raiseError {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+
+				samlSettings, err = client.Admin.Settings.SAML.Read(ctx)
+				require.NoError(t, err)
+				assert.Equal(t, tc.providerType, samlSettings.ProviderType)
+			})
 		}
 	})
 }

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -40,6 +40,7 @@ func TestAdminSettings_SAML_Read(t *testing.T) {
 	assert.NotNil(t, samlSettings.PrivateKey)
 	assert.NotNil(t, samlSettings.SignatureSigningMethod)
 	assert.NotNil(t, samlSettings.SignatureDigestMethod)
+	assert.NotNil(t, samlSettings.ProviderType)
 }
 
 func TestAdminSettings_SAML_Update(t *testing.T) {
@@ -129,5 +130,25 @@ func TestAdminSettings_SAML_Update(t *testing.T) {
 		samlSettings, err = client.Admin.Settings.SAML.RevokeIdpCert(ctx)
 		require.NoError(t, err)
 		assert.NotNil(t, samlSettings.IDPCert)
+	})
+
+	t.Run("with provider type defined", func(t *testing.T) {
+
+		providerTypesForTesting := []string{"okta", "entra", "saml", "unknown", "error"}
+		for _, providerType := range providerTypesForTesting {
+			_, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{
+				Enabled:      Bool(true),
+				ProviderType: String(providerType),
+			})
+			if providerType == "error" {
+				require.Error(t, err)
+				continue
+			}
+			require.NoError(t, err)
+
+			samlSettings, err = client.Admin.Settings.SAML.Read(ctx)
+			require.NoError(t, err)
+			assert.Equal(t, providerType, samlSettings.ProviderType)
+		}
 	})
 }

--- a/admin_setting_saml_integration_test.go
+++ b/admin_setting_saml_integration_test.go
@@ -133,7 +133,6 @@ func TestAdminSettings_SAML_Update(t *testing.T) {
 	})
 
 	t.Run("with provider type defined", func(t *testing.T) {
-
 		providerTypesForTesting := []string{"okta", "entra", "saml", "unknown", "error"}
 		for _, providerType := range providerTypesForTesting {
 			_, err := client.Admin.Settings.SAML.Update(ctx, AdminSAMLSettingsUpdateOptions{

--- a/errors.go
+++ b/errors.go
@@ -255,6 +255,8 @@ var (
 	ErrInvalidStackID = errors.New("invalid value for stack ID")
 
 	ErrInvalidRemoteStateOptions = errors.New("invalid attribute\n\nProject remote state cannot be enabled when global remote state sharing is enabled")
+
+	ErrInvalidSAMLProviderType = errors.New("invalid SAML provider type")
 )
 
 var (

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -133,6 +133,11 @@ func String(v string) *string {
 	return &v
 }
 
+// SAMLProvider returns a pointer to the given SAML provider type.
+func SAMLProvider(v SAMLProviderType) *SAMLProviderType {
+	return &v
+}
+
 func NullableBool(v bool) jsonapi.NullableAttr[bool] {
 	return jsonapi.NewNullableAttrWithValue[bool](v)
 }


### PR DESCRIPTION
## Description

This PR introduces support for configuring the `provider-type` SAML setting. It allows administrators to specify the identity provider type (e.g., `okta`, `entra`, or generic `saml`) directly in their TFE admin SAML configuration.

## Testing plan

1. Added validation for the `ProviderType` field inside `TestAdminSettings_SAML_Read` to confirm the value is successfully read.
2. Added a new sub-test ("with provider type defined") inside `TestAdminSettings_SAML_Update` to verify updates pass for valid provider types (`okta`, `entra`, `saml`, `unknown`) and appropriately error out on invalid ones.

## External links

- [JIRA](https://hashicorp.atlassian.net/browse/TF-35670)
- [RFC](https://hermes-sharepoint.hashicorp.services/document/01XOO7K4IWFH44KZAPDJC3QXNKIRWEZMBA) 

## Output from tests
<img width="807" height="92" alt="image" src="https://github.com/user-attachments/assets/afdceb0c-fb56-4432-83f0-8e4969873296" />

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

we can revert this pr

## Changes to Security Controls

NA
