### PR TITLE
feat: add TerraformVersion field to no-code module create workspace options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for trigger patterns and working directories to stacks by @aaabdelgany [#1305](https://github.com/hashicorp/go-tfe/pull/1305)
 * Adds `PolicyUpdatePatterns` to `PolicySet`, `PolicySetCreateOptions`, and `PolicySetUpdateOptions` to support `policy-update-patterns` by @nithishravindra [#1306](https://github.com/hashicorp/go-tfe/pull/1306/)
 * Adds `AdminSCIMGroups` to support fetching SCIM groups provisioned in Terraform Enterprise via an IdP by @skj-skj [#1314](https://github.com/hashicorp/go-tfe/pull/1314)
+* Adds `TerraformVersion` field to `RegistryNoCodeModuleCreateWorkspaceOptions` to support setting the Terraform version when creating a workspace from a no-code module by @IanOliv [#1320](https://github.com/hashicorp/go-tfe/pull/1320)
 
 # v1.103.0
 

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -118,6 +118,11 @@ type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 	// This is required when execution mode is set to "agent".
 	// This must not be specified when execution mode is set to "remote".
 	AgentPoolID *string `jsonapi:"attr,agent-pool-id,omitempty"`
+
+	// TerraformVersion is the Terraform version to use for the workspace.
+	// This must be a valid Terraform version string, such as "1.0.0".
+	// If not specified, the default Terraform version for the organization will be used.
+	TerraformVersion *string `jsonapi:"attr,terraform-version,omitempty"`
 }
 
 type RegistryNoCodeModuleUpgradeWorkspaceOptions struct {


### PR DESCRIPTION
This pull request introduces a new configuration option for workspace creation in the `registry_no_code_module.go` file. The main change is the addition of a `TerraformVersion` field to the `RegistryNoCodeModuleCreateWorkspaceOptions` struct, allowing users to specify which version of Terraform to use for a workspace.

Workspace configuration enhancement:

* Added a `TerraformVersion` field to the `RegistryNoCodeModuleCreateWorkspaceOptions` struct, enabling users to specify the Terraform version for new workspaces. If not provided, the organization's default will be used.