### PR TITLE
Adds SCIM Attributes in User and Team struct

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 ## Enhancements
-* Adds SCIM attribute fields (`IsSCIMManaged`, `SCIMUsername`, `SCIMUpdatedAt`) to `User` and `AdminUser`, and (`SCIMLinked`, `SCIMSyncPaused`, `SCIMGroupName`, `SCIMUpdatedAt`) to `Team` by @skj-skj
+* Adds SCIM attribute fields (`IsSCIMManaged`, `SCIMUsername`, `SCIMUpdatedAt`) to `User` and `AdminUser`, and (`SCIMLinked`, `SCIMSyncPaused`, `SCIMGroupName`, `SCIMUpdatedAt`) to `Team` by @skj-skj [#1335](https://github.com/hashicorp/go-tfe/pull/1335)
 
 # v1.105.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Enhancements
+* Adds SCIM attribute fields (`IsSCIMManaged`, `SCIMUsername`, `SCIMUpdatedAt`) to `User` and `AdminUser`, and (`SCIMLinked`, `SCIMSyncPaused`, `SCIMGroupName`, `SCIMUpdatedAt`) to `Team` by @skj-skj
+
 # v1.105.0
 
 ## Enhancements

--- a/admin_setting_scim_group_mapping_integration_test.go
+++ b/admin_setting_scim_group_mapping_integration_test.go
@@ -5,8 +5,6 @@ package tfe
 
 import (
 	"context"
-	"fmt"
-	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -43,10 +41,11 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 			for i, team := range createTeams(t, client, 2) {
 				group := tc.groupFor(i)
 				linkSCIMGroupMapping(ctx, t, scimClient, team.ID, group.ID)
-				scimAttr := getScimAttributeValues(ctx, t, client, team.ID)
-				assert.True(t, scimAttr.SCIMLinked, "Expected SCIMLinked to be true after creating mapping")
-				assert.Equal(t, group.Name, scimAttr.SCIMGroupName, "Expected SCIMGroupName to match the linked group")
-				assert.False(t, scimAttr.SCIMSyncPaused, "Expected SCIMSyncPaused to be false after creating mapping")
+				linkedTeam, err := client.Teams.Read(ctx, team.ID)
+				require.NoError(t, err)
+				assert.True(t, *linkedTeam.SCIMLinked, "Expected SCIMLinked to be true after creating mapping")
+				assert.Equal(t, group.Name, *linkedTeam.SCIMGroupName, "Expected SCIMGroupName to match the linked group")
+				assert.False(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be false after creating mapping")
 			}
 		})
 	}
@@ -57,9 +56,10 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 		require.NoError(t, deleteSCIMGroupMapping(ctx, scimClient, teamID))
 		linkSCIMGroupMapping(ctx, t, scimClient, teamID, scimGroups[1].ID)
 
-		scimAttr := getScimAttributeValues(ctx, t, client, teamID)
-		assert.True(t, scimAttr.SCIMLinked, "Expected SCIMLinked to be true after re-linking")
-		assert.Equal(t, scimGroups[1].Name, scimAttr.SCIMGroupName, "Expected SCIMGroupName to match the re-linked group")
+		linkedTeam, err := client.Teams.Read(ctx, teamID)
+		require.NoError(t, err)
+		assert.True(t, *linkedTeam.SCIMLinked, "Expected SCIMLinked to be true after re-linking")
+		assert.Equal(t, scimGroups[1].Name, *linkedTeam.SCIMGroupName, "Expected SCIMGroupName to match the re-linked group")
 	})
 
 	errorCases := []struct {
@@ -199,8 +199,9 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			setup:   linkedTeamSetup,
 			options: &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)},
 			assertAfter: func(t *testing.T, teamID string) {
-				scimAttr := getScimAttributeValues(ctx, t, client, teamID)
-				assert.True(t, scimAttr.SCIMSyncPaused, "Expected SCIMSyncPaused to be true after pausing sync")
+				linkedTeam, err := client.Teams.Read(ctx, teamID)
+				require.NoError(t, err)
+				assert.True(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be true after pausing sync")
 			},
 		},
 		{
@@ -212,8 +213,9 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			},
 			options: &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(false)},
 			assertAfter: func(t *testing.T, teamID string) {
-				scimAttr := getScimAttributeValues(ctx, t, client, teamID)
-				assert.False(t, scimAttr.SCIMSyncPaused, "Expected SCIMSyncPaused to be false after unpausing sync")
+				linkedTeam, err := client.Teams.Read(ctx, teamID)
+				require.NoError(t, err)
+				assert.False(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be false after unpausing sync")
 			},
 		},
 		{
@@ -253,8 +255,9 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			},
 			options: &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)},
 			assertAfter: func(t *testing.T, teamID string) {
-				scimAttr := getScimAttributeValues(ctx, t, client, teamID)
-				assert.True(t, scimAttr.SCIMSyncPaused, "Expected SCIMSyncPaused to remain true after re-pausing")
+				linkedTeam, err := client.Teams.Read(ctx, teamID)
+				require.NoError(t, err)
+				assert.True(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to remain true after re-pausing")
 			},
 		},
 		{
@@ -262,8 +265,9 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			setup:   linkedTeamSetup,
 			options: &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(false)},
 			assertAfter: func(t *testing.T, teamID string) {
-				scimAttr := getScimAttributeValues(ctx, t, client, teamID)
-				assert.False(t, scimAttr.SCIMSyncPaused, "Expected SCIMSyncPaused to remain false after unpausing")
+				linkedTeam, err := client.Teams.Read(ctx, teamID)
+				require.NoError(t, err)
+				assert.False(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to remain false after unpausing")
 			},
 		},
 		{
@@ -330,9 +334,10 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 				return teamID
 			},
 			assertAfter: func(t *testing.T, teamID string) {
-				scimAttr := getScimAttributeValues(ctx, t, client, teamID)
-				assert.False(t, scimAttr.SCIMLinked, "Expected SCIMLinked to be false after deleting mapping")
-				assert.Empty(t, scimAttr.SCIMGroupName, "Expected SCIMGroupName to be empty after deleting mapping")
+				unlinkedTeam, err := client.Teams.Read(ctx, teamID)
+				require.NoError(t, err)
+				assert.False(t, *unlinkedTeam.SCIMLinked, "Expected SCIMLinked to be false after deleting mapping")
+				assert.Nil(t, unlinkedTeam.SCIMGroupName, "Expected SCIMGroupName to be empty after deleting mapping")
 			},
 		},
 		{
@@ -362,9 +367,10 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 				return teamID
 			},
 			assertAfter: func(t *testing.T, teamID string) {
-				scimAttr := getScimAttributeValues(ctx, t, client, teamID)
-				assert.False(t, scimAttr.SCIMLinked, "Expected SCIMLinked to be false after deleting paused mapping")
-				assert.Empty(t, scimAttr.SCIMGroupName, "Expected SCIMGroupName to be empty after deleting paused mapping")
+				unlinkedTeam, err := client.Teams.Read(ctx, teamID)
+				require.NoError(t, err)
+				assert.False(t, *unlinkedTeam.SCIMLinked, "Expected SCIMLinked to be false after deleting paused mapping")
+				assert.Nil(t, unlinkedTeam.SCIMGroupName, "Expected SCIMGroupName to be empty after deleting paused mapping")
 			},
 		},
 	}
@@ -471,27 +477,4 @@ func setupSCIMGroups(ctx context.Context, t *testing.T, client *Client) (*SCIMRe
 		scimGroups = append(scimGroups, AdminSCIMGroup{ID: scimGroupID, Name: randomGroupName})
 	}
 	return client.Admin.Settings.SCIM, scimGroups
-}
-
-// teamSCIMAttributes is a temporary helper used until the Team struct exposes
-// SCIM attributes natively via the Team Read API. At that point this helper
-// can be removed
-// TODO(TF-35675): Expose SCIM attributes natively via the Team Read API so
-// this helper can be removed. https://hashicorp.atlassian.net/browse/TF-35675
-type teamSCIMAttributes struct {
-	SCIMGroupName  string `jsonapi:"attr,scim-group-name"`
-	SCIMLinked     bool   `jsonapi:"attr,scim-linked"`
-	SCIMSyncPaused bool   `jsonapi:"attr,scim-sync-paused"`
-}
-
-// getScimAttributeValues retrieves the SCIM-related attributes for the team with teamID.
-func getScimAttributeValues(ctx context.Context, t *testing.T, client *Client, teamID string) teamSCIMAttributes {
-	req, err := client.NewRequest("GET", fmt.Sprintf("teams/%s", url.PathEscape(teamID)), nil)
-	require.NoError(t, err)
-
-	var attrs teamSCIMAttributes
-	err = req.Do(ctx, &attrs)
-	require.NoError(t, err)
-
-	return attrs
 }

--- a/admin_setting_scim_group_mapping_integration_test.go
+++ b/admin_setting_scim_group_mapping_integration_test.go
@@ -43,6 +43,9 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 				linkSCIMGroupMapping(ctx, t, scimClient, team.ID, group.ID)
 				linkedTeam, err := client.Teams.Read(ctx, team.ID)
 				require.NoError(t, err)
+				require.NotNil(t, linkedTeam.SCIMLinked, "Expected SCIMLinked to be non-nil after creating mapping")
+				require.NotNil(t, linkedTeam.SCIMGroupName, "Expected SCIMGroupName to be non-nil after creating mapping")
+				require.NotNil(t, linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be non-nil after creating mapping")
 				assert.True(t, *linkedTeam.SCIMLinked, "Expected SCIMLinked to be true after creating mapping")
 				assert.Equal(t, group.Name, *linkedTeam.SCIMGroupName, "Expected SCIMGroupName to match the linked group")
 				assert.False(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be false after creating mapping")
@@ -58,6 +61,8 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 
 		linkedTeam, err := client.Teams.Read(ctx, teamID)
 		require.NoError(t, err)
+		require.NotNil(t, linkedTeam.SCIMLinked, "Expected SCIMLinked to be non-nil after re-linking")
+		require.NotNil(t, linkedTeam.SCIMGroupName, "Expected SCIMGroupName to be non-nil after re-linking")
 		assert.True(t, *linkedTeam.SCIMLinked, "Expected SCIMLinked to be true after re-linking")
 		assert.Equal(t, scimGroups[1].Name, *linkedTeam.SCIMGroupName, "Expected SCIMGroupName to match the re-linked group")
 	})
@@ -201,6 +206,7 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			assertAfter: func(t *testing.T, teamID string) {
 				linkedTeam, err := client.Teams.Read(ctx, teamID)
 				require.NoError(t, err)
+				require.NotNil(t, linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be non-nil after pausing sync")
 				assert.True(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be true after pausing sync")
 			},
 		},
@@ -215,6 +221,7 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			assertAfter: func(t *testing.T, teamID string) {
 				linkedTeam, err := client.Teams.Read(ctx, teamID)
 				require.NoError(t, err)
+				require.NotNil(t, linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be non-nil after unpausing sync")
 				assert.False(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be false after unpausing sync")
 			},
 		},
@@ -257,6 +264,7 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			assertAfter: func(t *testing.T, teamID string) {
 				linkedTeam, err := client.Teams.Read(ctx, teamID)
 				require.NoError(t, err)
+				require.NotNil(t, linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be non-nil after re-pausing")
 				assert.True(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to remain true after re-pausing")
 			},
 		},
@@ -267,6 +275,7 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			assertAfter: func(t *testing.T, teamID string) {
 				linkedTeam, err := client.Teams.Read(ctx, teamID)
 				require.NoError(t, err)
+				require.NotNil(t, linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to be non-nil after unpausing")
 				assert.False(t, *linkedTeam.SCIMSyncPaused, "Expected SCIMSyncPaused to remain false after unpausing")
 			},
 		},
@@ -336,6 +345,7 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 			assertAfter: func(t *testing.T, teamID string) {
 				unlinkedTeam, err := client.Teams.Read(ctx, teamID)
 				require.NoError(t, err)
+				require.NotNil(t, unlinkedTeam.SCIMLinked, "Expected SCIMLinked to be non-nil after deleting mapping")
 				assert.False(t, *unlinkedTeam.SCIMLinked, "Expected SCIMLinked to be false after deleting mapping")
 				assert.Nil(t, unlinkedTeam.SCIMGroupName, "Expected SCIMGroupName to be empty after deleting mapping")
 			},
@@ -369,6 +379,7 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 			assertAfter: func(t *testing.T, teamID string) {
 				unlinkedTeam, err := client.Teams.Read(ctx, teamID)
 				require.NoError(t, err)
+				require.NotNil(t, unlinkedTeam.SCIMLinked, "Expected SCIMLinked to be non-nil after deleting paused mapping")
 				assert.False(t, *unlinkedTeam.SCIMLinked, "Expected SCIMLinked to be false after deleting paused mapping")
 				assert.Nil(t, unlinkedTeam.SCIMGroupName, "Expected SCIMGroupName to be empty after deleting paused mapping")
 			},

--- a/admin_user.go
+++ b/admin_user.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // Compile-time proof of interface implementation.
@@ -59,6 +60,11 @@ type AdminUser struct {
 
 	// Relations
 	Organizations []*Organization `jsonapi:"relation,organizations"`
+
+	// SCIM Attributes
+	IsSCIMManaged *bool      `jsonapi:"attr,is-scim-managed"`
+	SCIMUsername  *string    `jsonapi:"attr,scim-username"`
+	SCIMUpdatedAt *time.Time `jsonapi:"attr,scim-updated-at,iso8601"`
 }
 
 // AdminUserList represents a list of users.

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -103,7 +103,6 @@ func TestAdminUsers_List(t *testing.T) {
 	})
 
 	t.Run("with scim attributes", func(t *testing.T) {
-		skipUnlessEnterprise(t)
 		enableSCIM(ctx, t, client, true)
 		t.Cleanup(func() {
 			enableSCIM(ctx, t, client, false)

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -13,7 +13,6 @@ import (
 )
 
 func TestAdminUsers_List(t *testing.T) {
-	t.Parallel()
 	skipUnlessEnterprise(t)
 
 	client := testClient(t)

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -6,6 +6,7 @@ package tfe
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -99,6 +100,45 @@ func TestAdminUsers_List(t *testing.T) {
 		// the tests, there could be multiple admins, depending on the
 		// ordering of the test runs.
 		assert.Equal(t, true, includesEmail(currentUser.Email, ul.Items))
+	})
+
+	t.Run("with scim attributes", func(t *testing.T) {
+		skipUnlessEnterprise(t)
+		enableSCIM(ctx, t, client, true)
+		t.Cleanup(func() {
+			enableSCIM(ctx, t, client, false)
+		})
+
+		scimToken, err := client.Admin.Settings.SCIM.Tokens.Create(ctx, "user integration test")
+		require.NoError(t, err)
+		require.NotNil(t, scimToken.Token)
+		t.Cleanup(func() {
+			err = client.Admin.Settings.SCIM.Tokens.Delete(ctx, scimToken.ID)
+			require.NoError(t, err)
+		})
+
+		userSCIMID, username := createSCIMUser(ctx, t, client, scimToken.Token, "")
+		t.Cleanup(func() {
+			deleteSCIMUser(ctx, t, client, scimToken.Token, userSCIMID)
+		})
+
+		users, err := client.Admin.Users.List(ctx, &AdminUserListOptions{Query: username})
+		require.NoError(t, err)
+		require.NotEmpty(t, users.Items)
+
+		var user *AdminUser
+		for _, u := range users.Items {
+			if u.SCIMUsername != nil && *u.SCIMUsername == username {
+				user = u
+				break
+			}
+		}
+		require.NotNil(t, user, "expected to find SCIM user %q in admin users list", username)
+		assert.Equal(t, username, *user.SCIMUsername)
+		require.NotNil(t, user.IsSCIMManaged)
+		assert.True(t, *user.IsSCIMManaged)
+		require.NotNil(t, user.SCIMUpdatedAt)
+		assert.WithinDuration(t, time.Now(), *user.SCIMUpdatedAt, 10*time.Second)
 	})
 }
 

--- a/admin_user_integration_test.go
+++ b/admin_user_integration_test.go
@@ -109,7 +109,7 @@ func TestAdminUsers_List(t *testing.T) {
 
 		scimToken, err := client.Admin.Settings.SCIM.Tokens.Create(ctx, "user integration test")
 		require.NoError(t, err)
-		require.NotNil(t, scimToken.Token)
+		require.NotEmpty(t, scimToken.Token)
 		t.Cleanup(func() {
 			err = client.Admin.Settings.SCIM.Tokens.Delete(ctx, scimToken.ID)
 			require.NoError(t, err)

--- a/helper_test.go
+++ b/helper_test.go
@@ -3523,6 +3523,31 @@ func setSAMLProviderType(ctx context.Context, t *testing.T, client *Client, setP
 	return err
 }
 
+func scimReq(t *testing.T, client *Client, method, path, scimToken string, body any) *retryablehttp.Request {
+	t.Helper()
+
+	u := client.BaseURL()
+	u.Path = path
+
+	var serializedBody any
+	if body != nil {
+		b, err := serializeRequestBody(body)
+		require.NoError(t, err)
+		serializedBody = b
+	}
+
+	req, err := retryablehttp.NewRequest(method, u.String(), serializedBody)
+	require.NoError(t, err)
+	req.Header = client.headers.Clone()
+	req.Header.Set("Authorization", "Bearer "+scimToken)
+	req.Header.Set("Accept", "application/scim+json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/scim+json; charset=utf-8")
+	}
+
+	return req
+}
+
 func createSCIMGroup(ctx context.Context, t *testing.T, client *Client, groupName, scimToken string) string {
 	t.Helper()
 
@@ -3534,23 +3559,12 @@ func createSCIMGroup(ctx context.Context, t *testing.T, client *Client, groupNam
 		Schemas:     []string{"urn:ietf:params:scim:schemas:core:2.0:Group"},
 	}
 
-	body, err := serializeRequestBody(&payload)
-	require.NoError(t, err)
-
-	u := client.BaseURL()
-	u.Path = "/scim/v2/Groups"
-
-	req, err := retryablehttp.NewRequest("POST", u.String(), body)
-	require.NoError(t, err)
-	req.Header = client.headers.Clone()
-	req.Header.Set("Authorization", "Bearer "+scimToken)
-	req.Header.Set("Accept", "application/scim+json")
-	req.Header.Set("Content-Type", "application/scim+json; charset=utf-8")
+	req := scimReq(t, client, "POST", "/scim/v2/Groups", scimToken, &payload)
 
 	var res struct {
 		ID string `json:"id"`
 	}
-	err = (&ClientRequest{
+	err := (&ClientRequest{
 		retryableRequest: req,
 		http:             client.http,
 		limiter:          client.limiter,
@@ -3565,15 +3579,75 @@ func createSCIMGroup(ctx context.Context, t *testing.T, client *Client, groupNam
 func deleteSCIMGroup(ctx context.Context, t *testing.T, client *Client, groupID, scimToken string) {
 	t.Helper()
 
-	u := client.BaseURL()
-	u.Path = "/scim/v2/Groups/" + url.PathEscape(groupID)
+	req := scimReq(t, client, "DELETE", "/scim/v2/Groups/"+url.PathEscape(groupID), scimToken, nil)
 
-	req, err := retryablehttp.NewRequest("DELETE", u.String(), nil)
+	err := (&ClientRequest{
+		retryableRequest: req,
+		http:             client.http,
+		limiter:          client.limiter,
+		Header:           req.Header,
+	}).Do(ctx, nil)
 	require.NoError(t, err)
-	req.Header = client.headers.Clone()
-	req.Header.Set("Authorization", "Bearer "+scimToken)
+}
 
-	err = (&ClientRequest{
+type scimUserEmail struct {
+	Primary bool   `json:"primary"`
+	Value   string `json:"value"`
+}
+
+type scimUserCreateRequest struct {
+	UserName    string          `json:"userName"`
+	DisplayName string          `json:"displayName"`
+	Emails      []scimUserEmail `json:"emails"`
+	Active      bool            `json:"active"`
+}
+
+func createSCIMUser(ctx context.Context, t *testing.T, client *Client, scimToken, userName string) (string, string) {
+	t.Helper()
+	if strings.TrimSpace(userName) == "" {
+		userName = randomStringWithoutSpecialChar(t)
+	}
+
+	if !strings.Contains(userName, "@") {
+		userName += "@test.com"
+	}
+
+	payload := scimUserCreateRequest{
+		UserName:    userName,
+		DisplayName: userName,
+		Emails: []scimUserEmail{
+			{
+				Primary: true,
+				Value:   userName,
+			},
+		},
+		Active: true,
+	}
+
+	req := scimReq(t, client, "POST", "/scim/v2/Users", scimToken, &payload)
+
+	var res struct {
+		ID string `json:"id"`
+	}
+
+	err := (&ClientRequest{
+		retryableRequest: req,
+		http:             client.http,
+		limiter:          client.limiter,
+		Header:           req.Header,
+	}).DoJSON(ctx, &res)
+
+	require.NoError(t, err)
+	require.NotEmpty(t, res.ID)
+
+	return res.ID, payload.UserName
+}
+
+func deleteSCIMUser(ctx context.Context, t *testing.T, client *Client, scimToken, userID string) {
+	t.Helper()
+
+	req := scimReq(t, client, "DELETE", "/scim/v2/Users/"+url.PathEscape(userID), scimToken, nil)
+	err := (&ClientRequest{
 		retryableRequest: req,
 		http:             client.http,
 		limiter:          client.limiter,

--- a/team.go
+++ b/team.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"time"
 )
 
 // Compile-time proof of interface implementation.
@@ -60,6 +61,12 @@ type Team struct {
 	// Relations
 	Users                   []*User                   `jsonapi:"relation,users"`
 	OrganizationMemberships []*OrganizationMembership `jsonapi:"relation,organization-memberships"`
+
+	// SCIM Attributes
+	SCIMLinked     *bool      `jsonapi:"attr,scim-linked"`
+	SCIMSyncPaused *bool      `jsonapi:"attr,scim-sync-paused"`
+	SCIMGroupName  *string    `jsonapi:"attr,scim-group-name"`
+	SCIMUpdatedAt  *time.Time `jsonapi:"attr,scim-updated-at,iso8601"`
 }
 
 // OrganizationAccess represents the team's permissions on its organization

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -266,6 +266,10 @@ func TestTeamsRead(t *testing.T) {
 
 		err = client.Admin.Settings.SCIM.SCIMGroupMappings.Create(ctx, team.ID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroupID})
 		require.NoError(t, err)
+		t.Cleanup(func() {
+			err = client.Admin.Settings.SCIM.SCIMGroupMappings.Delete(ctx, team.ID)
+			require.NoError(t, err)
+		})
 
 		linkedTeam, err := client.Teams.Read(ctx, team.ID)
 		require.NoError(t, err)

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -282,7 +282,6 @@ func TestTeamsRead(t *testing.T) {
 		assert.True(t, *linkedTeam.SCIMLinked, "team should be linked to a SCIM group")
 		assert.Equal(t, scimGroupName, *linkedTeam.SCIMGroupName, "team's SCIM group name should match the created SCIM group name")
 		assert.False(t, *linkedTeam.SCIMSyncPaused, "team's SCIM sync should not be paused")
-		assert.NotNil(t, linkedTeam.SCIMUpdatedAt, "team's SCIM updated at should not be nil")
 		assert.WithinDuration(t, time.Now(), *linkedTeam.SCIMUpdatedAt, 10*time.Second, "team's SCIM updated at should be recent")
 	})
 }

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	retryablehttp "github.com/hashicorp/go-retryablehttp"
 	"github.com/stretchr/testify/assert"
@@ -238,6 +239,42 @@ func TestTeamsRead(t *testing.T) {
 		tm, err := client.Teams.Read(ctx, badIdentifier)
 		assert.Nil(t, tm)
 		assert.Equal(t, err, ErrInvalidTeamID)
+	})
+
+	t.Run("with scim attributes", func(t *testing.T) {
+		skipUnlessEnterprise(t)
+
+		team, teamCleanup := createTeam(t, client, nil)
+		t.Cleanup(teamCleanup)
+
+		enableSCIM(ctx, t, client, true)
+		t.Cleanup(func() {
+			enableSCIM(ctx, t, client, false)
+		})
+
+		scimToken, err := client.Admin.Settings.SCIM.Tokens.Create(ctx, "team read test")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			client.Admin.Settings.SCIM.Tokens.Delete(ctx, scimToken.ID)
+		})
+
+		scimGroupName := randomStringWithoutSpecialChar(t)
+		scimGroupID := createSCIMGroup(ctx, t, client, scimGroupName, scimToken.Token)
+		t.Cleanup(func() {
+			deleteSCIMGroup(ctx, t, client, scimGroupID, scimToken.Token)
+		})
+
+		err = client.Admin.Settings.SCIM.SCIMGroupMappings.Create(ctx, team.ID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroupID})
+		require.NoError(t, err)
+
+		linkedTeam, err := client.Teams.Read(ctx, team.ID)
+		require.NoError(t, err)
+
+		assert.True(t, *linkedTeam.SCIMLinked, "team should be linked to a SCIM group")
+		assert.Equal(t, scimGroupName, *linkedTeam.SCIMGroupName, "team's SCIM group name should match the created SCIM group name")
+		assert.False(t, *linkedTeam.SCIMSyncPaused, "team's SCIM sync should not be paused")
+		assert.NotNil(t, linkedTeam.SCIMUpdatedAt, "team's SCIM updated at should not be nil")
+		assert.WithinDuration(t, time.Now(), *linkedTeam.SCIMUpdatedAt, 10*time.Second, "team's SCIM updated at should be recent")
 	})
 }
 

--- a/team_integration_test.go
+++ b/team_integration_test.go
@@ -176,7 +176,6 @@ func TestTeamsCreate(t *testing.T) {
 }
 
 func TestTeamsRead(t *testing.T) {
-	t.Parallel()
 	client := testClient(t)
 	ctx := context.Background()
 
@@ -255,7 +254,8 @@ func TestTeamsRead(t *testing.T) {
 		scimToken, err := client.Admin.Settings.SCIM.Tokens.Create(ctx, "team read test")
 		require.NoError(t, err)
 		t.Cleanup(func() {
-			client.Admin.Settings.SCIM.Tokens.Delete(ctx, scimToken.ID)
+			err = client.Admin.Settings.SCIM.Tokens.Delete(ctx, scimToken.ID)
+			require.NoError(t, err)
 		})
 
 		scimGroupName := randomStringWithoutSpecialChar(t)
@@ -269,6 +269,11 @@ func TestTeamsRead(t *testing.T) {
 
 		linkedTeam, err := client.Teams.Read(ctx, team.ID)
 		require.NoError(t, err)
+
+		require.NotNil(t, linkedTeam.SCIMLinked, "team's SCIM linked flag should not be nil")
+		require.NotNil(t, linkedTeam.SCIMGroupName, "team's SCIM group name should not be nil")
+		require.NotNil(t, linkedTeam.SCIMSyncPaused, "team's SCIM sync paused flag should not be nil")
+		require.NotNil(t, linkedTeam.SCIMUpdatedAt, "team's SCIM updated at should not be nil")
 
 		assert.True(t, *linkedTeam.SCIMLinked, "team should be linked to a SCIM group")
 		assert.Equal(t, scimGroupName, *linkedTeam.SCIMGroupName, "team's SCIM group name should match the created SCIM group name")

--- a/user.go
+++ b/user.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"time"
 )
 
 // Compile-time proof of interface implementation.
@@ -45,6 +46,11 @@ type User struct {
 
 	// Relations
 	// AuthenticationTokens *AuthenticationTokens `jsonapi:"relation,authentication-tokens"`
+
+	// SCIM Attributes
+	IsSCIMManaged *bool      `jsonapi:"attr,is-scim-managed"`
+	SCIMUsername  *string    `jsonapi:"attr,scim-username"`
+	SCIMUpdatedAt *time.Time `jsonapi:"attr,scim-updated-at,iso8601"`
 }
 
 // UserPermissions represents the user permissions.

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -30,6 +30,36 @@ func TestUsersReadCurrent(t *testing.T) {
 	t.Run("permissions are decoded", func(t *testing.T) {
 		assert.NotNil(t, u.Permissions)
 	})
+
+	t.Run("with no scim attributes", func(t *testing.T) {
+		skipUnlessEnterprise(t)
+		// When SCIM is disabled, the API omits all SCIM attributes from the response.
+		assert.Nil(t, u.IsSCIMManaged)
+		assert.Nil(t, u.SCIMUsername)
+		assert.Nil(t, u.SCIMUpdatedAt)
+	})
+
+	t.Run("with scim attributes", func(t *testing.T) {
+		skipUnlessEnterprise(t)
+		enableSCIM(ctx, t, client, true)
+		t.Cleanup(func() {
+			enableSCIM(ctx, t, client, false)
+		})
+
+		user, err := client.Users.ReadCurrent(ctx)
+		require.NoError(t, err)
+
+		// The current user (test runner) is not a SCIM-managed user, so we can
+		// only verify that IsSCIMManaged is populated (and false) when SCIM is
+		// enabled. Verifying the SCIM-managed path requires authenticating as
+		// the SCIM-provisioned user, which isn't possible here. See
+		// TestAdminUsers_List/with_scim_attributes for coverage of a
+		// SCIM-managed user via the admin API.
+		assert.NotNil(t, user.IsSCIMManaged)
+		assert.False(t, *user.IsSCIMManaged)
+		assert.Nil(t, user.SCIMUsername)
+		assert.Nil(t, user.SCIMUpdatedAt)
+	})
 }
 
 func TestUsersUpdate(t *testing.T) {

--- a/user_integration_test.go
+++ b/user_integration_test.go
@@ -12,7 +12,6 @@ import (
 )
 
 func TestUsersReadCurrent(t *testing.T) {
-	t.Parallel()
 	client := testClient(t)
 	ctx := context.Background()
 


### PR DESCRIPTION
## Description

This PR, Exposes SCIM attributes natively on `User`, `AdminUser`, and `Team` so callers can read SCIM state via the standard Read/List APIs.

`User` / `AdminUser`: `IsSCIMManaged`, `SCIMUsername`, `SCIMUpdatedAt`
`Team`: `SCIMLinked`, `SCIMSyncPaused`, `SCIMGroupName`, `SCIMUpdatedAt`
Fields are pointers since the API omits them when SCIM is disabled.

Removes the temporary `teamSCIMAttributes` helper in integartion test, now that `Team.Read` returns these directly.

this pr also includes new test cases in the existing integration test.

## Testing plan
Adds integration test in `TestUsersReadCurrent`, `TestAdminUsers_List` and `TestTeamsRead` and updated existing integration test `TestAdminSCIMGroupMappings_(Create,Update,Delete)` to read SCIM Attributes via `client.Teams.Read`

## External links
[JIRA](https://hashicorp.atlassian.net/browse/TF-35675)
[RFC](https://hermes-sharepoint.hashicorp.services/document/01XOO7K4IWFH44KZAPDJC3QXNKIRWEZMBA)

## Output from tests
1. `ENABLE_TFE=1 envchain scim gotest -v -run "TestUsersReadCurrent"`
    <img width="750" height="222" alt="image" src="https://github.com/user-attachments/assets/7301f9eb-7e9f-47f6-84dd-a7ea76dc64a0" />


2.  `ENABLE_TFE=1 envchain scim gotest -v -run "TestAdminUsers_List/with_scim_attributes"`
    <img width="888" height="135" alt="image" src="https://github.com/user-attachments/assets/8133df76-0f85-4797-b9c5-cff3301a029f" />


3. `ENABLE_TFE=1 envchain scim gotest -v -run "TestTeamsRead/with_scim_attributes"`
    <img width="888" height="135" alt="image" src="https://github.com/user-attachments/assets/6bd80c03-97b2-4c1d-85cb-9e9a96883782" />


4. `ENABLE_TFE=1 envchain scim gotest -v -run "TestAdminSCIMGroupMappings_(Create|Update|Delete)"`
    <img width="959" height="891" alt="image" src="https://github.com/user-attachments/assets/6bf1cd90-d647-42be-bc45-e387e081a6fa" />



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

we can revert this pr

## Changes to Security Controls

NA
