### PR TITLE
Return error for unsupported cost-estimation Logs function

### DIFF
--- a/v1.go
+++ b/v1.go
@@ -4238,7 +4238,8 @@ type CostEstimates interface {
 	Read(ctx context.Context, costEstimateID string) (*CostEstimate, error)
 
 	// Logs retrieves the logs of a costEstimate.
-	// Warning: This method is deprecated and will be removed from a future version of go-tfe. There is no replacement.
+
+	// Deprecated: Cost estimate logs are unsupported. There is no replacement.
 	Logs(ctx context.Context, costEstimateID string) (io.Reader, error)
 }
 
@@ -4306,9 +4307,10 @@ func (s *costEstimates) Read(ctx context.Context, costEstimateID string) (*CostE
 }
 
 // Logs retrieves the logs of a costEstimate.
-// Warning: This method is deprecated and will be removed from a future version of go-tfe. There is no replacement.
+
+// Deprecated: Cost estimate logs are unsupported. There is no replacement.
 func (s *costEstimates) Logs(ctx context.Context, costEstimateID string) (io.Reader, error) {
-	return nil, ErrCostEstimatesLogsUnsupported
+	return nil, ErrUnsupportedCostEstimateLogs
 }
 
 // DataRetentionPolicyChoice is a choice type struct that represents the possible types
@@ -4930,7 +4932,8 @@ var (
 
 // functionality which has been removed since v1
 var (
-	ErrCostEstimatesLogsUnsupported = errors.New("CostEstimates Logs() is now unsupported")
+	// ErrUnsupportedCostEstimateLogs is returned when cost estimate logs are requested.
+	ErrUnsupportedCostEstimateLogs = errors.New("cost estimate logs are unsupported")
 )
 
 // Copyright IBM Corp. 2018, 2026

--- a/v1.go
+++ b/v1.go
@@ -4238,6 +4238,7 @@ type CostEstimates interface {
 	Read(ctx context.Context, costEstimateID string) (*CostEstimate, error)
 
 	// Logs retrieves the logs of a costEstimate.
+	// Warning: This method is deprecated and will be removed from a future version of go-tfe. There is no replacement.
 	Logs(ctx context.Context, costEstimateID string) (io.Reader, error)
 }
 
@@ -4305,45 +4306,9 @@ func (s *costEstimates) Read(ctx context.Context, costEstimateID string) (*CostE
 }
 
 // Logs retrieves the logs of a costEstimate.
+// Warning: This method is deprecated and will be removed from a future version of go-tfe. There is no replacement.
 func (s *costEstimates) Logs(ctx context.Context, costEstimateID string) (io.Reader, error) {
-	if !validStringID(&costEstimateID) {
-		return nil, ErrInvalidCostEstimateID
-	}
-
-	// Loop until the context is canceled or the cost estimate is finished
-	// running. The cost estimate logs are not streamed and so only available
-	// once the estimate is finished.
-	for {
-		// Get the costEstimate to make sure it exists.
-		ce, err := s.Read(ctx, costEstimateID)
-		if err != nil {
-			return nil, err
-		}
-
-		switch ce.Status {
-		case CostEstimateQueued:
-			select {
-			case <-ctx.Done():
-				return nil, ctx.Err()
-			case <-time.After(1000 * time.Millisecond):
-				continue
-			}
-		}
-
-		u := fmt.Sprintf("cost-estimates/%s/output", url.PathEscape(costEstimateID))
-		req, err := s.client.NewRequest("GET", u, nil)
-		if err != nil {
-			return nil, err
-		}
-
-		logs := bytes.NewBuffer(nil)
-		err = req.Do(ctx, logs)
-		if err != nil {
-			return nil, err
-		}
-
-		return logs, nil
-	}
+	return nil, ErrCostEstimatesLogsUnsupported
 }
 
 // DataRetentionPolicyChoice is a choice type struct that represents the possible types
@@ -4961,6 +4926,11 @@ var (
 	ErrRequiredSCIMGroupMappingCreateOps = errors.New("Create Options are required to create a SCIM Group Mapping")
 
 	ErrRequiredSCIMGroupMappingUpdateOps = errors.New("Update Options are required to update SCIM Group Mapping")
+)
+
+// functionality which has been removed since v1
+var (
+	ErrCostEstimatesLogsUnsupported = errors.New("CostEstimates Logs() is now unsupported")
 )
 
 // Copyright IBM Corp. 2018, 2026


### PR DESCRIPTION
## Description

The `/api/v2/cost-estimates/:id/output` endpoint used by cost-estimation `Logs` is no longer supported. This changes the `Logs` function to return an unsupported error.

I regenerated the cost-estimation mocks using uber mockgen, but there was no change in the mock file. Should it be edited to always return `nil, errors.New("...")`, as the real implementation does?

The `/api/v2/cost-estimates/:id/output` route is still defined in Atlas but has no controller. The route will be removed in an Atlas PR.

Jira: https://hashicorp.atlassian.net/browse/TF-40447, https://hashicorp.atlassian.net/browse/TF-40504

## PCI review checklist

<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->

- [x] I have documented a clear reason for, and description of, the change I am making.

- [N/A] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.

- [N/A] If applicable, I've documented the impact of any changes to security controls.

  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.

