### PR TITLE
feat: TF-35806: Added BETA support for tag selectors on policy sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Add support for reading a registry provider by its unique identifier by  @mrinalirao [#1340](https://github.com/hashicorp/go-tfe/pull/1340)
 * Add `ProviderSet` resources with `Read`, `Update`, `Delete` and `Create` methods @mogrogan [#1346](https://github.com/hashicorp/go-tfe/pull/1346)
 * Adds `SourceModuleID` field to `Workspace` so callers can read the no-code source module identifier (e.g. `private/<org>/<name>/<provider>/<version>`) returned by the API by @a9logic [#1331](https://github.com/hashicorp/go-tfe/pull/1331)
+* Adds BETA support for tag selectors (inclusion/exclusion) on policy sets via `AddTagSelectors` and `RemoveTagSelectors` by @anubhav-goel [#1345](https://github.com/hashicorp/go-tfe/pull/1345)
 
 # v1.106.0
 

--- a/errors.go
+++ b/errors.go
@@ -193,6 +193,8 @@ var (
 
 	ErrInvalidPolicySetID = errors.New("invalid value for policy set ID")
 
+	ErrInvalidPolicySetScope = errors.New("invalid value for policy set scope")
+
 	ErrInvalidPolicyCheckID = errors.New("invalid value for policy check ID")
 
 	ErrInvalidPolicyEvaluationID = errors.New("invalid value for policy evaluation ID")

--- a/errors.go
+++ b/errors.go
@@ -193,8 +193,6 @@ var (
 
 	ErrInvalidPolicySetID = errors.New("invalid value for policy set ID")
 
-	ErrInvalidPolicySetScope = errors.New("invalid value for policy set scope")
-
 	ErrInvalidPolicyCheckID = errors.New("invalid value for policy check ID")
 
 	ErrInvalidPolicyEvaluationID = errors.New("invalid value for policy evaluation ID")
@@ -377,6 +375,10 @@ var (
 	ErrWorkspaceMinLimit = errors.New("must provide at least one workspace")
 
 	ErrProjectMinLimit = errors.New("must provide at least one project")
+
+	ErrRequiredTagSelectors = errors.New("tag selectors is required")
+
+	ErrTagSelectorMinLimit = errors.New("must provide at least one tag selector")
 
 	ErrRequiredPlan = errors.New("plan is required")
 

--- a/mocks/policy_set_mocks.go
+++ b/mocks/policy_set_mocks.go
@@ -82,6 +82,20 @@ func (mr *MockPolicySetsMockRecorder) AddProjects(ctx, policySetID, options any)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddProjects", reflect.TypeOf((*MockPolicySets)(nil).AddProjects), ctx, policySetID, options)
 }
 
+// AddTagSelectors mocks base method.
+func (m *MockPolicySets) AddTagSelectors(ctx context.Context, policySetID string, options tfe.PolicySetAddTagSelectorsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "AddTagSelectors", ctx, policySetID, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// AddTagSelectors indicates an expected call of AddTagSelectors.
+func (mr *MockPolicySetsMockRecorder) AddTagSelectors(ctx, policySetID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddTagSelectors", reflect.TypeOf((*MockPolicySets)(nil).AddTagSelectors), ctx, policySetID, options)
+}
+
 // AddWorkspaceExclusions mocks base method.
 func (m *MockPolicySets) AddWorkspaceExclusions(ctx context.Context, policySetID string, options tfe.PolicySetAddWorkspaceExclusionsOptions) error {
 	m.ctrl.T.Helper()
@@ -224,6 +238,20 @@ func (m *MockPolicySets) RemoveProjects(ctx context.Context, policySetID string,
 func (mr *MockPolicySetsMockRecorder) RemoveProjects(ctx, policySetID, options any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveProjects", reflect.TypeOf((*MockPolicySets)(nil).RemoveProjects), ctx, policySetID, options)
+}
+
+// RemoveTagSelectors mocks base method.
+func (m *MockPolicySets) RemoveTagSelectors(ctx context.Context, policySetID string, options tfe.PolicySetRemoveTagSelectorsOptions) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RemoveTagSelectors", ctx, policySetID, options)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// RemoveTagSelectors indicates an expected call of RemoveTagSelectors.
+func (mr *MockPolicySetsMockRecorder) RemoveTagSelectors(ctx, policySetID, options any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RemoveTagSelectors", reflect.TypeOf((*MockPolicySets)(nil).RemoveTagSelectors), ctx, policySetID, options)
 }
 
 // RemoveWorkspaceExclusions mocks base method.

--- a/policy_set.go
+++ b/policy_set.go
@@ -20,6 +20,7 @@ type PolicyKind string
 const (
 	OPA      PolicyKind = "opa"
 	Sentinel PolicyKind = "sentinel"
+	TFPolicy PolicyKind = "tfpolicy"
 )
 
 // PolicySets describes all the policy set related methods that the Terraform
@@ -76,6 +77,13 @@ type PolicySets interface {
 
 	// Delete a policy set by its ID.
 	Delete(ctx context.Context, policyID string) error
+
+	// Still in beta
+	// Add exclusion based on a specific tag to a policy set.
+	AddTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error
+
+	// Remove Tag Exclusion
+	RemoveTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error
 }
 
 // policySets implements PolicySets.
@@ -228,6 +236,9 @@ type PolicySetCreateOptions struct {
 
 	// Optional: The initial list of project exclusions for which the policy set should be enforced.
 	ProjectExclusions []*Project `jsonapi:"relation,project-exclusions,omitempty"`
+
+	// Optional: A list of tag selectors for enforcement/exclusion based on tags
+	TagSelectors []*PolicySetTagSelectors `jsonapi:"relation,tag-selectors,omitempty"`
 }
 
 // PolicySetUpdateOptions represents the options for updating a policy set.
@@ -338,6 +349,16 @@ type PolicySetAddProjectsOptions struct {
 type PolicySetRemoveProjectsOptions struct {
 	// The projects to remove from the policy set.
 	Projects []*Project
+}
+
+type PolicySetAddTagExclusionsOptions struct {
+	Tags []*PolicySetTagSelectors
+}
+
+type PolicySetTagSelectors struct {
+	Key       string `jsonapi:"attr,key"`
+	Value     string `jsonapi:"attr,value,omitempty"`
+	IsExclude bool   `jsonapi:"attr,is-exclude"`
 }
 
 // List all the policies for a given organization.
@@ -612,6 +633,36 @@ func (s *policySets) RemoveProjectExclusions(ctx context.Context, policySetID st
 
 	u := fmt.Sprintf("policy-sets/%s/relationships/project-exclusions", url.PathEscape(policySetID))
 	req, err := s.client.NewRequest("DELETE", u, options.ProjectExclusions)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// AddTagExclusion implements [
+func (s *policySets) AddTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error {
+	if !validStringID(&policySetID) {
+		return ErrInvalidPolicySetID
+	}
+
+	u := fmt.Sprintf("/policy-sets/%s/tag-selectors", url.PathEscape(policySetID))
+	req, err := s.client.NewRequest("POST", u, options.Tags)
+	if err != nil {
+		return err
+	}
+
+	return req.Do(ctx, nil)
+}
+
+// RemoveTagExclusion implements [PolicySets].
+func (s *policySets) RemoveTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error {
+	if !validStringID(&policySetID) {
+		return ErrInvalidPolicySetID
+	}
+
+	u := fmt.Sprintf("/policy-sets/%s/remove-tag-selectors", url.PathEscape(policySetID))
+	req, err := s.client.NewRequest("DELETE", u, options.Tags)
 	if err != nil {
 		return err
 	}

--- a/policy_set.go
+++ b/policy_set.go
@@ -244,8 +244,8 @@ type PolicySetCreateOptions struct {
 	// Optional: The initial list of project exclusions for which the policy set should be enforced.
 	ProjectExclusions []*Project `jsonapi:"relation,project-exclusions,omitempty"`
 
-	// Optional: A list of tag selectors for enforcement/exclusion based on tags
-	TagSelectors []*PolicySetTagSelectors `jsonapi:"relation,tag-selectors,omitempty"`
+	// BETA: Optional: A list of tag selectors for enforcement/exclusion based on tags
+	TagSelectors []*PolicySetTagSelector `jsonapi:"attr,tag-selectors,omitempty"`
 }
 
 // PolicySetUpdateOptions represents the options for updating a policy set.
@@ -362,14 +362,14 @@ type PolicySetRemoveProjectsOptions struct {
 // tag selectors to a policy set.
 type PolicySetAddTagSelectorsOptions struct {
 	// The tag selectors to add to the policy set.
-	TagSelectors []*PolicySetTagSelectors
+	TagSelectors []*PolicySetTagSelector
 }
 
 // PolicySetRemoveTagSelectorsOptions represents the options for removing
 // tag selectors from a policy set.
 type PolicySetRemoveTagSelectorsOptions struct {
 	// The tag selectors to remove from the policy set.
-	TagSelectors []*PolicySetTagSelectors
+	TagSelectors []*PolicySetTagSelector
 }
 
 // PolicySetTagSelectors represents a tag selector for a policy set.
@@ -378,7 +378,7 @@ type PolicySetRemoveTagSelectorsOptions struct {
 // The IsExclude field determines the behavior: false means inclusion,
 // true means exclusion. For tags that have only a key and no value,
 // set Value to nil.
-type PolicySetTagSelectors struct {
+type PolicySetTagSelector struct {
 	Key       string  `json:"tag-key"`
 	Value     *string `json:"tag-value"`
 	IsExclude bool    `json:"is-exclude"`
@@ -387,7 +387,7 @@ type PolicySetTagSelectors struct {
 // policySetTagSelectorsRequest is the wire format for the tag-selectors
 // POST and DELETE endpoints, which expect {"data": [...]}.
 type policySetTagSelectorsRequest struct {
-	Data []*PolicySetTagSelectors `json:"data"`
+	Data []*PolicySetTagSelector `json:"data"`
 }
 
 // List all the policies for a given organization.

--- a/policy_set.go
+++ b/policy_set.go
@@ -20,7 +20,6 @@ type PolicyKind string
 const (
 	OPA      PolicyKind = "opa"
 	Sentinel PolicyKind = "sentinel"
-	TFPolicy PolicyKind = "tfpolicy"
 )
 
 // PolicySets describes all the policy set related methods that the Terraform
@@ -78,12 +77,11 @@ type PolicySets interface {
 	// Delete a policy set by its ID.
 	Delete(ctx context.Context, policyID string) error
 
-	// Still in beta
-	// Add exclusion based on a specific tag to a policy set.
-	AddTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error
+	// BETA: AddTagSelectors adds tag selectors (i.e. tag inclusion / exclusion) to a policy set.
+	AddTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagSelectorsOptions) error
 
-	// Remove Tag Exclusion
-	RemoveTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error
+	// BETA: RemoveTagSelectors removes tag selectors (i.e. tag inclusion / exclusion) from a policy set.
+	RemoveTagSelectors(ctx context.Context, policySetID string, options PolicySetRemoveTagSelectorsOptions) error
 }
 
 // policySets implements PolicySets.
@@ -117,6 +115,8 @@ type PolicySet struct {
 	PolicyToolVersion string    `jsonapi:"attr,policy-tool-version"`
 
 	PolicyUpdatePatterns []string `jsonapi:"attr,policy-update-patterns"`
+	// BETA: The tag selectors for this policy set.
+	TagSelectors []*PolicySetTagSelectorAttr `jsonapi:"attr,tag-selectors"`
 
 	// Relations
 	// The organization to which the policy set belongs to.
@@ -137,6 +137,13 @@ type PolicySet struct {
 	Projects []*Project `jsonapi:"relation,projects"`
 	// The project exclusions to which the policy set applies.
 	ProjectExclusions []*Project `jsonapi:"relation,project-exclusions"`
+}
+
+// PolicySetTagSelectorAttr represents a tag selector as returned by the read API.
+type PolicySetTagSelectorAttr struct {
+	Key       string  `jsonapi:"attr,tag-key"`
+	Value     *string `jsonapi:"attr,tag-value"`
+	IsExclude bool    `jsonapi:"attr,is-exclude"`
 }
 
 // PolicySetIncludeOpt represents the available options for include query params.
@@ -351,14 +358,36 @@ type PolicySetRemoveProjectsOptions struct {
 	Projects []*Project
 }
 
-type PolicySetAddTagExclusionsOptions struct {
-	Tags []*PolicySetTagSelectors
+// PolicySetAddTagSelectorsOptions represents the options for adding
+// tag selectors to a policy set.
+type PolicySetAddTagSelectorsOptions struct {
+	// The tag selectors to add to the policy set.
+	TagSelectors []*PolicySetTagSelectors
 }
 
+// PolicySetRemoveTagSelectorsOptions represents the options for removing
+// tag selectors from a policy set.
+type PolicySetRemoveTagSelectorsOptions struct {
+	// The tag selectors to remove from the policy set.
+	TagSelectors []*PolicySetTagSelectors
+}
+
+// PolicySetTagSelectors represents a tag selector for a policy set.
+// Tag selectors control whether a policy set applies to (includes) or
+// is exempted from (excludes) workspaces that carry a matching tag.
+// The IsExclude field determines the behavior: false means inclusion,
+// true means exclusion. For tags that have only a key and no value,
+// set Value to nil.
 type PolicySetTagSelectors struct {
-	Key       string `jsonapi:"attr,key"`
-	Value     string `jsonapi:"attr,value,omitempty"`
-	IsExclude bool   `jsonapi:"attr,is-exclude"`
+	Key       string  `json:"tag-key"`
+	Value     *string `json:"tag-value"`
+	IsExclude bool    `json:"is-exclude"`
+}
+
+// policySetTagSelectorsRequest is the wire format for the tag-selectors
+// POST and DELETE endpoints, which expect {"data": [...]}.
+type policySetTagSelectorsRequest struct {
+	Data []*PolicySetTagSelectors `json:"data"`
 }
 
 // List all the policies for a given organization.
@@ -640,14 +669,17 @@ func (s *policySets) RemoveProjectExclusions(ctx context.Context, policySetID st
 	return req.Do(ctx, nil)
 }
 
-// AddTagExclusion implements [
-func (s *policySets) AddTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error {
+// BETA: AddTagSelectors adds tag selectors to a policy set.
+func (s *policySets) AddTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagSelectorsOptions) error {
 	if !validStringID(&policySetID) {
 		return ErrInvalidPolicySetID
 	}
+	if err := options.valid(); err != nil {
+		return err
+	}
 
-	u := fmt.Sprintf("/policy-sets/%s/tag-selectors", url.PathEscape(policySetID))
-	req, err := s.client.NewRequest("POST", u, options.Tags)
+	u := fmt.Sprintf("policy-sets/%s/tag-selectors", url.PathEscape(policySetID))
+	req, err := s.client.NewRequest("POST", u, &policySetTagSelectorsRequest{Data: options.TagSelectors})
 	if err != nil {
 		return err
 	}
@@ -655,14 +687,17 @@ func (s *policySets) AddTagSelectors(ctx context.Context, policySetID string, op
 	return req.Do(ctx, nil)
 }
 
-// RemoveTagExclusion implements [PolicySets].
-func (s *policySets) RemoveTagSelectors(ctx context.Context, policySetID string, options PolicySetAddTagExclusionsOptions) error {
+// BETA: RemoveTagSelectors removes tag selectors from a policy set.
+func (s *policySets) RemoveTagSelectors(ctx context.Context, policySetID string, options PolicySetRemoveTagSelectorsOptions) error {
 	if !validStringID(&policySetID) {
 		return ErrInvalidPolicySetID
 	}
+	if err := options.valid(); err != nil {
+		return err
+	}
 
-	u := fmt.Sprintf("/policy-sets/%s/remove-tag-selectors", url.PathEscape(policySetID))
-	req, err := s.client.NewRequest("DELETE", u, options.Tags)
+	u := fmt.Sprintf("policy-sets/%s/tag-selectors", url.PathEscape(policySetID))
+	req, err := s.client.NewRequest("DELETE", u, &policySetTagSelectorsRequest{Data: options.TagSelectors})
 	if err != nil {
 		return err
 	}
@@ -798,6 +833,26 @@ func (o PolicySetRemoveProjectExclusionsOptions) valid() error {
 	}
 	if len(o.ProjectExclusions) == 0 {
 		return ErrProjectMinLimit
+	}
+	return nil
+}
+
+func (o PolicySetAddTagSelectorsOptions) valid() error {
+	if o.TagSelectors == nil {
+		return ErrRequiredTagSelectors
+	}
+	if len(o.TagSelectors) == 0 {
+		return ErrTagSelectorMinLimit
+	}
+	return nil
+}
+
+func (o PolicySetRemoveTagSelectorsOptions) valid() error {
+	if o.TagSelectors == nil {
+		return ErrRequiredTagSelectors
+	}
+	if len(o.TagSelectors) == 0 {
+		return ErrTagSelectorMinLimit
 	}
 	return nil
 }

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -1503,7 +1503,7 @@ func TestPolicySetsAddTagSelectors(t *testing.T) {
 			ctx,
 			psTest.ID,
 			PolicySetAddTagSelectorsOptions{
-				TagSelectors: []*PolicySetTagSelectors{
+				TagSelectors: []*PolicySetTagSelector{
 					{Key: "env", Value: String("prod"), IsExclude: true},
 					{Key: "team", Value: nil, IsExclude: true},
 				},
@@ -1551,7 +1551,7 @@ func TestPolicySetsAddTagSelectors(t *testing.T) {
 			ctx,
 			psTest.ID,
 			PolicySetAddTagSelectorsOptions{
-				TagSelectors: []*PolicySetTagSelectors{
+				TagSelectors: []*PolicySetTagSelector{
 					{Key: "env", Value: String("staging"), IsExclude: false},
 					{Key: "region", Value: nil, IsExclude: false},
 				},
@@ -1597,7 +1597,7 @@ func TestPolicySetsAddTagSelectors(t *testing.T) {
 		err := client.PolicySets.AddTagSelectors(
 			ctx,
 			psTest.ID,
-			PolicySetAddTagSelectorsOptions{TagSelectors: []*PolicySetTagSelectors{}},
+			PolicySetAddTagSelectorsOptions{TagSelectors: []*PolicySetTagSelector{}},
 		)
 		assert.Equal(t, err, ErrTagSelectorMinLimit)
 	})
@@ -1607,7 +1607,7 @@ func TestPolicySetsAddTagSelectors(t *testing.T) {
 			ctx,
 			badIdentifier,
 			PolicySetAddTagSelectorsOptions{
-				TagSelectors: []*PolicySetTagSelectors{
+				TagSelectors: []*PolicySetTagSelector{
 					{Key: "env", Value: String("prod"), IsExclude: true},
 				},
 			},
@@ -1648,7 +1648,7 @@ func TestPolicySetsRemoveTagSelectors(t *testing.T) {
 			ctx,
 			psTest.ID,
 			PolicySetAddTagSelectorsOptions{
-				TagSelectors: []*PolicySetTagSelectors{
+				TagSelectors: []*PolicySetTagSelector{
 					{Key: "env", Value: String("prod"), IsExclude: true},
 					{Key: "team", Value: nil, IsExclude: true},
 				},
@@ -1660,7 +1660,7 @@ func TestPolicySetsRemoveTagSelectors(t *testing.T) {
 			ctx,
 			psTest.ID,
 			PolicySetRemoveTagSelectorsOptions{
-				TagSelectors: []*PolicySetTagSelectors{
+				TagSelectors: []*PolicySetTagSelector{
 					{Key: "env", Value: String("prod"), IsExclude: true},
 					{Key: "team", Value: nil, IsExclude: true},
 				},
@@ -1693,7 +1693,7 @@ func TestPolicySetsRemoveTagSelectors(t *testing.T) {
 		err := client.PolicySets.RemoveTagSelectors(
 			ctx,
 			psTest.ID,
-			PolicySetRemoveTagSelectorsOptions{TagSelectors: []*PolicySetTagSelectors{}},
+			PolicySetRemoveTagSelectorsOptions{TagSelectors: []*PolicySetTagSelector{}},
 		)
 		assert.Equal(t, err, ErrTagSelectorMinLimit)
 	})
@@ -1703,11 +1703,67 @@ func TestPolicySetsRemoveTagSelectors(t *testing.T) {
 			ctx,
 			badIdentifier,
 			PolicySetRemoveTagSelectorsOptions{
-				TagSelectors: []*PolicySetTagSelectors{
+				TagSelectors: []*PolicySetTagSelector{
 					{Key: "env", Value: String("prod"), IsExclude: true},
 				},
 			},
 		)
 		assert.Equal(t, err, ErrInvalidPolicySetID)
+	})
+}
+
+func TestPolicySetsCreateWithTagSelectors(t *testing.T) {
+	skipUnlessBeta(t)
+	t.Parallel()
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
+
+	t.Run("with tag selectors on non-global policy set", func(t *testing.T) {
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		defer wTestCleanup()
+
+		_, err := client.Workspaces.AddTagBindings(ctx, wTest.ID, WorkspaceAddTagBindingsOptions{
+			TagBindings: []*TagBinding{
+				{Key: "env", Value: "prod"},
+				{Key: "team"},
+			},
+		})
+		require.NoError(t, err)
+
+		options := PolicySetCreateOptions{
+			Name:   String("tag-selector-policy-set"),
+			Kind:   OPA,
+			Global: Bool(false),
+			TagSelectors: []*PolicySetTagSelector{
+				{Key: "env", Value: String("prod"), IsExclude: false},
+				{Key: "team", Value: nil, IsExclude: false},
+			},
+		}
+
+		ps, err := client.PolicySets.Create(ctx, orgTest.Name, options)
+		require.NoError(t, err)
+
+		psRead, err := client.PolicySets.Read(ctx, ps.ID)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(psRead.TagSelectors))
+
+		selectorsByKey := map[string]*PolicySetTagSelectorAttr{}
+		for _, ts := range psRead.TagSelectors {
+			selectorsByKey[ts.Key] = ts
+		}
+
+		require.Contains(t, selectorsByKey, "env")
+		require.Contains(t, selectorsByKey, "team")
+
+		assert.Equal(t, "prod", *selectorsByKey["env"].Value)
+		assert.False(t, selectorsByKey["env"].IsExclude)
+
+		assert.Nil(t, selectorsByKey["team"].Value)
+		assert.False(t, selectorsByKey["team"].IsExclude)
 	})
 }

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -1472,15 +1472,15 @@ func TestPolicySetsDelete(t *testing.T) {
 }
 
 func TestPolicySetsAddTagSelectors(t *testing.T) {
-	t.Parallel()
 	skipUnlessBeta(t)
+	t.Parallel()
 	client := testClient(t)
 	ctx := context.Background()
 
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	// upgradeOrganizationSubscription(t, client, orgTest)
+	upgradeOrganizationSubscription(t, client, orgTest)
 
 	t.Run("with exclusion tag selectors on global policy set", func(t *testing.T) {
 		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
@@ -1617,8 +1617,8 @@ func TestPolicySetsAddTagSelectors(t *testing.T) {
 }
 
 func TestPolicySetsRemoveTagSelectors(t *testing.T) {
-	t.Parallel()
 	skipUnlessBeta(t)
+	t.Parallel()
 	client := testClient(t)
 	ctx := context.Background()
 

--- a/policy_set_integration_test.go
+++ b/policy_set_integration_test.go
@@ -1470,3 +1470,244 @@ func TestPolicySetsDelete(t *testing.T) {
 		assert.Equal(t, err, ErrInvalidPolicySetID)
 	})
 }
+
+func TestPolicySetsAddTagSelectors(t *testing.T) {
+	t.Parallel()
+	skipUnlessBeta(t)
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	// upgradeOrganizationSubscription(t, client, orgTest)
+
+	t.Run("with exclusion tag selectors on global policy set", func(t *testing.T) {
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		defer wTestCleanup()
+
+		_, err := client.Workspaces.AddTagBindings(ctx, wTest.ID, WorkspaceAddTagBindingsOptions{
+			TagBindings: []*TagBinding{
+				{Key: "env", Value: "prod"},
+				{Key: "team"},
+			},
+		})
+		require.NoError(t, err)
+
+		psTest, psTestCleanup := createPolicySetWithOptions(t, client, orgTest, nil, nil, nil, nil, PolicySetCreateOptions{
+			Global: Bool(true),
+		})
+		defer psTestCleanup()
+
+		err = client.PolicySets.AddTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetAddTagSelectorsOptions{
+				TagSelectors: []*PolicySetTagSelectors{
+					{Key: "env", Value: String("prod"), IsExclude: true},
+					{Key: "team", Value: nil, IsExclude: true},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		ps, err := client.PolicySets.Read(ctx, psTest.ID)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(ps.TagSelectors))
+
+		selectorsByKey := map[string]*PolicySetTagSelectorAttr{}
+		for _, ts := range ps.TagSelectors {
+			selectorsByKey[ts.Key] = ts
+		}
+
+		require.Contains(t, selectorsByKey, "env")
+		require.Contains(t, selectorsByKey, "team")
+
+		assert.Equal(t, "prod", *selectorsByKey["env"].Value)
+		assert.True(t, selectorsByKey["env"].IsExclude)
+
+		assert.Nil(t, selectorsByKey["team"].Value)
+		assert.True(t, selectorsByKey["team"].IsExclude)
+	})
+
+	t.Run("with inclusion tag selectors on non-global policy set", func(t *testing.T) {
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		defer wTestCleanup()
+
+		_, err := client.Workspaces.AddTagBindings(ctx, wTest.ID, WorkspaceAddTagBindingsOptions{
+			TagBindings: []*TagBinding{
+				{Key: "env", Value: "staging"},
+				{Key: "region"},
+			},
+		})
+		require.NoError(t, err)
+
+		psTest, psTestCleanup := createPolicySetWithOptions(t, client, orgTest, nil, nil, nil, nil, PolicySetCreateOptions{
+			Global: Bool(false),
+		})
+		defer psTestCleanup()
+
+		err = client.PolicySets.AddTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetAddTagSelectorsOptions{
+				TagSelectors: []*PolicySetTagSelectors{
+					{Key: "env", Value: String("staging"), IsExclude: false},
+					{Key: "region", Value: nil, IsExclude: false},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		ps, err := client.PolicySets.Read(ctx, psTest.ID)
+		require.NoError(t, err)
+		require.Equal(t, 2, len(ps.TagSelectors))
+
+		selectorsByKey := map[string]*PolicySetTagSelectorAttr{}
+		for _, ts := range ps.TagSelectors {
+			selectorsByKey[ts.Key] = ts
+		}
+
+		require.Contains(t, selectorsByKey, "env")
+		require.Contains(t, selectorsByKey, "region")
+
+		assert.Equal(t, "staging", *selectorsByKey["env"].Value)
+		assert.False(t, selectorsByKey["env"].IsExclude)
+
+		assert.Nil(t, selectorsByKey["region"].Value)
+		assert.False(t, selectorsByKey["region"].IsExclude)
+	})
+
+	t.Run("without tag selectors provided", func(t *testing.T) {
+		psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, nil, "")
+		defer psTestCleanup()
+
+		err := client.PolicySets.AddTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetAddTagSelectorsOptions{},
+		)
+		assert.Equal(t, err, ErrRequiredTagSelectors)
+	})
+
+	t.Run("with empty tag selectors slice", func(t *testing.T) {
+		psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, nil, "")
+		defer psTestCleanup()
+
+		err := client.PolicySets.AddTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetAddTagSelectorsOptions{TagSelectors: []*PolicySetTagSelectors{}},
+		)
+		assert.Equal(t, err, ErrTagSelectorMinLimit)
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.AddTagSelectors(
+			ctx,
+			badIdentifier,
+			PolicySetAddTagSelectorsOptions{
+				TagSelectors: []*PolicySetTagSelectors{
+					{Key: "env", Value: String("prod"), IsExclude: true},
+				},
+			},
+		)
+		assert.Equal(t, err, ErrInvalidPolicySetID)
+	})
+}
+
+func TestPolicySetsRemoveTagSelectors(t *testing.T) {
+	t.Parallel()
+	skipUnlessBeta(t)
+	client := testClient(t)
+	ctx := context.Background()
+
+	orgTest, orgTestCleanup := createOrganization(t, client)
+	defer orgTestCleanup()
+
+	upgradeOrganizationSubscription(t, client, orgTest)
+
+	t.Run("with tag selectors provided", func(t *testing.T) {
+		wTest, wTestCleanup := createWorkspace(t, client, orgTest)
+		defer wTestCleanup()
+
+		_, err := client.Workspaces.AddTagBindings(ctx, wTest.ID, WorkspaceAddTagBindingsOptions{
+			TagBindings: []*TagBinding{
+				{Key: "env", Value: "prod"},
+				{Key: "team"},
+			},
+		})
+		require.NoError(t, err)
+
+		psTest, psTestCleanup := createPolicySetWithOptions(t, client, orgTest, nil, nil, nil, nil, PolicySetCreateOptions{
+			Global: Bool(true),
+		})
+		defer psTestCleanup()
+
+		err = client.PolicySets.AddTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetAddTagSelectorsOptions{
+				TagSelectors: []*PolicySetTagSelectors{
+					{Key: "env", Value: String("prod"), IsExclude: true},
+					{Key: "team", Value: nil, IsExclude: true},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		err = client.PolicySets.RemoveTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetRemoveTagSelectorsOptions{
+				TagSelectors: []*PolicySetTagSelectors{
+					{Key: "env", Value: String("prod"), IsExclude: true},
+					{Key: "team", Value: nil, IsExclude: true},
+				},
+			},
+		)
+		require.NoError(t, err)
+
+		ps, err := client.PolicySets.Read(ctx, psTest.ID)
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(ps.TagSelectors))
+		assert.Empty(t, ps.TagSelectors)
+	})
+
+	t.Run("without tag selectors provided", func(t *testing.T) {
+		psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, nil, "")
+		defer psTestCleanup()
+
+		err := client.PolicySets.RemoveTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetRemoveTagSelectorsOptions{},
+		)
+		assert.Equal(t, err, ErrRequiredTagSelectors)
+	})
+
+	t.Run("with empty tag selectors slice", func(t *testing.T) {
+		psTest, psTestCleanup := createPolicySet(t, client, orgTest, nil, nil, nil, nil, "")
+		defer psTestCleanup()
+
+		err := client.PolicySets.RemoveTagSelectors(
+			ctx,
+			psTest.ID,
+			PolicySetRemoveTagSelectorsOptions{TagSelectors: []*PolicySetTagSelectors{}},
+		)
+		assert.Equal(t, err, ErrTagSelectorMinLimit)
+	})
+
+	t.Run("without a valid ID", func(t *testing.T) {
+		err := client.PolicySets.RemoveTagSelectors(
+			ctx,
+			badIdentifier,
+			PolicySetRemoveTagSelectorsOptions{
+				TagSelectors: []*PolicySetTagSelectors{
+					{Key: "env", Value: String("prod"), IsExclude: true},
+				},
+			},
+		)
+		assert.Equal(t, err, ErrInvalidPolicySetID)
+	})
+}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Adds BETA support for tag selectors (inclusion/exclusion) on policy sets via AddTagSelectors and RemoveTagSelectors. Tag selectors allow scoping policy sets to workspaces based on tags.

The PolicySet struct now includes a TagSelectors field, so existing Read calls automatically return any tag selectors associated with a policy set.

#### Interface / Function additions
- `AddTagSelectors(ctx, policySetID, options)`: POST to `policy-sets/:id/tag-selectors`
- `RemoveTagSelectors(ctx, policySetID, options)`: DELETE to `policy-sets/:id/tag-selectors`

#### PolicySet struct
- Added `TagSelectors []*PolicySetTagSelectorAttr` field with `jsonapi:"attr,tag-selectors"` tag

#### Errors
- `ErrRequiredTagSelectors`: nil tag selectors
- `ErrTagSelectorMinLimit`: empty tag selectors slice

#### Integration tests
- `TestPolicySetsAddTagSelectors`: global exclusion + non-global inclusion subtests, plus error cases (nil options, empty slice, bad ID)
- `TestPolicySetsRemoveTagSelectors`: add, then remove round trip, plus error cases

## Testing plan
<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

1. Create a local instance of atlas
2. Create a admin token
3. Execute the following:
```
export TFE_ADDRESS="https://anubhavgoel.ngrok.app"
export TFE_TOKEN="<token>"
export ENABLE_BETA=1
go test -v -run 'TestPolicySetsAddTagSelectors|TestPolicySetsRemoveTagSelectors|TestPolicySetsCreateWithTagSelectors' ./...
```

## Output from tests
```
=== RUN   TestPolicySetsAddTagSelectors
=== PAUSE TestPolicySetsAddTagSelectors
=== RUN   TestPolicySetsRemoveTagSelectors
=== PAUSE TestPolicySetsRemoveTagSelectors
=== RUN   TestPolicySetsCreateWithTagSelectors
=== PAUSE TestPolicySetsCreateWithTagSelectors
=== CONT  TestPolicySetsAddTagSelectors
=== CONT  TestPolicySetsCreateWithTagSelectors
=== CONT  TestPolicySetsRemoveTagSelectors
=== RUN   TestPolicySetsRemoveTagSelectors/with_tag_selectors_provided
=== RUN   TestPolicySetsAddTagSelectors/with_exclusion_tag_selectors_on_global_policy_set
=== RUN   TestPolicySetsCreateWithTagSelectors/with_tag_selectors_on_non-global_policy_set
--- PASS: TestPolicySetsCreateWithTagSelectors (1.21s)
    --- PASS: TestPolicySetsCreateWithTagSelectors/with_tag_selectors_on_non-global_policy_set (0.67s)
=== RUN   TestPolicySetsAddTagSelectors/with_inclusion_tag_selectors_on_non-global_policy_set
=== RUN   TestPolicySetsRemoveTagSelectors/without_tag_selectors_provided
=== RUN   TestPolicySetsRemoveTagSelectors/with_empty_tag_selectors_slice
=== RUN   TestPolicySetsRemoveTagSelectors/without_a_valid_ID
--- PASS: TestPolicySetsRemoveTagSelectors (1.67s)
    --- PASS: TestPolicySetsRemoveTagSelectors/with_tag_selectors_provided (0.87s)
    --- PASS: TestPolicySetsRemoveTagSelectors/without_tag_selectors_provided (0.15s)
    --- PASS: TestPolicySetsRemoveTagSelectors/with_empty_tag_selectors_slice (0.14s)
    --- PASS: TestPolicySetsRemoveTagSelectors/without_a_valid_ID (0.00s)
=== RUN   TestPolicySetsAddTagSelectors/without_tag_selectors_provided
=== RUN   TestPolicySetsAddTagSelectors/with_empty_tag_selectors_slice
=== RUN   TestPolicySetsAddTagSelectors/without_a_valid_ID
--- PASS: TestPolicySetsAddTagSelectors (2.05s)
    --- PASS: TestPolicySetsAddTagSelectors/with_exclusion_tag_selectors_on_global_policy_set (0.85s)
    --- PASS: TestPolicySetsAddTagSelectors/with_inclusion_tag_selectors_on_non-global_policy_set (0.47s)
    --- PASS: TestPolicySetsAddTagSelectors/without_tag_selectors_provided (0.13s)
    --- PASS: TestPolicySetsAddTagSelectors/with_empty_tag_selectors_slice (0.12s)
    --- PASS: TestPolicySetsAddTagSelectors/without_a_valid_ID (0.00s)
PASS
ok      github.com/hashicorp/go-tfe     2.639s
?       github.com/hashicorp/go-tfe/examples/backing_data       [no test files]
?       github.com/hashicorp/go-tfe/examples/configuration_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/organizations      [no test files]
?       github.com/hashicorp/go-tfe/examples/projects   [no test files]
?       github.com/hashicorp/go-tfe/examples/registry_modules   [no test files]
?       github.com/hashicorp/go-tfe/examples/run_errors [no test files]
?       github.com/hashicorp/go-tfe/examples/state_versions     [no test files]
?       github.com/hashicorp/go-tfe/examples/users      [no test files]
?       github.com/hashicorp/go-tfe/examples/workspaces [no test files]
?       github.com/hashicorp/go-tfe/mocks       [no test files]
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
