### PR TITLE
add missing PolicyEvaluationQueued status to PolicyEvaluationStatus enum

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+## Bug Fixes
+
+* Adds `PolicyEvaluationQueued` to `PolicyEvaluationStatus` enum by @sagarp917 [#1402](https://github.com/hashicorp/go-tfe/pull/1402)
+
+## Enhancements
+
 * Enhancement: NewClient configuration now supports `HTTPTransport` option, allowing you to
 customize many more aspects of every request round trip.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,5 @@
 # Unreleased
 
-## Bug Fixes
-
-* Adds `PolicyEvaluationQueued` to `PolicyEvaluationStatus` enum by @sagarp917 [#1402](https://github.com/hashicorp/go-tfe/pull/1402)
-
-## Enhancements
-
 * Enhancement: NewClient configuration now supports `HTTPTransport` option, allowing you to
 customize many more aspects of every request round trip.
 

--- a/v1.go
+++ b/v1.go
@@ -9310,6 +9310,7 @@ const (
 	PolicyEvaluationPassed      PolicyEvaluationStatus = "passed"
 	PolicyEvaluationFailed      PolicyEvaluationStatus = "failed"
 	PolicyEvaluationPending     PolicyEvaluationStatus = "pending"
+	PolicyEvaluationQueued      PolicyEvaluationStatus = "queued"
 	PolicyEvaluationRunning     PolicyEvaluationStatus = "running"
 	PolicyEvaluationUnreachable PolicyEvaluationStatus = "unreachable"
 	PolicyEvaluationOverridden  PolicyEvaluationStatus = "overridden"


### PR DESCRIPTION
### Description
Adds the missing `queued` status to the `PolicyEvaluationStatus` enum in the `v1` package. The `queued` status is already present in the related `TFPolicyEvaluationStatus` enum, but was absent from `PolicyEvaluationStatus`, causing callers to receive an unrecognised string when a policy evaluation transitions through the queued state.

While working on the[ Terraform CLI fix](https://hashicorp.atlassian.net/browse/IPL-9136) for **"Terraform CLI hangs forever waiting for policies after a run task fails"**, I found that `PolicyEvaluation.Status` can legitimately contain the value `"queued"` when deserialized from the API. Although the related `TFPolicyEvaluationStatus` enum already defines a `Queued` constant, `PolicyEvaluationStatus` did not, forcing downstream callers to either compare against a string literal or perform a type conversion from the older `PolicyStatus` enum.

This change is based on review feedback from the Terraform team, which pointed out that status is a `PolicyEvaluationStatus`, so a `"queued"` value should either be part of that enum or the source of the invalid value should be identified. After tracing the flow, I confirmed that `"queued"` is a valid API response and is populated during JSON deserialization, making the missing enum constant the underlying issue rather than an invalid value.

Adding `PolicyEvaluationQueued` aligns `PolicyEvaluationStatus` with `TFPolicyEvaluationStatus`, removes the need for type conversions, and allows consumers to handle the queued state in a type-safe way. The Terraform CLI fix in [#38751](https://github.com/hashicorp/terraform/pull/38751) depends on this constant being present.

This is a const addition to the `v1` package, which is considered final but still accepts critical bug fixes and const additions per the package policy.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.