### PR TITLE
Adding Post Apply Status Constants in Run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Bug Fixes
+* Adds `RunPostApplyRunning`,`RunPostApplyCompleted` run status by @jose-kunnel [#1323](https://github.com/hashicorp/go-tfe/pull/1323)
+
 ## Enhancements
 * Adds `CanReadStateVersions` and `CanReadVariable` fields to `WorkspacePermissions` by @jondavidjohn [#1325](https://github.com/hashicorp/go-tfe/pull/1325)
 * Adds Registry Tagging support for registry modules, providers and component configurations by  @mrinalirao [#1318](https://github.com/hashicorp/go-tfe/pull/1318)

--- a/admin_run.go
+++ b/admin_run.go
@@ -190,6 +190,8 @@ func validateAdminRunFilterParams(runStatus string) error {
 				string(RunPreApplyCompleted),
 				string(RunPrePlanCompleted),
 				string(RunPrePlanRunning),
+				string(RunPostApplyCompleted),
+				string(RunPostApplyRunning),
 				string(RunQueuing),
 				string(RunQueuingApply),
 				"":

--- a/admin_run_test.go
+++ b/admin_run_test.go
@@ -40,6 +40,8 @@ func Test_validateAdminRunFilterParams(t *testing.T) {
 		"post_plan_running",
 		"pre_apply_running",
 		"pre_apply_completed",
+		"post_apply_running",
+		"post_apply_completed",
 		"pre_plan_completed",
 		"pre_plan_running",
 		"queuing",

--- a/run.go
+++ b/run.go
@@ -83,6 +83,8 @@ const (
 	RunPostPlanAwaitingDecision RunStatus = "post_plan_awaiting_decision"
 	RunPostPlanCompleted        RunStatus = "post_plan_completed"
 	RunPostPlanRunning          RunStatus = "post_plan_running"
+	RunPostApplyRunning         RunStatus = "post_apply_running"
+	RunPostApplyCompleted       RunStatus = "post_apply_completed"
 	RunPreApplyRunning          RunStatus = "pre_apply_running"
 	RunPreApplyCompleted        RunStatus = "pre_apply_completed"
 	RunPrePlanCompleted         RunStatus = "pre_plan_completed"


### PR DESCRIPTION
## Description
This PR introduces a new constant for run status, which needs to be included in the terraform-provider-tfe repository. Currently, the RUN status does not include RunPostApplyCompleted and RunPostApplyRunning, and these statuses are also missing from the applyPendingStatuses list in resource_tfe_workspace_run.go.

As a result, when creating a run with a post-apply run task configured, the status post_apply_running is not recognized and leads to an error due to it being treated as an invalid status.

To resolve this issue, these new run status constants must be added to terraform-provider-tfe.

## Testing plan
Create a Terraform run with either a global run task configured for post-apply or a run task configured at the workspace level.

Before the fix:
This setup results in an error, as the post_apply_running status is not recognized and is treated as invalid.

<img width="1186" height="257" alt="Screenshot 2026-04-30 at 11 02 40 AM" src="https://github.com/user-attachments/assets/30d8e444-8f72-41a7-b64c-608ad4607766" />

After the Fix
The run is created successfully, and no error occurs, as the post_apply_running status is now properly recognized.



## External links

[JIRA] https://hashicorp.atlassian.net/browse/IPL-9456


## Rollback Plan

Revert the PR
