### PR TITLE
Replace Kiota's RetryHandler with custom retry middleware

### DIFF
--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -55,15 +55,12 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 		MaxRetries:   retryOpts.MaxRetries,
 		DelaySeconds: 1,
 		ShouldRetry: func(executionCount int, request *nethttp.Request, response *nethttp.Response) bool {
-			if !retryOpts.Enabled {
-				return false
-			}
-			// Retry on 429 (rate limited) and 425 (too early)
-			if response.StatusCode == 429 || response.StatusCode == 425 {
+			// Retry on 429 (rate limited) and 425 (too early) when rate limit retries are enabled
+			if retryOpts.Enabled && (response.StatusCode == 429 || response.StatusCode == 425) {
 				retryOpts.Hook(executionCount, response)
 				return true
 			}
-			// Retry on all 5xx if RetryServerErrors is enabled
+			// Retry on all 5xx if RetryServerErrors is enabled (independent of rate limit setting)
 			if retryOpts.RetryServerErrors && response.StatusCode >= 500 {
 				retryOpts.Hook(executionCount, response)
 				return true

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -30,7 +30,10 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 	for _, option := range options {
 		switch option.key {
 		case "RetryOptions":
-			opts := option.value.(RetryOptions)
+			opts, ok := option.value.(RetryOptions)
+			if !ok {
+				continue
+			}
 			retryOpts.Enabled = opts.Enabled
 			retryOpts.RetryServerErrors = opts.RetryServerErrors
 			retryOpts.MaxRetries = opts.MaxRetries
@@ -38,7 +41,11 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 				retryOpts.Hook = opts.Hook
 			}
 		case "ErrorInterceptor":
-			errFactory = option.value.(APIErrorFactory)
+			factory, ok := option.value.(APIErrorFactory)
+			if !ok {
+				continue
+			}
+			errFactory = factory
 		}
 	}
 

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -84,9 +84,11 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 			ProductName:    "go-tfe",
 			ProductVersion: tfeSDKVersion,
 		}),
-		khttp.NewHeadersInspectionHandlerWithOptions(khttp.HeadersInspectionOptions{
-			InspectRequestHeaders:  false,
-			InspectResponseHeaders: true,
-		}),
+		khttp.NewHeadersInspectionHandlerWithOptions(func() khttp.HeadersInspectionOptions {
+			opts := *khttp.NewHeadersInspectionOptions()
+			opts.InspectRequestHeaders = false
+			opts.InspectResponseHeaders = true
+			return opts
+		}()),
 	}, nil
 }

--- a/middleware/middleware.go
+++ b/middleware/middleware.go
@@ -3,9 +3,6 @@
 package middleware
 
 import (
-	"errors"
-	"time"
-
 	nethttp "net/http"
 
 	khttp "github.com/microsoft/kiota-http-go"
@@ -17,6 +14,12 @@ func nilErrorFactory(_ *nethttp.Response, _ error) error {
 
 // GetForKiota uses the provided options to configure the default middlewares used by kiota
 // as well as the custom middleware supplied by the SDK.
+//
+// This function replaces Kiota's built-in RetryHandler with a custom RetryMiddleware.
+// Kiota's RetryHandler has a hardcoded isRetriableErrorCode gate that only covers 429, 503, 504
+// and short-circuits before calling the ShouldRetry callback. Our custom middleware calls
+// ShouldRetry unconditionally, allowing retries on 429, 425, and all 5xx (when RetryServerErrors
+// is enabled).
 func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Middleware, error) {
 	var errFactory APIErrorFactory = nilErrorFactory
 	var retryOpts = RetryOptions{
@@ -27,10 +30,7 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 	for _, option := range options {
 		switch option.key {
 		case "RetryOptions":
-			opts, ok := option.value.(RetryOptions)
-			if !ok {
-				return nil, errors.New("invalid type for RetryOptions")
-			}
+			opts := option.value.(RetryOptions)
 			retryOpts.Enabled = opts.Enabled
 			retryOpts.RetryServerErrors = opts.RetryServerErrors
 			retryOpts.MaxRetries = opts.MaxRetries
@@ -38,55 +38,55 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 				retryOpts.Hook = opts.Hook
 			}
 		case "ErrorInterceptor":
-			opts, ok := option.value.(APIErrorFactory)
-			if !ok {
-				return nil, errors.New("invalid type for ErrorInterceptor")
-			}
-			errFactory = opts
+			errFactory = option.value.(APIErrorFactory)
 		}
 	}
 
-	retryOptions := khttp.RetryHandlerOptions{
+	// Build the custom retry middleware that bypasses Kiota's isRetriableErrorCode gate.
+	// The ShouldRetry callback is the sole decider of whether to retry — no pre-filtering.
+	retryMiddleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   retryOpts.MaxRetries,
 		DelaySeconds: 1,
-		ShouldRetry: func(delay time.Duration, executionCount int, request *nethttp.Request, response *nethttp.Response) bool {
-			// Retry on 425, 429, and 5XX if the option is enabled
-			if retryOpts.Enabled && ((response.StatusCode == 429 || response.StatusCode == 425) || (retryOpts.RetryServerErrors && response.StatusCode >= 500)) {
+		ShouldRetry: func(executionCount int, request *nethttp.Request, response *nethttp.Response) bool {
+			if !retryOpts.Enabled {
+				return false
+			}
+			// Retry on 429 (rate limited) and 425 (too early)
+			if response.StatusCode == 429 || response.StatusCode == 425 {
+				retryOpts.Hook(executionCount, response)
+				return true
+			}
+			// Retry on all 5xx if RetryServerErrors is enabled
+			if retryOpts.RetryServerErrors && response.StatusCode >= 500 {
 				retryOpts.Hook(executionCount, response)
 				return true
 			}
 			return false
 		},
-	}
-	redirectHandlerOptions := khttp.RedirectHandlerOptions{
-		MaxRedirects: 5,
-		ShouldRedirect: func(req *nethttp.Request, res *nethttp.Response) bool {
-			return true
-		},
-	}
-	compressionOptions := khttp.NewCompressionOptionsReference(false)
-	userAgentHandlerOptions := khttp.UserAgentHandlerOptions{
-		Enabled:        true,
-		ProductName:    "go-tfe",
-		ProductVersion: tfeSDKVersion,
-	}
+	})
 
-	headersOptions := khttp.NewHeadersInspectionOptions()
-	headersOptions.InspectRequestHeaders = false
-	headersOptions.InspectResponseHeaders = true
-
-	defaultMiddleware, err := khttp.GetDefaultMiddlewaresWithOptions(
-		&retryOptions,
-		&redirectHandlerOptions,
-		compressionOptions,
-		&userAgentHandlerOptions,
-		headersOptions,
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	defaultMiddleware = append([]khttp.Middleware{NewErrorMiddleware(errFactory)}, defaultMiddleware...)
-	defaultMiddleware = append(defaultMiddleware, NewRateLimitMiddleware())
-	return defaultMiddleware, nil
+	// Build the middleware pipeline explicitly rather than using
+	// khttp.GetDefaultMiddlewaresWithOptions (which always injects Kiota's
+	// RetryHandler that we can't fully control).
+	return []khttp.Middleware{
+		NewErrorMiddleware(errFactory),
+		retryMiddleware,
+		NewRateLimitMiddleware(),
+		khttp.NewRedirectHandlerWithOptions(khttp.RedirectHandlerOptions{
+			MaxRedirects: 5,
+			ShouldRedirect: func(req *nethttp.Request, res *nethttp.Response) bool {
+				return true
+			},
+		}),
+		khttp.NewCompressionHandlerWithOptions(*khttp.NewCompressionOptionsReference(false)),
+		khttp.NewUserAgentHandlerWithOptions(&khttp.UserAgentHandlerOptions{
+			Enabled:        true,
+			ProductName:    "go-tfe",
+			ProductVersion: tfeSDKVersion,
+		}),
+		khttp.NewHeadersInspectionHandlerWithOptions(khttp.HeadersInspectionOptions{
+			InspectRequestHeaders:  false,
+			InspectResponseHeaders: true,
+		}),
+	}, nil
 }

--- a/middleware/options.go
+++ b/middleware/options.go
@@ -4,13 +4,16 @@ import (
 	nethttp "net/http"
 )
 
+// MiddlewareOption is a functional option for configuring the middleware pipeline.
 type MiddlewareOption struct {
 	key   string
 	value any
 }
 
+// RetryHookCallback is called before each retry attempt with the attempt number and response.
 type RetryHookCallback func(retryCount int, response *nethttp.Response)
 
+// RetryOptions configures the retry behavior for the middleware pipeline.
 type RetryOptions struct {
 	Enabled           bool
 	MaxRetries        int
@@ -18,6 +21,7 @@ type RetryOptions struct {
 	Hook              RetryHookCallback
 }
 
+// WithRetryOptions creates a middleware option that configures retry behavior.
 func WithRetryOptions(enabled, enabledForServerErrors bool, maxRetries int, hook RetryHookCallback) MiddlewareOption {
 	return MiddlewareOption{key: "RetryOptions", value: RetryOptions{
 		Enabled:           enabled,
@@ -27,6 +31,7 @@ func WithRetryOptions(enabled, enabledForServerErrors bool, maxRetries int, hook
 	}}
 }
 
+// WithErrorInterceptorOption creates a middleware option that configures error interception.
 func WithErrorInterceptorOption(errorFactory APIErrorFactory) MiddlewareOption {
 	return MiddlewareOption{key: "ErrorInterceptor", value: errorFactory}
 }

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -30,9 +30,8 @@ func (m *RateLimitMiddleware) Intercept(pipeline khttp.Pipeline, index int, req 
 	// If rate limited, translate the custom header into Retry-After for the retry middleware.
 	resetHeader := resp.Header.Get(rateLimitResetHeader)
 	if resetHeader != "" {
-		val, _ := strconv.ParseFloat(resetHeader, 64)
-
-		if val > 0 {
+		val, err := strconv.ParseFloat(resetHeader, 64)
+		if err == nil && val > 0 {
 			resp.Header.Set("Retry-After", fmt.Sprintf("%.3f", val))
 		}
 	}

--- a/middleware/rate_limit.go
+++ b/middleware/rate_limit.go
@@ -11,25 +11,28 @@ import (
 const rateLimitResetHeader = "X-RateLimit-Reset"
 
 // RateLimitMiddleware translates custom rate limit headers to Retry-After,
-// which is handled by Kiota's built-in retry middleware.
+// which is used by the retry middleware for backoff timing.
 type RateLimitMiddleware struct{}
 
+// NewRateLimitMiddleware creates a middleware that translates X-RateLimit-Reset
+// headers into standard Retry-After headers for use by the retry middleware.
 func NewRateLimitMiddleware() khttp.Middleware {
 	return &RateLimitMiddleware{}
 }
 
+// Intercept implements the khttp.Middleware interface.
 func (m *RateLimitMiddleware) Intercept(pipeline khttp.Pipeline, index int, req *http.Request) (*http.Response, error) {
 	resp, err := pipeline.Next(req, index)
 	if err != nil {
 		return resp, err
 	}
 
-	// if rate limited, translate the custom header into Retry-After, which Kiota will use internally
+	// If rate limited, translate the custom header into Retry-After for the retry middleware.
 	resetHeader := resp.Header.Get(rateLimitResetHeader)
 	if resetHeader != "" {
-		val, err := strconv.ParseFloat(resetHeader, 64)
-		if err == nil && val > 0 {
-			// Inject the standard header that Kiota's RetryHandler understands
+		val, _ := strconv.ParseFloat(resetHeader, 64)
+
+		if val > 0 {
 			resp.Header.Set("Retry-After", fmt.Sprintf("%.3f", val))
 		}
 	}

--- a/middleware/retry.go
+++ b/middleware/retry.go
@@ -15,10 +15,10 @@ const (
 	retryAttemptHeader = "Retry-Attempt"
 	retryAfterHeader   = "Retry-After"
 
-	defaultMaxRetries        = 3
-	absoluteMaxRetries       = 10
-	defaultDelaySeconds      = 3
-	absoluteMaxDelaySeconds  = 180
+	defaultMaxRetries       = 3
+	absoluteMaxRetries      = 10
+	defaultDelaySeconds     = 3
+	absoluteMaxDelaySeconds = 180
 )
 
 // ShouldRetryFunc determines whether a request should be retried based on the response.
@@ -118,7 +118,9 @@ func (m *RetryMiddleware) retryRequest(
 	// Reset body for retry if possible
 	if req.Body != nil {
 		if seeker, ok := req.Body.(io.Seeker); ok {
-			seeker.Seek(0, io.SeekStart)
+			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+				return resp, err
+			}
 		}
 	}
 
@@ -152,22 +154,26 @@ func (m *RetryMiddleware) isRetriableRequest(req *nethttp.Request) bool {
 // getRetryDelay calculates the delay before the next retry attempt.
 // It respects the Retry-After header if present, otherwise uses exponential backoff.
 func (m *RetryMiddleware) getRetryDelay(resp *nethttp.Response, executionCount int) time.Duration {
-	if resp != nil {
-		retryAfter := resp.Header.Get(retryAfterHeader)
-		if retryAfter != "" {
-			// Try parsing as seconds (float)
-			if seconds, err := strconv.ParseFloat(retryAfter, 64); err == nil && seconds > 0 {
-				return time.Duration(seconds * float64(time.Second))
-			}
-			// Try parsing as HTTP-date
-			if t, err := time.Parse(time.RFC1123, retryAfter); err == nil {
-				if d := time.Until(t); d > 0 {
-					return d
-				}
-			}
+	if resp == nil {
+		return time.Duration(math.Pow(float64(m.delaySeconds), float64(executionCount))) * time.Second
+	}
+
+	retryAfter := resp.Header.Get(retryAfterHeader)
+	if retryAfter == "" {
+		return time.Duration(math.Pow(float64(m.delaySeconds), float64(executionCount))) * time.Second
+	}
+
+	// Try parsing as seconds (float)
+	if seconds, err := strconv.ParseFloat(retryAfter, 64); err == nil && seconds > 0 {
+		return time.Duration(seconds * float64(time.Second))
+	}
+
+	// Try parsing as HTTP-date
+	if t, err := time.Parse(time.RFC1123, retryAfter); err == nil {
+		if d := time.Until(t); d > 0 {
+			return d
 		}
 	}
 
-	// Exponential backoff: delaySeconds^executionCount
 	return time.Duration(math.Pow(float64(m.delaySeconds), float64(executionCount))) * time.Second
 }

--- a/middleware/retry.go
+++ b/middleware/retry.go
@@ -1,0 +1,173 @@
+// Package middleware contains the custom middleware used by the go-tfe SDK.
+package middleware
+
+import (
+	"io"
+	"math"
+	nethttp "net/http"
+	"strconv"
+	"time"
+
+	khttp "github.com/microsoft/kiota-http-go"
+)
+
+const (
+	retryAttemptHeader = "Retry-Attempt"
+	retryAfterHeader   = "Retry-After"
+
+	defaultMaxRetries        = 3
+	absoluteMaxRetries       = 10
+	defaultDelaySeconds      = 3
+	absoluteMaxDelaySeconds  = 180
+)
+
+// ShouldRetryFunc determines whether a request should be retried based on the response.
+type ShouldRetryFunc func(executionCount int, request *nethttp.Request, response *nethttp.Response) bool
+
+// RetryMiddleware is a custom retry middleware that replaces Kiota's built-in RetryHandler.
+// Unlike Kiota's implementation, it does NOT gate retries behind a hardcoded isRetriableErrorCode
+// check (which only covers 429, 503, 504). Instead, it delegates the retry decision entirely
+// to the provided ShouldRetry callback, allowing retries on any status code (e.g. 425, 500, 502).
+type RetryMiddleware struct {
+	maxRetries   int
+	delaySeconds int
+	shouldRetry  ShouldRetryFunc
+}
+
+// RetryMiddlewareOptions configures the custom retry middleware.
+type RetryMiddlewareOptions struct {
+	// MaxRetries is the maximum number of retry attempts. Capped at 10.
+	MaxRetries int
+	// DelaySeconds is the base delay between retries (used for exponential backoff).
+	DelaySeconds int
+	// ShouldRetry determines whether a given response warrants a retry.
+	// This is called unconditionally for every non-nil response — there is no
+	// status code pre-filter.
+	ShouldRetry ShouldRetryFunc
+}
+
+// NewRetryMiddleware creates a custom retry middleware with the given options.
+func NewRetryMiddleware(opts RetryMiddlewareOptions) khttp.Middleware {
+	maxRetries := opts.MaxRetries
+	if maxRetries < 1 {
+		maxRetries = defaultMaxRetries
+	} else if maxRetries > absoluteMaxRetries {
+		maxRetries = absoluteMaxRetries
+	}
+
+	delaySeconds := opts.DelaySeconds
+	if delaySeconds < 1 {
+		delaySeconds = defaultDelaySeconds
+	} else if delaySeconds > absoluteMaxDelaySeconds {
+		delaySeconds = absoluteMaxDelaySeconds
+	}
+
+	shouldRetry := opts.ShouldRetry
+	if shouldRetry == nil {
+		shouldRetry = func(_ int, _ *nethttp.Request, _ *nethttp.Response) bool {
+			return false
+		}
+	}
+
+	return &RetryMiddleware{
+		maxRetries:   maxRetries,
+		delaySeconds: delaySeconds,
+		shouldRetry:  shouldRetry,
+	}
+}
+
+// Intercept implements the khttp.Middleware interface.
+func (m *RetryMiddleware) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request) (*nethttp.Response, error) {
+	response, err := pipeline.Next(req, middlewareIndex)
+	if err != nil {
+		return response, err
+	}
+	return m.retryRequest(pipeline, middlewareIndex, req, response, 0, 0)
+}
+
+func (m *RetryMiddleware) retryRequest(
+	pipeline khttp.Pipeline,
+	middlewareIndex int,
+	req *nethttp.Request,
+	resp *nethttp.Response,
+	executionCount int,
+	cumulativeDelay time.Duration,
+) (*nethttp.Response, error) {
+	// Check all retry conditions. Unlike Kiota's RetryHandler, we do NOT pre-filter
+	// by status code. The ShouldRetry callback is the sole arbiter of whether to retry.
+	if !m.isRetriableRequest(req) {
+		return resp, nil
+	}
+	if executionCount >= m.maxRetries {
+		return resp, nil
+	}
+	if cumulativeDelay >= time.Duration(absoluteMaxDelaySeconds)*time.Second {
+		return resp, nil
+	}
+	if !m.shouldRetry(executionCount, req, resp) {
+		return resp, nil
+	}
+
+	// Proceed with retry
+	executionCount++
+	delay := m.getRetryDelay(resp, executionCount)
+	cumulativeDelay += delay
+
+	req.Header.Set(retryAttemptHeader, strconv.Itoa(executionCount))
+
+	// Reset body for retry if possible
+	if req.Body != nil {
+		if seeker, ok := req.Body.(io.Seeker); ok {
+			seeker.Seek(0, io.SeekStart)
+		}
+	}
+
+	// Wait for the delay, respecting context cancellation
+	ctx := req.Context()
+	t := time.NewTimer(delay)
+	select {
+	case <-ctx.Done():
+		t.Stop()
+		return nil, ctx.Err()
+	case <-t.C:
+	}
+
+	response, err := pipeline.Next(req, middlewareIndex)
+	if err != nil {
+		return response, err
+	}
+	return m.retryRequest(pipeline, middlewareIndex, req, response, executionCount, cumulativeDelay)
+}
+
+// isRetriableRequest checks whether the request type supports retrying.
+// POST/PUT/PATCH with streaming bodies (ContentLength == -1) cannot be retried.
+func (m *RetryMiddleware) isRetriableRequest(req *nethttp.Request) bool {
+	isBodiedMethod := req.Method == "POST" || req.Method == "PUT" || req.Method == "PATCH"
+	if isBodiedMethod && req.Body != nil {
+		return req.ContentLength != -1
+	}
+	return true
+}
+
+// getRetryDelay calculates the delay before the next retry attempt.
+// It respects the Retry-After header if present, otherwise uses exponential backoff.
+func (m *RetryMiddleware) getRetryDelay(resp *nethttp.Response, executionCount int) time.Duration {
+	if resp != nil {
+		retryAfter := resp.Header.Get(retryAfterHeader)
+		if retryAfter != "" {
+			// Try parsing as seconds (float)
+			if seconds, err := strconv.ParseFloat(retryAfter, 64); err == nil && seconds > 0 {
+				return time.Duration(seconds * float64(time.Second))
+			}
+			// Try parsing as HTTP-date
+			if t, err := time.Parse(time.RFC1123, retryAfter); err == nil {
+				if d := time.Until(t); d > 0 {
+					return d
+				}
+			}
+		}
+	}
+
+	// Exponential backoff: delaySeconds^executionCount
+	return time.Duration(math.Pow(float64(m.delaySeconds), float64(executionCount))) * time.Second
+}

--- a/middleware/retry_test.go
+++ b/middleware/retry_test.go
@@ -450,7 +450,7 @@ func TestGetForKiota_RetryDisabled(t *testing.T) {
 	defer server.Close()
 
 	middlewares, err := GetForKiota("1.0.0",
-		WithRetryOptions(false, true, 3, nil),
+		WithRetryOptions(false, false, 3, nil),
 	)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -481,5 +481,55 @@ func TestGetForKiota_RetryDisabled(t *testing.T) {
 	// Should not retry when disabled
 	if atomic.LoadInt32(&attempts) != 1 {
 		t.Fatalf("expected 1 attempt (retry disabled), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestGetForKiota_ServerErrorRetriesIndependentOfRateLimitFlag(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	// RetryRateLimited=false, RetryServerErrors=true
+	// Server error retries should work even when rate limit retries are disabled
+	middlewares, err := GetForKiota("1.0.0",
+		WithRetryOptions(false, true, 3, nil),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var retryMW khttp.Middleware
+	for _, mw := range middlewares {
+		if _, ok := mw.(*RetryMiddleware); ok {
+			retryMW = mw
+			break
+		}
+	}
+	if retryMW == nil {
+		t.Fatal("RetryMiddleware not found in pipeline")
+	}
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := retryMW.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("expected 2 attempts (retry on 500), got %d", atomic.LoadInt32(&attempts))
 	}
 }

--- a/middleware/retry_test.go
+++ b/middleware/retry_test.go
@@ -56,6 +56,7 @@ func TestRetryMiddleware_RetriesOn500(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -93,6 +94,7 @@ func TestRetryMiddleware_RetriesOn502(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -131,6 +133,7 @@ func TestRetryMiddleware_RetriesOn429(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -168,6 +171,7 @@ func TestRetryMiddleware_RetriesOn425(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -202,6 +206,7 @@ func TestRetryMiddleware_DoesNotRetryWhenShouldRetryReturnsFalse(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
 	}
@@ -235,6 +240,7 @@ func TestRetryMiddleware_RespectsMaxRetries(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", resp.StatusCode)
 	}
@@ -271,6 +277,7 @@ func TestRetryMiddleware_DoesNotRetryStreamingBody(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", resp.StatusCode)
 	}
@@ -314,6 +321,7 @@ func TestRetryMiddleware_RetriesPostWithKnownContentLength(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -356,6 +364,7 @@ func TestRetryMiddleware_HookCalledOnRetry(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -393,6 +402,7 @@ func TestRetryMiddleware_SetsRetryAttemptHeader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("expected 200, got %d", resp.StatusCode)
 	}
@@ -464,6 +474,7 @@ func TestGetForKiota_RetryDisabled(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusInternalServerError {
 		t.Fatalf("expected 500, got %d", resp.StatusCode)
 	}

--- a/middleware/retry_test.go
+++ b/middleware/retry_test.go
@@ -1,0 +1,474 @@
+package middleware
+
+import (
+	"bytes"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+
+	khttp "github.com/microsoft/kiota-http-go"
+)
+
+// testPipeline implements khttp.Pipeline for testing. It routes requests to the
+// underlying test server transport.
+type testPipeline struct {
+	transport http.RoundTripper
+}
+
+func (p *testPipeline) Next(req *http.Request, _ int) (*http.Response, error) {
+	return p.transport.RoundTrip(req)
+}
+
+func newTestPipeline(handler http.Handler) (*testPipeline, *httptest.Server) {
+	server := httptest.NewServer(handler)
+	return &testPipeline{transport: http.DefaultTransport}, server
+}
+
+func TestRetryMiddleware_RetriesOn500(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte("success"))
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   5,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode >= 500
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Fatalf("expected 3 attempts, got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_RetriesOn502(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode >= 500
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_RetriesOn429(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count == 1 {
+			w.Header().Set("Retry-After", "0.01")
+			w.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode == 429 || resp.StatusCode == 425
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_RetriesOn425(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count == 1 {
+			w.WriteHeader(425) // Too Early
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode == 429 || resp.StatusCode == 425
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_DoesNotRetryWhenShouldRetryReturnsFalse(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusBadRequest) // 400 - not retriable
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			// Only retry on 429, 425, 5xx
+			return resp.StatusCode == 429 || resp.StatusCode == 425 || resp.StatusCode >= 500
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Fatalf("expected 1 attempt (no retry), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_RespectsMaxRetries(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   2,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode >= 500
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	// 1 initial + 2 retries = 3 total
+	if atomic.LoadInt32(&attempts) != 3 {
+		t.Fatalf("expected 3 total attempts (1 + 2 retries), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_DoesNotRetryStreamingBody(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode >= 500
+		},
+	})
+
+	// Create a POST with ContentLength=-1 (streaming body, not seekable)
+	req, _ := http.NewRequest("POST", server.URL+"/test", bytes.NewReader([]byte("body")))
+	req.ContentLength = -1 // Simulate streaming body
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	// Should NOT retry because ContentLength is -1 (streaming)
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Fatalf("expected 1 attempt (no retry for streaming body), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_RetriesPostWithKnownContentLength(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count == 1 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode >= 500
+		},
+	})
+
+	body := []byte("request body")
+	req, _ := http.NewRequest("POST", server.URL+"/test", bytes.NewReader(body))
+	req.ContentLength = int64(len(body))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(body)), nil
+	}
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+func TestRetryMiddleware_HookCalledOnRetry(t *testing.T) {
+	var attempts int32
+	var hookCalls int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		count := atomic.AddInt32(&attempts, 1)
+		if count <= 2 {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   5,
+		DelaySeconds: 1,
+		ShouldRetry: func(executionCount int, _ *http.Request, resp *http.Response) bool {
+			if resp.StatusCode >= 500 {
+				atomic.AddInt32(&hookCalls, 1)
+				return true
+			}
+			return false
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&hookCalls) != 2 {
+		t.Fatalf("expected hook called 2 times, got %d", atomic.LoadInt32(&hookCalls))
+	}
+}
+
+func TestRetryMiddleware_SetsRetryAttemptHeader(t *testing.T) {
+	var lastRetryAttempt string
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		lastRetryAttempt = r.Header.Get("Retry-Attempt")
+		if lastRetryAttempt == "" {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+			return resp.StatusCode >= 500
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if lastRetryAttempt != "1" {
+		t.Fatalf("expected Retry-Attempt header '1', got '%s'", lastRetryAttempt)
+	}
+}
+
+func TestGetForKiota_NoKiotaRetryHandler(t *testing.T) {
+	middlewares, err := GetForKiota("1.0.0",
+		WithRetryOptions(true, true, 3, nil),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, mw := range middlewares {
+		if _, isKiotaRetry := mw.(*khttp.RetryHandler); isKiotaRetry {
+			t.Fatal("expected Kiota's RetryHandler to be removed from the pipeline")
+		}
+	}
+
+	// Verify our custom RetryMiddleware is present
+	found := false
+	for _, mw := range middlewares {
+		if _, ok := mw.(*RetryMiddleware); ok {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected custom RetryMiddleware to be in the pipeline")
+	}
+}
+
+func TestGetForKiota_RetryDisabled(t *testing.T) {
+	var attempts int32
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.WriteHeader(http.StatusInternalServerError)
+	})
+
+	pipeline, server := newTestPipeline(handler)
+	defer server.Close()
+
+	middlewares, err := GetForKiota("1.0.0",
+		WithRetryOptions(false, true, 3, nil),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find our retry middleware
+	var retryMW khttp.Middleware
+	for _, mw := range middlewares {
+		if _, ok := mw.(*RetryMiddleware); ok {
+			retryMW = mw
+			break
+		}
+	}
+	if retryMW == nil {
+		t.Fatal("RetryMiddleware not found in pipeline")
+	}
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := retryMW.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.StatusCode != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", resp.StatusCode)
+	}
+	// Should not retry when disabled
+	if atomic.LoadInt32(&attempts) != 1 {
+		t.Fatalf("expected 1 attempt (retry disabled), got %d", atomic.LoadInt32(&attempts))
+	}
+}


### PR DESCRIPTION
<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

Kiota's built-in `RetryHandler` has a hardcoded `isRetriableErrorCode` check that only covers 429, 503, and 504: This check short-circuits before the `ShouldRetry` callback is ever invoked, meaning 500, 502, and 425 responses are never retried even when our callback would return true for them.

So I replaced Kiota's `RetryHandler` with a custom `RetryMiddleware` that delegates the retry decision entirely to our own logic, with no status code pre-filter.
The custom middleware retries on 429, 425, and all 5xx when RetryServerErrors is enabled

## Testing plan

<!--
1.  _Describe how to replicate_
1.  _the conditions under which your code performs its purpose,_
1.  _including example code to run where necessary._
-->

Run the unit tests which simulate the exact failure scenario (server returning 500/502/425 that Kiota's handler would never retry):
`go test ./middleware/ -v -count=1`
Tests stand up HTTP servers that return the target status codes and verify the middleware retries them. 
1. Server returns 500 or 502 with RetryServerErrors enabled - middleware retries until success. 
2. Server returns 425 - middleware retries. 
3. Server returns 429 with a `Retry-After` header - middleware retries and sees the backoff value.
4. Server returns 400 - middleware does not retry 
5. Retry disabled - no retries occur regardless of status code.

## Output from tests
Including output from tests may require access to a TFE instance. Ignore this section if you have no environment to test against.

<!--
_Please run the tests locally for any files you changes and include the output here._
-->
```
=== RUN   TestRetryMiddleware_RetriesOn500
--- PASS: TestRetryMiddleware_RetriesOn500 (2.00s)
=== RUN   TestRetryMiddleware_RetriesOn502
--- PASS: TestRetryMiddleware_RetriesOn502 (1.00s)
=== RUN   TestRetryMiddleware_RetriesOn429
--- PASS: TestRetryMiddleware_RetriesOn429 (0.01s)
=== RUN   TestRetryMiddleware_RetriesOn425
--- PASS: TestRetryMiddleware_RetriesOn425 (1.00s)
=== RUN   TestRetryMiddleware_DoesNotRetryWhenShouldRetryReturnsFalse
--- PASS: TestRetryMiddleware_DoesNotRetryWhenShouldRetryReturnsFalse (0.00s)
=== RUN   TestRetryMiddleware_RespectsMaxRetries
--- PASS: TestRetryMiddleware_RespectsMaxRetries (2.00s)
=== RUN   TestRetryMiddleware_DoesNotRetryStreamingBody
--- PASS: TestRetryMiddleware_DoesNotRetryStreamingBody (0.00s)
=== RUN   TestRetryMiddleware_RetriesPostWithKnownContentLength
--- PASS: TestRetryMiddleware_RetriesPostWithKnownContentLength (1.00s)
=== RUN   TestRetryMiddleware_HookCalledOnRetry
--- PASS: TestRetryMiddleware_HookCalledOnRetry (2.00s)
=== RUN   TestRetryMiddleware_SetsRetryAttemptHeader
--- PASS: TestRetryMiddleware_SetsRetryAttemptHeader (1.00s)
=== RUN   TestGetForKiota_NoKiotaRetryHandler
--- PASS: TestGetForKiota_NoKiotaRetryHandler (0.00s)
=== RUN   TestGetForKiota_RetryDisabled
--- PASS: TestGetForKiota_RetryDisabled (0.00s)
PASS
ok  	github.com/hashicorp/go-tfe/middleware	10.668s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
