### PR TITLE
docs: add changelog entry for content type middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+* Bug Fix: Set `Content-Type: application/vnd.api+json` on POST, PATCH, and DELETE requests without
+a body.
+
 * Enhancement: NewClient configuration now supports `HTTPTransport` option, allowing you to
 customize many more aspects of every request round trip.
 


### PR DESCRIPTION
## Description

Adds the missing changelog entry for #1422, documenting that POST, PATCH, and DELETE requests without a body now receive the JSON:API `Content-Type` header.

## PCI review checklist

- [x] I have documented a clear reason for, and description of, the change I am making.
- [x] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request. Not applicable; this is documentation only.
- [x] If applicable, I've documented the impact of any changes to security controls. Not applicable; this is documentation only.