### PR TITLE
allow retries on connection/transport errors

### DIFF
--- a/v2/middleware/middleware.go
+++ b/v2/middleware/middleware.go
@@ -21,8 +21,9 @@ func nilErrorFactory(_ *nethttp.Response, _ error) error {
 // This function replaces Kiota's built-in RetryHandler with a custom RetryMiddleware.
 // Kiota's RetryHandler has a hardcoded isRetriableErrorCode gate that only covers 429, 503, 504
 // and short-circuits before calling the ShouldRetry callback. Our custom middleware calls
-// ShouldRetry unconditionally, allowing retries on 429, 425, and all 5xx (when RetryServerErrors
-// is enabled).
+// ShouldRetry unconditionally, allowing retries on 429, 425, all 5xx, and transport/connection
+// errors. 5xx responses and transport/connection errors are retried when RetryServerErrors
+// is enabled.
 func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Middleware, error) {
 	var errFactory APIErrorFactory = nilErrorFactory
 	var retryOpts = RetryOptions{
@@ -64,7 +65,16 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 	retryMiddleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   retryOpts.MaxRetries,
 		DelaySeconds: 1,
-		ShouldRetry: func(executionCount int, request *nethttp.Request, response *nethttp.Response) bool {
+		ShouldRetry: func(executionCount int, request *nethttp.Request, response *nethttp.Response, err error) bool {
+			// Transport/connection errors are retried when RetryServerErrors
+			// is enabled. The hook receives a nil response in this case.
+			if err != nil || response == nil {
+				if retryOpts.RetryServerErrors {
+					retryOpts.Hook(executionCount, response)
+					return true
+				}
+				return false
+			}
 			// Retry on 429 (rate limited) and 425 (too early) when rate limit retries are enabled
 			if retryOpts.Enabled && (response.StatusCode == 429 || response.StatusCode == 425) {
 				retryOpts.Hook(executionCount, response)

--- a/v2/middleware/options.go
+++ b/v2/middleware/options.go
@@ -21,6 +21,7 @@ func (o MiddlewareOption) Value(key string) any {
 }
 
 // RetryHookCallback is called before each retry attempt with the attempt number and response.
+// The response is nil when the retry is triggered by a transport/connection error.
 type RetryHookCallback func(retryCount int, response *nethttp.Response)
 
 // RetryOptions configures the retry behavior for the middleware pipeline.

--- a/v2/middleware/retry.go
+++ b/v2/middleware/retry.go
@@ -4,6 +4,7 @@
 package middleware
 
 import (
+	"cmp"
 	"io"
 	"math"
 	nethttp "net/http"
@@ -122,10 +123,7 @@ func (m *RetryMiddleware) retryRequest(
 		if seeker, ok := req.Body.(io.Seeker); ok {
 			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
 				// Prefer surfacing the original transport error over the seek error.
-				if respErr != nil {
-					return resp, respErr
-				}
-				return resp, err
+				return resp, cmp.Or(respErr, err)
 			}
 		}
 	}

--- a/v2/middleware/retry.go
+++ b/v2/middleware/retry.go
@@ -23,8 +23,10 @@ const (
 	absoluteMaxDelaySeconds = 180
 )
 
-// ShouldRetryFunc determines whether a request should be retried based on the response.
-type ShouldRetryFunc func(executionCount int, request *nethttp.Request, response *nethttp.Response) bool
+// ShouldRetryFunc determines whether a request should be retried based on the response
+// and/or the error returned by the transport. When a transport/connection error occurs
+// (e.g. connection refused, DNS failure), response is nil and err is non-nil.
+type ShouldRetryFunc func(executionCount int, request *nethttp.Request, response *nethttp.Response, err error) bool
 
 // RetryMiddleware is a custom retry middleware that replaces Kiota's built-in RetryHandler.
 // Unlike Kiota's implementation, it does NOT gate retries behind a hardcoded isRetriableErrorCode
@@ -42,9 +44,9 @@ type RetryMiddlewareOptions struct {
 	MaxRetries int
 	// DelaySeconds is the base delay between retries (used for exponential backoff).
 	DelaySeconds int
-	// ShouldRetry determines whether a given response warrants a retry.
-	// This is called unconditionally for every non-nil response — there is no
-	// status code pre-filter.
+	// ShouldRetry determines whether a given response (or transport error) warrants
+	// a retry. It is called unconditionally for every attempt — there is no status
+	// code pre-filter, and transport errors are passed through with a nil response.
 	ShouldRetry ShouldRetryFunc
 }
 
@@ -66,7 +68,7 @@ func NewRetryMiddleware(opts RetryMiddlewareOptions) khttp.Middleware {
 
 	shouldRetry := opts.ShouldRetry
 	if shouldRetry == nil {
-		shouldRetry = func(_ int, _ *nethttp.Request, _ *nethttp.Response) bool {
+		shouldRetry = func(_ int, _ *nethttp.Request, _ *nethttp.Response, _ error) bool {
 			return false
 		}
 	}
@@ -81,10 +83,7 @@ func NewRetryMiddleware(opts RetryMiddlewareOptions) khttp.Middleware {
 // Intercept implements the khttp.Middleware interface.
 func (m *RetryMiddleware) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request) (*nethttp.Response, error) {
 	response, err := pipeline.Next(req, middlewareIndex)
-	if err != nil {
-		return response, err
-	}
-	return m.retryRequest(pipeline, middlewareIndex, req, response, 0, 0)
+	return m.retryRequest(pipeline, middlewareIndex, req, response, err, 0, 0)
 }
 
 func (m *RetryMiddleware) retryRequest(
@@ -92,22 +91,23 @@ func (m *RetryMiddleware) retryRequest(
 	middlewareIndex int,
 	req *nethttp.Request,
 	resp *nethttp.Response,
+	respErr error,
 	executionCount int,
 	cumulativeDelay time.Duration,
 ) (*nethttp.Response, error) {
 	// Check all retry conditions. Unlike Kiota's RetryHandler, we do NOT pre-filter
 	// by status code. The ShouldRetry callback is the sole arbiter of whether to retry.
 	if !m.isRetriableRequest(req) {
-		return resp, nil
+		return resp, respErr
 	}
 	if executionCount >= m.maxRetries {
-		return resp, nil
+		return resp, respErr
 	}
 	if cumulativeDelay >= time.Duration(absoluteMaxDelaySeconds)*time.Second {
-		return resp, nil
+		return resp, respErr
 	}
-	if !m.shouldRetry(executionCount, req, resp) {
-		return resp, nil
+	if !m.shouldRetry(executionCount, req, resp, respErr) {
+		return resp, respErr
 	}
 
 	// Proceed with retry
@@ -121,6 +121,10 @@ func (m *RetryMiddleware) retryRequest(
 	if req.Body != nil {
 		if seeker, ok := req.Body.(io.Seeker); ok {
 			if _, err := seeker.Seek(0, io.SeekStart); err != nil {
+				// Prefer surfacing the original transport error over the seek error.
+				if respErr != nil {
+					return resp, respErr
+				}
 				return resp, err
 			}
 		}
@@ -137,10 +141,7 @@ func (m *RetryMiddleware) retryRequest(
 	}
 
 	response, err := pipeline.Next(req, middlewareIndex)
-	if err != nil {
-		return response, err
-	}
-	return m.retryRequest(pipeline, middlewareIndex, req, response, executionCount, cumulativeDelay)
+	return m.retryRequest(pipeline, middlewareIndex, req, response, err, executionCount, cumulativeDelay)
 }
 
 // isRetriableRequest checks whether the request type supports retrying.

--- a/v2/middleware/retry_test.go
+++ b/v2/middleware/retry_test.go
@@ -4,6 +4,7 @@ package middleware
 
 import (
 	"bytes"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -47,7 +48,7 @@ func TestRetryMiddleware_RetriesOn500(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   5,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode >= 500
 		},
 	})
@@ -85,7 +86,7 @@ func TestRetryMiddleware_RetriesOn502(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   3,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode >= 500
 		},
 	})
@@ -124,7 +125,7 @@ func TestRetryMiddleware_RetriesOn429(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   3,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode == 429 || resp.StatusCode == 425
 		},
 	})
@@ -162,7 +163,7 @@ func TestRetryMiddleware_RetriesOn425(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   3,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode == 429 || resp.StatusCode == 425
 		},
 	})
@@ -196,7 +197,7 @@ func TestRetryMiddleware_DoesNotRetryWhenShouldRetryReturnsFalse(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   3,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			// Only retry on 429, 425, 5xx
 			return resp.StatusCode == 429 || resp.StatusCode == 425 || resp.StatusCode >= 500
 		},
@@ -231,7 +232,7 @@ func TestRetryMiddleware_RespectsMaxRetries(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   2,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode >= 500
 		},
 	})
@@ -266,7 +267,7 @@ func TestRetryMiddleware_DoesNotRetryStreamingBody(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   3,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode >= 500
 		},
 	})
@@ -307,7 +308,7 @@ func TestRetryMiddleware_RetriesPostWithKnownContentLength(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   3,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode >= 500
 		},
 	})
@@ -351,7 +352,7 @@ func TestRetryMiddleware_HookCalledOnRetry(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   5,
 		DelaySeconds: 1,
-		ShouldRetry: func(executionCount int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(executionCount int, _ *http.Request, resp *http.Response, _ error) bool {
 			if resp.StatusCode >= 500 {
 				atomic.AddInt32(&hookCalls, 1)
 				return true
@@ -393,7 +394,7 @@ func TestRetryMiddleware_SetsRetryAttemptHeader(t *testing.T) {
 	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
 		MaxRetries:   3,
 		DelaySeconds: 1,
-		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response) bool {
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, _ error) bool {
 			return resp.StatusCode >= 500
 		},
 	})
@@ -483,6 +484,214 @@ func TestGetForKiota_RetryDisabled(t *testing.T) {
 	// Should not retry when disabled
 	if atomic.LoadInt32(&attempts) != 1 {
 		t.Fatalf("expected 1 attempt (retry disabled), got %d", atomic.LoadInt32(&attempts))
+	}
+}
+
+// flakyPipeline implements khttp.Pipeline for testing transport errors. It returns
+// a transport error for the first `failures` attempts, then routes to the transport.
+type flakyPipeline struct {
+	transport http.RoundTripper
+	failures  int32
+	attempts  int32
+	err       error
+}
+
+func (p *flakyPipeline) Next(req *http.Request, _ int) (*http.Response, error) {
+	n := atomic.AddInt32(&p.attempts, 1)
+	if n <= p.failures {
+		return nil, p.err
+	}
+	return p.transport.RoundTrip(req)
+}
+
+func TestRetryMiddleware_RetriesTransportErrors(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	pipeline := &flakyPipeline{
+		transport: http.DefaultTransport,
+		failures:  2,
+		err:       errors.New("connection refused"),
+	}
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   5,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, err error) bool {
+			return err != nil || resp == nil
+		},
+	})
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	// 2 failed attempts + 1 success
+	if atomic.LoadInt32(&pipeline.attempts) != 3 {
+		t.Fatalf("expected 3 attempts, got %d", atomic.LoadInt32(&pipeline.attempts))
+	}
+}
+
+func TestRetryMiddleware_ReturnsErrorWhenTransportRetriesExhausted(t *testing.T) {
+	transportErr := errors.New("connection reset by peer")
+	pipeline := &flakyPipeline{
+		transport: http.DefaultTransport,
+		failures:  100, // always fail
+		err:       transportErr,
+	}
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   2,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, err error) bool {
+			return err != nil
+		},
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.invalid/test", nil)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+	if resp != nil {
+		t.Fatalf("expected nil response, got %v", resp)
+	}
+	// 1 initial + 2 retries = 3 total
+	if atomic.LoadInt32(&pipeline.attempts) != 3 {
+		t.Fatalf("expected 3 total attempts (1 initial + 2 retries), got %d", atomic.LoadInt32(&pipeline.attempts))
+	}
+}
+
+func TestRetryMiddleware_DoesNotRetryTransportErrorWhenShouldRetryReturnsFalse(t *testing.T) {
+	transportErr := errors.New("connection refused")
+	pipeline := &flakyPipeline{
+		transport: http.DefaultTransport,
+		failures:  100,
+		err:       transportErr,
+	}
+
+	middleware := NewRetryMiddleware(RetryMiddlewareOptions{
+		MaxRetries:   3,
+		DelaySeconds: 1,
+		ShouldRetry: func(_ int, _ *http.Request, resp *http.Response, err error) bool {
+			// Only retry on responses, never on transport errors
+			return resp != nil && resp.StatusCode >= 500
+		},
+	})
+
+	req, _ := http.NewRequest("GET", "http://example.invalid/test", nil)
+	_, err := middleware.Intercept(pipeline, 0, req)
+
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+	if atomic.LoadInt32(&pipeline.attempts) != 1 {
+		t.Fatalf("expected 1 attempt (no retry), got %d", atomic.LoadInt32(&pipeline.attempts))
+	}
+}
+
+func TestGetForKiota_TransportErrorRetriedWhenRetryServerErrorsEnabled(t *testing.T) {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	server := httptest.NewServer(handler)
+	defer server.Close()
+
+	pipeline := &flakyPipeline{
+		transport: http.DefaultTransport,
+		failures:  1,
+		err:       errors.New("connection refused"),
+	}
+
+	var hookCalls int32
+	hook := func(retryCount int, response *http.Response) {
+		atomic.AddInt32(&hookCalls, 1)
+		if response != nil {
+			t.Errorf("expected nil response in hook for transport error, got %v", response)
+		}
+	}
+
+	middlewares, err := GetForKiota("1.0.0",
+		WithRetryOptions(false, true, 3, hook),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var retryMW khttp.Middleware
+	for _, mw := range middlewares {
+		if _, ok := mw.(*RetryMiddleware); ok {
+			retryMW = mw
+			break
+		}
+	}
+	if retryMW == nil {
+		t.Fatal("RetryMiddleware not found in pipeline")
+	}
+
+	req, _ := http.NewRequest("GET", server.URL+"/test", nil)
+	resp, err := retryMW.Intercept(pipeline, 0, req)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+	if atomic.LoadInt32(&pipeline.attempts) != 2 {
+		t.Fatalf("expected 2 attempts, got %d", atomic.LoadInt32(&pipeline.attempts))
+	}
+	if atomic.LoadInt32(&hookCalls) != 1 {
+		t.Fatalf("expected hook called 1 time, got %d", atomic.LoadInt32(&hookCalls))
+	}
+}
+
+func TestGetForKiota_TransportErrorNotRetriedWhenRetryServerErrorsDisabled(t *testing.T) {
+	transportErr := errors.New("connection refused")
+	pipeline := &flakyPipeline{
+		transport: http.DefaultTransport,
+		failures:  100,
+		err:       transportErr,
+	}
+
+	// RetryRateLimited=true but RetryServerErrors=false: transport errors must not retry
+	middlewares, err := GetForKiota("1.0.0",
+		WithRetryOptions(true, false, 3, nil),
+	)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var retryMW khttp.Middleware
+	for _, mw := range middlewares {
+		if _, ok := mw.(*RetryMiddleware); ok {
+			retryMW = mw
+			break
+		}
+	}
+	if retryMW == nil {
+		t.Fatal("RetryMiddleware not found in pipeline")
+	}
+
+	req, _ := http.NewRequest("GET", "http://example.invalid/test", nil)
+	_, err = retryMW.Intercept(pipeline, 0, req)
+
+	if !errors.Is(err, transportErr) {
+		t.Fatalf("expected transport error, got %v", err)
+	}
+	if atomic.LoadInt32(&pipeline.attempts) != 1 {
+		t.Fatalf("expected 1 attempt (no retry), got %d", atomic.LoadInt32(&pipeline.attempts))
 	}
 }
 

--- a/v2/middleware/retry_test.go
+++ b/v2/middleware/retry_test.go
@@ -559,12 +559,13 @@ func TestRetryMiddleware_ReturnsErrorWhenTransportRetriesExhausted(t *testing.T)
 
 	req, _ := http.NewRequest("GET", "http://example.invalid/test", nil)
 	resp, err := middleware.Intercept(pipeline, 0, req)
+	if resp != nil {
+		defer resp.Body.Close()
+		t.Fatalf("expected nil response, got %v", resp)
+	}
 
 	if !errors.Is(err, transportErr) {
 		t.Fatalf("expected transport error, got %v", err)
-	}
-	if resp != nil {
-		t.Fatalf("expected nil response, got %v", resp)
 	}
 	// 1 initial + 2 retries = 3 total
 	if atomic.LoadInt32(&pipeline.attempts) != 3 {
@@ -590,7 +591,10 @@ func TestRetryMiddleware_DoesNotRetryTransportErrorWhenShouldRetryReturnsFalse(t
 	})
 
 	req, _ := http.NewRequest("GET", "http://example.invalid/test", nil)
-	_, err := middleware.Intercept(pipeline, 0, req)
+	resp, err := middleware.Intercept(pipeline, 0, req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	if !errors.Is(err, transportErr) {
 		t.Fatalf("expected transport error, got %v", err)
@@ -685,7 +689,10 @@ func TestGetForKiota_TransportErrorNotRetriedWhenRetryServerErrorsDisabled(t *te
 	}
 
 	req, _ := http.NewRequest("GET", "http://example.invalid/test", nil)
-	_, err = retryMW.Intercept(pipeline, 0, req)
+	resp, err := retryMW.Intercept(pipeline, 0, req)
+	if resp != nil {
+		defer resp.Body.Close()
+	}
 
 	if !errors.Is(err, transportErr) {
 		t.Fatalf("expected transport error, got %v", err)


### PR DESCRIPTION
## Retry transport/connection errors in the v2 client

### Problem

The v2 retry middleware returned immediately on any error from the transport pipeline — connection refused, connection reset, DNS failures, etc. were not retried. This is a regression from v1, where `retryHTTPCheck` retries transport errors whenever `RetryServerErrors` is enabled.

### What changed

- **`v2/middleware/retry.go`**: `Intercept` and the internal retry loop no longer short-circuit on a pipeline error. The error is passed into the retry decision alongside the (nil) response, so transport failures go through the same max-retries / cumulative-delay / retriable-request checks as status-code retries. When retries are exhausted, the last transport error is returned to the caller.

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [x] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
