### PR TITLE
Update documentation for provider sets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ## Enhancements
 * Add support for reading a registry provider by its unique identifier by  @mrinalirao [#1340](https://github.com/hashicorp/go-tfe/pull/1340)
-* Add `ProviderSet` resources with `Read`, `Update`, `Delete` and `Create` methods @mogrogan [#1346](https://github.com/hashicorp/go-tfe/pull/1346)
 * Adds `SourceModuleID` field to `Workspace` so callers can read the no-code source module identifier (e.g. `private/<org>/<name>/<provider>/<version>`) returned by the API by @a9logic [#1331](https://github.com/hashicorp/go-tfe/pull/1331)
 
 # v1.106.0

--- a/provider_set.go
+++ b/provider_set.go
@@ -14,7 +14,8 @@ var _ ProviderSets = (*providerSets)(nil)
 // ProviderSets describes all the Provider Set related methods that the
 // Terraform Enterprise API supports.
 //
-// TFE API docs: https://developer.hashicorp.com/terraform/cloud-docs/api-docs/provider-sets
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 type ProviderSets interface {
 	// Create is used to create a new provider set.
 	Create(ctx context.Context, organization string, options ProviderSetCreateOptions) (*ProviderSet, error)
@@ -29,7 +30,10 @@ type ProviderSets interface {
 	Delete(ctx context.Context, providerSetID string) error
 }
 
-// ProviderSet describes all the Provider Set related methods that the
+// ProviderSet represents a Terraform enterprise provider set.
+//
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 type ProviderSet struct {
 	ID               string `jsonapi:"primary,provider-sets"`
 	Name             string `jsonapi:"attr,name"`
@@ -50,6 +54,9 @@ type providerSets struct {
 }
 
 // ProviderSetCreateOptions represents the options for creating a new provider set.
+
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 type ProviderSetCreateOptions struct {
 	// Type is a public field utilized by JSON:API to
 	// set the resource type via the field tag.
@@ -79,7 +86,10 @@ type ProviderSetCreateOptions struct {
 	Projects []*Project `jsonapi:"relation,projects,omitempty"`
 }
 
-// ProviderSetUpdateOptions represents the options for creating a new provider set.
+// ProviderSetUpdateOptions represents the options for updating a new provider set.
+
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 type ProviderSetUpdateOptions struct {
 	// Optional: Name of the provider set.
 	Name *string
@@ -163,6 +173,9 @@ func (o ProviderSetUpdateOptions) payload() *providerSetUpdatePayload {
 }
 
 // Create is used to create a new provider set.
+//
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 func (p *providerSets) Create(ctx context.Context, organization string, options ProviderSetCreateOptions) (*ProviderSet, error) {
 	if !validStringID(&organization) {
 		return nil, ErrInvalidOrg
@@ -187,6 +200,9 @@ func (p *providerSets) Create(ctx context.Context, organization string, options 
 }
 
 // Read a provider set by its ID.
+//
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 func (p *providerSets) Read(ctx context.Context, providerSetID string) (*ProviderSet, error) {
 	if !validStringID(&providerSetID) {
 		return nil, ErrInvalidProviderSetID
@@ -208,6 +224,9 @@ func (p *providerSets) Read(ctx context.Context, providerSetID string) (*Provide
 }
 
 // Update values of an existing provider set.
+//
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 func (p *providerSets) Update(ctx context.Context, providerSetID string, options ProviderSetUpdateOptions) (*ProviderSet, error) {
 	if !validStringID(&providerSetID) {
 		return nil, ErrInvalidProviderSetID
@@ -231,6 +250,9 @@ func (p *providerSets) Update(ctx context.Context, providerSetID string, options
 }
 
 // Delete a provider set by its ID.
+//
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
 func (p *providerSets) Delete(ctx context.Context, providerSetID string) error {
 	if !validStringID(&providerSetID) {
 		return ErrInvalidProviderSetID


### PR DESCRIPTION


<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Just a docs change. This PR is a slight amendment to #1346 - provider sets are experimental, and the godocs + changelog are updated as such.

The [release description](https://github.com/hashicorp/go-tfe/releases/tag/v1.107.0) will be updated to remove the changelog entry as well.

## Testing plan

Read! 😄 

## External links

N/A

## Output from tests

N/A

## Rollback Plan

Revert PR.

## Changes to Security Controls

N/A