### PR TITLE
Fixed Integration Test Failure in `TestAdminSCIMGroupMappings_Create`

### DIFF
--- a/admin_setting_scim_group_mapping_integration_test.go
+++ b/admin_setting_scim_group_mapping_integration_test.go
@@ -75,6 +75,9 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 		// nil-options validation path.
 		nilOptions  bool
 		expectedErr error
+		// apiError is true when expectedErr is a substring of an API-derived error
+		// whose title varies across TFE releases. Use ErrorContains in that case
+		apiError bool
 	}{
 		{
 			name: "team already mapped",
@@ -118,6 +121,7 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 				return teamList.Items[0].ID, scimGroups[0].ID
 			},
 			expectedErr: ErrSCIMGroupMappingOwnersTeam,
+			apiError:    true,
 		},
 		{
 			name: "site admin group not allowed",
@@ -133,6 +137,7 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 				return teamID, siteAdminGroupID
 			},
 			expectedErr: ErrSCIMGroupMappingSiteAdminGroup,
+			apiError:    true,
 		},
 		{
 			name: "invalid team ID",
@@ -167,7 +172,11 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 			} else {
 				err = scimClient.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroupID})
 			}
-			require.ErrorContains(t, err, tc.expectedErr.Error())
+			if tc.apiError {
+				require.ErrorContains(t, err, tc.expectedErr.Error())
+			} else {
+				require.EqualError(t, err, tc.expectedErr.Error())
+			}
 		})
 	}
 }

--- a/admin_setting_scim_group_mapping_integration_test.go
+++ b/admin_setting_scim_group_mapping_integration_test.go
@@ -55,8 +55,8 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 
 	t.Run("re-link after delete on same team", func(t *testing.T) {
 		teamID := createSingleTeam(t, client)
-		require.NoError(t, createSCIMGroupMapping(ctx, scimClient, teamID, scimGroups[0].ID))
-		require.NoError(t, deleteSCIMGroupMapping(ctx, scimClient, teamID))
+		require.NoError(t, scimClient.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroups[0].ID}))
+		require.NoError(t, scimClient.SCIMGroupMappings.Delete(ctx, teamID))
 		linkSCIMGroupMapping(ctx, t, scimClient, teamID, scimGroups[1].ID)
 
 		linkedTeam, err := client.Teams.Read(ctx, teamID)
@@ -71,8 +71,8 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 		name string
 		// setup returns the teamID and scimGroupID to use for the Create call.
 		setup func(t *testing.T) (teamID, scimGroupID string)
-		// nilOptions, when true, calls Create directly with nil options instead of
-		// going through the createSCIMGroupMapping wrapper.
+		// nilOptions, when true, calls Create with nil options to exercise the
+		// nil-options validation path.
 		nilOptions  bool
 		expectedErr error
 	}{
@@ -165,9 +165,9 @@ func TestAdminSCIMGroupMappings_Create(t *testing.T) {
 			if tc.nilOptions {
 				err = scimClient.SCIMGroupMappings.Create(ctx, teamID, nil)
 			} else {
-				err = createSCIMGroupMapping(ctx, scimClient, teamID, scimGroupID)
+				err = scimClient.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroupID})
 			}
-			require.EqualError(t, err, tc.expectedErr.Error())
+			require.ErrorContains(t, err, tc.expectedErr.Error())
 		})
 	}
 }
@@ -214,7 +214,7 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			name: "unpause sync",
 			setup: func(t *testing.T) string {
 				teamID := linkedTeamSetup(t)
-				require.NoError(t, updateSCIMGroupMapping(ctx, scimClient, teamID, &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)}))
+				require.NoError(t, scimClient.SCIMGroupMappings.Update(ctx, teamID, &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)}))
 				return teamID
 			},
 			options: &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(false)},
@@ -257,7 +257,7 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			name: "idempotent pause - already paused",
 			setup: func(t *testing.T) string {
 				teamID := linkedTeamSetup(t)
-				require.NoError(t, updateSCIMGroupMapping(ctx, scimClient, teamID, &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)}))
+				require.NoError(t, scimClient.SCIMGroupMappings.Update(ctx, teamID, &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)}))
 				return teamID
 			},
 			options: &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)},
@@ -283,8 +283,8 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			name: "team linked then unlinked",
 			setup: func(t *testing.T) string {
 				teamID := createSingleTeam(t, client)
-				require.NoError(t, createSCIMGroupMapping(ctx, scimClient, teamID, scimGroups[0].ID))
-				require.NoError(t, deleteSCIMGroupMapping(ctx, scimClient, teamID))
+				require.NoError(t, scimClient.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroups[0].ID}))
+				require.NoError(t, scimClient.SCIMGroupMappings.Delete(ctx, teamID))
 				return teamID
 			},
 			options:     &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)},
@@ -303,9 +303,9 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			teamID := tc.setup(t)
-			err := updateSCIMGroupMapping(ctx, scimClient, teamID, tc.options)
+			err := scimClient.SCIMGroupMappings.Update(ctx, teamID, tc.options)
 			if tc.shouldError {
-				require.EqualError(t, err, tc.expectedErr.Error())
+				require.ErrorContains(t, err, tc.expectedErr.Error())
 				return
 			}
 			require.NoError(t, err)
@@ -339,7 +339,7 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 			name: "unlink mapped team",
 			setup: func(t *testing.T) string {
 				teamID := createSingleTeam(t, client)
-				require.NoError(t, createSCIMGroupMapping(ctx, scimClient, teamID, scimGroups[0].ID))
+				require.NoError(t, scimClient.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroups[0].ID}))
 				return teamID
 			},
 			assertAfter: func(t *testing.T, teamID string) {
@@ -372,8 +372,8 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 			name: "delete after pause",
 			setup: func(t *testing.T) string {
 				teamID := createSingleTeam(t, client)
-				require.NoError(t, createSCIMGroupMapping(ctx, scimClient, teamID, scimGroups[0].ID))
-				require.NoError(t, updateSCIMGroupMapping(ctx, scimClient, teamID, &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)}))
+				require.NoError(t, scimClient.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: scimGroups[0].ID}))
+				require.NoError(t, scimClient.SCIMGroupMappings.Update(ctx, teamID, &AdminSCIMGroupMappingUpdateOptions{SCIMSyncPaused: Bool(true)}))
 				return teamID
 			},
 			assertAfter: func(t *testing.T, teamID string) {
@@ -389,9 +389,9 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
 			teamID := tc.setup(t)
-			err := deleteSCIMGroupMapping(ctx, scimClient, teamID)
+			err := scimClient.SCIMGroupMappings.Delete(ctx, teamID)
 			if tc.shouldError {
-				require.EqualError(t, err, tc.expectedErr.Error())
+				require.ErrorContains(t, err, tc.expectedErr.Error())
 				return
 			}
 			require.NoError(t, err)
@@ -402,35 +402,13 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 	}
 }
 
-// SCIM group mapping API wrappers. Sleep only for calls that are expected
-// to reach the API, so validation-only failures don't incur unnecessary
-// delay in test cases while still throttling real Create/Update/Delete
-// requests to avoid 429s. The delay is an empirically chosen stable value,
-// not a precise encoding of a specific requests-per-minute limit.
-
-// createSCIMGroupMapping links teamID to groupID.
-func createSCIMGroupMapping(ctx context.Context, scim *SCIMResource, teamID, groupID string) error {
-	return scim.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: groupID})
-}
-
-// updateSCIMGroupMapping updates the mapping for teamID with the provided options.
-func updateSCIMGroupMapping(ctx context.Context, scim *SCIMResource, teamID string, opts *AdminSCIMGroupMappingUpdateOptions) error {
-	return scim.SCIMGroupMappings.Update(ctx, teamID, opts)
-}
-
-// deleteSCIMGroupMapping unlinks any SCIM group mapping for teamID.
-func deleteSCIMGroupMapping(ctx context.Context, scim *SCIMResource, teamID string) error {
-	return scim.SCIMGroupMappings.Delete(ctx, teamID)
-}
-
 // linkSCIMGroupMapping links teamID to groupID, and registers a
 // cleanup function that deletes the mapping after the test finishes.
 func linkSCIMGroupMapping(ctx context.Context, t *testing.T, scim *SCIMResource, teamID, groupID string) {
 	t.Helper()
-	require.NoError(t, createSCIMGroupMapping(ctx, scim, teamID, groupID))
+	require.NoError(t, scim.SCIMGroupMappings.Create(ctx, teamID, &AdminSCIMGroupMappingCreateOptions{SCIMGroupID: groupID}))
 	t.Cleanup(func() {
-		err := deleteSCIMGroupMapping(ctx, scim, teamID)
-		require.NoError(t, err)
+		require.NoError(t, scim.SCIMGroupMappings.Delete(ctx, teamID))
 	})
 }
 

--- a/admin_setting_scim_group_mapping_integration_test.go
+++ b/admin_setting_scim_group_mapping_integration_test.go
@@ -314,7 +314,7 @@ func TestAdminSCIMGroupMappings_Update(t *testing.T) {
 			teamID := tc.setup(t)
 			err := scimClient.SCIMGroupMappings.Update(ctx, teamID, tc.options)
 			if tc.shouldError {
-				require.ErrorContains(t, err, tc.expectedErr.Error())
+				require.EqualError(t, err, tc.expectedErr.Error())
 				return
 			}
 			require.NoError(t, err)
@@ -400,7 +400,7 @@ func TestAdminSCIMGroupMappings_Delete(t *testing.T) {
 			teamID := tc.setup(t)
 			err := scimClient.SCIMGroupMappings.Delete(ctx, teamID)
 			if tc.shouldError {
-				require.ErrorContains(t, err, tc.expectedErr.Error())
+				require.EqualError(t, err, tc.expectedErr.Error())
 				return
 			}
 			require.NoError(t, err)

--- a/errors.go
+++ b/errors.go
@@ -97,19 +97,22 @@ var (
 	// for a team that is already mapped to a SCIM group.
 	ErrSCIMTeamAlreadyMapped = errors.New("conflict\n\nTeam is already linked to a SCIM group")
 
-	// ErrSCIMGroupMappingOwnersTeam is returned when attempting to link the owners team
-	// to a SCIM group, which is not yet supported. The HTTP status-code title is
-	// omitted from the message because different TFE releases may render it
-	// differently; pair with require.ErrorContains in tests. The leading capital
-	// matches the server's response verbatim so substring assertions work as-is.
+	// ErrSCIMGroupMappingOwnersTeam is the stable detail substring of the API error
+	// returned when attempting to link the owners team to a SCIM group. The HTTP
+	// status-code title (e.g., "unprocessable entity" vs "unprocessable content")
+	// varies across TFE releases, so the title is intentionally omitted and this
+	// value is meant for substring matching only — use require.ErrorContains, not
+	// errors.Is or require.EqualError. The leading capital matches the server's response verbatim.
 	//nolint:staticcheck // ST1005: server response begins with a capital letter; preserved for verbatim substring matching.
 	ErrSCIMGroupMappingOwnersTeam = errors.New("Owners team SCIM linking is not yet supported")
 
-	// ErrSCIMGroupMappingSiteAdminGroup is returned when attempting to link a team to the
-	// site admin SCIM group, which is not allowed. The HTTP status-code title is
-	// omitted from the message because different TFE releases may render it
-	// differently; pair with require.ErrorContains in tests. The leading capital
-	// matches the server's response verbatim so substring assertions work as-is.
+	// ErrSCIMGroupMappingSiteAdminGroup is the stable detail substring of the API error
+	// returned when attempting to link a team to the site admin SCIM group, which is
+	// not allowed. The HTTP status-code title (e.g., "unprocessable entity" vs
+	// "unprocessable content") varies across TFE releases, so the title is
+	// intentionally omitted and this value is meant for substring matching only —
+	// use require.ErrorContains, not errors.Is or require.EqualError. The leading
+	// capital matches the server's response verbatim.
 	//nolint:staticcheck // ST1005: server response begins with a capital letter; preserved for verbatim substring matching.
 	ErrSCIMGroupMappingSiteAdminGroup = errors.New("The site admin group cannot be linked to a team")
 

--- a/errors.go
+++ b/errors.go
@@ -98,12 +98,20 @@ var (
 	ErrSCIMTeamAlreadyMapped = errors.New("conflict\n\nTeam is already linked to a SCIM group")
 
 	// ErrSCIMGroupMappingOwnersTeam is returned when attempting to link the owners team
-	// to a SCIM group, which is not yet supported.
-	ErrSCIMGroupMappingOwnersTeam = errors.New("unprocessable entity\n\nOwners team SCIM linking is not yet supported")
+	// to a SCIM group, which is not yet supported. The HTTP status-code title is
+	// omitted from the message because different TFE releases may render it
+	// differently; pair with require.ErrorContains in tests. The leading capital
+	// matches the server's response verbatim so substring assertions work as-is.
+	//nolint:staticcheck // ST1005: server response begins with a capital letter; preserved for verbatim substring matching.
+	ErrSCIMGroupMappingOwnersTeam = errors.New("Owners team SCIM linking is not yet supported")
 
 	// ErrSCIMGroupMappingSiteAdminGroup is returned when attempting to link a team to the
-	// site admin SCIM group, which is not allowed.
-	ErrSCIMGroupMappingSiteAdminGroup = errors.New("unprocessable entity\n\nThe site admin group cannot be linked to a team")
+	// site admin SCIM group, which is not allowed. The HTTP status-code title is
+	// omitted from the message because different TFE releases may render it
+	// differently; pair with require.ErrorContains in tests. The leading capital
+	// matches the server's response verbatim so substring assertions work as-is.
+	//nolint:staticcheck // ST1005: server response begins with a capital letter; preserved for verbatim substring matching.
+	ErrSCIMGroupMappingSiteAdminGroup = errors.New("The site admin group cannot be linked to a team")
 
 	// ErrSCIMGroupMappingTeamNotLinked is returned when attempting to update a SCIM
 	// group mapping for a team that is not linked to a SCIM group.


### PR DESCRIPTION
## Description

This PR fixes integration test failures in `TestAdminSCIMGroupMappings_Create` from the `Nightly TFE tests`.
The [failures](https://github.com/hashicorp/go-tfe/actions/runs/25787328481/job/75745431598#step:4:7181) were caused by a mismatch in the `422` error title. In `v2.0.x`, the title is `"unprocessable entity"`, while a recent [Atlas change](https://github.com/hashicorp/atlas/pull/28061/changes) updated it to `"unprocessable content"`. This led to assertion failures due to exact error matching.
To make the tests resilient to such changes, this PR switches from `require.EqualError` to `require.ErrorContains` and removes reliance on the error title.
Additionally, this PR cleans up stale comments and removes redundant wrapper functions in the integration tests.


## Testing plan
Ran Integration Test on both `v2.0.1` and on main branch build

## External links
[JIRA](https://hashicorp.atlassian.net/browse/TF-35676)
[RFC](https://hermes-sharepoint.hashicorp.services/document/01XOO7K4IWFH44KZAPDJC3QXNKIRWEZMBA)

## Output from tests
Ran `ENABLE_TFE=1 envchain scim gotest -v -run "TestAdminSCIMGroupMappings_(Create|Update|Delete)"`

1. on `v2.0.1`
    <img width="709" height="851" alt="Untitled 2" src="https://github.com/user-attachments/assets/f6cbbbf4-e97e-44d0-bedf-246472206871" />

2. on main branch build
    <img width="909" height="968" alt="Untitled 2" src="https://github.com/user-attachments/assets/c0f0c0b6-b83c-42aa-9d13-40f257d500f0" />


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

we can revert this pr

## Changes to Security Controls

NA