### PR TITLE
middleware: set Content-Type for POST/PATCH/DELETE requests without a body

### DIFF
--- a/v2/middleware/content_type.go
+++ b/v2/middleware/content_type.go
@@ -1,0 +1,34 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package middleware
+
+import (
+	"net/http"
+
+	khttp "github.com/microsoft/kiota-http-go"
+)
+
+const contentTypeJSONAPI = "application/vnd.api+json"
+
+// ContentTypeMiddleware ensures that POST, PATCH, and DELETE requests always
+// carry a Content-Type: application/vnd.api+json header, even when the Kiota
+// request builder did not set one because the request has no body.
+//
+// The Atlas API requires this header on all mutating requests regardless of
+// whether a body is present; omitting it results in a 415 Unsupported Media
+// Type response.  The go-tfe v1 client set this header unconditionally for
+// POST, PATCH, and DELETE; this middleware restores that behavior for the v2
+// Kiota-based client.
+type ContentTypeMiddleware struct{}
+
+// Intercept implements the khttp.Middleware interface.
+func (m *ContentTypeMiddleware) Intercept(pipeline khttp.Pipeline, middlewareIndex int, req *http.Request) (*http.Response, error) {
+	switch req.Method {
+	case http.MethodPost, http.MethodPatch, http.MethodDelete:
+		if req.Header.Get("Content-Type") == "" {
+			req.Header.Set("Content-Type", contentTypeJSONAPI)
+		}
+	}
+	return pipeline.Next(req, middlewareIndex)
+}

--- a/v2/middleware/content_type_test.go
+++ b/v2/middleware/content_type_test.go
@@ -1,0 +1,76 @@
+// Copyright IBM Corp. 2018, 2026
+// SPDX-License-Identifier: MPL-2.0
+
+package middleware
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// terminalPipeline is a minimal khttp.Pipeline that returns the given response
+// and lets the test inspect the final request headers.
+type terminalPipeline struct {
+	capturedReq *http.Request
+	resp        *http.Response
+}
+
+func (p *terminalPipeline) Next(req *http.Request, _ int) (*http.Response, error) {
+	p.capturedReq = req
+	return p.resp, nil
+}
+
+func TestContentTypeMiddleware_setsMissingHeader(t *testing.T) {
+	tests := []struct {
+		method      string
+		wantHeader  bool
+		presetValue string
+	}{
+		{method: http.MethodPost, wantHeader: true},
+		{method: http.MethodPatch, wantHeader: true},
+		{method: http.MethodDelete, wantHeader: true},
+		{method: http.MethodGet, wantHeader: false},
+		{method: http.MethodPut, wantHeader: false},
+		// Pre-existing Content-Type must not be overwritten.
+		{method: http.MethodPost, wantHeader: true, presetValue: "application/octet-stream"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.method+"_preset="+tc.presetValue, func(t *testing.T) {
+			req := httptest.NewRequest(tc.method, "https://example.com/api/v2/test", nil)
+			if tc.presetValue != "" {
+				req.Header.Set("Content-Type", tc.presetValue)
+			}
+
+			resp := &http.Response{StatusCode: http.StatusOK}
+			pipeline := &terminalPipeline{resp: resp}
+
+			m := &ContentTypeMiddleware{}
+			_, err := m.Intercept(pipeline, 0, req)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			got := pipeline.capturedReq.Header.Get("Content-Type")
+
+			if tc.presetValue != "" {
+				// Pre-existing header must be preserved.
+				if got != tc.presetValue {
+					t.Errorf("Content-Type modified: got %q, want %q", got, tc.presetValue)
+				}
+				return
+			}
+
+			if tc.wantHeader {
+				if got != contentTypeJSONAPI {
+					t.Errorf("Content-Type = %q, want %q", got, contentTypeJSONAPI)
+				}
+			} else {
+				if got != "" {
+					t.Errorf("Content-Type should not be set for %s, got %q", tc.method, got)
+				}
+			}
+		})
+	}
+}

--- a/v2/middleware/content_type_test.go
+++ b/v2/middleware/content_type_test.go
@@ -43,14 +43,15 @@ func TestContentTypeMiddleware_setsMissingHeader(t *testing.T) {
 				req.Header.Set("Content-Type", tc.presetValue)
 			}
 
-			resp := &http.Response{StatusCode: http.StatusOK}
+			resp := &http.Response{StatusCode: http.StatusOK, Body: http.NoBody}
 			pipeline := &terminalPipeline{resp: resp}
 
 			m := &ContentTypeMiddleware{}
-			_, err := m.Intercept(pipeline, 0, req)
+			gotResp, err := m.Intercept(pipeline, 0, req)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
+			defer gotResp.Body.Close()
 
 			got := pipeline.capturedReq.Header.Get("Content-Type")
 

--- a/v2/middleware/middleware.go
+++ b/v2/middleware/middleware.go
@@ -106,6 +106,7 @@ func GetForKiota(tfeSDKVersion string, options ...MiddlewareOption) ([]khttp.Mid
 		}),
 		khttp.NewCompressionHandlerWithOptions(*khttp.NewCompressionOptionsReference(false)),
 		headersMiddleware,
+		&ContentTypeMiddleware{},
 		khttp.NewUserAgentHandlerWithOptions(&khttp.UserAgentHandlerOptions{
 			Enabled:        headerOpts.Get("User-Agent") == "",
 			ProductName:    "go-tfe",


### PR DESCRIPTION
## Summary

The Atlas API requires `Content-Type: application/vnd.api+json` on all mutating requests, even when the request body is empty (e.g. action endpoints like `/workspaces/{id}/actions/safe-delete`). When this header is absent, Atlas returns `415 Unsupported Media Type`.

The go-tfe v1 client set this header unconditionally for POST, PATCH, and DELETE in `NewRequestWithAdditionalQueryParams`. The Kiota-based v2 client only sets `Content-Type` when `SetContentFromParsable` (or similar) is called, so requests with no body omit it.

## Change

Add `ContentTypeMiddleware` to the default Kiota middleware pipeline. It sets `Content-Type: application/vnd.api+json` on POST, PATCH, and DELETE requests that do not already carry a `Content-Type` header. Pre-existing values (e.g. `application/octet-stream` for binary uploads) are preserved unchanged.

## Testing

Unit test in `content_type_test.go` covers all six cases: POST/PATCH/DELETE (header set), GET/PUT (header not set), and POST with a pre-existing Content-Type (header preserved).