### PR TITLE
feat(workspace): expose source-module-id attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Enhancements
 * Add support for reading a registry provider by its unique identifier by  @mrinalirao [#1340](https://github.com/hashicorp/go-tfe/pull/1340)
 * Add `ProviderSet` resources with `Read`, `Update`, `Delete` and `Create` methods @mogrogan [#1346](https://github.com/hashicorp/go-tfe/pull/1346)
+* Adds `SourceModuleID` field to `Workspace` so callers can read the no-code source module identifier (e.g. `private/<org>/<name>/<provider>/<version>`) returned by the API by @a9logic
 
 # v1.106.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## Enhancements
 * Add support for reading a registry provider by its unique identifier by  @mrinalirao [#1340](https://github.com/hashicorp/go-tfe/pull/1340)
 * Add `ProviderSet` resources with `Read`, `Update`, `Delete` and `Create` methods @mogrogan [#1346](https://github.com/hashicorp/go-tfe/pull/1346)
-* Adds `SourceModuleID` field to `Workspace` so callers can read the no-code source module identifier (e.g. `private/<org>/<name>/<provider>/<version>`) returned by the API by @a9logic
+* Adds `SourceModuleID` field to `Workspace` so callers can read the no-code source module identifier (e.g. `private/<org>/<name>/<provider>/<version>`) returned by the API by @a9logic [#1331](https://github.com/hashicorp/go-tfe/pull/1331)
 
 # v1.106.0
 

--- a/registry_no_code_module_integration_test.go
+++ b/registry_no_code_module_integration_test.go
@@ -404,6 +404,11 @@ func TestRegistryNoCodeModulesCreateWorkspace(t *testing.T) {
 		r.Equal(sn, w.SourceName)
 		r.Equal(su, w.SourceURL)
 		r.Equal("remote", w.ExecutionMode)
+		r.NotEmpty(w.SourceModuleID)
+
+		read, err := client.Workspaces.Read(ctx, org.Name, w.Name)
+		r.NoError(err)
+		r.Equal(w.SourceModuleID, read.SourceModuleID)
 	})
 
 	t.Run("fail to create a workspace with a bad module ID", func(t *testing.T) {

--- a/workspace.go
+++ b/workspace.go
@@ -212,6 +212,7 @@ type Workspace struct {
 	Source                      WorkspaceSource                 `jsonapi:"attr,source"`
 	SourceName                  string                          `jsonapi:"attr,source-name"`
 	SourceURL                   string                          `jsonapi:"attr,source-url"`
+	SourceModuleID              string                          `jsonapi:"attr,source-module-id"`
 	StructuredRunOutputEnabled  bool                            `jsonapi:"attr,structured-run-output-enabled"`
 	TerraformVersion            string                          `jsonapi:"attr,terraform-version"`
 	TriggerPrefixes             []string                        `jsonapi:"attr,trigger-prefixes"`


### PR DESCRIPTION
## Description

Resolves #1117. Adds the `SourceModuleID` field to the `Workspace` struct so callers can read the no-code source module identifier (e.g. `private/<org>/<name>/<provider>/<version>`) that the API already returns on workspaces provisioned from a no-code module. Today callers have to bypass go-tfe and hit the raw API to get this value.

Partially addresses #1273 by enabling client-side filtering of workspaces by source module. A server-side filter on `WorkspaceListOptions` is intentionally **out of scope** for this PR because no such filter is documented in the public [Workspaces API](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces); adding one speculatively would likely no-op against the server. A follow-up PR can add a real filter once HashiCorp confirms or adds API support.

The change is purely additive (one new struct field, one read-only attribute) and follows the same shape as PRs #1189 (added `Source`) and #1325 (added fields to `WorkspacePermissions`).

Continuation of #1329 .

## Testing plan

The new field is exercised inside the existing `TestRegistryNoCodeModulesCreateWorkspace` integration test, which already creates a no-code-provisioned workspace via `RegistryNoCodeModules.CreateWorkspace`. Three new lines:

1. `r.NotEmpty(w.SourceModuleID)` — assert the field is populated on the create response.
2. A subsequent `client.Workspaces.Read(...)` call.
3. `r.Equal(w.SourceModuleID, read.SourceModuleID)` — assert the field round-trips through `Workspaces.Read`.

The test is gated by `skipUnlessBeta(t)` (no-code provisioning is still beta-flagged in the existing test suite) and additionally requires `GITHUB_REGISTRY_NO_CODE_MODULE_IDENTIFIER` and an OAuth token because no-code modules need a VCS-backed registry module to provision against.

**Note for reviewers:** I do not have access to HCP Terraform Standard tier or higher, and no-code provisioning is excluded from the Essentials tier per the [pricing page](https://www.hashicorp.com/products/terraform/pricing), so I was unable to run the integration test against a real backend. Verified locally:

- `go build ./...` — OK
- `go vet . ./mocks/...` — OK (the pre-existing `examples/backing_data` vet failure on `main` is unrelated)
- `gofmt -s -l workspace.go registry_no_code_module_integration_test.go` — clean
- `golangci-lint run .` — 0 issues
- `./generate_mocks.sh` — ran cleanly, zero diff (struct-field-only change does not affect interface mocks)
- `go test -run TestRegistryNoCodeModulesCreateWorkspace -count=1 -c -o NUL .` — test compiles
- `go test -run TestRegistryNoCodeModulesCreateWorkspace -v -count=1 .` (without `ENABLE_BETA=1`) — confirms `skipUnlessBeta` gating works: `--- SKIP:` clean

Requesting a maintainer please validate the integration run via internal CI per the documented fork-rebase flow in [docs/CONTRIBUTING.md](https://github.com/hashicorp/go-tfe/blob/main/docs/CONTRIBUTING.md#rebasing-a-fork-to-trigger-ci-maintainers-only).

## External links

- Issue #1117 (read-side request)
- Issue #1273 (filter request — partially addressed; see Description)
- API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/workspaces
- Reference PRs for similar single-attribute additions: #1189, #1325

## Output from tests

```
$ go build ./...
(no output)

$ go vet . ./mocks/...
(no output)

$ gofmt -s -l workspace.go registry_no_code_module_integration_test.go
(no output)

$ golangci-lint run .
0 issues.

$ ./generate_mocks.sh
(no output; git diff mocks/ shows no changes)

$ go test -run TestRegistryNoCodeModulesCreateWorkspace -v -count=1 .
=== RUN TestRegistryNoCodeModulesCreateWorkspace
=== PAUSE TestRegistryNoCodeModulesCreateWorkspace
=== CONT TestRegistryNoCodeModulesCreateWorkspace
registry_no_code_module_integration_test.go:340: Skipping test related to a HCP Terraform beta feature. Set ENABLE_BETA=1 to run.
--- SKIP: TestRegistryNoCodeModulesCreateWorkspace (0.00s)
PASS
ok github.com/hashicorp/go-tfe 1.075s
```

## Rollback Plan

Revert the commit. The change is purely additive: one struct field and three test-assertion lines. There are no callers of `SourceModuleID` inside the SDK, so a revert is safe at any time.

## Changes to Security Controls

None.