### PR TITLE
chore: fix CI by not referencing sunset Trial entitlement

### DIFF
--- a/run_task_integration_test.go
+++ b/run_task_integration_test.go
@@ -109,7 +109,7 @@ func TestRunTasksCreateWithoutGlobalEntitlement(t *testing.T) {
 	orgTest, orgTestCleanup := createOrganization(t, client)
 	defer orgTestCleanup()
 
-	newSubscriptionUpdater(orgTest).WithTrialPlan().Update(t)
+	newSubscriptionUpdater(orgTest).WithFreePlan().Update(t)
 
 	if v, err := hasGlobalRunTasks(client, orgTest.Name); err != nil {
 		t.Fatalf("Could not retrieve the entitlements for the test organization.: %s", err)

--- a/subscription_updater_test.go
+++ b/subscription_updater_test.go
@@ -71,8 +71,8 @@ func (b *organizationSubscriptionUpdater) WithBusinessPlan() *organizationSubscr
 	return b
 }
 
-func (b *organizationSubscriptionUpdater) WithTrialPlan() *organizationSubscriptionUpdater {
-	b.planName = "Trial"
+func (b *organizationSubscriptionUpdater) WithFreePlan() *organizationSubscriptionUpdater {
+	b.planName = "Free"
 	ceiling := 1
 	b.updateOpts.RunsCeiling = &ceiling
 	return b


### PR DESCRIPTION

<!--
Thank you for contributing to hashicorp/go-tfe! Please read docs/CONTRIBUTING.md for detailed information when preparing your change.

Here's what to expect after the pull request is opened:

The test suite contains many acceptance tests that are run against a test version of HCP Terraform, and additional testing is done against Terraform Enterprise. You can read more about running the tests against your own Terraform Enterprise environment in TESTS.md. Our CI system (Github Actions) will not test your fork until a one-time approval takes place.

Your change, depending on its impact, may be released in the following ways:

  1. For impactful bug fixes, it can be released fairly quickly as a patch release.
  2. For noncritical bug fixes and new features, it will be incorporated into the next minor version release.
  3. For breaking changes (those changes that alter the public method signatures), more consideration must be made and alternatives may be considered, depending on upgrade difficulty and release schedule.

Please note that API features that are not generally available should not be merged/released without prior discussion with the maintainers. See docs/CONTRIBUTING Section "Adding API changes that are not generally available" for more information.

Please fill out the remaining template to assist code reviewers and testers with incorporating your change. If a section does not apply, feel free to delete it.
-->

## Description

-no longer reference the Trial entitlement which was recently sunset in tests (use Free instead)

## Testing plan

Just a change to tests so no testing plan needed

## Rollback Plan

Revert the PR
