### PR TITLE
feat: add TerraformVersion to RegistryNoCodeModuleCreateWorkspaceOptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 * Add support for trigger patterns and working directories to stacks by @aaabdelgany [#1305](https://github.com/hashicorp/go-tfe/pull/1305)
 * Adds `PolicyUpdatePatterns` to `PolicySet`, `PolicySetCreateOptions`, and `PolicySetUpdateOptions` to support `policy-update-patterns` by @nithishravindra [#1306](https://github.com/hashicorp/go-tfe/pull/1306/)
 * Adds `AdminSCIMGroups` to support fetching SCIM groups provisioned in Terraform Enterprise via an IdP by @skj-skj [#1314](https://github.com/hashicorp/go-tfe/pull/1314)
+* Adds `TerraformVersion` field to `RegistryNoCodeModuleCreateWorkspaceOptions` to allow specifying the Terraform version when creating a workspace from a no-code module
 
 # v1.103.0
 

--- a/registry_no_code_module.go
+++ b/registry_no_code_module.go
@@ -118,6 +118,11 @@ type RegistryNoCodeModuleCreateWorkspaceOptions struct {
 	// This is required when execution mode is set to "agent".
 	// This must not be specified when execution mode is set to "remote".
 	AgentPoolID *string `jsonapi:"attr,agent-pool-id,omitempty"`
+
+	// TerraformVersion is the version of Terraform to use for this workspace.
+	// Must be a valid semver string, such as "1.5.0". If not specified, the
+	// workspace will use the latest Terraform version available on the platform.
+	TerraformVersion *string `jsonapi:"attr,terraform-version,omitempty"`
 }
 
 type RegistryNoCodeModuleUpgradeWorkspaceOptions struct {

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -417,6 +417,23 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		)
 		r.Error(err)
 	})
+
+	t.Run("test creating a workspace with a specified terraform version", func(t *testing.T) {
+		wn := fmt.Sprintf("foo-%s", randomString(t))
+		tfVersion := "1.3.0"
+		w, err := client.RegistryNoCodeModules.CreateWorkspace(
+			ctx,
+			ncm.ID,
+			&RegistryNoCodeModuleCreateWorkspaceOptions{
+				Name:             wn,
+				ExecutionMode:    String("remote"),
+				TerraformVersion: String(tfVersion),
+			},
+		)
+		r.NoError(err)
+		r.Equal(wn, w.Name)
+		r.Equal(tfVersion, w.TerraformVersion)
+	})
 }
 
 func TestRegistryNoCodeModuleWorkspaceUpgrade(t *testing.T) {


### PR DESCRIPTION
## Description

The no-code module workspace creation API accepts a terraform-version attribute, but the Go client struct was missing the field, making it impossible to specify a Terraform version at creation time.

Add the field with an accurate doc comment (the fallback is the platform's latest available Terraform version, not an org-level default) and a corresponding integration test subcase that verifies the value roundtrips correctly through the API.