### PR TITLE
Add CanReadStateVersions and CanReadVariable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
 * Adds `PolicyUpdatePatterns` to `PolicySet`, `PolicySetCreateOptions`, and `PolicySetUpdateOptions` to support `policy-update-patterns` by @nithishravindra [#1306](https://github.com/hashicorp/go-tfe/pull/1306/)
 * Adds `AdminSCIMGroups` to support fetching SCIM groups provisioned in Terraform Enterprise via an IdP by @skj-skj [#1314](https://github.com/hashicorp/go-tfe/pull/1314)
 * Adds `TerraformVersion` field to `RegistryNoCodeModuleCreateWorkspaceOptions` to allow specifying the Terraform version when creating a workspace from a no-code module
+* Adds `CanReadStateVersions` and `CanReadVariable` fields to `WorkspacePermissions` by @jondavidjohn
 
 # v1.103.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@
 * Add support for trigger patterns and working directories to stacks by @aaabdelgany [#1305](https://github.com/hashicorp/go-tfe/pull/1305)
 * Adds `PolicyUpdatePatterns` to `PolicySet`, `PolicySetCreateOptions`, and `PolicySetUpdateOptions` to support `policy-update-patterns` by @nithishravindra [#1306](https://github.com/hashicorp/go-tfe/pull/1306/)
 * Adds `AdminSCIMGroups` to support fetching SCIM groups provisioned in Terraform Enterprise via an IdP by @skj-skj [#1314](https://github.com/hashicorp/go-tfe/pull/1314)
-* Adds `TerraformVersion` field to `RegistryNoCodeModuleCreateWorkspaceOptions` to allow specifying the Terraform version when creating a workspace from a no-code module
+* Adds `TerraformVersion` field to `RegistryNoCodeModuleCreateWorkspaceOptions` to allow specifying the Terraform version when creating a workspace from a no-code module by @chrisarcand [#1322](https://github.com/hashicorp/go-tfe/pull/1322)
 
 # v1.103.0
 

--- a/workspace.go
+++ b/workspace.go
@@ -305,19 +305,21 @@ type WorkspaceActions struct {
 
 // WorkspacePermissions represents the workspace permissions.
 type WorkspacePermissions struct {
-	CanDestroy        bool  `jsonapi:"attr,can-destroy"`
-	CanForceUnlock    bool  `jsonapi:"attr,can-force-unlock"`
-	CanLock           bool  `jsonapi:"attr,can-lock"`
-	CanManageRunTasks bool  `jsonapi:"attr,can-manage-run-tasks"`
-	CanManageHYOK     bool  `jsonapi:"attr,can-manage-hyok"`
-	CanQueueApply     bool  `jsonapi:"attr,can-queue-apply"`
-	CanQueueDestroy   bool  `jsonapi:"attr,can-queue-destroy"`
-	CanQueueRun       bool  `jsonapi:"attr,can-queue-run"`
-	CanReadSettings   bool  `jsonapi:"attr,can-read-settings"`
-	CanUnlock         bool  `jsonapi:"attr,can-unlock"`
-	CanUpdate         bool  `jsonapi:"attr,can-update"`
-	CanUpdateVariable bool  `jsonapi:"attr,can-update-variable"`
-	CanForceDelete    *bool `jsonapi:"attr,can-force-delete"` // pointer b/c it will be useful to check if this property exists, as opposed to having it default to false
+	CanDestroy           bool  `jsonapi:"attr,can-destroy"`
+	CanForceUnlock       bool  `jsonapi:"attr,can-force-unlock"`
+	CanLock              bool  `jsonapi:"attr,can-lock"`
+	CanManageRunTasks    bool  `jsonapi:"attr,can-manage-run-tasks"`
+	CanManageHYOK        bool  `jsonapi:"attr,can-manage-hyok"`
+	CanQueueApply        bool  `jsonapi:"attr,can-queue-apply"`
+	CanQueueDestroy      bool  `jsonapi:"attr,can-queue-destroy"`
+	CanQueueRun          bool  `jsonapi:"attr,can-queue-run"`
+	CanReadSettings      bool  `jsonapi:"attr,can-read-settings"`
+	CanReadStateVersions bool  `jsonapi:"attr,can-read-state-versions"`
+	CanReadVariable      bool  `jsonapi:"attr,can-read-variable"`
+	CanUnlock            bool  `jsonapi:"attr,can-unlock"`
+	CanUpdate            bool  `jsonapi:"attr,can-update"`
+	CanUpdateVariable    bool  `jsonapi:"attr,can-update-variable"`
+	CanForceDelete       *bool `jsonapi:"attr,can-force-delete"` // pointer b/c it will be useful to check if this property exists, as opposed to having it default to false
 }
 
 // WSIncludeOpt represents the available options for include query params.

--- a/workspace_integration_test.go
+++ b/workspace_integration_test.go
@@ -3083,8 +3083,10 @@ func TestWorkspace_Unmarshal(t *testing.T) {
 				"created-at":     "2020-07-15T23:38:43.821Z",
 				"resource-count": 2,
 				"permissions": map[string]interface{}{
-					"can-update": true,
-					"can-lock":   true,
+					"can-update":              true,
+					"can-lock":                true,
+					"can-read-state-versions": true,
+					"can-read-variable":       true,
 				},
 				"vcs-repo": map[string]interface{}{
 					"branch":              "main",
@@ -3124,6 +3126,8 @@ func TestWorkspace_Unmarshal(t *testing.T) {
 	assert.Equal(t, ws.ResourceCount, 2)
 	assert.Equal(t, ws.Permissions.CanUpdate, true)
 	assert.Equal(t, ws.Permissions.CanLock, true)
+	assert.Equal(t, ws.Permissions.CanReadStateVersions, true)
+	assert.Equal(t, ws.Permissions.CanReadVariable, true)
 	assert.Equal(t, ws.VCSRepo.Branch, "main")
 	assert.Equal(t, ws.VCSRepo.DisplayIdentifier, "repo-name")
 	assert.Equal(t, ws.VCSRepo.Identifier, "hashicorp/repo-name")


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Just adding a few existing workspace permissions: `CanReadStateVersions` and `CanReadVariable`

## Testing plan

Added some assertions that these permissions come back correct