### PR TITLE
calling setting up defer fn before checking error to prevent panic

### DIFF
--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -159,11 +159,11 @@ func TestPolicySetsCreate(t *testing.T) {
 		Beta:       Bool(false),
 	}
 	sv, err := client.Admin.SentinelVersions.Create(ctx, opts)
+	require.NoError(t, err)
 	defer func() {
 		err := client.Admin.SentinelVersions.Delete(ctx, sv.ID)
 		require.NoError(t, err)
 	}()
-	require.NoError(t, err)
 
 	var vcsPolicyID string
 
@@ -677,11 +677,11 @@ func TestPolicySetsUpdate(t *testing.T) {
 		Beta:       Bool(false),
 	}
 	sv, err := client.Admin.SentinelVersions.Create(ctx, opts)
+	require.NoError(t, err)
 	defer func() {
 		err := client.Admin.SentinelVersions.Delete(ctx, sv.ID)
 		require.NoError(t, err)
 	}()
-	require.NoError(t, err)
 
 	options := PolicySetCreateOptions{
 		Kind:              Sentinel,

--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -356,13 +356,12 @@ func TestRunTasksAttachToWorkspace(t *testing.T) {
 
 	t.Run("to a valid workspace", func(t *testing.T) {
 		wr, err := client.RunTasks.AttachToWorkspace(ctx, wkspaceTest.ID, runTaskTest.ID, Advisory)
+		require.NoError(t, err)
 
 		defer func() {
 			err = client.WorkspaceRunTasks.Delete(ctx, wkspaceTest.ID, wr.ID)
 			require.NoError(t, err)
 		}()
-
-		require.NoError(t, err)
 		require.NotNil(t, wr.ID)
 	})
 }

--- a/team_access_integration_test.go
+++ b/team_access_integration_test.go
@@ -110,14 +110,14 @@ func TestTeamAccessesAdd(t *testing.T) {
 		}
 
 		ta, err := client.TeamAccess.Add(ctx, options)
+		require.NoError(t, err)
+
 		defer func() {
 			err := client.TeamAccess.Remove(ctx, ta.ID)
 			if err != nil {
 				t.Logf("error removing team access (%s): %s", ta.ID, err)
 			}
 		}()
-
-		require.NoError(t, err)
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.TeamAccess.Read(ctx, ta.ID)
@@ -142,14 +142,14 @@ func TestTeamAccessesAdd(t *testing.T) {
 		}
 
 		ta, err := client.TeamAccess.Add(ctx, options)
+		require.NoError(t, err)
+
 		defer func() {
 			err := client.TeamAccess.Remove(ctx, ta.ID)
 			if err != nil {
 				t.Logf("error removing team access (%s): %s", ta.ID, err)
 			}
 		}()
-
-		require.NoError(t, err)
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.TeamAccess.Read(ctx, ta.ID)

--- a/team_project_access_integration_test.go
+++ b/team_project_access_integration_test.go
@@ -146,14 +146,14 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 		}
 
 		tpa, err := client.TeamProjectAccess.Add(ctx, options)
+		require.NoError(t, err)
+
 		defer func() {
 			err := client.TeamProjectAccess.Remove(ctx, tpa.ID)
 			if err != nil {
 				t.Logf("error removing team access (%s): %s", tpa.ID, err)
 			}
 		}()
-
-		require.NoError(t, err)
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.TeamProjectAccess.Read(ctx, tpa.ID)
@@ -188,14 +188,14 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 		}
 
 		tpa, err := client.TeamProjectAccess.Add(ctx, options)
+		require.NoError(t, err)
+
 		defer func() {
 			err := client.TeamProjectAccess.Remove(ctx, tpa.ID)
 			if err != nil {
 				t.Logf("error removing team access (%s): %s", tpa.ID, err)
 			}
 		}()
-
-		require.NoError(t, err)
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.TeamProjectAccess.Read(ctx, tpa.ID)
@@ -242,14 +242,14 @@ func TestTeamProjectAccessesAdd(t *testing.T) {
 		}
 
 		tpa, err := client.TeamProjectAccess.Add(ctx, options)
+		require.NoError(t, err)
+
 		defer func() {
 			err := client.TeamProjectAccess.Remove(ctx, tpa.ID)
 			if err != nil {
 				t.Logf("error removing team access (%s): %s", tpa.ID, err)
 			}
 		}()
-
-		require.NoError(t, err)
 
 		// Get a refreshed view from the API.
 		refreshed, err := client.TeamProjectAccess.Read(ctx, tpa.ID)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Some tests was setting up defer fn before checking error which caused panic when actual errors happended. This panics would mask the actual error. Checking for error before defer function ensures there is no attempt to dereference nil values.

## Testing plan

Run Automated tests

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://example" TFE_TOKEN="example" go test ./... -v -run TestFunctionsAffectedByChange

...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
