### PR TITLE
Update nightly-api-update.yml

### DIFF
--- a/.github/workflows/nightly-api-update.yml
+++ b/.github/workflows/nightly-api-update.yml
@@ -46,13 +46,11 @@ jobs:
           echo "has_changes=false" >> "$GITHUB_OUTPUT"
 
       - name: Create update branch name
-        if: steps.changes.outputs.has_changes == 'true'
         id: branch
         run: |
           echo "name=${BRANCH_PREFIX}/$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
       - name: Close older nightly PRs
-        if: steps.changes.outputs.has_changes == 'true'
         id: close_older_nightly_prs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:

--- a/.github/workflows/nightly-api-update.yml
+++ b/.github/workflows/nightly-api-update.yml
@@ -52,13 +52,17 @@ jobs:
           echo "name=${BRANCH_PREFIX}/$(date -u +%Y%m%d)" >> "$GITHUB_OUTPUT"
 
       - name: Close older nightly PRs
+        if: steps.changes.outputs.has_changes == 'true'
         id: close_older_nightly_prs
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        env:
+          CURRENT_BRANCH_NAME: ${{ steps.branch.outputs.name }}
         with:
           script: |
             const branchPrefix = process.env.BRANCH_PREFIX;
             const nightlyLabel = process.env.NIGHTLY_LABEL;
             const nightlyAuthor = process.env.NIGHTLY_AUTHOR;
+            const currentBranchName = process.env.CURRENT_BRANCH_NAME;
             const { owner, repo } = context.repo;
 
             const prs = await github.paginate(github.rest.pulls.list, {
@@ -78,14 +82,12 @@ jobs:
             );
 
             if (nightlyPrs.length === 0) {
-              core.info('No open nightly API PRs found');
               return;
             }
 
-            const [latestPr, ...olderPrs] = nightlyPrs;
-            core.setOutput('latest_pr_number', String(latestPr.number));
+            const prsToClose = nightlyPrs.filter((pr) => pr.head.ref !== currentBranchName);
 
-            for (const pr of olderPrs) {
+            for (const pr of prsToClose) {
               await github.rest.pulls.update({
                 owner,
                 repo,


### PR DESCRIPTION
## Description

Old PR's weren't being closed by the nightly `make api` update because my code was just not closing the latest PR. Now, the nightly should close any PR that isn't for today, allowing the PR to update the same branch for the same day, but closing all previous days

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
