### PR TITLE
Skip test for beta feature

### DIFF
--- a/registry_provider_integration_test.go
+++ b/registry_provider_integration_test.go
@@ -342,6 +342,7 @@ func TestRegistryProvidersRead(t *testing.T) {
 			})
 
 			t.Run("with a unique ID field for the provider", func(t *testing.T) {
+				skipUnlessBeta(t)
 				registryProviderTest, providerTestCleanup := createRegistryProvider(t, client, orgTest, prvCtx.RegistryName)
 				defer providerTestCleanup()
 


### PR DESCRIPTION
## Description

A previous PR ([#1340](https://github.com/hashicorp/go-tfe/pull/1340)) introduced support for reading a provider by its external ID. This route is currently gated behind the registry-tagging feature flag, which is in public beta.
As a result, tests relying on this behaviour fail in CI ([link](https://github.com/hashicorp/go-tfe/actions/runs/25838606936/job/77729611923#step:4:1367)).
To avoid these failures, the affected test is temporarily skipped in CI. It will be re-enabled once the feature reaches GA, which is planned for the end of this quarter.

## Testing plan

Ensure CI passes


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

revert PR

## Changes to Security Controls

NA
