### PR TITLE
Adds HTTPTransport config option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+* Enhancement: NewClient configuration now supports a parent `http.RoundTripper`, allowing you to
+customize many more aspects of every request round trip.
+
 # v2.2.0
 
 The latest public endpoints are available

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Enhancement: NewClient configuration now supports a parent `http.RoundTripper`, allowing you to
+* Enhancement: NewClient configuration now supports `HTTPTransport` option, allowing you to
 customize many more aspects of every request round trip.
 
 # v2.2.0

--- a/v2/adapter.go
+++ b/v2/adapter.go
@@ -29,7 +29,20 @@ func NewHTTPClient(options []middleware.MiddlewareOption) (*nethttp.Client, erro
 	if err != nil {
 		return nil, err
 	}
+
+	var parentTransport nethttp.RoundTripper
+	for _, opt := range options {
+		if t, ok := opt.Value("HTTPTransport").(nethttp.RoundTripper); ok {
+			parentTransport = t
+		}
+	}
+
 	httpClient := khttp.GetDefaultClient(mw...)
+
+	if parentTransport != nil {
+		httpClient.Transport = khttp.NewCustomTransportWithParentTransport(parentTransport, mw...)
+	}
+
 	return httpClient, nil
 }
 

--- a/v2/middleware/options.go
+++ b/v2/middleware/options.go
@@ -12,6 +12,14 @@ type MiddlewareOption struct {
 	value any
 }
 
+// Value returns the option's value if the key matches, otherwise nil.
+func (o MiddlewareOption) Value(key string) any {
+	if o.key == key {
+		return o.value
+	}
+	return nil
+}
+
 // RetryHookCallback is called before each retry attempt with the attempt number and response.
 type RetryHookCallback func(retryCount int, response *nethttp.Response)
 
@@ -41,4 +49,11 @@ func WithErrorInterceptorOption(errorFactory APIErrorFactory) MiddlewareOption {
 // WithHeaders creates a middleware option that adds the provided headers to each request.
 func WithHeaders(headers nethttp.Header) MiddlewareOption {
 	return MiddlewareOption{key: "Headers", value: headers}
+}
+
+// WithHTTPTransport creates a middleware option that sets a custom parent transport for the HTTP
+// client. When set, it is used as the base RoundTripper for the kiota middleware pipeline via
+// khttp.NewCustomTransportWithParentTransport. If nil, the kiota default transport is used.
+func WithHTTPTransport(transport nethttp.RoundTripper) MiddlewareOption {
+	return MiddlewareOption{key: "HTTPTransport", value: transport}
 }

--- a/v2/tfe.go
+++ b/v2/tfe.go
@@ -49,6 +49,11 @@ type Config struct {
 
 	// RetryMaxRetries sets the maximum number of retries for a request before giving up.
 	RetryMaxRetries int
+
+	// HTTPTransport is an optional parent transport for the HTTP client. When set,
+	// it is used as the base transport for the kiota middleware pipeline via
+	// khttp.NewCustomTransportWithParentTransport. If nil, the kiota default transport is used.
+	HTTPTransport http.RoundTripper
 }
 
 // DefaultConfig returns a default config structure.
@@ -112,6 +117,7 @@ func NewClient(cfg *Config) (*Client, error) {
 		if cfg.RetryMaxRetries != 0 {
 			config.RetryMaxRetries = cfg.RetryMaxRetries
 		}
+		config.HTTPTransport = cfg.HTTPTransport
 	}
 
 	// Parse the address to make sure its a valid URL.
@@ -143,6 +149,7 @@ func NewClient(cfg *Config) (*Client, error) {
 	authProvider := auth.NewBaseBearerTokenAuthenticationProvider(tokenProvider)
 
 	adapter, err := NewRequestAdapter(baseURL.String(), []middleware.MiddlewareOption{
+		middleware.WithHTTPTransport(config.HTTPTransport),
 		middleware.WithErrorInterceptorOption(APIErrorFactory),
 		middleware.WithRetryOptions(config.RetryRateLimited, config.RetryServerErrors, config.RetryMaxRetries, config.RetryHook),
 		middleware.WithHeaders(config.Headers),

--- a/v2/tfe_test.go
+++ b/v2/tfe_test.go
@@ -5,6 +5,7 @@ package tfe
 
 import (
 	"context"
+	"crypto/tls"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -381,4 +382,57 @@ func TestGetStream_OnlySendsAuthorizationHeaderToAllowedHosts(t *testing.T) {
 
 	assert.Equal(t, "Bearer test-token", allowedAuthHeader)
 	assert.Empty(t, disallowedAuthHeader)
+}
+
+func TestHTTPTransport(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("/api/v2/account/details", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/vnd.api+json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"data":{"id":"usr-1234","type":"users","attributes":{"email":"test@example.com"}}}`))
+	})
+	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte(`{"errors":[{"status":"404","title":"not found"}]}`))
+	})
+
+	ts := httptest.NewTLSServer(mux)
+	defer ts.Close()
+
+	t.Run("fails without a custom transport", func(t *testing.T) {
+		client, err := NewClient(&Config{
+			Address: ts.URL,
+			Token:   "test-token",
+		})
+		if err != nil {
+			t.Fatalf("unexpected NewClient error: %v", err)
+		}
+
+		_, err = client.API.Account().Details().Get(context.Background(), nil)
+		if err == nil {
+			t.Fatal("expected TLS error, got nil")
+		}
+		var certErr *tls.CertificateVerificationError
+		assert.ErrorAs(t, err, &certErr, "expected a TLS certificate verification error")
+	})
+
+	t.Run("succeeds with a custom transport that skips TLS verification", func(t *testing.T) {
+		insecureTransport := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+		client, err := NewClient(&Config{
+			Address:       ts.URL,
+			Token:         "test-token",
+			HTTPTransport: insecureTransport,
+		})
+		if err != nil {
+			t.Fatalf("unexpected NewClient error: %v", err)
+		}
+
+		resp, err := client.API.Account().Details().Get(context.Background(), nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		assert.Equal(t, "test@example.com", *resp.GetData().GetAttributes().GetEmail())
+	})
 }


### PR DESCRIPTION
## Description

Allows callers to customize the request roundtrip by configuration, for instance, by skipping TLS certificate verification.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
