### PR TITLE
ci: declare permissions on ci, create-jira-issue, jira-pr-transition, nightly-tfe-ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,9 @@ concurrency:
   group: ${{ github.head_ref || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     name: Lint

--- a/.github/workflows/create-jira-issue.yml
+++ b/.github/workflows/create-jira-issue.yml
@@ -6,6 +6,12 @@ on:
   issue_comment:
     types: [created]
 
+# Reusable Jira sync only reads issue metadata; writes go to Jira via the
+# inherited Jira API token secret.
+permissions:
+  contents: read
+  issues: read
+
 jobs:
   call-workflow:
     uses: hashicorp/terraform-provider-tfe/.github/workflows/jira-issue-sync.yml@main

--- a/.github/workflows/jira-pr-transition.yml
+++ b/.github/workflows/jira-pr-transition.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [opened, closed, reopened, converted_to_draft, ready_for_review]
 
+# Reusable Jira PR transition only reads PR metadata; Jira writes go via
+# the inherited Jira API token secret.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   call-workflow:
     uses: hashicorp/terraform-provider-tfe/.github/workflows/jira-pr-transition.yml@main

--- a/.github/workflows/nightly-tfe-ci.yml
+++ b/.github/workflows/nightly-tfe-ci.yml
@@ -5,6 +5,11 @@ on:
     # Monday-Friday at 7:30AM UTC (90 minutes after infrastructure rebuild)
     - cron: '30 7 * * 1-5'
 
+# TFE infra provisioning uses TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN; tests just
+# checkout + run go test.
+permissions:
+  contents: read
+
 jobs:
   instance:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Pins the default `GITHUB_TOKEN` for the four workflows still inheriting org defaults. The shared Jira sync reusables (`terraform-provider-tfe/.github/workflows/jira-{issue-sync,pr-transition}.yml@main`) and the nightly TFE provisioner each use their own dedicated secrets, so the GitHub token can stay read-only:

- `ci.yml` — `contents: read`. Lint + Go matrix tests.
- `create-jira-issue.yml` — `contents: read` + `issues: read`. Caller for the Jira issue sync reusable; Jira writes via the inherited Jira API token.
- `jira-pr-transition.yml` — `contents: read` + `pull-requests: read`. Same pattern for the PR transition reusable.
- `nightly-tfe-ci.yml` — `contents: read`. The Terraform Cloud apply step uses `TF_WORKFLOW_TFLOCAL_CLOUD_TFC_TOKEN`.

YAML validated with `yaml.safe_load`.