### PR TITLE
Add `FollowAPIRedirect` method for streaming redirect endpoint responses

### DIFF
--- a/adapter.go
+++ b/adapter.go
@@ -23,11 +23,11 @@ type TFERequestAdapter struct {
 }
 
 func NewHTTPClient(options []middleware.MiddlewareOption) (*nethttp.Client, error) {
-	middleware, err := middleware.GetForKiota(version, options...)
+	mw, err := middleware.GetForKiota(version, options...)
 	if err != nil {
 		return nil, err
 	}
-	httpClient := khttp.GetDefaultClient(middleware...)
+	httpClient := khttp.GetDefaultClient(mw...)
 	return httpClient, nil
 }
 

--- a/follow_redirect.go
+++ b/follow_redirect.go
@@ -13,11 +13,33 @@ import (
 
 const maxRedirectHops = 10
 
+// ErrRedirectLoop is returned when a redirect cycle is detected or the
+// maximum number of redirect hops is exceeded.
 var ErrRedirectLoop = errors.New("redirect loop detected")
 
+// FollowAPIRedirect follows the redirect chain from an API response until it
+// reaches the final response body, returning it as an io.ReadCloser. The caller
+// is responsible for closing the returned body and for limiting the amount of
+// data read (the response may be arbitrarily large).
+//
+// This is intended for API endpoints that return a 302 redirect to an Archivist
+// presigned URL, which may in turn issue a 307 redirect to a storage backend
+// (e.g., S3). The method intentionally does NOT reuse the client's own HTTP
+// transport or send the Authorization header on follow-up requests, because the
+// redirect targets are presigned URLs that are self-authenticating and must not
+// receive the bearer token.
+//
+// Returns ErrRedirectLoop if a cycle is detected or more than 10 hops occur.
+// Returns an error if the final response status is not 200.
 func (c *Client) FollowAPIRedirect(ctx context.Context, resp *http.Response) (io.ReadCloser, error) {
 	if resp == nil {
 		return nil, errors.New("response must not be nil")
+	}
+
+	httpClient := &http.Client{
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
 	}
 
 	visited := make(map[string]struct{})
@@ -53,12 +75,6 @@ func (c *Client) FollowAPIRedirect(ctx context.Context, resp *http.Response) (io
 		req, err := http.NewRequestWithContext(ctx, http.MethodGet, location, nil)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create redirect request: %w", err)
-		}
-
-		httpClient := &http.Client{
-			CheckRedirect: func(req *http.Request, via []*http.Request) error {
-				return http.ErrUseLastResponse
-			},
 		}
 
 		currentResp, err = httpClient.Do(req)

--- a/follow_redirect.go
+++ b/follow_redirect.go
@@ -1,0 +1,74 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+)
+
+const maxRedirectHops = 10
+
+var ErrRedirectLoop = errors.New("redirect loop detected")
+
+func (c *Client) FollowAPIRedirect(ctx context.Context, resp *http.Response) (io.ReadCloser, error) {
+	if resp == nil {
+		return nil, errors.New("response must not be nil")
+	}
+
+	visited := make(map[string]struct{})
+	currentResp := resp
+
+	for i := 0; i < maxRedirectHops; i++ {
+		if currentResp.StatusCode == http.StatusOK {
+			return currentResp.Body, nil
+		}
+
+		if currentResp.StatusCode != http.StatusFound &&
+			currentResp.StatusCode != http.StatusMovedPermanently &&
+			currentResp.StatusCode != http.StatusTemporaryRedirect &&
+			currentResp.StatusCode != http.StatusPermanentRedirect &&
+			currentResp.StatusCode != http.StatusSeeOther {
+			currentResp.Body.Close() //nolint:errcheck
+			return nil, fmt.Errorf("unexpected response status: %d", currentResp.StatusCode)
+		}
+
+		location := currentResp.Header.Get("Location")
+		if location == "" {
+			currentResp.Body.Close() //nolint:errcheck
+			return nil, errors.New("redirect response missing Location header")
+		}
+
+		currentResp.Body.Close() //nolint:errcheck
+
+		if _, ok := visited[location]; ok {
+			return nil, ErrRedirectLoop
+		}
+		visited[location] = struct{}{}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, location, nil)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create redirect request: %w", err)
+		}
+
+		httpClient := &http.Client{
+			CheckRedirect: func(req *http.Request, via []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+
+		currentResp, err = httpClient.Do(req)
+		if err != nil {
+			return nil, fmt.Errorf("failed to follow redirect: %w", err)
+		}
+	}
+
+	if currentResp != nil && currentResp.Body != nil {
+		currentResp.Body.Close() //nolint:errcheck
+	}
+	return nil, ErrRedirectLoop
+}

--- a/follow_redirect_test.go
+++ b/follow_redirect_test.go
@@ -1,0 +1,181 @@
+// Copyright IBM Corp. 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFollowAPIRedirect_SingleRedirect(t *testing.T) {
+	finalServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("hello from archivist")) //nolint:errcheck
+	}))
+	t.Cleanup(finalServer.Close)
+
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{finalServer.URL}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	client := &Client{}
+	body, err := client.FollowAPIRedirect(context.Background(), resp)
+	require.NoError(t, err)
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "hello from archivist", string(data))
+}
+
+func TestFollowAPIRedirect_TFEToArchivistToS3(t *testing.T) {
+	s3Server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("plan export content from s3")) //nolint:errcheck
+	}))
+	t.Cleanup(s3Server.Close)
+
+	archivistServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", s3Server.URL+"/bucket/object?X-Amz-Signature=abc123")
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(archivistServer.Close)
+
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{archivistServer.URL + "/v1/object/abc"}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	client := &Client{}
+	body, err := client.FollowAPIRedirect(context.Background(), resp)
+	require.NoError(t, err)
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "plan export content from s3", string(data))
+}
+
+func TestFollowAPIRedirect_ArchivistNoRedirect(t *testing.T) {
+	archivistServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("proxied content from archivist")) //nolint:errcheck
+	}))
+	t.Cleanup(archivistServer.Close)
+
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{archivistServer.URL + "/v1/object/abc"}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	client := &Client{}
+	body, err := client.FollowAPIRedirect(context.Background(), resp)
+	require.NoError(t, err)
+	defer body.Close()
+
+	data, err := io.ReadAll(body)
+	require.NoError(t, err)
+	assert.Equal(t, "proxied content from archivist", string(data))
+}
+
+func TestFollowAPIRedirect_RedirectLoop(t *testing.T) {
+	var serverA, serverB *httptest.Server
+
+	serverA = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", serverB.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(serverA.Close)
+
+	serverB = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Location", serverA.URL)
+		w.WriteHeader(http.StatusTemporaryRedirect)
+	}))
+	t.Cleanup(serverB.Close)
+
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{serverA.URL}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	client := &Client{}
+	_, err := client.FollowAPIRedirect(context.Background(), resp)
+	assert.ErrorIs(t, err, ErrRedirectLoop)
+}
+
+func TestFollowAPIRedirect_Non200FinalResponse(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	t.Cleanup(server.Close)
+
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{server.URL}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	client := &Client{}
+	_, err := client.FollowAPIRedirect(context.Background(), resp)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected response status: 403")
+}
+
+func TestFollowAPIRedirect_StreamingBody(t *testing.T) {
+	largeContent := strings.Repeat("x", 1024*1024)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(largeContent)) //nolint:errcheck
+	}))
+	t.Cleanup(server.Close)
+
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{server.URL}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	client := &Client{}
+	body, err := client.FollowAPIRedirect(context.Background(), resp)
+	require.NoError(t, err)
+	defer body.Close()
+
+	buf := make([]byte, 10)
+	n, err := body.Read(buf)
+	require.NoError(t, err)
+	assert.Equal(t, 10, n)
+	assert.Equal(t, "xxxxxxxxxx", string(buf))
+}
+
+func TestFollowAPIRedirect_NoAuthHeaderSent(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Empty(t, r.Header.Get("Authorization"))
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("ok")) //nolint:errcheck
+	}))
+	t.Cleanup(server.Close)
+
+	resp := &http.Response{
+		StatusCode: http.StatusFound,
+		Header:     http.Header{"Location": []string{server.URL}},
+		Body:       io.NopCloser(strings.NewReader("")),
+	}
+
+	client := &Client{token: "secret-token"}
+	body, err := client.FollowAPIRedirect(context.Background(), resp)
+	require.NoError(t, err)
+	body.Close()
+}

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.23.0
 toolchain go1.23.8
 
 require (
+	github.com/google/uuid v1.6.0
 	github.com/microsoft/kiota-abstractions-go v1.9.2
 	github.com/microsoft/kiota-http-go v1.5.3
 	github.com/microsoft/kiota-serialization-form-go v1.1.2
@@ -18,7 +19,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
-	github.com/google/uuid v1.6.0 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/std-uritemplate/std-uritemplate/go/v2 v2.0.3 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect

--- a/ip_ranges.go
+++ b/ip_ranges.go
@@ -50,7 +50,11 @@ func deserializeStringArray(n serialization.ParseNode) ([]string, error) {
 	if val != nil {
 		result := make([]string, len(val))
 		for i, v := range val {
-			result[i] = *v.(*string)
+			s, ok := v.(*string)
+			if !ok {
+				return nil, fmt.Errorf("unexpected type in string array at index %d", i)
+			}
+			result[i] = *s
 		}
 		return result, nil
 	}
@@ -94,7 +98,7 @@ func (m *IPRange) GetFieldDeserializers() map[string]func(serialization.ParseNod
 	}
 }
 
-func firstError(todo ...(func() error)) error {
+func firstError(todo ...func() error) error {
 	for _, fn := range todo {
 		if err := fn(); err != nil {
 			return err
@@ -158,6 +162,9 @@ func (i *ipRanges) Read(ctx context.Context, modifiedSince string) (*IPRange, er
 	if err != nil {
 		return nil, err
 	}
-	ir := resp.(*IPRange)
+	ir, ok := resp.(*IPRange)
+	if !ok {
+		return nil, fmt.Errorf("unexpected response type: %T", resp)
+	}
 	return ir, nil
 }


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description
Several API endpoints return a 302 redirect to Archivist. The generated client can't handle these because it uses `SendNoContent` (the OpenAPI spec doesn't define a body on 302 responses). This method gives SDK callers a supported way to follow those redirects and stream the content.

- Adds `Client.FollowAPIRedirect` which follows the redirect chain from TFE API endpoints that return 302 → Archivist (307) → S3 (200), returning the final body as an `io.ReadCloser` without buffering into memory
- Handles the case where Archivist proxies content directly (redirects disabled) as well as multi-hop presigned URL redirects
- Detects redirect loops and returns `tfe.ErrRedirectLoop` and returns an error on non-200 final status

## Testing plan
Tests use `httptest.NewServer` to simulate:
- Single redirect (TFE → Archivist proxied response)
- Real redirect chain (TFE 302 → Archivist 307 → S3 200)
- Redirect loop detection
- Non-200 final response error
- Streaming body (only reads 10 bytes of 1MB to prove no buffering)
- No Authorization header leaked to redirect targets

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

```
=== RUN   TestFollowAPIRedirect_SingleRedirect
--- PASS: TestFollowAPIRedirect_SingleRedirect (0.00s)
=== RUN   TestFollowAPIRedirect_TFEToArchivistToS3
--- PASS: TestFollowAPIRedirect_TFEToArchivistToS3 (0.00s)
=== RUN   TestFollowAPIRedirect_ArchivistNoRedirect
--- PASS: TestFollowAPIRedirect_ArchivistNoRedirect (0.00s)
=== RUN   TestFollowAPIRedirect_RedirectLoop
--- PASS: TestFollowAPIRedirect_RedirectLoop (0.00s)
=== RUN   TestFollowAPIRedirect_Non200FinalResponse
--- PASS: TestFollowAPIRedirect_Non200FinalResponse (0.00s)
=== RUN   TestFollowAPIRedirect_StreamingBody
--- PASS: TestFollowAPIRedirect_StreamingBody (0.00s)
=== RUN   TestFollowAPIRedirect_NoAuthHeaderSent
--- PASS: TestFollowAPIRedirect_NoAuthHeaderSent (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe	0.465s
```

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
