### PR TITLE
Add support to read a provider by its external ID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+## Enhancements
+* Add support for reading a registry provider by its unique identifier by  @mrinalirao [#1340](https://github.com/hashicorp/go-tfe/pull/1340)
+
 # v1.106.0
 
 ## BREAKING CHANGES

--- a/helper_test.go
+++ b/helper_test.go
@@ -2226,6 +2226,7 @@ func createRegistryProvider(t *testing.T, client *Client, org *Organization, reg
 
 	return prv, func() {
 		id := RegistryProviderID{
+			ID:               prv.ID,
 			OrganizationName: org.Name,
 			RegistryName:     prv.RegistryName,
 			Namespace:        prv.Namespace,

--- a/registry_provider.go
+++ b/registry_provider.go
@@ -104,6 +104,8 @@ type RegistryProviderList struct {
 
 // RegistryProviderID is the multi key ID for addressing a provider
 type RegistryProviderID struct {
+	// The unique ID of the provider. If given, the other fields are ignored.
+	ID               string
 	OrganizationName string
 	RegistryName     RegistryName
 	Namespace        string
@@ -244,13 +246,19 @@ func (r *registryProviders) Read(ctx context.Context, providerID RegistryProvide
 		return nil, err
 	}
 
-	u := fmt.Sprintf(
-		"organizations/%s/registry-providers/%s/%s/%s",
-		url.PathEscape(providerID.OrganizationName),
-		url.PathEscape(string(providerID.RegistryName)),
-		url.PathEscape(providerID.Namespace),
-		url.PathEscape(providerID.Name),
-	)
+	var u string
+	if providerID.ID == "" {
+		u = fmt.Sprintf(
+			"organizations/%s/registry-providers/%s/%s/%s",
+			url.PathEscape(providerID.OrganizationName),
+			url.PathEscape(string(providerID.RegistryName)),
+			url.PathEscape(providerID.Namespace),
+			url.PathEscape(providerID.Name),
+		)
+	} else {
+		u = fmt.Sprintf("registry-providers/%s", url.PathEscape(providerID.ID))
+	}
+
 	req, err := r.client.NewRequest("GET", u, options)
 	if err != nil {
 		return nil, err
@@ -296,6 +304,9 @@ func (o RegistryProviderCreateOptions) valid() error {
 }
 
 func (id RegistryProviderID) valid() error {
+	if validString(&id.ID) && validStringID(&id.ID) {
+		return nil
+	}
 	if !validStringID(&id.OrganizationName) {
 		return ErrInvalidOrg
 	}

--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -341,6 +341,34 @@ func TestRegistryProvidersRead(t *testing.T) {
 				})
 			})
 
+			t.Run("with a unique ID field for the provider", func(t *testing.T) {
+				registryProviderTest, providerTestCleanup := createRegistryProvider(t, client, orgTest, prvCtx.RegistryName)
+				defer providerTestCleanup()
+
+				id := RegistryProviderID{
+					ID: registryProviderTest.ID,
+				}
+
+				prv, err := client.RegistryProviders.Read(ctx, id, nil)
+				require.NoError(t, err)
+
+				assert.NotEmpty(t, prv.ID)
+				assert.Equal(t, registryProviderTest.ID, prv.ID)
+
+				t.Run("permissions are properly decoded", func(t *testing.T) {
+					assert.True(t, prv.Permissions.CanDelete)
+				})
+
+				t.Run("relationships are properly decoded", func(t *testing.T) {
+					assert.Equal(t, orgTest.Name, prv.Organization.Name)
+				})
+
+				t.Run("timestamps are properly decoded", func(t *testing.T) {
+					assert.NotEmpty(t, prv.CreatedAt)
+					assert.NotEmpty(t, prv.UpdatedAt)
+				})
+			})
+
 			t.Run("when the registry provider does not exist", func(t *testing.T) {
 				id := RegistryProviderID{
 					OrganizationName: orgTest.Name,
@@ -536,6 +564,13 @@ func TestRegistryProvidersIDValidation(t *testing.T) {
 			RegistryName:     registryName,
 			Namespace:        "namespace",
 			Name:             "name",
+		}
+		require.NoError(t, id.valid())
+	})
+
+	t.Run("valid ID", func(t *testing.T) {
+		id := RegistryProviderID{
+			ID: "prv_12345678",
 		}
 		require.NoError(t, id.valid())
 	})


### PR DESCRIPTION
## Description

Today, registry resources are fetched using different identifiers depending on the artifact type:

Providers and modules are typically addressed via structured paths (org/registry_name/namespace/name/...).
Component configurations are fetched using their external ID.
This inconsistency becomes problematic when working with shared abstractions like tfe_registry_artifact_tag, which operates across all registry artifact types.

We require a uniform way to resolve registry artifacts regardless of their type. However currently only providers cannot currently be fetched via external ID.
This PR adds support to read a provider by its external ID.

## Testing plan

Unit tests

## External links

- [Related PR](https://github.com/hashicorp/atlas/pull/28639)


## Output from tests
<img width="1288" height="761" alt="Screenshot 2026-05-13 at 11 48 59 am" src="https://github.com/user-attachments/assets/0ece0d0b-d2d3-49d6-a24b-292a11e22eb5" />
<img width="1248" height="519" alt="Screenshot 2026-05-13 at 11 36 38 am" src="https://github.com/user-attachments/assets/fdeffc84-c217-4828-8526-25ffd42c81ea" />
<img width="851" height="849" alt="Screenshot 2026-05-13 at 11 37 48 am" src="https://github.com/user-attachments/assets/a67f70cb-71db-467b-9285-dc4c86d6e32b" />


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

Revert PR

