### PR TITLE
Support unlinking site admin SCIM group via explicit null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-## Breaking Changes
+## BREAKING CHANGES
 * Changes `AdminSCIMSettingUpdateOptions.SiteAdminGroupSCIMID` from `*string` to `jsonapi.NullableAttr[string]` so callers can explicitly unlink the site admin group with `NullString()` by @skj-skj [#1337](https://github.com/hashicorp/go-tfe/pull/1337)
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Breaking Changes
+* Changes `AdminSCIMSettingUpdateOptions.SiteAdminGroupSCIMID` from `*string` to `jsonapi.NullableAttr[string]` so callers can explicitly unlink the site admin group with `NullString()` by @skj-skj
+
 ## Enhancements
 * Adds SCIM attribute fields (`IsSCIMManaged`, `SCIMUsername`, `SCIMUpdatedAt`) to `User` and `AdminUser`, and (`SCIMLinked`, `SCIMSyncPaused`, `SCIMGroupName`, `SCIMUpdatedAt`) to `Team` by @skj-skj [#1335](https://github.com/hashicorp/go-tfe/pull/1335)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Unreleased
 
 ## Breaking Changes
-* Changes `AdminSCIMSettingUpdateOptions.SiteAdminGroupSCIMID` from `*string` to `jsonapi.NullableAttr[string]` so callers can explicitly unlink the site admin group with `NullString()` by @skj-skj
+* Changes `AdminSCIMSettingUpdateOptions.SiteAdminGroupSCIMID` from `*string` to `jsonapi.NullableAttr[string]` so callers can explicitly unlink the site admin group with `NullString()` by @skj-skj [#1337](https://github.com/hashicorp/go-tfe/pull/1337)
 
 ## Enhancements
 * Adds SCIM attribute fields (`IsSCIMManaged`, `SCIMUsername`, `SCIMUpdatedAt`) to `User` and `AdminUser`, and (`SCIMLinked`, `SCIMSyncPaused`, `SCIMGroupName`, `SCIMUpdatedAt`) to `Team` by @skj-skj [#1335](https://github.com/hashicorp/go-tfe/pull/1335)

--- a/admin_setting_scim.go
+++ b/admin_setting_scim.go
@@ -5,6 +5,8 @@ package tfe
 
 import (
 	"context"
+
+	"github.com/hashicorp/jsonapi"
 )
 
 // Compile-time proof of interface implementation.
@@ -40,10 +42,20 @@ type AdminSCIMSetting struct {
 }
 
 // AdminSCIMSettingUpdateOptions represents the options for updating an admin SCIM setting.
+//
+// SiteAdminGroupSCIMID is a nullable attribute. Use NullableString(value) to set the
+// site admin group, or NullString() to explicitly clear (unlink) it. Leaving the
+// field as its zero value omits it from the request so the existing value on
+// the server is preserved.
 type AdminSCIMSettingUpdateOptions struct {
-	Enabled              *bool   `jsonapi:"attr,enabled,omitempty"`
-	Paused               *bool   `jsonapi:"attr,paused,omitempty"`
-	SiteAdminGroupSCIMID *string `jsonapi:"attr,site-admin-group-scim-id,omitempty"`
+	// Enabled toggles SCIM provisioning on or off.
+	Enabled *bool `jsonapi:"attr,enabled,omitempty"`
+	// Paused toggles whether SCIM provisioning is paused.
+	Paused *bool `jsonapi:"attr,paused,omitempty"`
+	// SiteAdminGroupSCIMID sets the SCIM group linked to the site admin role.
+	// Use NullableString(value) to link a group, or NullString() to explicitly unlink it.
+	// Leaving it as the zero value omits the field so the server-side value is preserved.
+	SiteAdminGroupSCIMID jsonapi.NullableAttr[string] `jsonapi:"attr,site-admin-group-scim-id,omitempty"`
 }
 
 // Read scim setting.

--- a/admin_setting_scim_group_mapping_integration_test.go
+++ b/admin_setting_scim_group_mapping_integration_test.go
@@ -124,10 +124,10 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 			setup: func(t *testing.T) (string, string) {
 				siteAdminGroupID := scimGroups[0].ID
 				teamID := createSingleTeam(t, client)
-				_, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: &siteAdminGroupID})
+				_, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: NullableString(siteAdminGroupID)})
 				require.NoError(t, err, "Failed to set site admin group")
 				t.Cleanup(func() {
-					_, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: nil})
+					_, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: NullString()})
 					require.NoError(t, err, "Failed to clear site admin group")
 				})
 				return teamID, siteAdminGroupID

--- a/admin_setting_scim_integration_test.go
+++ b/admin_setting_scim_integration_test.go
@@ -102,7 +102,7 @@ func TestAdminSettings_SCIM_Update(t *testing.T) {
 
 		for _, tc := range testCases {
 			t.Run(tc.name, func(t *testing.T) {
-				_, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: &tc.scimGroupID})
+				_, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: NullableString(tc.scimGroupID)})
 				if tc.raiseError {
 					require.Error(t, err)
 					return
@@ -114,6 +114,36 @@ func TestAdminSettings_SCIM_Update(t *testing.T) {
 				assert.Equal(t, "foo", scimSettings.SiteAdminGroupDisplayName)
 			})
 		}
+	})
+
+	t.Run("link and unlink site admin group", func(t *testing.T) {
+		err := setSAMLProviderType(ctx, t, client, true)
+		require.NoErrorf(t, err, "failed to set SAML provider type")
+		defer cleanupSCIMSettings(ctx, t, client)
+
+		_, err = scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{Enabled: Bool(true)})
+		require.NoError(t, err)
+
+		scimToken, err := scimClient.Tokens.Create(ctx, "scim integration test token")
+		require.NoError(t, err)
+		require.NotEmpty(t, scimToken.Token)
+		scimGroupID := createSCIMGroup(ctx, t, client, "foo", scimToken.Token)
+
+		// link scim group to site admin role
+		scimSettings, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: NullableString(scimGroupID)})
+		require.NoError(t, err)
+		assert.Equal(t, scimGroupID, scimSettings.SiteAdminGroupSCIMID)
+
+		// updating an unrelated field should not clear the site admin group
+		scimSettings, err = scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{Paused: Bool(true)})
+		require.NoError(t, err)
+		assert.Equal(t, scimGroupID, scimSettings.SiteAdminGroupSCIMID)
+
+		// unlink scim group from site admin role by explicitly setting null
+		scimSettings, err = scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: NullString()})
+		require.NoError(t, err)
+		assert.Empty(t, scimSettings.SiteAdminGroupSCIMID)
+		assert.Empty(t, scimSettings.SiteAdminGroupDisplayName)
 	})
 }
 

--- a/admin_setting_scim_integration_test.go
+++ b/admin_setting_scim_integration_test.go
@@ -119,7 +119,9 @@ func TestAdminSettings_SCIM_Update(t *testing.T) {
 	t.Run("link and unlink site admin group", func(t *testing.T) {
 		err := setSAMLProviderType(ctx, t, client, true)
 		require.NoErrorf(t, err, "failed to set SAML provider type")
-		defer cleanupSCIMSettings(ctx, t, client)
+		t.Cleanup(func() {
+			cleanupSCIMSettings(ctx, t, client)
+		})
 
 		_, err = scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{Enabled: Bool(true)})
 		require.NoError(t, err)
@@ -127,7 +129,15 @@ func TestAdminSettings_SCIM_Update(t *testing.T) {
 		scimToken, err := scimClient.Tokens.Create(ctx, "scim integration test token")
 		require.NoError(t, err)
 		require.NotEmpty(t, scimToken.Token)
+		t.Cleanup(func() {
+			deleteErr := scimClient.Tokens.Delete(ctx, scimToken.ID)
+			require.NoError(t, deleteErr, "failed to delete scim token")
+		})
+
 		scimGroupID := createSCIMGroup(ctx, t, client, "foo", scimToken.Token)
+		t.Cleanup(func() {
+			deleteSCIMGroup(ctx, t, client, scimGroupID, scimToken.Token)
+		})
 
 		// link scim group to site admin role
 		scimSettings, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: NullableString(scimGroupID)})
@@ -138,6 +148,12 @@ func TestAdminSettings_SCIM_Update(t *testing.T) {
 		scimSettings, err = scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{Paused: Bool(true)})
 		require.NoError(t, err)
 		assert.Equal(t, scimGroupID, scimSettings.SiteAdminGroupSCIMID)
+		t.Cleanup(func() {
+			// unpause SCIM provisioning before other cleanups run: while SCIM is paused,
+			// deleting the SCIM group returns an error, so we must unpause first.
+			_, err := scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{Paused: Bool(false)})
+			require.NoError(t, err)
+		})
 
 		// unlink scim group from site admin role by explicitly setting null
 		scimSettings, err = scimClient.Update(ctx, AdminSCIMSettingUpdateOptions{SiteAdminGroupSCIMID: NullString()})

--- a/type_helpers.go
+++ b/type_helpers.go
@@ -154,6 +154,16 @@ func NullTime() jsonapi.NullableAttr[time.Time] {
 	return jsonapi.NewNullNullableAttr[time.Time]()
 }
 
+// NullableString returns a NullableAttr wrapping the given string value.
+func NullableString(v string) jsonapi.NullableAttr[string] {
+	return jsonapi.NewNullableAttrWithValue[string](v)
+}
+
+// NullString returns a NullableAttr that explicitly serializes as null.
+func NullString() jsonapi.NullableAttr[string] {
+	return jsonapi.NewNullNullableAttr[string]()
+}
+
 // Ptr returns a pointer to the given value of any type.
 func Ptr[T any](v T) *T {
 	return &v


### PR DESCRIPTION
## Description

This PR makes it possible to unlink the site admin SCIM group cleanly. The SCIM settings update endpoint is a `PATCH`, so callers should be able to send only the fields they want to change. Previously `SiteAdminGroupSCIMID` was a `*string` with `omitempty`, which meant `nil` got dropped from the request body and could not be used to unlink, the workaround was sending an empty string, which is awkward and not a great API.

To fix this, `SiteAdminGroupSCIMID` is now a `jsonapi.NullableAttr[string]`. Callers now have three clear options:
1. `NullableString(value)`: link a SCIM group
2. `NullString()`: explicitly unlink it (sent as JSON null)
3. zero value: leave the field out of the PATCH and preserve whatever the server has

this is a breaking change for anyone currently passing `*string` to `SiteAdminGroupSCIMID`, they will need to switch to `NullableString(v)`.

## Testing plan

Added a new integration test `link and unlink site admin group` in `TestAdminSettings_SCIM_Update` and Updated existing call sites in `TestAdminSettings_SCIM_Update` and `TestAdminSCIMGroupMappings_Create`

## External links

[JIRA](https://hashicorp.atlassian.net/browse/TF-37246)
[RFC](https://hermes-sharepoint.hashicorp.services/document/01XOO7K4IWFH44KZAPDJC3QXNKIRWEZMBA)

## Output from tests
1. `ENABLE_TFE=1 envchain scim gotest -v -run "TestAdminSettings_SCIM_(Read|Update|Delete)"`
    <img width="1151" height="481" alt="image" src="https://github.com/user-attachments/assets/5cc4bb8b-ab23-4f14-a4c9-798ed3a5561a" />

2. `ENABLE_TFE=1 envchain scim gotest -v -run "TestAdminSCIMGroupMappings_(Create|Update|Delete)"`
    <img width="1151" height="900" alt="image" src="https://github.com/user-attachments/assets/912762e5-c194-47cb-82d0-ef6e51853209" />



<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

we can revert this pr

## Changes to Security Controls

NA
