### PR TITLE
Document v2 No-Code workspace metadata in the CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+* Enhancement: Workspace reads in the v2 client now include No-Code metadata: nullable
+  `source-module-id` and `no-code-upgrade-available` attributes, plus a `no-code-module-version`
+  relationship to a typed `no-code-module-versions` resource (`module-version`, `version-number`).
+  These fields are omitted or null when the workspace is not No-Code. Prefer the relationship over
+  `source-module-id` for a typed link to the current module version.
+
 # v2.6.0
 
 * The latest public endpoints are available


### PR DESCRIPTION
## Description
Adds a user-facing CHANGELOG note for No-Code workspace metadata that already merged in the generated v2 client via nightly OpenAPI regen ([#1429](https://github.com/hashicorp/go-tfe/pull/1429)). Nightly PRs are labeled no-changelog-needed; product asked for an explicit SDK note so callers can find the new read fields.

v2 workspace reads now expose:
-  nullable `source-module-id` and `no-code-upgrade-available`
- `no-code-module-version` relationship to a typed `no-code-module-versions` resource (`module-version`, `version-number`)

Omitted or null when the workspace is not No-Code. Prefer the relationship over `source-module-id`

No generated code changes. Docs only.

Jira: [TFECO-12943](https://hashicorp.atlassian.net/browse/TFECO-12943)
Customer FR: [FRB-7716](https://hashicorp.atlassian.net/browse/FRB-7716)

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [X] I have documented a clear reason for, and description of, the change I am making.

- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [ ] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.


[TFECO-12943]: https://hashicorp.atlassian.net/browse/TFECO-12943?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[FRB-7716]: https://hashicorp.atlassian.net/browse/FRB-7716?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ