### PR TITLE
feat:  expose infragraph entitlement fields from API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Enhancements
 * Adds BETA support for listing `TFPolicyEvaluationOutcome`, which is EXPERIMENTAL, SUBJECT TO CHANGE, and may not be available to all users by @subhro-acharjee-1 [#1313](https://github.com/hashicorp/go-tfe/pull/1313)
+* Add Infragraph entitlements (the `infragraph` and `infragraph-with-nrtu` attributes) to `Entitlements` by @jadhavpoonam [#1351](https://github.com/hashicorp/go-tfe/pull/1351)
 
 # v1.107.0
 

--- a/organization.go
+++ b/organization.go
@@ -179,6 +179,8 @@ type Entitlements struct {
 	VCSIntegrations            bool   `jsonapi:"attr,vcs-integrations"`
 	WaypointActions            bool   `jsonapi:"attr,waypoint-actions"`
 	WaypointTemplatesAndAddons bool   `jsonapi:"attr,waypoint-templates-and-addons"`
+	Infragraph                  bool   `jsonapi:"attr,infragraph"`
+	InfragraphWithNRTU          bool   `jsonapi:"attr,infragraph-with-nrtu"`
 }
 
 // RunQueue represents the current run queue of an organization.

--- a/organization.go
+++ b/organization.go
@@ -179,8 +179,8 @@ type Entitlements struct {
 	VCSIntegrations            bool   `jsonapi:"attr,vcs-integrations"`
 	WaypointActions            bool   `jsonapi:"attr,waypoint-actions"`
 	WaypointTemplatesAndAddons bool   `jsonapi:"attr,waypoint-templates-and-addons"`
-	Infragraph                  bool   `jsonapi:"attr,infragraph"`
-	InfragraphWithNRTU          bool   `jsonapi:"attr,infragraph-with-nrtu"`
+	Infragraph                 bool   `jsonapi:"attr,infragraph"`
+	InfragraphWithNRTU         bool   `jsonapi:"attr,infragraph-with-nrtu"`
 }
 
 // RunQueue represents the current run queue of an organization.

--- a/organization_integration_test.go
+++ b/organization_integration_test.go
@@ -619,6 +619,8 @@ func TestOrganizationsReadEntitlements(t *testing.T) {
 		assert.True(t, entitlements.VCSIntegrations)
 		assert.False(t, entitlements.WaypointActions)
 		assert.True(t, entitlements.WaypointTemplatesAndAddons)
+		assert.True(t, entitlements.Infragraph)
+		assert.False(t, entitlements.InfragraphWithNRTU)
 	})
 
 	t.Run("with invalid name", func(t *testing.T) {


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

<!-- Describe why you're making this change. -->
Adds Infragraph and InfragraphWithNRTU boolean fields to the Entitlements struct, mapping to the infragraph and infragraph-with-nrtu HTTP API attributes.

## Testing plan
Tested in staging by assigning my user admin role.

1.  Assign my user admin role
1.  Generate user token
1.  Set env vars `export TFE_ADMIN_PROVISION_LICENSES_TOKEN="<token>"` and `export TFE_ADDRESS="https://app.staging.terraform.io"`

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/hashicorp/atlas/pull/28915)

-->
Atlas changes in the
[Related PR](https://github.com/hashicorp/atlas/pull/28915)
[Jira ticket
](https://hashicorp.atlassian.net/browse/IG-2129)
## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ TFE_ADDRESS="https://app.staging.terraform.io" TFE_TOKEN="token" go test ./... -v -run TestOrganizationsReadEntitlements

go test -v -run TestOrganizationsReadEntitlements -timeout 120s                                                                                                                        
=== RUN   TestOrganizationsReadEntitlements
=== PAUSE TestOrganizationsReadEntitlements
=== CONT  TestOrganizationsReadEntitlements
=== RUN   TestOrganizationsReadEntitlements/when_the_org_exists
=== RUN   TestOrganizationsReadEntitlements/with_invalid_name
=== RUN   TestOrganizationsReadEntitlements/when_the_org_does_not_exist
--- PASS: TestOrganizationsReadEntitlements (2.49s)
    --- PASS: TestOrganizationsReadEntitlements/when_the_org_exists (0.13s)
    --- PASS: TestOrganizationsReadEntitlements/with_invalid_name (0.00s)
    --- PASS: TestOrganizationsReadEntitlements/when_the_org_does_not_exist (0.11s)
PASS
ok      github.com/hashicorp/go-tfe     2.746s
```


<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
