### PR TITLE
[TF-37921] Add VCS connection fields to registry module update options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+## Enhancements
+* Adds `Identifier`, `OAuthTokenID`, and `GHAInstallationID` fields to `RegistryModuleVCSRepoUpdateOptions` so callers can update a registry module's VCS repository identifier and connection (OAuth token or GitHub App installation) via the `Update` method; setting both `OAuthTokenID` and `GHAInstallationID` in the same call returns `ErrMutuallyExclusiveOAuthTokenAndGHAInstallation` [#1376](https://github.com/hashicorp/go-tfe/pull/1376)
+
 # v2.0.0
 
 The go-tfe v2 package has been added to this repository and contains substantial breaking changes

--- a/go.mod
+++ b/go.mod
@@ -9,9 +9,15 @@ require (
 	github.com/hashicorp/go-slug v0.16.8
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/jsonapi v1.4.3-0.20250220162346-81a76b606f3e
+	github.com/stretchr/testify v1.11.1
 	go.uber.org/mock v0.4.0
 	golang.org/x/sync v0.21.0
 	golang.org/x/time v0.15.0
 )
 
-require golang.org/x/sys v0.35.0 // indirect
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	golang.org/x/sys v0.35.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.16.0 h1:zmkK9Ngbjj+K0yRhTVONQh1p/HknKYSlNT+vZCzyokM=
 github.com/fatih/color v1.16.0/go.mod h1:fL2Sau1YI5c0pdGEVCbKQbLXB6edEj1ZgiY4NijnWvE=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
@@ -21,6 +23,10 @@ github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxec
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
+github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
 go.uber.org/mock v0.4.0 h1:VcM4ZOtdbR4f6VXfiOpwpVJDL6lCReaZ6mw31wqh7KU=
 go.uber.org/mock v0.4.0/go.mod h1:a6FSlNadKUHUa9IP5Vyt1zh4fC7uAwxMutEAscFbkZc=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
@@ -29,3 +35,7 @@ golang.org/x/sys v0.35.0 h1:vz1N37gP5bs89s7He8XuIYXpyY0+QlsKmzipCbUtyxI=
 golang.org/x/sys v0.35.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
 golang.org/x/time v0.15.0 h1:bbrp8t3bGUeFOx08pvsMYRTCVSMk89u4tKbNOZbp88U=
 golang.org/x/time v0.15.0/go.mod h1:Y4YMaQmXwGQZoFaVFk4YpCt4FLQMYKZe9oeV/f4MSno=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/registry_module_test.go
+++ b/registry_module_test.go
@@ -1,0 +1,97 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package tfe
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRegistryModules_Update_VCSRepoMutualExclusionValidation(t *testing.T) {
+	t.Parallel()
+	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer testServer.Close()
+
+	client, err := NewClient(&Config{
+		Address: testServer.URL,
+		Token:   "fake-token",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	ctx := context.Background()
+
+	moduleID := RegistryModuleID{
+		Organization: "test-org",
+		Name:         "test-module",
+		Provider:     "aws",
+		Namespace:    "test-namespace",
+		RegistryName: PrivateRegistry,
+	}
+
+	t.Run("errors when both OAuthTokenID and GHAInstallationID are set", func(t *testing.T) {
+		options := RegistryModuleUpdateOptions{
+			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
+				Identifier:        String("test-org/terraform-aws-module"),
+				OAuthTokenID:      String("ot-123"),
+				GHAInstallationID: String("ghain-456"),
+			},
+		}
+
+		rm, err := client.RegistryModules.Update(ctx, moduleID, options)
+		assert.Error(t, err)
+		assert.Equal(t, ErrMutuallyExclusiveOAuthTokenAndGHAInstallation, err)
+		assert.Nil(t, rm)
+	})
+
+	t.Run("succeeds when only OAuthTokenID is set", func(t *testing.T) {
+		options := RegistryModuleUpdateOptions{
+			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
+				Identifier:   String("test-org/terraform-aws-module"),
+				OAuthTokenID: String("ot-123"),
+			},
+		}
+
+		// Validation passes; expect a network/API error, not our validation error
+		_, err := client.RegistryModules.Update(ctx, moduleID, options)
+		if err != nil {
+			assert.NotEqual(t, ErrMutuallyExclusiveOAuthTokenAndGHAInstallation, err)
+		}
+	})
+
+	t.Run("succeeds when only GHAInstallationID is set", func(t *testing.T) {
+		options := RegistryModuleUpdateOptions{
+			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
+				Identifier:        String("test-org/terraform-aws-module"),
+				GHAInstallationID: String("ghain-456"),
+			},
+		}
+
+		// Validation passes; expect a network/API error, not our validation error
+		_, err := client.RegistryModules.Update(ctx, moduleID, options)
+		if err != nil {
+			assert.NotEqual(t, ErrMutuallyExclusiveOAuthTokenAndGHAInstallation, err)
+		}
+	})
+
+	t.Run("succeeds when neither OAuthTokenID nor GHAInstallationID is set", func(t *testing.T) {
+		options := RegistryModuleUpdateOptions{
+			VCSRepo: &RegistryModuleVCSRepoUpdateOptions{
+				Identifier: String("test-org/terraform-aws-module"),
+			},
+		}
+
+		// Validation passes; expect a network/API error, not our validation error
+		_, err := client.RegistryModules.Update(ctx, moduleID, options)
+		if err != nil {
+			assert.NotEqual(t, ErrMutuallyExclusiveOAuthTokenAndGHAInstallation, err)
+		}
+	})
+}

--- a/v1.go
+++ b/v1.go
@@ -4782,6 +4782,8 @@ var (
 
 	ErrRequiredOauthTokenOrGithubAppInstallationID = errors.New("either oauth token ID or github app installation ID is required")
 
+	ErrMutuallyExclusiveOAuthTokenAndGHAInstallation = errors.New("oauth token ID and github app installation ID are mutually exclusive")
+
 	ErrRequiredTestNumber = errors.New("TestNumber is required")
 
 	ErrMissingTagIdentifier = errors.New("must specify at least one tag by ID or name")
@@ -12745,6 +12747,18 @@ type RegistryModuleVCSRepoUpdateOptions struct {
 	// Optional: If set, the registry module will be branch-based or tag-based
 	SourceDirectory *string `json:"source-directory,omitempty"`
 	TagPrefix       *string `json:"tag-prefix,omitempty"`
+
+	// Optional: The repository identifier (e.g. "org/repo"). When provided,
+	// the module's VCS connection is re-pointed to this repository.
+	Identifier *string `json:"identifier,omitempty"`
+
+	// Optional: The OAuth token ID to use for the VCS connection. Mutually
+	// exclusive with GHAInstallationID.
+	OAuthTokenID *string `json:"oauth-token-id,omitempty"`
+
+	// Optional: The GitHub App installation ID to use for the VCS connection.
+	// Mutually exclusive with OAuthTokenID.
+	GHAInstallationID *string `json:"github-app-installation-id,omitempty"`
 }
 
 // List all the registry modules within an organization.
@@ -12875,6 +12889,9 @@ func (r *registryModules) Update(ctx context.Context, moduleID RegistryModuleID,
 	if options.VCSRepo != nil {
 		if options.VCSRepo.Tags != nil && *options.VCSRepo.Tags && validString(options.VCSRepo.Branch) {
 			return nil, ErrBranchMustBeEmptyWhenTagsEnabled
+		}
+		if validString(options.VCSRepo.OAuthTokenID) && validString(options.VCSRepo.GHAInstallationID) {
+			return nil, ErrMutuallyExclusiveOAuthTokenAndGHAInstallation
 		}
 	}
 


### PR DESCRIPTION
## Description

Adds `Identifier`, `OAuthTokenID`, and `GHAInstallationID` to `RegistryModuleVCSRepoUpdateOptions` so callers can update a registry module's VCS connection — its repository identifier and the OAuth token or GitHub App installation — via `RegistryModules.Update`, not just the publishing mechanism (branch/tags). Setting both `OAuthTokenID` and `GHAInstallationID` in the same call returns the new `ErrMutuallyExclusiveOAuthTokenAndGHAInstallation`.

This matches the corresponding HCP Terraform / Atlas registry-module API change, which is now generally available.

## Testing plan

1. The mutual-exclusion validation runs before any network call, so it is covered by a self-contained unit test (an `httptest` server stands in for the API):

```
go test -run TestRegistryModules_Update_VCSRepoMutualExclusionValidation .
```

It asserts both IDs set → `ErrMutuallyExclusiveOAuthTokenAndGHAInstallation`, and that only-one / neither set does not return that validation error.

## External links

- [Related Atlas PR](https://github.com/hashicorp/atlas/pull/29638)

## Output from tests

```
$ go test -run TestRegistryModules_Update_VCSRepoMutualExclusionValidation .
ok  	github.com/hashicorp/go-tfe	0.605s
```

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
## Rollback Plan

If this change needs to be reverted, revert the pull request. The change is additive (new optional option fields plus one validation error) with no data migration or stateful component.

## Changes to Security Controls

None.
