### PR TITLE
fix: concurrency-related panic in v2 pipeline

### DIFF
--- a/v2/middleware/middleware.go
+++ b/v2/middleware/middleware.go
@@ -101,12 +101,6 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 			ProductName:    "go-tfe",
 			ProductVersion: tfeSDKVersion,
 		}),
-		// safeHeadersInspectionHandler replaces khttp.HeadersInspectionHandler
-		// to fix a data race: the upstream handler shares a single
-		// HeadersInspectionOptions (and its ResponseHeaders map) across all
-		// concurrent requests that don't carry a per-request option, causing
-		// fatal concurrent map writes. Our implementation allocates fresh
-		// options per-request when none is provided by the caller.
-		newSafeHeadersInspectionHandler(false, true),
+		NewHeadersInspectionHandler(false, true),
 	}, nil
 }

--- a/v2/middleware/middleware.go
+++ b/v2/middleware/middleware.go
@@ -101,11 +101,12 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 			ProductName:    "go-tfe",
 			ProductVersion: tfeSDKVersion,
 		}),
-		khttp.NewHeadersInspectionHandlerWithOptions(func() khttp.HeadersInspectionOptions {
-			opts := *khttp.NewHeadersInspectionOptions()
-			opts.InspectRequestHeaders = false
-			opts.InspectResponseHeaders = true
-			return opts
-		}()),
+		// safeHeadersInspectionHandler replaces khttp.HeadersInspectionHandler
+		// to fix a data race: the upstream handler shares a single
+		// HeadersInspectionOptions (and its ResponseHeaders map) across all
+		// concurrent requests that don't carry a per-request option, causing
+		// fatal concurrent map writes. Our implementation allocates fresh
+		// options per-request when none is provided by the caller.
+		newSafeHeadersInspectionHandler(false, true),
 	}, nil
 }

--- a/v2/middleware/safe_headers_inspection.go
+++ b/v2/middleware/safe_headers_inspection.go
@@ -9,16 +9,11 @@ import (
 	khttp "github.com/microsoft/kiota-http-go"
 )
 
-// headersInspectionReqKey mirrors the unexported headersInspectionKeyValue in
-// kiota-http-go (headers_inspection_handler.go) so that context lookups are
-// wire-compatible with any per-request HeadersInspectionOptions that a caller
-// may have stored via khttp.NewHeadersInspectionOptions().GetKey().
+// headersInspectionReqKey is the context key used by kiota-http-go to store
+// per-request HeadersInspectionOptions.
 var headersInspectionReqKey = abs.RequestOptionKey{Key: "nethttplibrary.HeadersInspectionOptions"}
 
-// headersInspectionOptsIface mirrors the unexported headersInspectionOptionsInt
-// interface in kiota-http-go so that we can type-assert per-request options
-// stored in the context without importing an internal type.
-type headersInspectionOptsIface interface {
+type headersInspectionOptions interface {
 	abs.RequestOption
 	GetInspectRequestHeaders() bool
 	GetInspectResponseHeaders() bool
@@ -26,42 +21,27 @@ type headersInspectionOptsIface interface {
 	GetResponseHeaders() *abs.ResponseHeaders
 }
 
-// safeHeadersInspectionHandler is a concurrent-safe replacement for
-// khttp.HeadersInspectionHandler.
-//
-// The upstream handler (kiota-http-go v1.5.6) contains a data race: when a
-// request does not carry a per-request HeadersInspectionOptions in its
-// context, Intercept falls back to &middleware.options — a pointer into the
-// handler struct itself. All concurrent goroutines then share that single
-// HeadersInspectionOptions value and race writing response headers into the
-// embedded ResponseHeaders map, producing:
-//
-//	fatal error: concurrent map read and map write
-//	github.com/microsoft/kiota-abstractions-go.(*header).Add
-//	github.com/microsoft/kiota-http-go.HeadersInspectionHandler.Intercept
-//
-// This implementation allocates a fresh HeadersInspectionOptions for every
-// request that does not already carry one, so each goroutine writes into its
-// own private map. Per-request options provided by callers (the intended
-// consumption pattern) are honoured unchanged.
-type safeHeadersInspectionHandler struct {
+// headersInspectionHandler implements khttp.Middleware. It retrieves
+// HeadersInspectionOptions from the request context when present, or creates
+// fresh options with the configured defaults. This ensures each concurrent
+// request writes into its own headers map.
+type headersInspectionHandler struct {
 	inspectRequestHeaders  bool
 	inspectResponseHeaders bool
 }
 
-func newSafeHeadersInspectionHandler(inspectRequest, inspectResponse bool) *safeHeadersInspectionHandler {
-	return &safeHeadersInspectionHandler{
+// NewHeadersInspectionHandler returns a headersInspectionHandler configured
+// with the given defaults.
+func NewHeadersInspectionHandler(inspectRequest, inspectResponse bool) *headersInspectionHandler {
+	return &headersInspectionHandler{
 		inspectRequestHeaders:  inspectRequest,
 		inspectResponseHeaders: inspectResponse,
 	}
 }
 
 // Intercept implements khttp.Middleware.
-func (h *safeHeadersInspectionHandler) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request) (*nethttp.Response, error) {
-	// Prefer a per-request option already stored in the context (set by the
-	// caller to observe specific request/response headers). If none is present,
-	// allocate a fresh one for this request only — never touch shared state.
-	reqOption, ok := req.Context().Value(headersInspectionReqKey).(headersInspectionOptsIface)
+func (h *headersInspectionHandler) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request) (*nethttp.Response, error) {
+	reqOption, ok := req.Context().Value(headersInspectionReqKey).(headersInspectionOptions)
 	if !ok {
 		freshOpts := khttp.NewHeadersInspectionOptions()
 		freshOpts.InspectRequestHeaders = h.inspectRequestHeaders

--- a/v2/middleware/safe_headers_inspection.go
+++ b/v2/middleware/safe_headers_inspection.go
@@ -1,0 +1,98 @@
+// Copyright IBM Corp. 2018, 2026
+
+package middleware
+
+import (
+	nethttp "net/http"
+
+	abs "github.com/microsoft/kiota-abstractions-go"
+	khttp "github.com/microsoft/kiota-http-go"
+)
+
+// headersInspectionReqKey mirrors the unexported headersInspectionKeyValue in
+// kiota-http-go (headers_inspection_handler.go) so that context lookups are
+// wire-compatible with any per-request HeadersInspectionOptions that a caller
+// may have stored via khttp.NewHeadersInspectionOptions().GetKey().
+var headersInspectionReqKey = abs.RequestOptionKey{Key: "nethttplibrary.HeadersInspectionOptions"}
+
+// headersInspectionOptsIface mirrors the unexported headersInspectionOptionsInt
+// interface in kiota-http-go so that we can type-assert per-request options
+// stored in the context without importing an internal type.
+type headersInspectionOptsIface interface {
+	abs.RequestOption
+	GetInspectRequestHeaders() bool
+	GetInspectResponseHeaders() bool
+	GetRequestHeaders() *abs.RequestHeaders
+	GetResponseHeaders() *abs.ResponseHeaders
+}
+
+// safeHeadersInspectionHandler is a concurrent-safe replacement for
+// khttp.HeadersInspectionHandler.
+//
+// The upstream handler (kiota-http-go v1.5.6) contains a data race: when a
+// request does not carry a per-request HeadersInspectionOptions in its
+// context, Intercept falls back to &middleware.options — a pointer into the
+// handler struct itself. All concurrent goroutines then share that single
+// HeadersInspectionOptions value and race writing response headers into the
+// embedded ResponseHeaders map, producing:
+//
+//	fatal error: concurrent map read and map write
+//	github.com/microsoft/kiota-abstractions-go.(*header).Add
+//	github.com/microsoft/kiota-http-go.HeadersInspectionHandler.Intercept
+//
+// This implementation allocates a fresh HeadersInspectionOptions for every
+// request that does not already carry one, so each goroutine writes into its
+// own private map. Per-request options provided by callers (the intended
+// consumption pattern) are honoured unchanged.
+type safeHeadersInspectionHandler struct {
+	inspectRequestHeaders  bool
+	inspectResponseHeaders bool
+}
+
+func newSafeHeadersInspectionHandler(inspectRequest, inspectResponse bool) *safeHeadersInspectionHandler {
+	return &safeHeadersInspectionHandler{
+		inspectRequestHeaders:  inspectRequest,
+		inspectResponseHeaders: inspectResponse,
+	}
+}
+
+// Intercept implements khttp.Middleware.
+func (h *safeHeadersInspectionHandler) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *nethttp.Request) (*nethttp.Response, error) {
+	// Prefer a per-request option already stored in the context (set by the
+	// caller to observe specific request/response headers). If none is present,
+	// allocate a fresh one for this request only — never touch shared state.
+	reqOption, ok := req.Context().Value(headersInspectionReqKey).(headersInspectionOptsIface)
+	if !ok {
+		freshOpts := khttp.NewHeadersInspectionOptions()
+		freshOpts.InspectRequestHeaders = h.inspectRequestHeaders
+		freshOpts.InspectResponseHeaders = h.inspectResponseHeaders
+		reqOption = freshOpts
+	}
+
+	if reqOption.GetInspectRequestHeaders() {
+		for k, v := range req.Header {
+			if len(v) == 1 {
+				reqOption.GetRequestHeaders().Add(k, v[0])
+			} else {
+				reqOption.GetRequestHeaders().Add(k, v[0], v[1:]...)
+			}
+		}
+	}
+
+	response, err := pipeline.Next(req, middlewareIndex)
+	if err != nil {
+		return response, err
+	}
+
+	if reqOption.GetInspectResponseHeaders() {
+		for k, v := range response.Header {
+			if len(v) == 1 {
+				reqOption.GetResponseHeaders().Add(k, v[0])
+			} else {
+				reqOption.GetResponseHeaders().Add(k, v[0], v[1:]...)
+			}
+		}
+	}
+
+	return response, err
+}

--- a/v2/middleware/safe_headers_inspection_test.go
+++ b/v2/middleware/safe_headers_inspection_test.go
@@ -12,15 +12,11 @@ import (
 	khttp "github.com/microsoft/kiota-http-go"
 )
 
-// TestSafeHeadersInspectionHandler_NoConcurrentMapWrite reproduces the race
-// that was present when khttp.HeadersInspectionHandler was used directly in
-// the middleware pipeline. With default pipeline settings no per-request
-// HeadersInspectionOptions is placed in the context, so previously all
-// goroutines shared &middleware.options and raced on the embedded
-// ResponseHeaders map.
+// TestHeadersInspectionHandler_NoConcurrentMapWrite verifies that concurrent
+// requests do not race on a shared ResponseHeaders map.
 //
-// Run with: go test -race ./middleware/ -run TestSafeHeadersInspectionHandler_NoConcurrentMapWrite
-func TestSafeHeadersInspectionHandler_NoConcurrentMapWrite(t *testing.T) {
+// Run with: go test -race ./middleware/ -run TestHeadersInspectionHandler_NoConcurrentMapWrite
+func TestHeadersInspectionHandler_NoConcurrentMapWrite(t *testing.T) {
 	// Server that always responds with a handful of headers.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("X-Request-Id", "abc123")
@@ -30,7 +26,7 @@ func TestSafeHeadersInspectionHandler_NoConcurrentMapWrite(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	handler := newSafeHeadersInspectionHandler(false, true)
+	handler := NewHeadersInspectionHandler(false, true)
 
 	// pipeline terminates at the test server.
 	pipeline := &testPipeline{transport: http.DefaultTransport}
@@ -59,18 +55,17 @@ func TestSafeHeadersInspectionHandler_NoConcurrentMapWrite(t *testing.T) {
 	wg.Wait()
 }
 
-// TestSafeHeadersInspectionHandler_PerRequestOptionHonoured verifies that
-// when a caller injects their own HeadersInspectionOptions into the request
-// context, the handler populates that caller-provided instance rather than
-// discarding it.
-func TestSafeHeadersInspectionHandler_PerRequestOptionHonoured(t *testing.T) {
+// TestHeadersInspectionHandler_PerRequestOptionHonoured verifies that when a
+// caller injects their own HeadersInspectionOptions into the request context,
+// the handler populates that instance rather than discarding it.
+func TestHeadersInspectionHandler_PerRequestOptionHonoured(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.Header().Set("X-Custom-Header", "hello")
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
-	handler := newSafeHeadersInspectionHandler(false, true)
+	handler := NewHeadersInspectionHandler(false, true)
 	pipeline := &testPipeline{transport: http.DefaultTransport}
 
 	inspectionOpts := khttp.NewHeadersInspectionOptions()
@@ -94,16 +89,16 @@ func TestSafeHeadersInspectionHandler_PerRequestOptionHonoured(t *testing.T) {
 	}
 }
 
-// TestSafeHeadersInspectionHandler_RequestHeadersInspected verifies that when
+// TestHeadersInspectionHandler_RequestHeadersInspected verifies that when
 // InspectRequestHeaders is true the outgoing request headers are captured into
 // the RequestHeaders of the per-request option.
-func TestSafeHeadersInspectionHandler_RequestHeadersInspected(t *testing.T) {
+func TestHeadersInspectionHandler_RequestHeadersInspected(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
-	handler := newSafeHeadersInspectionHandler(true, false)
+	handler := NewHeadersInspectionHandler(true, false)
 	pipeline := &testPipeline{transport: http.DefaultTransport}
 
 	inspectionOpts := khttp.NewHeadersInspectionOptions()

--- a/v2/middleware/safe_headers_inspection_test.go
+++ b/v2/middleware/safe_headers_inspection_test.go
@@ -1,0 +1,129 @@
+// Copyright IBM Corp. 2018, 2026
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"sync"
+	"testing"
+
+	khttp "github.com/microsoft/kiota-http-go"
+)
+
+// TestSafeHeadersInspectionHandler_NoConcurrentMapWrite reproduces the race
+// that was present when khttp.HeadersInspectionHandler was used directly in
+// the middleware pipeline. With default pipeline settings no per-request
+// HeadersInspectionOptions is placed in the context, so previously all
+// goroutines shared &middleware.options and raced on the embedded
+// ResponseHeaders map.
+//
+// Run with: go test -race ./middleware/ -run TestSafeHeadersInspectionHandler_NoConcurrentMapWrite
+func TestSafeHeadersInspectionHandler_NoConcurrentMapWrite(t *testing.T) {
+	// Server that always responds with a handful of headers.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Request-Id", "abc123")
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("X-RateLimit-Limit", "100")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	handler := newSafeHeadersInspectionHandler(false, true)
+
+	// pipeline terminates at the test server.
+	pipeline := &testPipeline{transport: http.DefaultTransport}
+
+	const goroutines = 20
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+
+	for i := 0; i < goroutines; i++ {
+		go func() {
+			defer wg.Done()
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, srv.URL, nil)
+			if err != nil {
+				t.Errorf("new request: %v", err)
+				return
+			}
+			resp, err := handler.Intercept(pipeline, 0, req)
+			if err != nil {
+				t.Errorf("Intercept: %v", err)
+				return
+			}
+			resp.Body.Close()
+		}()
+	}
+
+	wg.Wait()
+}
+
+// TestSafeHeadersInspectionHandler_PerRequestOptionHonoured verifies that
+// when a caller injects their own HeadersInspectionOptions into the request
+// context, the handler populates that caller-provided instance rather than
+// discarding it.
+func TestSafeHeadersInspectionHandler_PerRequestOptionHonoured(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("X-Custom-Header", "hello")
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	handler := newSafeHeadersInspectionHandler(false, true)
+	pipeline := &testPipeline{transport: http.DefaultTransport}
+
+	inspectionOpts := khttp.NewHeadersInspectionOptions()
+	inspectionOpts.InspectResponseHeaders = true
+
+	ctx := context.WithValue(context.Background(), headersInspectionReqKey, inspectionOpts)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+
+	resp, err := handler.Intercept(pipeline, 0, req)
+	if err != nil {
+		t.Fatalf("Intercept: %v", err)
+	}
+	resp.Body.Close()
+
+	got := inspectionOpts.GetResponseHeaders().Get("x-custom-header")
+	if len(got) == 0 || got[0] != "hello" {
+		t.Errorf("expected ResponseHeaders to contain X-Custom-Header=hello, got %v", got)
+	}
+}
+
+// TestSafeHeadersInspectionHandler_RequestHeadersInspected verifies that when
+// InspectRequestHeaders is true the outgoing request headers are captured into
+// the RequestHeaders of the per-request option.
+func TestSafeHeadersInspectionHandler_RequestHeadersInspected(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	handler := newSafeHeadersInspectionHandler(true, false)
+	pipeline := &testPipeline{transport: http.DefaultTransport}
+
+	inspectionOpts := khttp.NewHeadersInspectionOptions()
+	inspectionOpts.InspectRequestHeaders = true
+
+	ctx := context.WithValue(context.Background(), headersInspectionReqKey, inspectionOpts)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, srv.URL, nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("X-Trace-Id", "trace-42")
+
+	resp, err := handler.Intercept(pipeline, 0, req)
+	if err != nil {
+		t.Fatalf("Intercept: %v", err)
+	}
+	resp.Body.Close()
+
+	got := inspectionOpts.GetRequestHeaders().Get("x-trace-id")
+	if len(got) == 0 || got[0] != "trace-42" {
+		t.Errorf("expected RequestHeaders to contain X-Trace-Id=trace-42, got %v", got)
+	}
+}


### PR DESCRIPTION
When using Terraform built against go-tfe/v2 to create multiple resources in parallel, the provider binary crashes with:

```
fatal error: concurrent map read and map write
github.com/microsoft/kiota-abstractions-go.(*header).Add 
github.com/microsoft/kiota-http-go.HeadersInspectionHandler.Intercept
```

To reproduce: Using a go-tfe/v2-enabled Teraform build, run `terraform apply` with any config containing ≥2 tfe_team resources.

Root cause: `GetForKiota` creates one `khttp.HeadersInspectionHandler` per `NewClient` call. The upstream `Intercept` method falls back to `&middleware.options` (which is shared handler state) when options are not already set per request. Multiple goroutines all write into the same `ResponseHeaders` map, which causes a fatal concurrent map write.

Fix: Implement a `safeHeadersInspectionHandler` in the middleware package that creates a fresh `HeadersInspectionOptions` per request when options are not already set per request, eliminating any shared mutable state.
