### PR TITLE
add `ReadByName` to provider-set

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -348,6 +348,8 @@ var (
 
 	ErrRequiredProvider = errors.New("provider is required")
 
+	ErrRequiredProviderSetID = errors.New("provider set ID is required")
+
 	ErrRequiredOauthToken = errors.New("OAuth token is required")
 
 	ErrRequiredOauthTokenOrGithubAppInstallationID = errors.New("either oauth token ID or github app installation ID is required")

--- a/mocks/provider_set_mocks.go
+++ b/mocks/provider_set_mocks.go
@@ -84,6 +84,21 @@ func (mr *MockProviderSetsMockRecorder) Read(ctx, providerSetID any) *gomock.Cal
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Read", reflect.TypeOf((*MockProviderSets)(nil).Read), ctx, providerSetID)
 }
 
+// ReadByName mocks base method.
+func (m *MockProviderSets) ReadByName(ctx context.Context, organization, name string) (*tfe.ProviderSet, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReadByName", ctx, organization, name)
+	ret0, _ := ret[0].(*tfe.ProviderSet)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReadByName indicates an expected call of ReadByName.
+func (mr *MockProviderSetsMockRecorder) ReadByName(ctx, organization, name any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReadByName", reflect.TypeOf((*MockProviderSets)(nil).ReadByName), ctx, organization, name)
+}
+
 // Update mocks base method.
 func (m *MockProviderSets) Update(ctx context.Context, providerSetID string, options tfe.ProviderSetUpdateOptions) (*tfe.ProviderSet, error) {
 	m.ctrl.T.Helper()

--- a/provider_set.go
+++ b/provider_set.go
@@ -23,6 +23,9 @@ type ProviderSets interface {
 	// Read a provider set by its ID.
 	Read(ctx context.Context, providerSetID string) (*ProviderSet, error)
 
+	// Read a provider set by its name.
+	ReadByName(ctx context.Context, organization string, name string) (*ProviderSet, error)
+
 	// Update values of an existing provider set.
 	Update(ctx context.Context, providerSetID string, options ProviderSetUpdateOptions) (*ProviderSet, error)
 
@@ -204,11 +207,45 @@ func (p *providerSets) Create(ctx context.Context, organization string, options 
 // Note: This API is experimental and intended for internal use only. It is
 // subject to change or removal without notice.
 func (p *providerSets) Read(ctx context.Context, providerSetID string) (*ProviderSet, error) {
+	if !validString(&providerSetID) {
+		return nil, ErrRequiredProviderSetID
+	}
 	if !validStringID(&providerSetID) {
 		return nil, ErrInvalidProviderSetID
 	}
 
 	u := fmt.Sprintf("provider-sets/%s", url.PathEscape(providerSetID))
+	req, err := p.client.NewRequest("GET", u, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	ps := &ProviderSet{}
+	err = req.Do(ctx, ps)
+	if err != nil {
+		return nil, err
+	}
+
+	return ps, nil
+}
+
+// ReadByName is used to read a provider set by its name.
+//
+// Note: This API is experimental and intended for internal use only. It is
+// subject to change or removal without notice.
+func (p *providerSets) ReadByName(ctx context.Context, organization, name string) (*ProviderSet, error) {
+	if !validStringID(&organization) {
+		return nil, ErrInvalidOrg
+	}
+	if !validString(&name) {
+		return nil, ErrRequiredName
+	}
+	if !validStringID(&name) {
+		return nil, ErrInvalidName
+	}
+
+	u := fmt.Sprintf("organizations/%s/provider-sets/%s",
+		url.PathEscape(organization), url.PathEscape(name))
 	req, err := p.client.NewRequest("GET", u, nil)
 	if err != nil {
 		return nil, err

--- a/provider_set_integration_test.go
+++ b/provider_set_integration_test.go
@@ -28,39 +28,96 @@ func TestProviderSetsRead(t *testing.T) {
 	// likely a NOOP but added for consistency and future-proofing
 	defer workspaceCleanup()
 
-	createOptions := providerSetTestCreateOptionsWithRelationships(t,
+	createOptions := providerSetTestCreateOptionsWithRelationships(
+		t,
 		[]*Project{project},
 		[]*Workspace{workspace},
 	)
 	ps, err := client.ProviderSets.Create(ctx, orgTest.Name, createOptions)
 	require.NoError(t, err)
 
-	t.Run("with valid provider id", func(t *testing.T) {
-		psRead, err := client.ProviderSets.Read(ctx, ps.ID)
-		require.NoError(t, err)
+	t.Run("ReadById", func(t *testing.T) {
+		t.Run("with valid provider set id", func(t *testing.T) {
+			psRead, err := client.ProviderSets.Read(ctx, ps.ID)
+			require.NoError(t, err)
 
-		assert.Equal(t, ps.ID, psRead.ID)
-		assert.Equal(t, ps.Name, psRead.Name)
-		assert.Equal(t, ps.Description, psRead.Description)
-		assert.Equal(t, ps.ProviderSource, psRead.ProviderSource)
-		assert.Equal(t, ps.ConfigurationHcl, psRead.ConfigurationHcl)
+			assert.Equal(t, ps.ID, psRead.ID)
+			assert.Equal(t, ps.Name, psRead.Name)
+			assert.Equal(t, ps.Description, psRead.Description)
+			assert.Equal(t, ps.ProviderSource, psRead.ProviderSource)
+			assert.Equal(t, ps.ConfigurationHcl, psRead.ConfigurationHcl)
 
-		require.Len(t, ps.Projects, 1)
-		require.Len(t, ps.Workspaces, 1)
-		assert.Equal(t, ps.Projects[0].ID, createOptions.Projects[0].ID)
-		assert.Equal(t, ps.Workspaces[0].ID, createOptions.Workspaces[0].ID)
+			require.Len(t, psRead.Projects, 1)
+			require.Len(t, psRead.Workspaces, 1)
+			assert.Equal(t, psRead.Projects[0].ID, createOptions.Projects[0].ID)
+			assert.Equal(t, psRead.Workspaces[0].ID, createOptions.Workspaces[0].ID)
+		})
+
+		t.Run("with invalid provider set ID", func(t *testing.T) {
+			psRead, err := client.ProviderSets.Read(ctx, "invalid/id")
+			assert.EqualError(t, err, ErrInvalidProviderSetID.Error())
+			assert.Nil(t, psRead)
+		})
+
+		t.Run("with unexisting provider set ID", func(t *testing.T) {
+			psRead, err := client.ProviderSets.Read(ctx, "unexisting-id")
+			assert.EqualError(t, err, ErrResourceNotFound.Error())
+			assert.Nil(t, psRead)
+		})
+
+		t.Run("with empty provider set id", func(t *testing.T) {
+			ps, err := client.ProviderSets.Read(ctx, "")
+			assert.EqualError(t, err, ErrRequiredProviderSetID.Error())
+			assert.Nil(t, ps)
+		})
 	})
 
-	t.Run("with invalid provider set ID", func(t *testing.T) {
-		psRead, err := client.ProviderSets.Read(ctx, "invalid/id")
-		assert.EqualError(t, err, ErrInvalidProviderSetID.Error())
-		assert.Nil(t, psRead)
-	})
+	t.Run("ReadByName", func(t *testing.T) {
+		t.Run("with valid provider set name", func(t *testing.T) {
+			psRead, err := client.ProviderSets.ReadByName(ctx, orgTest.Name, createOptions.Name)
+			require.NoError(t, err)
 
-	t.Run("with unexisting provider set ID", func(t *testing.T) {
-		psRead, err := client.ProviderSets.Read(ctx, "unexisting-id")
-		assert.EqualError(t, err, ErrResourceNotFound.Error())
-		assert.Nil(t, psRead)
+			assert.Equal(t, ps.ID, psRead.ID)
+			assert.Equal(t, ps.Name, psRead.Name)
+			assert.Equal(t, ps.Description, psRead.Description)
+			assert.Equal(t, ps.ProviderSource, psRead.ProviderSource)
+			assert.Equal(t, ps.ConfigurationHcl, psRead.ConfigurationHcl)
+
+			require.Len(t, psRead.Projects, 1)
+			require.Len(t, psRead.Workspaces, 1)
+			assert.Equal(t, psRead.Projects[0].ID, createOptions.Projects[0].ID)
+			assert.Equal(t, psRead.Workspaces[0].ID, createOptions.Workspaces[0].ID)
+		})
+
+		t.Run("with unexisting org ID", func(t *testing.T) {
+			psRead, err := client.ProviderSets.ReadByName(ctx, "unexisting-id", createOptions.Name)
+			assert.EqualError(t, err, ErrResourceNotFound.Error())
+			assert.Nil(t, psRead)
+		})
+
+		t.Run("with unexisting provider set", func(t *testing.T) {
+			psRead, err := client.ProviderSets.ReadByName(ctx, orgTest.Name, "unexisting-provider-set")
+			assert.EqualError(t, err, ErrResourceNotFound.Error())
+			assert.Nil(t, psRead)
+		})
+
+		t.Run("with invalid org ID", func(t *testing.T) {
+			ps, err := client.ProviderSets.ReadByName(ctx, "invalid/org", createOptions.Name)
+			assert.EqualError(t, err, ErrInvalidOrg.Error())
+			assert.Nil(t, ps)
+		})
+
+		t.Run("with invalid provider set name", func(t *testing.T) {
+			ps, err := client.ProviderSets.ReadByName(ctx, orgTest.Name, "invalid/name")
+			assert.EqualError(t, err, ErrInvalidName.Error())
+			assert.Nil(t, ps)
+		})
+
+		t.Run("with empty provider set name", func(t *testing.T) {
+			ps, err := client.ProviderSets.ReadByName(ctx, orgTest.Name, "")
+			assert.EqualError(t, err, ErrRequiredName.Error())
+			assert.Nil(t, ps)
+		})
 	})
 }
 
@@ -191,7 +248,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with relationships", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			[]*Project{project},
 			[]*Workspace{workspace},
 		)
@@ -207,7 +265,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with relationships on a global provider set", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			[]*Project{project},
 			[]*Workspace{workspace},
 		)
@@ -219,7 +278,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with missing project ID", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			[]*Project{{ID: ""}},
 			nil,
 		)
@@ -230,7 +290,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with invalid project ID", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			[]*Project{{ID: "invalid id"}},
 			nil,
 		)
@@ -241,7 +302,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with unexisting project ID", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			[]*Project{{ID: "unexisting-id"}},
 			nil,
 		)
@@ -252,7 +314,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with missing workspace ID", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			nil,
 			[]*Workspace{{ID: ""}},
 		)
@@ -263,7 +326,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with invalid workspace ID", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			nil,
 			[]*Workspace{{ID: "invalid id"}},
 		)
@@ -274,7 +338,8 @@ func TestProviderSetsCreate(t *testing.T) {
 	})
 
 	t.Run("with unexisting workspace ID", func(t *testing.T) {
-		options := providerSetTestCreateOptionsWithRelationships(t,
+		options := providerSetTestCreateOptionsWithRelationships(
+			t,
 			nil,
 			[]*Workspace{{ID: "unexisting-id"}},
 		)
@@ -445,7 +510,8 @@ func TestProviderSetsUpdate(t *testing.T) {
 		},
 		"with empty relationships when has initial relationships": {
 			initial: func(t *testing.T) ProviderSetCreateOptions {
-				return providerSetTestCreateOptionsWithRelationships(t,
+				return providerSetTestCreateOptionsWithRelationships(
+					t,
 					[]*Project{{ID: project.ID}},
 					[]*Workspace{{ID: workspace.ID}},
 				)
@@ -462,7 +528,8 @@ func TestProviderSetsUpdate(t *testing.T) {
 		},
 		"with nil relationships when has initial relationships": {
 			initial: func(t *testing.T) ProviderSetCreateOptions {
-				return providerSetTestCreateOptionsWithRelationships(t,
+				return providerSetTestCreateOptionsWithRelationships(
+					t,
 					[]*Project{{ID: project.ID}},
 					[]*Workspace{{ID: workspace.ID}},
 				)
@@ -539,7 +606,7 @@ func TestProviderSetsUpdate(t *testing.T) {
 		t.Run(desc, func(t *testing.T) {
 			initial := providerSetTestCreateOptions(t)
 			if testCase.initial != nil {
-				initial = (testCase.initial)(t)
+				initial = testCase.initial(t)
 			}
 			ps, err := client.ProviderSets.Create(ctx, orgTest.Name, initial)
 			require.NoError(t, err)


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

This changes add a new method `ReadByName` to `ProviderSet`

This method goal is to be able to read a provider set by providing `organization` and `name` 

## Testing plan

1. Just running the test would be fine for now 

## External links

<!--
_Include any links here that might be helpful for people reviewing your PR. If there are none, feel free to delete this section._

- [API documentation](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/xxxx)
- [Related PR](https://github.com/terraform-providers/terraform-provider-tfe/pull/xxxx)

-->

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
$ ENABLE_BETA=1 go test -run '^TestProviderSets(Read|Create|Update|Delete)' -v
=== RUN   TestProviderSetsRead
=== PAUSE TestProviderSetsRead
=== RUN   TestProviderSetsDelete
=== PAUSE TestProviderSetsDelete
=== RUN   TestProviderSetsCreate
=== PAUSE TestProviderSetsCreate
=== RUN   TestProviderSetsUpdate
=== PAUSE TestProviderSetsUpdate
=== CONT  TestProviderSetsRead
=== CONT  TestProviderSetsCreate
=== CONT  TestProviderSetsUpdate
=== CONT  TestProviderSetsDelete
=== RUN   TestProviderSetsDelete/with_valid_provider_id
=== RUN   TestProviderSetsCreate/with_valid_attributes
=== RUN   TestProviderSetsUpdate/with_invalid_workspace_ID
=== RUN   TestProviderSetsRead/ReadById
=== RUN   TestProviderSetsRead/ReadById/with_valid_provider_id
=== RUN   TestProviderSetsCreate/with_global_valid_attributes
=== RUN   TestProviderSetsUpdate/with_valid_full_attributes
=== RUN   TestProviderSetsRead/ReadById/with_invalid_provider_set_ID
=== RUN   TestProviderSetsRead/ReadById/with_unexisting_provider_set_ID
=== RUN   TestProviderSetsCreate/with_invalid_org_ID
=== RUN   TestProviderSetsCreate/with_non_existing_org
=== RUN   TestProviderSetsDelete/with_invalid_provider_set_ID
=== RUN   TestProviderSetsDelete/with_unexisting_provider_set_ID
=== RUN   TestProviderSetsRead/ReadById/with_empty_provider_set_name
=== RUN   TestProviderSetsRead/ReadByName
=== RUN   TestProviderSetsRead/ReadByName/with_valid_provider_id
=== RUN   TestProviderSetsCreate/with_invalid_name
=== RUN   TestProviderSetsCreate/with_missing_name
=== RUN   TestProviderSetsCreate/with_missing_provider_source
=== RUN   TestProviderSetsCreate/with_missing_configuration_hcl
=== RUN   TestProviderSetsCreate/with_relationships
=== RUN   TestProviderSetsRead/ReadByName/with_unexisting_org_ID
=== RUN   TestProviderSetsUpdate/with_only_description
=== RUN   TestProviderSetsCreate/with_relationships_on_a_global_provider_set
=== RUN   TestProviderSetsCreate/with_missing_project_ID
=== RUN   TestProviderSetsCreate/with_invalid_project_ID
=== RUN   TestProviderSetsCreate/with_unexisting_project_ID
=== RUN   TestProviderSetsRead/ReadByName/with_unexisting_provider-set
=== RUN   TestProviderSetsCreate/with_missing_workspace_ID
=== RUN   TestProviderSetsCreate/with_invalid_workspace_ID
=== RUN   TestProviderSetsCreate/with_unexisting_workspace_ID
--- PASS: TestProviderSetsDelete (2.28s)
    --- PASS: TestProviderSetsDelete/with_valid_provider_id (0.56s)
    --- PASS: TestProviderSetsDelete/with_invalid_provider_set_ID (0.00s)
    --- PASS: TestProviderSetsDelete/with_unexisting_provider_set_ID (0.11s)
=== RUN   TestProviderSetsRead/ReadByName/with_invalid_org_ID
=== RUN   TestProviderSetsRead/ReadByName/with_invalid_provider_set_name
=== RUN   TestProviderSetsRead/ReadByName/with_empty_provider_set_name
=== RUN   TestProviderSetsUpdate/with_only_configuration_hcl
=== RUN   TestProviderSetsUpdate/with_only_global_true
--- PASS: TestProviderSetsRead (2.76s)
    --- PASS: TestProviderSetsRead/ReadById (0.31s)
        --- PASS: TestProviderSetsRead/ReadById/with_valid_provider_id (0.18s)
        --- PASS: TestProviderSetsRead/ReadById/with_invalid_provider_set_ID (0.00s)
        --- PASS: TestProviderSetsRead/ReadById/with_unexisting_provider_set_ID (0.13s)
        --- PASS: TestProviderSetsRead/ReadById/with_empty_provider_set_name (0.00s)
    --- PASS: TestProviderSetsRead/ReadByName (0.39s)
        --- PASS: TestProviderSetsRead/ReadByName/with_valid_provider_id (0.12s)
        --- PASS: TestProviderSetsRead/ReadByName/with_unexisting_org_ID (0.11s)
        --- PASS: TestProviderSetsRead/ReadByName/with_unexisting_provider-set (0.15s)
        --- PASS: TestProviderSetsRead/ReadByName/with_invalid_org_ID (0.00s)
        --- PASS: TestProviderSetsRead/ReadByName/with_invalid_provider_set_name (0.00s)
        --- PASS: TestProviderSetsRead/ReadByName/with_empty_provider_set_name (0.00s)
--- PASS: TestProviderSetsCreate (2.87s)
    --- PASS: TestProviderSetsCreate/with_valid_attributes (0.17s)
    --- PASS: TestProviderSetsCreate/with_global_valid_attributes (0.13s)
    --- PASS: TestProviderSetsCreate/with_invalid_org_ID (0.00s)
    --- PASS: TestProviderSetsCreate/with_non_existing_org (0.10s)
    --- PASS: TestProviderSetsCreate/with_invalid_name (0.00s)
    --- PASS: TestProviderSetsCreate/with_missing_name (0.00s)
    --- PASS: TestProviderSetsCreate/with_missing_provider_source (0.00s)
    --- PASS: TestProviderSetsCreate/with_missing_configuration_hcl (0.00s)
    --- PASS: TestProviderSetsCreate/with_relationships (0.17s)
    --- PASS: TestProviderSetsCreate/with_relationships_on_a_global_provider_set (0.00s)
    --- PASS: TestProviderSetsCreate/with_missing_project_ID (0.00s)
    --- PASS: TestProviderSetsCreate/with_invalid_project_ID (0.00s)
    --- PASS: TestProviderSetsCreate/with_unexisting_project_ID (0.15s)
    --- PASS: TestProviderSetsCreate/with_missing_workspace_ID (0.00s)
    --- PASS: TestProviderSetsCreate/with_invalid_workspace_ID (0.00s)
    --- PASS: TestProviderSetsCreate/with_unexisting_workspace_ID (0.17s)
=== RUN   TestProviderSetsUpdate/with_invalid_name
=== RUN   TestProviderSetsUpdate/with_nil_relationships_when_has_initial_relationships
=== RUN   TestProviderSetsUpdate/with_unexisting_workspace_ID
=== RUN   TestProviderSetsUpdate/with_only_name
=== RUN   TestProviderSetsUpdate/with_only_provider_source
=== RUN   TestProviderSetsUpdate/with_unexisting_provider_set_ID
=== RUN   TestProviderSetsUpdate/with_empty_relationships_when_has_initial_relationships
=== RUN   TestProviderSetsUpdate/with_missing_project_ID
=== RUN   TestProviderSetsUpdate/with_invalid_project_ID
=== RUN   TestProviderSetsUpdate/with_invalid_providerSetID
=== RUN   TestProviderSetsUpdate/with_missing_workspace_ID
=== RUN   TestProviderSetsUpdate/with_relationships
=== RUN   TestProviderSetsUpdate/with_unexisting_project_ID
--- PASS: TestProviderSetsUpdate (6.14s)
    --- PASS: TestProviderSetsUpdate/with_invalid_workspace_ID (0.20s)
    --- PASS: TestProviderSetsUpdate/with_valid_full_attributes (0.34s)
    --- PASS: TestProviderSetsUpdate/with_only_description (0.32s)
    --- PASS: TestProviderSetsUpdate/with_only_configuration_hcl (0.31s)
    --- PASS: TestProviderSetsUpdate/with_only_global_true (0.27s)
    --- PASS: TestProviderSetsUpdate/with_invalid_name (0.14s)
    --- PASS: TestProviderSetsUpdate/with_nil_relationships_when_has_initial_relationships (0.27s)
    --- PASS: TestProviderSetsUpdate/with_unexisting_workspace_ID (0.27s)
    --- PASS: TestProviderSetsUpdate/with_only_name (0.25s)
    --- PASS: TestProviderSetsUpdate/with_only_provider_source (0.27s)
    --- PASS: TestProviderSetsUpdate/with_unexisting_provider_set_ID (0.25s)
    --- PASS: TestProviderSetsUpdate/with_empty_relationships_when_has_initial_relationships (0.27s)
    --- PASS: TestProviderSetsUpdate/with_missing_project_ID (0.14s)
    --- PASS: TestProviderSetsUpdate/with_invalid_project_ID (0.13s)
    --- PASS: TestProviderSetsUpdate/with_invalid_providerSetID (0.14s)
    --- PASS: TestProviderSetsUpdate/with_missing_workspace_ID (0.13s)
    --- PASS: TestProviderSetsUpdate/with_relationships (0.27s)
    --- PASS: TestProviderSetsUpdate/with_unexisting_project_ID (0.27s)
PASS
ok      github.com/hashicorp/go-tfe     6.376s
...
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

none required as it's still a Beta feature and not used by any customers yet
<!--
Please outline a plan in the event changes need to be rolled back

Example: If a change needs to be reverted, we will roll out an update to the code within 7 days.
-->

## Changes to Security Controls

none
<!--
Are there any changes to security controls (access controls, encryption, logging) in this pull request? If so, explain.
-->
