### PR TITLE
Don't block s390x tool versions in go-tfe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@
 ## Enhancements
 * Adds support for `NotificationConfigurationSubscribableChoice` type `Project` to support Project Level Notifications by @jillirami [#1350](https://github.com/hashicorp/go-tfe/pull/1350)
 
+## Bug Fixes
+* Don't block s390x tool versions
+
 # v1.108.0
 
 ## Enhancements

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 * Adds support for `NotificationConfigurationSubscribableChoice` type `Project` to support Project Level Notifications by @jillirami [#1350](https://github.com/hashicorp/go-tfe/pull/1350)
 
 ## Bug Fixes
-* Don't block s390x tool versions
+* Adds support for s390x tool versions, which were previously blocked by @JenGoldstrich [#1357](https://github.com/hashicorp/go-tfe/pull/1357)
 
 # v1.108.0
 

--- a/admin_opa_version_integration_test.go
+++ b/admin_opa_version_integration_test.go
@@ -130,7 +130,14 @@ func TestAdminOPAVersions_CreateDelete(t *testing.T) {
 					Sha:  *String(genSha(t)),
 					OS:   linux,
 					Arch: arm64,
-				}},
+				},
+				{
+					URL:  url,
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: s390x,
+				},
+			},
 		}
 		ov, err := client.Admin.OPAVersions.Create(ctx, opts)
 		require.NoError(t, err)

--- a/admin_sentinel_version_integration_test.go
+++ b/admin_sentinel_version_integration_test.go
@@ -129,7 +129,14 @@ func TestAdminSentinelVersions_CreateDelete(t *testing.T) {
 					Sha:  *String(genSha(t)),
 					OS:   linux,
 					Arch: arm64,
-				}},
+				},
+				{
+					URL:  url,
+					Sha:  *String(genSha(t)),
+					OS:   linux,
+					Arch: s390x,
+				},
+			},
 		}
 		sv, err := client.Admin.SentinelVersions.Create(ctx, opts)
 		require.NoError(t, err)

--- a/admin_terraform_version.go
+++ b/admin_terraform_version.go
@@ -18,6 +18,7 @@ const (
 	linux = "linux"
 	amd64 = "amd64"
 	arm64 = "arm64"
+	s390x = "s390x"
 )
 
 // AdminTerraformVersions describes all the admin terraform versions related methods that
@@ -237,5 +238,5 @@ func (o AdminTerraformVersionCreateOptions) validArchs() bool {
 }
 
 func validArch(a *ToolVersionArchitecture) bool {
-	return a.URL != "" && a.Sha != "" && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64)
+	return a.URL != "" && a.Sha != "" && a.OS == linux && (a.Arch == amd64 || a.Arch == arm64 || a.Arch == s390x)
 }

--- a/admin_terraform_version_integration_test.go
+++ b/admin_terraform_version_integration_test.go
@@ -129,7 +129,14 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 					Sha:  genSha(t),
 					OS:   linux,
 					Arch: arm64,
-				}},
+				},
+				{
+					URL:  url,
+					Sha:  genSha(t),
+					OS:   linux,
+					Arch: s390x,
+				},
+			},
 		}
 		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
 		require.NoError(t, err)
@@ -280,7 +287,8 @@ func TestAdminTerraformVersions_CreateDelete(t *testing.T) {
 					Sha:  *String(genSha(t)),
 					OS:   linux,
 					Arch: arm64,
-				}},
+				},
+			},
 		}
 		tfv, err := client.Admin.TerraformVersions.Create(ctx, opts)
 		require.NoError(t, err)


### PR DESCRIPTION
## Description

go-tfe currently blocks s390x tool versions, which prevents the usage of s390x agents.

## Testing plan

Try and upload a linux s390x Terraform version.

## Output from tests

N/A

## Rollback Plan

N/A

## Changes to Security Controls

N/A
