### PR TITLE
Request response error handling now unwraps both JsonApi & json errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+## Bug Fixes
+* Improve API error handling to decode both JSON:API error objects and regular JSON errors arrays by @uk1288 [#1304](https://github.com/hashicorp/go-tfe/pull/1304)
+
+
 # v1.103.0
 
 ## Enhancements

--- a/tfe.go
+++ b/tfe.go
@@ -1099,22 +1099,33 @@ func checkResponseCode(r *http.Response) error {
 func decodeErrorPayload(r *http.Response) ([]string, error) {
 	// Decode the error payload.
 	var errs []string
-	errPayload := &jsonapi.ErrorsPayload{}
-	err := json.NewDecoder(r.Body).Decode(errPayload)
-	if err != nil || len(errPayload.Errors) == 0 {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
 		return errs, errors.New(r.Status)
 	}
 
-	// Parse and format the errors.
-	for _, e := range errPayload.Errors {
-		if e.Detail == "" {
-			errs = append(errs, e.Title)
-		} else {
-			errs = append(errs, fmt.Sprintf("%s\n\n%s", e.Title, e.Detail))
+	// attempt JSON:API error payloads unwrapping
+	errPayload := &jsonapi.ErrorsPayload{}
+	if err := json.Unmarshal(body, errPayload); err == nil && len(errPayload.Errors) > 0 {
+		for _, e := range errPayload.Errors {
+			if e.Detail == "" {
+				errs = append(errs, e.Title)
+			} else {
+				errs = append(errs, fmt.Sprintf("%s\n\n%s", e.Title, e.Detail))
+			}
 		}
+		return errs, nil
 	}
 
-	return errs, nil
+	// attempt JSON error payloads unwrapping: like {"errors":["..."]}.
+	var rawErrs struct {
+		Errors []string `json:"errors"`
+	}
+	if err := json.Unmarshal(body, &rawErrs); err == nil && len(rawErrs.Errors) > 0 {
+		return rawErrs.Errors, nil
+	}
+
+	return errs, errors.New(r.Status)
 }
 
 func errorPayloadContains(payloadErrors []string, match string) bool {

--- a/tfe_test.go
+++ b/tfe_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -121,6 +122,82 @@ func Test_unmarshalResponse(t *testing.T) {
 		err := unmarshalResponse(responseBody, notStruct)
 		assert.Error(t, err)
 		assert.EqualError(t, err, fmt.Sprintf("%v must be a struct or an io.Writer", notStruct))
+	})
+}
+
+func Test_decodeErrorPayload(t *testing.T) {
+	t.Parallel()
+
+	t.Run("with jsonapi errors payload", func(t *testing.T) {
+		resp := &http.Response{
+			Status:     "400 Bad Request",
+			StatusCode: http.StatusBadRequest,
+			Body: io.NopCloser(bytes.NewBufferString(
+				`{"errors":[{"title":"org name invalid","detail":"Org name is invalid"}]}`,
+			)),
+		}
+
+		errs, err := decodeErrorPayload(resp)
+		require.NoError(t, err)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "org name invalid\n\nOrg name is invalid", errs[0])
+	})
+
+	t.Run("with regular json errors payload", func(t *testing.T) {
+		resp := &http.Response{
+			Status:     "400 Bad Request",
+			StatusCode: http.StatusBadRequest,
+			Body: io.NopCloser(bytes.NewBufferString(
+				`{"errors":["Unsupported GPG Key algorithm. Supported key algorithms are [RSA, DSA]"]}`,
+			)),
+		}
+
+		errs, err := decodeErrorPayload(resp)
+		require.NoError(t, err)
+		require.Len(t, errs, 1)
+		assert.Equal(t, "Unsupported GPG Key algorithm. Supported key algorithms are [RSA, DSA]", errs[0])
+	})
+
+	t.Run("with non-json error body", func(t *testing.T) {
+		resp := &http.Response{
+			Status:     "400 Bad Request",
+			StatusCode: http.StatusBadRequest,
+			Body:       io.NopCloser(bytes.NewBufferString("this is not json")),
+		}
+
+		errs, err := decodeErrorPayload(resp)
+		require.EqualError(t, err, "400 Bad Request")
+		assert.Empty(t, errs)
+	})
+}
+
+func Test_checkResponseCode(t *testing.T) {
+	t.Parallel()
+
+	t.Run("returns regular json error message", func(t *testing.T) {
+		resp := &http.Response{
+			Status:     "400 Bad Request",
+			StatusCode: http.StatusBadRequest,
+			Body: io.NopCloser(bytes.NewBufferString(
+				`{"errors":["Unsupported GPG Key algorithm. Supported key algorithms are [RSA, DSA]"]}`,
+			)),
+		}
+
+		err := checkResponseCode(resp)
+		require.EqualError(t, err, "Unsupported GPG Key algorithm. Supported key algorithms are [RSA, DSA]")
+	})
+
+	t.Run("still maps invalid include message", func(t *testing.T) {
+		resp := &http.Response{
+			Status:     "400 Bad Request",
+			StatusCode: http.StatusBadRequest,
+			Body: io.NopCloser(bytes.NewBufferString(
+				`{"errors":["include parameter is invalid"]}`,
+			)),
+		}
+
+		err := checkResponseCode(resp)
+		assert.ErrorIs(t, err, ErrInvalidIncludeValue)
 	})
 }
 


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Previously JSON errors were swallowed and defaulted to `bad request`. With this PR both jsonapi and json formatted errors are unwrapped as expected.

## Testing plan

### Run any endpoint that returns a json error type like the GPG create interface:
```
package main

import (
	"context"
	"fmt"
	"os"

	tfe "github.com/hashicorp/go-tfe"
)

// This is an invalid public key, which should trigger an error.
const hardcodedPublicKey = `-----BEGIN PGP PUBLIC KEY BLOCK-----

ABC
-----END PGP PUBLIC KEY BLOCK-----`

func main() {
	if token == "REPLACE_WITH_TFE_TOKEN" || organization == "REPLACE_WITH_ORGANIZATION" {
		fmt.Fprintln(os.Stderr, "error: set token and organization constants in debug/repro/main.go")
		os.Exit(1)
	}

	cfg := &tfe.Config{
		Address: fmt.Sprintf("https://%s", hostname),
		Token:   token,
	}

	client, err := tfe.NewClient(cfg)
	if err != nil {
		fmt.Fprintf(os.Stderr, "error creating TFE client: %v\n", err)
		os.Exit(1)
	}

	ctx := context.Background()

	opts := tfe.GPGKeyCreateOptions{
		Namespace:  organization,
		AsciiArmor: hardcodedPublicKey,
	}

	fmt.Printf("Calling GPGKeys.Create() for namespace %q on %s\n", organization, hostname)

	key, err := client.GPGKeys.Create(ctx, tfe.PrivateRegistry, opts)
	if err != nil {
		fmt.Fprintf(os.Stderr, "GPGKeys.Create() error: %v\n", err)
		os.Exit(1)
	}

	fmt.Printf("Success! KeyID: %s\n", key.KeyID)
}
```
Previously this would result in `Bad Request`. But now the actual error is surface, `Invalid key`

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->
Revert PR and make a new release.

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
